### PR TITLE
Fix missing metrics

### DIFF
--- a/deploy/helm/overrides.yaml
+++ b/deploy/helm/overrides.yaml
@@ -121,7 +121,10 @@ prometheus:
         regex: POD
         sourceLabels: [container_name]
       - action: keep
-        regex: kubelet;container_spec_memory_(?:|swap|reservation)_limit_bytes
+        regex: kubelet;container_spec_memory_limit_bytes
+        sourceLabels: [job, __name__]
+      - action: keep
+        regex: kubelet;container_spec_memory_(?:swap|reservation)_limit_bytes
         sourceLabels: [job, __name__]
       - action: keep
         regex: kubelet;container_spec_cpu_(?:|quota|period)

--- a/deploy/helm/overrides.yaml
+++ b/deploy/helm/overrides.yaml
@@ -165,7 +165,7 @@ prometheus:
     - url: http://fluentd:9888/prometheus.metrics.node
       writeRelabelConfigs:
       - action: keep
-        regex: node-exporter;node_memory_(?:MemAvailable|MemTotal|Buffers|SwapCached|Cached|Free)_bytes
+        regex: node-exporter;node_memory_(?:MemAvailable|MemTotal|Buffers|SwapCached|Cached|MemFree|SwapFree)_bytes
         sourceLabels: [job, __name__]
     - url: http://fluentd:9888/prometheus.metrics.node
       writeRelabelConfigs:

--- a/deploy/helm/overrides.yaml
+++ b/deploy/helm/overrides.yaml
@@ -54,7 +54,7 @@ prometheus:
     - url: http://fluentd:9888/prometheus.metrics.controller-manager
       writeRelabelConfigs:
       - action: keep
-        regex: kube-controller-manager;cloudprovider_.*_api_request_duration_seconds.*
+        regex: kubelet;cloudprovider_.*_api_request_duration_seconds.*
         sourceLabels: [job, __name__]
     # scheduler metrics
     - url: http://fluentd:9888/prometheus.metrics.scheduler

--- a/deploy/helm/overrides.yaml
+++ b/deploy/helm/overrides.yaml
@@ -121,11 +121,16 @@ prometheus:
         regex: POD
         sourceLabels: [container_name]
       - action: keep
-        regex: kubelet;container_spec_memory_limit_bytes
+        regex: kubelet;container_spec_memory_(?:|swap_|reservation_)limit_bytes
         sourceLabels: [job, __name__]
-      - action: keep
-        regex: kubelet;container_spec_memory_(?:swap|reservation)_limit_bytes
-        sourceLabels: [job, __name__]
+    - url: http://fluentd:9888/prometheus.metrics.container
+      writeRelabelConfigs:
+      - action: drop
+        regex: POD
+        sourceLabels: [container]
+      - action: drop
+        regex: POD
+        sourceLabels: [container_name]
       - action: keep
         regex: kubelet;container_spec_cpu_(?:|quota|period)
         sourceLabels: [job, __name__]

--- a/deploy/helm/overrides.yaml
+++ b/deploy/helm/overrides.yaml
@@ -110,7 +110,7 @@ prometheus:
         regex: POD
         sourceLabels: [container_name]
       - action: keep
-        regex: kubelet;container_memory_(?:usage_bytes|memory_swap|working_set_bytes)
+        regex: kubelet;container_memory_(?:usage_bytes|swap|working_set_bytes)
         sourceLabels: [job, __name__]
     - url: http://fluentd:9888/prometheus.metrics.container
       writeRelabelConfigs:


### PR DESCRIPTION
During testing we found the following metrics were missing:
- `cloudprovider_.*_api_request_duration_seconds.*`
  - this was due to the job changing from `kube-controller-manager` to `kubelet`
- `container_memory_swap`
  - this was due to a bug in the regex
- `container_spec_.*`
  - this was due to trying to add multiple regex matchers in the same writeRelabelConfigs section, which I believe is piped and therefore the metrics were being dropped
- `node_memory_Free_bytes`
  - this metric was renamed to `node_memory_MemFree_bytes` and `node_memory_SwapFree_bytes`

cc @ggarg2906sumo 