### PR TITLE
Add "patch" configmaps capability for fluentd

### DIFF
--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -36,7 +36,7 @@ rules:
 - apiGroups: [""]
   resources:
     - configmaps
-  verbs: ["create", "update"]
+  verbs: ["create", "update", "patch"]
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -36,7 +36,7 @@ rules:
 - apiGroups: [""]
   resources:
     - configmaps
-  verbs: ["create", "update", "patch"]
+  verbs: ["create", "patch"]
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
Noticed on my kubernetes deployment with RBAC enabled, I was getting an error from `fluentd-events` pod with 403 error trying to "patch" the config map:

```ruby
2019-07-17 20:53:07 +0000 [error]: #0 Unexpected error raised. Stopping the timer. title=:events_monitor error_class=Kubeclient::HttpError error="HTTP status code 403, configmaps \"fluentd-config-resource-version\" is forbidden: User \"system:serviceaccount:sumologic:fluentd\" cannot patch configmaps in the namespace \"sumologic\" for PATCH https://100.64.0.1/api/v1/namespaces/sumologic/configmaps/fluentd-config-resource-version"
  2019-07-17 20:53:07 +0000 [error]: #0 /usr/lib/ruby/gems/2.5.0/gems/kubeclient-4.4.0/lib/kubeclient/common.rb:129:in `rescue in handle_exception'
```

Adding "patch" verb to configmaps capability fixed the issue.