### PR TITLE
Make imagePullPolicy and latest tag explicit for now

### DIFF
--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -285,7 +285,7 @@ spec:
           name: fluentd-config
       containers:
       - name: fluentd
-        image: sumologic/kubernetes-fluentd:latest
+        image: sumologic/kubernetes-fluentd:0.0.0
         imagePullPolicy: Always
         resources:
           limits:
@@ -409,7 +409,7 @@ spec:
           name: fluentd-events-config
       containers:
       - name: fluentd-events
-        image: sumologic/kubernetes-fluentd:latest
+        image: sumologic/kubernetes-fluentd:0.0.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -285,8 +285,8 @@ spec:
           name: fluentd-config
       containers:
       - name: fluentd
-        image: sumologic/kubernetes-fluentd
-        imagePullPolicy: IfNotPresent
+        image: sumologic/kubernetes-fluentd:latest
+        imagePullPolicy: Always
         resources:
           limits:
             memory: 1Gi
@@ -409,8 +409,8 @@ spec:
           name: fluentd-events-config
       containers:
       - name: fluentd-events
-        image: sumologic/kubernetes-fluentd
-        imagePullPolicy: IfNotPresent
+        image: sumologic/kubernetes-fluentd:latest
+        imagePullPolicy: Always
         resources:
           limits:
             memory: 256Mi

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -286,7 +286,7 @@ spec:
       containers:
       - name: fluentd
         image: sumologic/kubernetes-fluentd
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         resources:
           limits:
             memory: 1Gi
@@ -410,7 +410,7 @@ spec:
       containers:
       - name: fluentd-events
         image: sumologic/kubernetes-fluentd
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         resources:
           limits:
             memory: 256Mi


### PR DESCRIPTION
Until we start tagging our `sumologic/kubernetes-fluentd` releases, we should be explicit about the `Always` imagePullPolicy and `0.0.0` tag.

Once we start tagging, we can change this to:
```
image: sumologic/kubernetes-fluentd:v1.blah
imagePullPolicy: IfNotPresent
```