### PR TITLE
Use fluentd helper function

### DIFF
--- a/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
@@ -11,6 +11,7 @@ module Fluent
 
       helpers :record_accessor
       helpers :thread
+      helpers :timer
       include SumoLogic::Kubernetes::Connector
       include SumoLogic::Kubernetes::Reader
       include SumoLogic::Kubernetes::CacheStrategy


### PR DESCRIPTION
It is found that having the `while` loop in the main thread blocks fluentd from running multiple input sources simultaneously. @samjsong found the `timer_execute` helper function from `timer` helper being used in the tail input source, which works with multiple tail sources. 

The `while` loops in events and service monitor are replaced by `timer_execute`. The sleep for the timer is determined by the sleep used in the `while` loops before (which is different from how often watcher recreates)
