### PR TITLE
Forwarding all Remote Write Metrics

### DIFF
--- a/deploy/helm/overrides.yaml
+++ b/deploy/helm/overrides.yaml
@@ -238,7 +238,7 @@ prometheus:
       - action: keep
         regex: up
         sourceLabels: [__name__]
-    # prometheus metrics
+    # prometheus remote write metrics
     - url: http://fluentd:9888/prometheus.metrics
       writeRelabelConfigs:
       - action: keep

--- a/deploy/helm/overrides.yaml
+++ b/deploy/helm/overrides.yaml
@@ -238,3 +238,9 @@ prometheus:
       - action: keep
         regex: up
         sourceLabels: [__name__]
+    # prometheus metrics
+    - url: http://fluentd:9888/prometheus.metrics
+      writeRelabelConfigs:
+      - action: keep
+        regex: 'prometheus_remote_storage_*'
+        sourceLabels: [__name__]


### PR DESCRIPTION
* Sending all remote write related Prometheus metrics to Sumo
* This will allow us to monitor and manage Prometheus better on customer accounts by showing us the delays, replays, and instability in using Prometheus as a collector.