### PR TITLE
Attach service metadata

### DIFF
--- a/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
@@ -80,6 +80,12 @@ module Fluent
           else
             record.merge! metadata
           end
+          service = @pods_to_services[pod_name]
+          if service.nil? || service.empty?
+            log.debug "Cannot get service for pod #{namespace_name}::#{pod_name}, skip."
+          else
+            record['service'] = service.join('_')
+          end
         end
       end
 

--- a/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
@@ -84,7 +84,7 @@ module Fluent
           if service.nil? || service.empty?
             log.debug "Cannot get service for pod #{namespace_name}::#{pod_name}, skip."
           else
-            record['service'] = service.join('_')
+            record['service'] = service.sort!.join('_')
           end
         end
       end

--- a/fluent-plugin-enhance-k8s-metadata/test/sumologic/kubernetes/test_service_monitor.rb
+++ b/fluent-plugin-enhance-k8s-metadata/test/sumologic/kubernetes/test_service_monitor.rb
@@ -67,6 +67,7 @@ class ServiceMonitorTest < Test::Unit::TestCase
     test 'endpoint with subsets and notReadyAddresses with targetRef and type is Pods' do
       input = get_test_endpoint[6]
       expected = ['fluentd-59d9c9656d-cg5m4', 'fluentd-59d9c9656d-5pwjg', 'fluentd-59d9c9656d-zlhjh']
+      assert_equal expected, get_pods_for_service(input)
     end
   end
 


### PR DESCRIPTION
We attach the service metadata to the record in the `enhance_k8s_metadata` filter plugin. In the off chance that a pod maps to more than one service, we merge the service names with an underscore after sorting alphabetically.

For example (screenshot from Sumo UI):

![image](https://user-images.githubusercontent.com/14362712/61087470-96d92a00-a3ea-11e9-9e2c-66225852e999.png)

These pods started with just service `fluentd`, after which I attached another service `ssong-2nd`, then attached another service `middle-test`.

(also noticed one of the `service_monitor` UT's was missing an assert statement so I added that)

cc @Gourav2906 @abhi-sumo @frankreno