### PR TITLE
Increase the resource limits on CPU and memory for fluentd deployment

### DIFF
--- a/deploy/kubernetes/fluentd-sumologic.yaml
+++ b/deploy/kubernetes/fluentd-sumologic.yaml
@@ -291,11 +291,11 @@ spec:
         imagePullPolicy: Always
         resources:
           limits:
-            memory: 256Mi
-            cpu: "100m"
+            memory: 1000Mi
+            cpu: 1
           requests:
-            memory: 256Mi
-            cpu: "100m"
+            memory: 700Mi
+            cpu: 0.5
         ports:
         - name: prom-write
           containerPort: 9888

--- a/deploy/kubernetes/fluentd-sumologic.yaml
+++ b/deploy/kubernetes/fluentd-sumologic.yaml
@@ -291,10 +291,10 @@ spec:
         imagePullPolicy: Always
         resources:
           limits:
-            memory: 1000Mi
+            memory: 1Gi
             cpu: 1
           requests:
-            memory: 700Mi
+            memory: 768Mi
             cpu: 0.5
         ports:
         - name: prom-write


### PR DESCRIPTION
Based on the metrics I collected on CPU and Memory usage, I feel these are reasonable numbers for request and limit. This is sufficient for collecting up to 5MB/sec = 432GB/day rates. For greater loads, we can either increase the number of Fluentd replicas, or increase the CPU limits. Memory usage seems to be relatively stable even with higher loads.

FYI @ggarg2906sumo @lei-sumo @maimaisie @yuting-liu @frankreno 