### PR TITLE
Parameterize resource name to support watching other resources in events plugin

### DIFF
--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -373,7 +373,7 @@ data:
   events.conf: |-
     <source>
       @type events
-      namespace $NAMESPACE
+      deploy_namespace $NAMESPACE
     </source>
     <match kubernetes.**>
       @type sumologic

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -373,6 +373,7 @@ data:
   events.conf: |-
     <source>
       @type events
+      namespace $NAMESPACE
     </source>
     <match kubernetes.**>
       @type sumologic

--- a/fluent-plugin-events/lib/fluent/plugin/in_events.rb
+++ b/fluent-plugin-events/lib/fluent/plugin/in_events.rb
@@ -14,7 +14,7 @@ module Fluent
       
       # parameters for connecting to k8s api server
       config_param :kubernetes_url, :string, default: nil
-      config_param :apiVersion, :string, default: 'v1'
+      config_param :api_version, :string, default: 'v1'
       config_param :client_cert, :string, default: nil
       config_param :client_key, :string, default: nil
       config_param :ca_file, :string, default: nil
@@ -28,6 +28,7 @@ module Fluent
       config_param :ssl_partial_chain, :bool, default: false
       
       # parameters for events collection
+      config_param :resource_name, :string, default: "events"
       config_param :tag, :string, default: 'kubernetes.*'
       config_param :namespace, :string, default: nil
       config_param :label_selector, :string, default: nil
@@ -55,7 +56,7 @@ module Fluent
   
       def stop
         log.debug "Clean up before stopping completely"
-        update_config_map
+        patch_config_map
         @watch_stream.finish if @watch_stream
         super
       end
@@ -96,7 +97,7 @@ module Fluent
             log.debug "last_recreated updated to #{last_recreated}"
           end
 
-          update_config_map
+          patch_config_map
           sleep(@configmap_update_interval_seconds)
         end
       end
@@ -111,11 +112,11 @@ module Fluent
         params[:namespace] = @namespace
         params[:timeout_seconds] = @watch_interval_seconds + 60
 
-        @watcher = @client.public_send("watch_events", params).tap do |watcher|
-          thread_create(:"watch_events") do
+        @watcher = @client.public_send("watch_#{resource_name}", params).tap do |watcher|
+          thread_create(:"watch_#{resource_name}") do
             @watch_stream = watcher
             @watcher_id = Thread.current.object_id
-            log.debug "New thread to watch events #{@watcher_id} from resource version #{params[:resource_version]}"
+            log.debug "New thread to watch #{resource_name} #{@watcher_id} from resource version #{params[:resource_version]}"
 
             watcher.each do |entity|
               begin
@@ -138,22 +139,21 @@ module Fluent
       end
 
       def create_config_map
-        @resource_version = 0
-        @configmap.data = { "resource-version": "#{@resource_version}" }
+        @configmap.data = { "resource-version-#{resource_name}": "#{@resource_version}" }
         @client.public_send("create_config_map", @configmap).tap do |map|
           log.debug "Created config map: #{map}"
         end
       end
 
-      def update_config_map
+      def patch_config_map
         pull_resource_version
-        @configmap.data = { "resource-version": "#{@resource_version}"}
-        @client.public_send("update_config_map", @configmap).tap do |map|
-          log.debug "Updated config map: #{map}"
+        @client.public_send("patch_config_map", "fluentd-config-resource-version", {data: { "resource-version-#{resource_name}": "#{@resource_version}"}}, "sumologic").tap do |map|
+          log.debug "Patched config map: #{map}"
         end
       end
 
       def initialize_resource_version
+        @resource_version = 0
         @configmap = ::Kubeclient::Resource.new
         @configmap.metadata = {
           name: "fluentd-config-resource-version",
@@ -164,7 +164,7 @@ module Fluent
         begin
           @client.public_send("get_config_map", "fluentd-config-resource-version", "sumologic").tap do |resource|
             log.debug "Got config map: #{resource}"
-            version = resource.data['resource-version']
+            version = resource.data["resource-version-#{resource_name}"]
             @resource_version = version.to_i if version
           end
         rescue Kubeclient::ResourceNotFoundError
@@ -175,7 +175,7 @@ module Fluent
       def pull_resource_version
         params = Hash.new
         params[:as] = :raw
-        response = @client.public_send "get_events", params
+        response = @client.public_send "get_#{resource_name}", params
         result = JSON.parse(response)
 
         resource_version = result.fetch('resourceVersion') do

--- a/fluent-plugin-events/lib/fluent/plugin/in_events.rb
+++ b/fluent-plugin-events/lib/fluent/plugin/in_events.rb
@@ -147,7 +147,7 @@ module Fluent
 
       def patch_config_map
         pull_resource_version
-        @client.public_send("patch_config_map", "fluentd-config-resource-version", {data: { "resource-version-#{resource_name}": "#{@resource_version}"}}, "sumologic").tap do |map|
+        @client.public_send("patch_config_map", "fluentd-config-resource-version", {data: { "resource-version-#{resource_name}": "#{@resource_version}"}}, @namespace).tap do |map|
           log.debug "Patched config map: #{map}"
         end
       end
@@ -157,12 +157,12 @@ module Fluent
         @configmap = ::Kubeclient::Resource.new
         @configmap.metadata = {
           name: "fluentd-config-resource-version",
-          namespace: "sumologic"
+          namespace: @namespace
         }
 
         # get or create the config map
         begin
-          @client.public_send("get_config_map", "fluentd-config-resource-version", "sumologic").tap do |resource|
+          @client.public_send("get_config_map", "fluentd-config-resource-version", @namespace).tap do |resource|
             log.debug "Got config map: #{resource}"
             version = resource.data["resource-version-#{resource_name}"]
             @resource_version = version.to_i if version

--- a/fluent-plugin-events/lib/sumologic/kubernetes/connector.rb
+++ b/fluent-plugin-events/lib/sumologic/kubernetes/connector.rb
@@ -9,7 +9,7 @@ module SumoLogic
   
         def connect_kubernetes
           @client = Kubeclient::Client.new(
-            @kubernetes_url, @apiVersion,
+            @kubernetes_url, @api_version,
             ssl_options: ssl_options,
             auth_options: auth_options
           )


### PR DESCRIPTION
Introduce new config param `resource_name` to take in a resource name to watch, defaulted to `events`. Use the same config map to store per-resource RV using key in the `resource-version-<resource-name>` format.

Minor change: rename `apiVersion` to `api_version` to follow the convention of other config param naming.

FYI @rvmiller89 @lei-sumo 