### PR TITLE
Update default label behaviour for metadata enhancement plugin

### DIFF
--- a/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
@@ -61,11 +61,15 @@ module Fluent
         elsif pod_name.nil?
           log.debug "Record doesn't have [#{@in_pod_path}] field"
         else
+          if record.key? 'service'
+            record['prometheus_service'] = record['service']
+            record.delete('service')
+          end
           metadata = get_pod_metadata(namespace_name, pod_name)
           if metadata.empty?
             log.debug "Cannot get labels on pod #{namespace_name}::#{pod_name}, skip."
           else
-            record[@out_root] = metadata
+            record.merge! metadata
           end
         end
       end

--- a/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/reader.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/reader.rb
@@ -33,7 +33,7 @@ module SumoLogic
         owners = fetch_owners(namespace, pod)
         result = {}
         owners.each do |owner|
-          result[owner['kind'].downcase] = { 'name' => owner['metadata']['name'] }
+          result[owner['kind'].downcase] = owner['metadata']['name']
         end
         result
       end

--- a/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/reader.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/reader.rb
@@ -22,7 +22,7 @@ module SumoLogic
 
         metadata = {}
         labels = pod['metadata']['labels']
-        metadata['pod'] = { 'labels' => labels } if labels.is_a?(Hash)
+        metadata['pod_labels'] = labels if labels.is_a?(Hash)
 
         owners = fetch_pod_owners(namespace, pod)
         metadata.merge!(owners)

--- a/fluent-plugin-enhance-k8s-metadata/test/sumologic/kubernetes/test_cache_strategy.rb
+++ b/fluent-plugin-enhance-k8s-metadata/test/sumologic/kubernetes/test_cache_strategy.rb
@@ -25,23 +25,21 @@ class CacheStrategyTest < Test::Unit::TestCase
   test 'get_pod_metadata load labels from API' do
     metadata = get_pod_metadata('sumologic', 'somepod')
     assert_not_nil metadata
-    assert_equal metadata['pod']['labels']['pod-template-hash'], '1691804713'
-    assert_equal metadata['pod']['labels']['run'], 'curl-byi'
+    assert_equal metadata['pod_labels']['pod-template-hash'], '1691804713'
+    assert_equal metadata['pod_labels']['run'], 'curl-byi'
   end
 
   test 'get_pod_metadata load labels from cache if already exist' do
     assert_not_nil @cache
     @cache['sumologic::somepod'] = {
-      'pod' => {
-        'labels' => {
-          'pod-template-hash' => '0',
-          'run' => 'from-cache'
-        }
+      'pod_labels' => {
+        'pod-template-hash' => '0',
+        'run' => 'from-cache'
       }
     }
     metadata = get_pod_metadata('sumologic', 'somepod')
-    assert_equal metadata['pod']['labels']['pod-template-hash'], '0'
-    assert_equal metadata['pod']['labels']['run'], 'from-cache'
+    assert_equal metadata['pod_labels']['pod-template-hash'], '0'
+    assert_equal metadata['pod_labels']['run'], 'from-cache'
   end
 
   test 'get_pod_metadata cache empty result' do

--- a/fluent-plugin-enhance-k8s-metadata/test/sumologic/kubernetes/test_reader.rb
+++ b/fluent-plugin-enhance-k8s-metadata/test/sumologic/kubernetes/test_reader.rb
@@ -41,8 +41,8 @@ class ReaderTest < Test::Unit::TestCase
   test 'fetch_pod_metadata get owners' do
     metadata = fetch_pod_metadata('kube-system', 'somepod')
     assert_not_nil metadata
-    assert_equal metadata['replicaset']['name'], 'kube-dns-5fbcb4d67b'
-    assert_equal metadata['deployment']['name'], 'kube-dns'
+    assert_equal metadata['replicaset'], 'kube-dns-5fbcb4d67b'
+    assert_equal metadata['deployment'], 'kube-dns'
   end
 
   test 'fetch_pod_metadata returns empty map if resource not found' do

--- a/fluent-plugin-enhance-k8s-metadata/test/sumologic/kubernetes/test_reader.rb
+++ b/fluent-plugin-enhance-k8s-metadata/test/sumologic/kubernetes/test_reader.rb
@@ -34,8 +34,8 @@ class ReaderTest < Test::Unit::TestCase
   test 'fetch_pod_metadata get labels' do
     metadata = fetch_pod_metadata('sumologic', 'somepod')
     assert_not_nil metadata
-    assert_equal metadata['pod']['labels']['pod-template-hash'], '1691804713'
-    assert_equal metadata['pod']['labels']['run'], 'curl-byi'
+    assert_equal metadata['pod_labels']['pod-template-hash'], '1691804713'
+    assert_equal metadata['pod_labels']['run'], 'curl-byi'
   end
 
   test 'fetch_pod_metadata get owners' do

--- a/fluent-plugin-prometheus-format/lib/fluent/plugin/filter_prometheus_format.rb
+++ b/fluent-plugin-prometheus-format/lib/fluent/plugin/filter_prometheus_format.rb
@@ -58,7 +58,7 @@ module Fluent
       KEY_TIMESTAMP = '@timestamp'.freeze
       KEY_VALUE = '@value'.freeze
       KEY_MESSAGE = 'message'.freeze
-      SPLITOR = '.'.freeze
+      SPLITOR = '_'.freeze
 
       ORIGIN_KEY = '_origin'.freeze
       ORIGIN_VALUE = 'kubernetes'.freeze

--- a/fluent-plugin-prometheus-format/test/plugin/test_filter_prometheus_format.rb
+++ b/fluent-plugin-prometheus-format/test/plugin/test_filter_prometheus_format.rb
@@ -62,8 +62,8 @@ class PrometheusFormatFilterTest < Test::Unit::TestCase
       config = %([
         relabel {
           "service" : "",
-          "kubernetes.service.name" : "service_name",
-          "kubernetes.pod.name" : "pod_name"
+          "kubernetes_service_name" : "service_name",
+          "kubernetes_pod_name" : "pod_name"
         }
       ])
       outputs = filter_datapoints(config, 'datapoint.nested')
@@ -75,12 +75,11 @@ class PrometheusFormatFilterTest < Test::Unit::TestCase
       config = %([
         relabel {
           "service" : "",
-          "kubernetes.service.na e" : "service_na e",
-          "kubernetes.pod.na e" : "pod_na e"
+          "kubernetes_service_na e" : "service_na e",
+          "kubernetes_pod_na e" : "pod_na e"
         }
       ])
       outputs = filter_datapoints(config, 'datapoint.nested.spaces')
-      puts outputs
       assert_equal 1, outputs.length
       verify_with_expected outputs, 'output.datapoint.nested.spaces.relabel'
     end
@@ -88,7 +87,6 @@ class PrometheusFormatFilterTest < Test::Unit::TestCase
     test 'transform data point with escaped sequences' do
       config = %([])
       outputs = filter_datapoints(config, 'datapoint.nested.escape')
-      puts outputs
       assert_equal 1, outputs.length
       verify_with_expected outputs, 'output.datapoint.nested.escape'
     end
@@ -396,8 +394,8 @@ class PrometheusFormatFilterTest < Test::Unit::TestCase
       config = %([
         relabel {
           "service" : "",
-          "kubernetes.service.name" : "service_name",
-          "kubernetes.pod.name" : "pod_name"
+          "kubernetes_service_name" : "service_name",
+          "kubernetes_pod_name" : "pod_name"
         }
         inclusions { "pod_name" : "^kube-scheduler-.*" }
       ])
@@ -413,8 +411,8 @@ class PrometheusFormatFilterTest < Test::Unit::TestCase
       config = %([
         relabel {
           "service" : "",
-          "kubernetes.service.name" : "service_name",
-          "kubernetes.pod.name" : "pod_name"
+          "kubernetes_service_name" : "service_name",
+          "kubernetes_pod_name" : "pod_name"
         }
         inclusions { "pod_name" : "^cube-scheduler-.*" }
       ])
@@ -431,8 +429,8 @@ class PrometheusFormatFilterTest < Test::Unit::TestCase
       config = %([
         relabel {
           "service" : "",
-          "kubernetes.service.name" : "service_name",
-          "kubernetes.pod.name" : "pod_name"
+          "kubernetes_service_name" : "service_name",
+          "kubernetes_pod_name" : "pod_name"
         }
         exclusions { "pod_name" : "^cube-scheduler.*" }
       ])
@@ -448,8 +446,8 @@ class PrometheusFormatFilterTest < Test::Unit::TestCase
       config = %([
         relabel {
           "service" : "",
-          "kubernetes.service.name" : "service_name",
-          "kubernetes.pod.name" : "pod_name"
+          "kubernetes_service_name" : "service_name",
+          "kubernetes_pod_name" : "pod_name"
         }
         exclusions { "pod_name" : "^kube-scheduler.*" }
       ])

--- a/fluent-plugin-prometheus-format/test/resources/output.datapoint.nested.escape.json
+++ b/fluent-plugin-prometheus-format/test/resources/output.datapoint.nested.escape.json
@@ -1,7 +1,7 @@
 {
     "outputs": [
         {
-            "message": "http_request_size_bytes_sum{endpoint=\"http-metrics\",error=\"No file:\\n\\\"FILE.TXT\\\"\",handler=\"prometheus\",instance=\"172.20.36.191:10251\",job=\"kube-scheduler\",kubernetes.pod.name=\"kube-scheduler-ip-172-20-36-191.us-west-1.compute.internal\",kubernetes.service.name=\"kube-scheduler\",namespace=\"kube-system\",path=\"C:\\\\DIR\\\\FILE.TXT\",prometheus=\"monitoring/prometheus-operator-prometheus\",prometheus_replica=\"prometheus-prometheus-operator-prometheus-0\",service=\"prometheus-operator-kube-scheduler\",_origin=\"kubernetes\"} 1619905.0 1550862304339"
+            "message": "http_request_size_bytes_sum{endpoint=\"http-metrics\",error=\"No file:\\n\\\"FILE.TXT\\\"\",handler=\"prometheus\",instance=\"172.20.36.191:10251\",job=\"kube-scheduler\",kubernetes_pod_name=\"kube-scheduler-ip-172-20-36-191.us-west-1.compute.internal\",kubernetes_service_name=\"kube-scheduler\",namespace=\"kube-system\",path=\"C:\\\\DIR\\\\FILE.TXT\",prometheus=\"monitoring/prometheus-operator-prometheus\",prometheus_replica=\"prometheus-prometheus-operator-prometheus-0\",service=\"prometheus-operator-kube-scheduler\",_origin=\"kubernetes\"} 1619905.0 1550862304339"
         }
     ]
 }

--- a/fluent-plugin-prometheus-format/test/resources/output.datapoint.nested.json
+++ b/fluent-plugin-prometheus-format/test/resources/output.datapoint.nested.json
@@ -1,7 +1,7 @@
 {
     "outputs": [
         {
-            "message": "http_request_size_bytes_sum{endpoint=\"http-metrics\",handler=\"prometheus\",instance=\"172.20.36.191:10251\",job=\"kube-scheduler\",kubernetes.pod.name=\"kube-scheduler-ip-172-20-36-191.us-west-1.compute.internal\",kubernetes.service.name=\"kube-scheduler\",namespace=\"kube-system\",prometheus=\"monitoring/prometheus-operator-prometheus\",prometheus_replica=\"prometheus-prometheus-operator-prometheus-0\",service=\"prometheus-operator-kube-scheduler\",_origin=\"kubernetes\"} 1619905.0 1550862304339"
+            "message": "http_request_size_bytes_sum{endpoint=\"http-metrics\",handler=\"prometheus\",instance=\"172.20.36.191:10251\",job=\"kube-scheduler\",kubernetes_pod_name=\"kube-scheduler-ip-172-20-36-191.us-west-1.compute.internal\",kubernetes_service_name=\"kube-scheduler\",namespace=\"kube-system\",prometheus=\"monitoring/prometheus-operator-prometheus\",prometheus_replica=\"prometheus-prometheus-operator-prometheus-0\",service=\"prometheus-operator-kube-scheduler\",_origin=\"kubernetes\"} 1619905.0 1550862304339"
         }
     ]
 }


### PR DESCRIPTION
1) We remove the `kubernetes` prefix from all of the enhanced metadata attached by the `enhance_k8s_metadata` filter plugin, including `pod.labels.foo`
2) We rename `service` metadata to `prometheus_service` to avoid collision with the future attached `service` metadata.

Example metric output:
```
up {cluster="ssong-k8s-stag-9", _collector="kubernetes-1561673833", _collectorId="00000000061841EB", _contentType="Prometheus", _origin="kubernetes", _source="(default-metrics)", _sourceCategory="Http Input", _sourceId="00000000062EEE26", _sourceName="Http Input", deployment.name="kube-dns", endpoint="http-metrics", instance="100.115.226.65:9153", job="coredns", namespace="kube-system", pod.labels.k8s-app="kube-dns", pod.labels.pod-template-hash="2609061007", prometheus="sumologic/prometheus-operator-prometheus", prometheus_replica="prometheus-prometheus-operator-prometheus-0", prometheus_service="prometheus-operator-coredns", replicaset.name="kube-dns-6b4f4b544c", source="Metrics"}
```