### PR TITLE
use-fields-log-format

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -41,7 +41,7 @@ RUN gem sources --clear-all \
        && rm -f ./*.gem
 
 # Default settings for log collection
-ENV LOG_FORMAT "json"
+ENV LOG_FORMAT "fields"
 ENV FLUSH_INTERVAL "5s"
 ENV NUM_THREADS "1"
 ENV SOURCE_CATEGORY "%{namespace}/%{pod_name}"


### PR DESCRIPTION
Switch default log_format to fields to ensure log metadata is delivered as expected.