### PR TITLE
Byi more replicas

### DIFF
--- a/deploy/helm/overrides.yaml
+++ b/deploy/helm/overrides.yaml
@@ -84,7 +84,7 @@ prometheus:
         regex: POD
         sourceLabels: [container_name]
       - action: keep
-        regex: kubelet;container_cpu_(?:load_average_10s|(?:system|usage)_seconds_total)
+        regex: kubelet;container_cpu_(?:load_average_10s|(?:system|usage|cfs_throttled)_seconds_total)
         sourceLabels: [job, __name__]
     - url: http://fluentd:9888/prometheus.metrics.container
       writeRelabelConfigs:

--- a/deploy/kubernetes/fluentd-sumologic.yaml
+++ b/deploy/kubernetes/fluentd-sumologic.yaml
@@ -155,7 +155,7 @@ spec:
   selector:
     matchLabels:
       k8s-app: fluentd-sumologic
-  replicas: 1
+  replicas: 3
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/fluentd-sumologic.yaml
+++ b/deploy/kubernetes/fluentd-sumologic.yaml
@@ -176,11 +176,11 @@ spec:
         imagePullPolicy: Always
         resources:
           limits:
-            memory: 2Gi
-            cpu: "200m"
+            memory: 256Mi
+            cpu: "100m"
           requests:
-            memory: 2Gi
-            cpu: "200m"
+            memory: 256Mi
+            cpu: "100m"
         ports:
         - name: prom-write
           containerPort: 9888


### PR DESCRIPTION
Tuning fluentd resource to fix [Context canceled issue](https://jira.kumoroku.com/jira/browse/SUMO-109456)

- Use `3` replica rather than `1`
- Reduce Memory from `2Gi` to `256Mi` (each container)
- Reduce CPU from `200m` to `100m` (each container)

Monitoring for couple of hours and looks like no more `context canceled` error in Prometheus log now

FYI - [definition of Kubernetes resource limitation](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/)
@frankreno @ggarg2906sumo 
