### PR TITLE
Add configurable event type filter

### DIFF
--- a/fluent-plugin-events/lib/fluent/plugin/in_events.rb
+++ b/fluent-plugin-events/lib/fluent/plugin/in_events.rb
@@ -40,8 +40,8 @@ module Fluent
         super
 
         @valid_types = ["ADDED", "MODIFIED", "DELETED"]
-        raise Fluent::ConfigError, 'type_selector needs to be an array with maximum 3 elements: ADDED, MODIFIED and DELETED.' \
-          if @type_selector.length > 3 || !@type_selector.any? || !@type_selector.all? {|type| @valid_types.any? {|valid| valid.casecmp?(type)}}
+        raise Fluent::ConfigError, "type_selector needs to be an array with maximum #{@valid_types.length} elements: #{@valid_types.join(", ")}." \
+          if @type_selector.length > @valid_types.length || !@type_selector.any? || !@type_selector.all? {|type| @valid_types.any? {|valid| valid.casecmp?(type)}}
 
         normalize_param
         connect_kubernetes

--- a/fluent-plugin-events/lib/fluent/plugin/in_events.rb
+++ b/fluent-plugin-events/lib/fluent/plugin/in_events.rb
@@ -41,7 +41,7 @@ module Fluent
 
         @valid_types = ["ADDED", "MODIFIED", "DELETED"]
         raise Fluent::ConfigError, 'type_selector needs to be an array with maximum 3 elements: ADDED, MODIFIED and DELETED.' \
-          if @type_selector.length > 3 || !@type_selector.any? || !@type_selector.all? {|type| @valid_types.any? {|valid| valid.casecmp(type) == 0}}
+          if @type_selector.length > 3 || !@type_selector.any? || !@type_selector.all? {|type| @valid_types.any? {|valid| valid.casecmp?(type)}}
 
         normalize_param
         connect_kubernetes
@@ -120,7 +120,7 @@ module Fluent
             watcher.each do |entity|
               begin
                 entity = JSON.parse(entity)
-                router.emit tag, Fluent::Engine.now, entity if @type_selector.any? {|type| type.casecmp(entity['type']) == 0}
+                router.emit tag, Fluent::Engine.now, entity if @type_selector.any? {|type| type.casecmp?(entity['type'])}
                 rv = entity['object']['metadata']['resourceVersion']
               rescue => e
                 log.error "Got exception #{e} parsing entity #{entity}. Skipping."


### PR DESCRIPTION
This PR adds a fluentd config param for specifying a list of event types to ingest. An error will be thrown if (1) the list is empty; (2) the list size exceeds three; (3) each element in the list is not one of ADDED, MODIFIED or DELETED (uses **case-insensitive** string compare, Ruby's `casecmp` is case insensitive and returns 0 if two strings are the same ignoring case, ie, `"ADDED".casecmp("addED") == 0`)

User can then have something like this:
```
    <source>
      @type events
      type_selector ["ADDED", "deleted"]
    </source>
```
