### PR TITLE
Added in the working_set_bytes metric

### DIFF
--- a/deploy/helm/overrides.yaml
+++ b/deploy/helm/overrides.yaml
@@ -110,7 +110,7 @@ prometheus:
         regex: POD
         sourceLabels: [container_name]
       - action: keep
-        regex: kubelet;container_memory_(?:usage_bytes|memory_swap)
+        regex: kubelet;container_memory_(?:usage_bytes|memory_swap|working_set_bytes)
         sourceLabels: [job, __name__]
     - url: http://fluentd:9888/prometheus.metrics.container
       writeRelabelConfigs:


### PR DESCRIPTION
Hey Sumo,

Added in a regex match for `working_set_bytes` so that we can keep that metric and send it along to Sumo as well. `working_set_bytes` is used to track the working memory and is what the Kubernetes system uses to trigger OOMkills and restarts against the limits.