### PR TITLE
Byi remove container eq pod

### DIFF
--- a/deploy/helm/overrides.yaml
+++ b/deploy/helm/overrides.yaml
@@ -77,26 +77,56 @@ prometheus:
     # cadvisor container metrics
     - url: http://fluentd:9888/prometheus.metrics.container
       writeRelabelConfigs:
+      - action: drop
+        regex: POD
+        sourceLabels: [container]
+      - action: drop
+        regex: POD
+        sourceLabels: [container_name]
       - action: keep
         regex: kubelet;container_cpu_(?:load_average_10s|(?:system|usage)_seconds_total)
         sourceLabels: [job, __name__]
     - url: http://fluentd:9888/prometheus.metrics.container
       writeRelabelConfigs:
+      - action: drop
+        regex: POD
+        sourceLabels: [container]
+      - action: drop
+        regex: POD
+        sourceLabels: [container_name]
       - action: keep
         regex: kubelet;container_memory_(?:usage_bytes|memory_swap)
         sourceLabels: [job, __name__]
     - url: http://fluentd:9888/prometheus.metrics.container
       writeRelabelConfigs:
+      - action: drop
+        regex: POD
+        sourceLabels: [container]
+      - action: drop
+        regex: POD
+        sourceLabels: [container_name]
       - action: keep
         regex: kubelet;container_spec_memory_(?:|swap|reservation)_limit_bytes
         sourceLabels: [job, __name__]
     - url: http://fluentd:9888/prometheus.metrics.container
       writeRelabelConfigs:
+      - action: drop
+        regex: POD
+        sourceLabels: [container]
+      - action: drop
+        regex: POD
+        sourceLabels: [container_name]
       - action: keep
         regex: kubelet;container_fs_(?:(?:usage|limit)_bytes|(?:reads|writes)_bytes_total)
         sourceLabels: [job, __name__]
     - url: http://fluentd:9888/prometheus.metrics.container
       writeRelabelConfigs:
+      - action: drop
+        regex: POD
+        sourceLabels: [container]
+      - action: drop
+        regex: POD
+        sourceLabels: [container_name]
       - action: keep
         regex: kubelet;container_network_(?:receive|transmit)_(?:bytes|errors)_total
         sourceLabels: [job, __name__]

--- a/deploy/kubernetes/fluentd-sumologic.yaml
+++ b/deploy/kubernetes/fluentd-sumologic.yaml
@@ -81,42 +81,49 @@ data:
       endpoint "#{ENV['SUMO_ENDPOINT_METRICS_APISERVER']}"
       data_type metrics
       metric_data_format prometheus
+      disable_cookies true
     </match>
     <match prometheus.datapoint.kubelet**>
       @type sumologic
       endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBELET']}"
       data_type metrics
       metric_data_format prometheus
+      disable_cookies true
     </match>
     <match prometheus.datapoint.kube-controller-manager**>
       @type sumologic
       endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBE_CONTROLLER_MANAGER']}"
       data_type metrics
       metric_data_format prometheus
+      disable_cookies true
     </match>
     <match prometheus.datapoint.kube-scheduler**>
       @type sumologic
       endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBE_SCHEDULER']}"
       data_type metrics
       metric_data_format prometheus
+      disable_cookies true
     </match>
     <match prometheus.datapoint.kube-state**>
       @type sumologic
       endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBE_STATE']}"
       data_type metrics
       metric_data_format prometheus
+      disable_cookies true
     </match>
     <match prometheus.datapoint.node-exporter**>
       @type sumologic
       endpoint "#{ENV['SUMO_ENDPOINT_METRICS_NODE_EXPORTER']}"
       data_type metrics
       metric_data_format prometheus
+      disable_cookies true
     </match>
     <match prometheus.datapoint**>
       @type sumologic
       endpoint "#{ENV['SUMO_ENDPOINT_METRICS']}"
       data_type metrics
       metric_data_format prometheus
+      disable_cookies true
     </match>
   events.conf: |-
     <source>


### PR DESCRIPTION
Fix two issues:
- remove any metrics with `container=POD` in cAdvisor container_*
- disable cookies support on all output plugins since it's useless and generating batch of "Unknown key: MAX-AGE = 604800" in fluentd log

FYI @frankreno @lei-sumo 