### PR TITLE
Use different label in events deployment

### DIFF
--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -388,15 +388,15 @@ kind: Deployment
 metadata:
   name: fluentd-events
   labels:
-    k8s-app: fluentd-sumologic
+    k8s-app: fluentd-sumologic-events
 spec:
   selector:
     matchLabels:
-      k8s-app: fluentd-sumologic
+      k8s-app: fluentd-sumologic-events
   template:
     metadata:
       labels:
-        k8s-app: fluentd-sumologic
+        k8s-app: fluentd-sumologic-events
     spec:
       serviceAccountName: fluentd
       volumes:


### PR DESCRIPTION
Currently we are using the same label in the events deployment and the logs/metrics deployment. The `Service` we defined in the yaml uses this label as selector and opens two ports (one for prometheus and one for fluent-bit) for all pods that have this label, but it is not needed by the events collection. @abhi-sumo reported it caused some issue to a customer, so we will use a different label for events.