### PR TITLE
space_as parameter

### DIFF
--- a/fluent-plugin-carbon-v2/README.md
+++ b/fluent-plugin-carbon-v2/README.md
@@ -33,7 +33,7 @@
 
 ```json
 {
-    "message": "metric=http_request_size_bytes_sum _sourceType=kubernetes endpoint=http-metrics handler=prometheus instance=172.20.36.191:10251 job=kube-scheduler kubernetes.pod.name=kube-scheduler-ip-172-20-36-191.us-west-1.compute.internal kubernetes.service.name=kube-scheduler namespace=kube-system prometheus=monitoring/prometheus-operator-prometheus prometheus_replica=prometheus-prometheus-operator-prometheus-0 service=prometheus-operator-kube-scheduler   1619905.0 1550862304339"
+    "message": "metric=http_request_size_bytes_sum _origin=kubernetes endpoint=http-metrics handler=prometheus instance=172.20.36.191:10251 job=kube-scheduler kubernetes.pod.name=kube-scheduler-ip-172-20-36-191.us-west-1.compute.internal kubernetes.service.name=kube-scheduler namespace=kube-system prometheus=monitoring/prometheus-operator-prometheus prometheus_replica=prometheus-prometheus-operator-prometheus-0 service=prometheus-operator-kube-scheduler   1619905.0 1550862304339"
 }
 ```
 

--- a/fluent-plugin-carbon-v2/README.md
+++ b/fluent-plugin-carbon-v2/README.md
@@ -100,4 +100,10 @@ If `true`, records missing any field in keys of `exclusions` will be dropped.
 
 Default value: `false`
 
-__NOTE__ inclusions/exclusions rules are applied after relabeling and flatten
+__NOTE__ inclusions/exclusions rules are applied after relabeling and flatten.
+
+### space_as (string) (optional)
+
+The space (`' '`) in the name or value of fields will be replaced with the given string in output.
+
+Default value: `_`

--- a/fluent-plugin-carbon-v2/lib/fluent/plugin/filter_carbon_v2.rb
+++ b/fluent-plugin-carbon-v2/lib/fluent/plugin/filter_carbon_v2.rb
@@ -31,6 +31,7 @@ module Fluent
       )
       config_param :strict_inclusions, :bool, default: false
       config_param :strict_exclusions, :bool, default: false
+      config_param :space_as, :string, default: '_'
       config_param :sort_labels, :bool, default: true
 
       def configure(conf)
@@ -68,7 +69,7 @@ module Fluent
       ORIGIN_VALUE = 'kubernetes'.freeze
 
       def to_carbon_line(record)
-        metric = @metric_accessor.call(record)
+        metric = @metric_accessor.call(record).gsub(/\s/, @space_as)
         timestamp = @timestamp_accessor.call(record)
         value = @value_accessor.call(record)
         "metric=#{metric} #{to_tags(record)}   #{value} #{timestamp}"
@@ -123,7 +124,7 @@ module Fluent
       def to_tags(hash)
         array = @sort_labels ? hash.sort : hash.to_a
         array.map do |key, value|
-          "#{key}=#{value}"\
+          "#{key.gsub(/\s/, @space_as)}=#{value.gsub(/\s/, @space_as)}"\
             unless [KEY_METRIC, KEY_TIMESTAMP, KEY_VALUE].include?(key)
         end.compact.join(' ')
       end

--- a/fluent-plugin-carbon-v2/test/plugin/test_filter_carbon_v2.rb
+++ b/fluent-plugin-carbon-v2/test/plugin/test_filter_carbon_v2.rb
@@ -70,6 +70,21 @@ class CarbonV2FilterTest < Test::Unit::TestCase
       assert_equal 1, outputs.length
       verify_with_expected outputs, 'output.datapoint.nested.relabel'
     end
+
+    test 'relabel keys before convert space' do
+      config = %([
+        relabel {
+          "service" : "",
+          "kubernetes.service.na e" : "service_na e",
+          "kubernetes.pod.na e" : "pod_na e"
+        }
+        space_as '*'
+      ])
+      outputs = filter_datapoints(config, 'datapoint.nested.spaces')
+      puts outputs
+      assert_equal 1, outputs.length
+      verify_with_expected outputs, 'output.datapoint.nested.spaces.relabel'
+    end
   end
 
   sub_test_case 'inclusions, non-strict mode' do

--- a/fluent-plugin-carbon-v2/test/resources/datapoint.nested.spaces.json
+++ b/fluent-plugin-carbon-v2/test/resources/datapoint.nested.spaces.json
@@ -1,0 +1,25 @@
+{
+    "datapoints": [
+        {
+            "endpoint": "http- etrics",
+            "handler": "pro etheus",
+            "instance": "172.20.36.191:10251",
+            "job": "kube-scheduler",
+            "na espace": "kube-syste ",
+            "kubernetes": {
+                "pod": {
+                    "na e": "kube-scheduler-ip-172-20-36-191.us-west-1.co pute.internal"
+                },
+                "service": {
+                    "na e": "kube-scheduler"
+                }
+            },
+            "pro etheus": " onitoring/pro etheus-operator-pro etheus",
+            "pro etheus_replica": "pro etheus-pro etheus-operator-pro etheus-0",
+            "service": "pro etheus-operator-kube-scheduler",
+            "@metric": "http_request_size_bytes_su ",
+            "@timestamp": 1550862304339,
+            "@value": 1619905.0
+        }
+    ]
+}

--- a/fluent-plugin-carbon-v2/test/resources/output.datapoint.nested.spaces.relabel.json
+++ b/fluent-plugin-carbon-v2/test/resources/output.datapoint.nested.spaces.relabel.json
@@ -1,7 +1,7 @@
 {
     "outputs": [
         {
-            "message": "metric=http_request_size_bytes_su* _sourceType=kubernetes endpoint=http-*etrics handler=pro*etheus instance=172.20.36.191:10251 job=kube-scheduler na*espace=kube-syste* pod_na*e=kube-scheduler-ip-172-20-36-191.us-west-1.co*pute.internal pro*etheus=*onitoring/pro*etheus-operator-pro*etheus pro*etheus_replica=pro*etheus-pro*etheus-operator-pro*etheus-0 service_na*e=kube-scheduler   1619905.0 1550862304339"
+            "message": "metric=http_request_size_bytes_su* _origin=kubernetes endpoint=http-*etrics handler=pro*etheus instance=172.20.36.191:10251 job=kube-scheduler na*espace=kube-syste* pod_na*e=kube-scheduler-ip-172-20-36-191.us-west-1.co*pute.internal pro*etheus=*onitoring/pro*etheus-operator-pro*etheus pro*etheus_replica=pro*etheus-pro*etheus-operator-pro*etheus-0 service_na*e=kube-scheduler   1619905.0 1550862304339"
         }
     ]
 }

--- a/fluent-plugin-carbon-v2/test/resources/output.datapoint.nested.spaces.relabel.json
+++ b/fluent-plugin-carbon-v2/test/resources/output.datapoint.nested.spaces.relabel.json
@@ -1,0 +1,7 @@
+{
+    "outputs": [
+        {
+            "message": "metric=http_request_size_bytes_su* _sourceType=kubernetes endpoint=http-*etrics handler=pro*etheus instance=172.20.36.191:10251 job=kube-scheduler na*espace=kube-syste* pod_na*e=kube-scheduler-ip-172-20-36-191.us-west-1.co*pute.internal pro*etheus=*onitoring/pro*etheus-operator-pro*etheus pro*etheus_replica=pro*etheus-pro*etheus-operator-pro*etheus-0 service_na*e=kube-scheduler   1619905.0 1550862304339"
+        }
+    ]
+}


### PR DESCRIPTION
Since the space is not allowed in carbon V2 tags (name or value), add a parameter `space_as` to handle this case with replace all spaces in tags to a given string (by default use `_`)