### PR TITLE
add fluent metrics

### DIFF
--- a/deploy/fluent-bit/overrides.yaml
+++ b/deploy/fluent-bit/overrides.yaml
@@ -8,6 +8,9 @@ backend:
     tls_debug: 1
     shared_key:
 
+metrics:
+  enabled: true
+
 trackOffsets: true
 
 tolerations:

--- a/deploy/helm/overrides.yaml
+++ b/deploy/helm/overrides.yaml
@@ -252,3 +252,15 @@ prometheus:
       - action: keep
         regex: 'prometheus_remote_storage_*'
         sourceLabels: [__name__]
+    # fluentd metrics
+    - url: http://fluentd:9888/prometheus.metrics
+      writeRelabelConfigs:
+        - action: keep
+          regex: 'fluentd_*'
+          sourceLabels: [__name__]
+      # fluent-bit metrics
+    - url: http://fluentd:9888/prometheus.metrics
+      writeRelabelConfigs:
+        - action: keep
+          regex: 'fluentbit_*'
+          sourceLabels: [__name__]

--- a/deploy/kubernetes/fluentd-sumologic.yaml
+++ b/deploy/kubernetes/fluentd-sumologic.yaml
@@ -378,11 +378,51 @@ data:
     <source>
       @type events
     </source>
+    <source>
+      @type prometheus
+      bind 0.0.0.0
+      port 24322
+      metrics_path /metrics
+    </source>
+    <source>
+      @type prometheus_output_monitor
+      interval 10
+      <labels>
+        hostname ${hostname}
+      </labels>
+    </source>
+    <filter kubernetes.**>
+      @type prometheus
+      <metric>
+        name fluentd_input_status_num_records_total
+        type counter
+        desc The total number of incoming records
+        <labels>
+          tag ${tag}
+          hostname ${hostname}
+        </labels>
+      </metric>
+    </filter>
     <match kubernetes.**>
-      @type sumologic
-      endpoint "#{ENV['SUMO_ENDPOINT_EVENTS']}"
-      data_type logs
-      disable_cookies true
+      @type copy
+      <store>
+        @type sumologic
+        endpoint "#{ENV['SUMO_ENDPOINT_EVENTS']}"
+        data_type logs
+        disable_cookies true
+      </store>
+      <store>
+        @type prometheus
+        <metric>
+          name fluentd_output_status_num_records_total
+          type counter
+          desc The total number of outgoing records
+          <labels>
+            tag ${tag}
+            hostname ${hostname}
+          </labels>
+        </metric>
+      </store>
     </match>
 ---
 apiVersion: apps/v1
@@ -391,15 +431,15 @@ metadata:
   name: fluentd-events
   namespace: sumologic
   labels:
-    k8s-app: fluentd-sumologic
+    k8s-app: fluentd-sumologic-events
 spec:
   selector:
     matchLabels:
-      k8s-app: fluentd-sumologic
+      k8s-app: fluentd-sumologic-events
   template:
     metadata:
       labels:
-        k8s-app: fluentd-sumologic
+        k8s-app: fluentd-sumologic-events
     spec:
       serviceAccountName: fluentd
       volumes:
@@ -451,5 +491,9 @@ spec:
   - name: fluent-bit
     port: 24321
     targetPort: 24321
+    protocol: TCP
+  - name: metrics
+    port: 24322
+    targetPort: 24322
     protocol: TCP
 ---


### PR DESCRIPTION
Not Complete, don't merge just yet.  This PR does the following:

1) Enables Fluent-Bit metrics in Fluent-Bit helm overrides
2) Adds the writeLabelConfig to collect fluentD and Fluent-Bit metrics
3) Adds the configuration needed to expose fluentD metrics in Event pod

