### PR TITLE
Fix events plugin

### DIFF
--- a/fluent-plugin-events/lib/fluent/plugin/in_events.rb
+++ b/fluent-plugin-events/lib/fluent/plugin/in_events.rb
@@ -131,19 +131,19 @@ module Fluent
         end
       end
 
-      def create_config_maps
+      def create_config_map
         @resource_version = 0
         @configmap.data = { "resource-version": "#{@resource_version}" }
-        @client.public_send("create_config_map", @configmap).tap do |maps|
-          log.debug "Created config maps: #{maps}"
+        @client.public_send("create_config_map", @configmap).tap do |map|
+          log.debug "Created config map: #{map}"
         end
       end
 
       def update_config_map
         pull_resource_version
         @configmap.data = { "resource-version": "#{@resource_version}"}
-        @client.public_send("update_config_map", @configmap).tap do |maps|
-          log.debug "Updated config maps: #{maps}"
+        @client.public_send("update_config_map", @configmap).tap do |map|
+          log.debug "Updated config map: #{map}"
         end
       end
 
@@ -157,12 +157,12 @@ module Fluent
         # get or create the config map
         begin
           @client.public_send("get_config_map", "fluentd-config-resource-version", "sumologic").tap do |resource|
-            log.debug "Got config maps: #{resource}"
+            log.debug "Got config map: #{resource}"
             version = resource.data['resource-version']
             @resource_version = version.to_i if version
           end
         rescue Kubeclient::ResourceNotFoundError
-          create_config_maps
+          create_config_map
         end
       end
 

--- a/fluent-plugin-events/lib/fluent/plugin/in_events.rb
+++ b/fluent-plugin-events/lib/fluent/plugin/in_events.rb
@@ -78,11 +78,11 @@ module Fluent
           # Periodically restart watcher connection by checking if enough time has passed since 
           # last time watcher thread was recreated or if the watcher thread has been stopped.
           now = Time.now.to_i
-          if now - last_recreated >= @watch_interval_seconds ||
-            (Thread.list.select {|thread| thread.object_id == @watcher_id && thread.alive?}.count < 1)
+          watcher_exists = Thread.list.select {|thread| thread.object_id == @watcher_id && thread.alive?}.count > 0
+          if now - last_recreated >= @watch_interval_seconds || !watcher_exists
             
-            log.debug "Recreating watcher thread. Use resource version from latest snapshot unless it's the first time"
-            pull_resource_version if @watcher_id
+            log.debug "Recreating watcher thread. Use resource version from latest snapshot if watcher is running"
+            pull_resource_version if watcher_exists
             @watch_stream.finish if @watch_stream
 
             start_watcher_thread

--- a/fluent-plugin-events/lib/fluent/plugin/in_events.rb
+++ b/fluent-plugin-events/lib/fluent/plugin/in_events.rb
@@ -47,80 +47,122 @@ module Fluent
         start_monitor
       end
   
-      def close
-        log.info "closing"
+      def stop
+        log.debug "Clean up before stopping completely"
         update_config_map
-        log.info "updated configmap"
-        @watcher.each &:finish
+        @watch_stream.finish if @watch_stream
         super
       end
 
-      def start_monitor
-        last_http_start = Time.now.to_i
-        log.info "last_http_start initialized to #{last_http_start}"
-
-        @resource = ::Kubeclient::Resource.new
-        @resource.metadata = {
-          name: "fluentd-config-resource-version",
-          namespace: "sumologic"
-        }
-        
-        while true do
-          # Periodically restart watcher connection by checking if enough time has passed since 
-          # last time watcher thread was recreated or if the watcher thread has died.
-          now = Time.now.to_i
-          log.info "now is #{now}"
-          log.info "is there no thread with same id? #{Thread.list.select {|thread| thread.object_id == @watcher_id}.count < 1}"
-          log.info "is there no thread with same id and running? #{Thread.list.select {|thread| thread.object_id == @watcher_id && thread.status == "run"}.count < 1}"
-          log.info "thread with id #{@watcher_id} has status #{Thread.list.select {|thread| thread.object_id == @watcher_id}.first.status}"
-          
-          if now - last_http_start >= @watch_interval_seconds ||
-            Thread.list.select {
-              |thread| thread.object_id == @watcher_id && thread.status == "run"
-            }.count < 1
-            
-            log.info "time to recreate watcher thread"
-            pull_resource_version
-            
-            log.info "watch_stream has type #{@watch_stream.class}"
-            @watch_stream.each &:finish if @watch_stream
-            
-            start_watcher_thread
-
-            last_http_start = now
-            log.info "last_http_start updated to #{last_http_start}"
-
-          end
-
-          sleep(@configmap_update_interval_seconds)
-          log.info
-          update_config_map
+      # Listen for SIGTERM but do not trap
+      def prepend_handler(signal, &handler)
+        previous = Signal.trap(signal) do
+          previous = -> { raise SignalException, signal} unless previous.respond_to?(:call)
+          handler.call(previous)
         end
       end
 
-      def initialize_resource_version
-        # get or create the config map
-        begin
-          @client.public_send("get_config_map", "fluentd-config-resource-version", "sumologic").tap do |resource|
-            log.info "Get config maps: #{resource}"
-            version = resource.data['resource-version']
-            @resource_version = version.to_i + 1 if version
+      def start_monitor
+        log.info "Starting events collection"
+
+        last_recreated = Time.now.to_i
+        log.debug "last_recreated initialized to #{last_recreated}"
+
+        interrupted = false
+        prepend_handler("TERM") do |old|
+          interrupted = true
+          old.call
+        end
+
+        while !interrupted do
+          # Periodically restart watcher connection by checking if enough time has passed since 
+          # last time watcher thread was recreated or if the watcher thread has been stopped.
+          now = Time.now.to_i
+          if now - last_recreated >= @watch_interval_seconds ||
+            (Thread.list.select {|thread| thread.object_id == @watcher_id && thread.alive?}.count < 1)
+            
+            log.debug "Recreating watcher thread. Use resource version from latest snapshot unless it's the first time"
+            pull_resource_version if @watcher_id
+            @watch_stream.finish if @watch_stream
+
+            start_watcher_thread
+            last_recreated = now
+            log.debug "last_recreated updated to #{last_recreated}"
           end
-        rescue Kubeclient::ResourceNotFoundError
-          create_config_maps
+
+          update_config_map
+          sleep(@configmap_update_interval_seconds)
+        end
+      end
+  
+      def start_watcher_thread
+        log.debug "Starting watcher thread"
+        params = Hash.new
+        params[:as] = :raw
+        params[:resource_version] = @resource_version
+        params[:field_selector] = @field_selector
+        params[:label_selector] = @label_selector
+        params[:namespace] = @namespace
+        params[:timeout_seconds] = @watch_interval_seconds + 60
+
+        @watcher = @client.public_send("watch_events", params).tap do |watcher|
+          thread_create(:"watch_events") do
+            @watch_stream = watcher
+            @watcher_id = Thread.current.object_id
+            log.debug "New thread to watch events #{@watcher_id} from resource version #{params[:resource_version]}"
+
+            watcher.each do |entity|
+              begin
+                entity = JSON.parse(entity)
+                router.emit tag, Fluent::Engine.now, entity
+                rv = entity['object']['metadata']['resourceVersion']
+              rescue => e
+                log.error "Got exception #{e} parsing entity #{entity}. Skipping."
+              end
+
+              if (!rv)
+                log.error "Resource version #{rv} expired, waiting for stream to be recreated with more recent version."
+                break
+              end
+            end
+
+            log.debug "Closing watch stream"
+          end
         end
       end
 
       def create_config_maps
         @resource_version = 0
-        resource = ::Kubeclient::Resource.new
-        resource.metadata = {
+        @configmap.data = { "resource-version": "#{@resource_version}" }
+        @client.public_send("create_config_map", @configmap).tap do |maps|
+          log.debug "Created config maps: #{maps}"
+        end
+      end
+
+      def update_config_map
+        pull_resource_version
+        @configmap.data = { "resource-version": "#{@resource_version}"}
+        @client.public_send("update_config_map", @configmap).tap do |maps|
+          log.debug "Updated config maps: #{maps}"
+        end
+      end
+
+      def initialize_resource_version
+        @configmap = ::Kubeclient::Resource.new
+        @configmap.metadata = {
           name: "fluentd-config-resource-version",
           namespace: "sumologic"
         }
-        resource.data = { "resource-version": "#{@resource_version}" }
-        @client.public_send("create_config_map", resource).tap do |maps|
-          log.info "Created config maps: #{maps}"
+
+        # get or create the config map
+        begin
+          @client.public_send("get_config_map", "fluentd-config-resource-version", "sumologic").tap do |resource|
+            log.debug "Got config maps: #{resource}"
+            version = resource.data['resource-version']
+            @resource_version = version.to_i if version
+          end
+        rescue Kubeclient::ResourceNotFoundError
+          create_config_maps
         end
       end
 
@@ -134,70 +176,7 @@ module Fluent
           result.fetch('metadata', {})['resourceVersion']
         end
 
-        log.info "resource version is #{resource_version}"
         @resource_version = resource_version
-      end
-  
-      def start_watcher_thread
-        log.info "Starting watcher thread #{Thread.current.object_id}"
-        params = Hash.new
-        params[:as] = :raw
-        params[:resource_version] = @resource_version
-        params[:field_selector] = @field_selector
-        params[:label_selector] = @label_selector
-        params[:namespace] = @namespace
-        params[:timeout_seconds] = @watch_interval_seconds + 60
-
-        @watcher = @client.public_send("watch_events", params).tap do |watcher|
-          thread_create(:"watch_events") do
-            @watcher_id = Thread.current.object_id
-            log.info "New thread to watch events #{@watcher_id} with watcher type #{watcher.class}"
-            log.info "!!!!!!! #{Thread.list.select {|thread| thread.object_id == @watcher_id}.count}"
-            @watch_stream = watcher
-           
-            watcher.each do |entity|
-              # log.debug "Before parse #{entity.class} and entity #{entity}"
-              begin
-                entity = JSON.parse(entity)
-                log.debug "Got new event"
-                router.emit tag, Fluent::Engine.now, entity
-                rv = entity['object']['metadata']['resourceVersion']
-              rescue => e
-                log.error "Got exception #{e} parsing entity #{entity}. Skipping."
-              end
-
-              if (!rv)
-                log.error "Resource version #{rv} expired"
-                @resource_version = current snapshot (pull first)
-                sleep(5)
-                start_watcher_thread
-                break
-              end
-            end
-          end
-
-          log.info "Watcher has type #{@watcher.class}"
-        end
-      end
-
-      def start_configmap_flush_thread
-        thread_create(:"update_configmap") do
-          
-          while true do
-            sleep(@configmap_update_interval_seconds)
-            update_config_map
-          end
-        end
-      end
-
-      def update_config_map
-        pull_resource_version
-        @resource.data = { "resource-version": "#{@resource_version}"}
-
-        # update the config map
-        @client.public_send("update_config_map", @resource).tap do |maps|
-          log.debug "Updated config maps: #{maps}"
-        end
       end
 
       def normalize_param
@@ -208,13 +187,13 @@ module Fluent
           env_port = ENV['KUBERNETES_SERVICE_PORT']
           @kubernetes_url = "https://#{env_host}:#{env_port}/api" unless env_host.nil? || env_port.nil?
         end
-        log.info "Kubernetes URL: '#{@kubernetes_url}'"
+        log.debug "Kubernetes URL: '#{@kubernetes_url}'"
 
         @ca_file = File.join(@secret_dir, K8_POD_CA_CERT) if @ca_file.nil?
-        log.info "ca_file: '#{@ca_file}', exist: #{File.exist?(@ca_file)}"
+        log.debug "ca_file: '#{@ca_file}', exist: #{File.exist?(@ca_file)}"
 
         @bearer_token_file = File.join(@secret_dir, K8_POD_TOKEN) if @bearer_token_file.nil?
-        log.info "bearer_token_file: '#{@bearer_token_file}', exist: #{File.exist?(@bearer_token_file)}"
+        log.debug "bearer_token_file: '#{@bearer_token_file}', exist: #{File.exist?(@bearer_token_file)}"
       end
     end
   end

--- a/fluent-plugin-events/lib/sumologic/kubernetes/connector.rb
+++ b/fluent-plugin-events/lib/sumologic/kubernetes/connector.rb
@@ -42,7 +42,7 @@ module SumoLogic
             ssl_options[:client_key] = OpenSSL::PKey::RSA.new(File.read(@client_key))
           end
           ssl_options[:cert_store] = ssl_store if @ssl_partial_chain
-          log.info "ssl_options: #{ssl_options}"
+          log.debug "ssl_options: #{ssl_options}"
           ssl_options
         end
   
@@ -51,7 +51,7 @@ module SumoLogic
           if !@bearer_token_file.nil? && File.exist?(@bearer_token_file)
             auth_options[:bearer_token] = File.read(@bearer_token_file)
           end
-          log.info "auth_options: #{ssl_options}"
+          log.debug "auth_options: #{ssl_options}"
           auth_options
         end
       end


### PR DESCRIPTION
After discovering the issue with k8s watch and list API regarding the resource version parameter, we redesigned the plugin flow. Now, the main thread acts as a monitor that loops forever (until the plugin is told to shut down) to update configmap and preemptively recreate the watch thread periodically. In more detail, it mainly does these things:
1. Pull latest resource version from the `List` API and store in configmap every `configmap_update_interval_seconds` (10s by default).
2. Check if the watch thread is running. If it's not, create the watcher thread using the resource version from the the configmap to resume from an earlier point in time if 
    1. this is the first iteration (when the plugin just started and the watch thread does not exist)
    2. the watcher thread somehow died (thread is not alive)
3. Check if it has been `watch_interval_seconds` since the last time we recreated the watch thread. If so, first pull latest resource version, close the watch thread by calling kubeclient method to close the http connection, then create a new watch stream using the RV we just pulled

We listen for SIGTERM so on graceful shutdown we can break out of the while loop in `start_monitor` (apparently if the while loop keeps running, the shutdown sequence won't get triggered)

FYI @rvmiller89 @lei-sumo @frankreno 