### PR TITLE
Fix remote storage regex prometheus override

### DIFF
--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -262,5 +262,5 @@ prometheus:
     - url: http://fluentd:9888/prometheus.metrics
       writeRelabelConfigs:
       - action: keep
-        regex: 'prometheus_remote_storage_*'
+        regex: 'prometheus_remote_storage_.*'
         sourceLabels: [__name__]


### PR DESCRIPTION
Fix regex expression to collect remote_storage metrics from https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/42