### PR TITLE
Split metrics to multiple http sources

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -14,6 +14,7 @@ RUN apk add --no-cache --update --virtual .build-deps sudo build-base ruby-dev \
        && gem install snappy
 
 RUN gem install fluent-plugin-sumologic_output \
+       && gem install fluent-plugin-rewrite-tag-filter \
        && gem install fluent-plugin-carbon-v2 \
        && gem install fluent-plugin-datapoint \
        && gem install fluent-plugin-protobuf

--- a/deploy/kubernetes/fluentd-sumologic.yaml
+++ b/deploy/kubernetes/fluentd-sumologic.yaml
@@ -84,17 +84,17 @@ data:
       @type datapoint
       tag "prometheus.datapoint"
     </match>
-    <filter prometheus.datapoint>
-      @type carbon_v2
-    </filter>
     <match prometheus.datapoint>
       @type rewrite_tag_filter
       <rule>
-        key message
-        pattern job=(.*?)\s
+        key job
+        pattern ^(.*)$
         tag ${tag}.$1
       </rule>
     </match>
+    <filter prometheus.datapoint.**>
+      @type carbon_v2
+    </filter>
 
     <match prometheus.datapoint.apiserver**>
       @type sumologic

--- a/deploy/kubernetes/fluentd-sumologic.yaml
+++ b/deploy/kubernetes/fluentd-sumologic.yaml
@@ -14,6 +14,14 @@ metadata:
 type: Opaque
 stringData:
   endpoint-metrics: XXXX
+  endpoint-metrics-apiserver: XXXX
+  endpoint-metrics-cadvisor: XXXX
+  endpoint-metrics-kubelet: XXXX
+  endpoint-metrics-kube-controller-manager: XXXX
+  endpoint-metrics-kube-scheduler: XXXX
+  endpoint-metrics-kube-state: XXXX
+  endpoint-metrics-node-exporter: XXXX
+  endpoint-metrics-prometheus-operator: XXXX
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -78,8 +86,65 @@ data:
     </match>
     <filter prometheus.datapoint>
       @type carbon_v2
-    </filter>    
+    </filter>
     <match prometheus.datapoint>
+      @type rewrite_tag_filter
+      <rule>
+        key message
+        pattern job=(.*?)\s
+        tag ${tag}.$1
+      </rule>
+    </match>
+
+    <match prometheus.datapoint.apiserver**>
+      @type sumologic
+      endpoint "#{ENV['SUMO_ENDPOINT_METRICS_APISERVER']}"
+      data_type metrics
+      metric_data_format carbon2
+    </match>
+    <match prometheus.datapoint.cadvisor**>
+      @type sumologic
+      endpoint "#{ENV['SUMO_ENDPOINT_METRICS_CADVISOR']}"
+      data_type metrics
+      metric_data_format carbon2
+    </match>
+    <match prometheus.datapoint.kubelet**>
+      @type sumologic
+      endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBELET']}"
+      data_type metrics
+      metric_data_format carbon2
+    </match>
+    <match prometheus.datapoint.kube-controller-manager**>
+      @type sumologic
+      endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBE_CONTROLLER_MANAGER']}"
+      data_type metrics
+      metric_data_format carbon2
+    </match>
+    <match prometheus.datapoint.kube-scheduler**>
+      @type sumologic
+      endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBE_SCHEDULER']}"
+      data_type metrics
+      metric_data_format carbon2
+    </match>
+    <match prometheus.datapoint.kube-state**>
+      @type sumologic
+      endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBE_STATE']}"
+      data_type metrics
+      metric_data_format carbon2
+    </match>
+    <match prometheus.datapoint.node-exporter**>
+      @type sumologic
+      endpoint "#{ENV['SUMO_ENDPOINT_METRICS_NODE_EXPORTER']}"
+      data_type metrics
+      metric_data_format carbon2
+    </match>
+    <match prometheus.datapoint.prometheus-operator**>
+      @type sumologic
+      endpoint "#{ENV['SUMO_ENDPOINT_METRICS_PROMETHEUS_OPERATOR']}"
+      data_type metrics
+      metric_data_format carbon2
+    </match>
+    <match prometheus.datapoint.**>
       @type sumologic
       endpoint "#{ENV['SUMO_ENDPOINT_METRICS']}"
       data_type metrics
@@ -172,6 +237,46 @@ spec:
             secretKeyRef:
               name: sumologic
               key: endpoint-metrics
+        - name: SUMO_ENDPOINT_METRICS_APISERVER
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-metrics-apiserver
+        - name: SUMO_ENDPOINT_METRICS_CADVISOR
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-metrics-cadvisor
+        - name: SUMO_ENDPOINT_METRICS_KUBELET
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-metrics-kubelet
+        - name: SUMO_ENDPOINT_METRICS_KUBE_CONTROLLER_MANAGER
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-metrics-kube-controller-manager
+        - name: SUMO_ENDPOINT_METRICS_KUBE_SCHEDULER
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-metrics-kube-scheduler
+        - name: SUMO_ENDPOINT_METRICS_KUBE_STATE
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-metrics-kube-state
+        - name: SUMO_ENDPOINT_METRICS_NODE_EXPORTER
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-metrics-node-exporter
+        - name: SUMO_ENDPOINT_METRICS_PROMETHEUS_OPERATOR
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-metrics-prometheus-operator
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
We want to split metrics to multiple HTTP sources to prevent blacklisting. Synced with Frank about the more common jobs we'd want to separate out, which included:
```
apiserver
cadvisor
kubelet
kube-controller-manager
kube-scheduler
kube-state*
node-exporter
prometheus-operator-*
```
We still include a catchall http source for those metrics not belonging to any of the above jobs.

@frankreno @bin3377 @lei-sumo 

FYI - @rvmiller89 @ggarg2906sumo 