### PR TITLE
Push alpha docker image on merge push CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ services: docker
 before_install:
   - rm -f ./Gemfile.lock
   - gem install bundler
-script: ci/build.sh
+script: bash ci/build.sh

--- a/deploy/test/test_docker.rb
+++ b/deploy/test/test_docker.rb
@@ -22,7 +22,7 @@ class TestDocker < Test::Unit::TestCase
   end
 
   def test_docker_image_runnable
-    id = `docker run -d --rm --name #{CONTAINER_NAME} #{docker_tag}:latest`
+    id = `docker run -d --rm --name #{CONTAINER_NAME} #{docker_tag}:local`
     assert !id.nil? && !id.empty?
     sleep_time = 15
     sleep sleep_time


### PR DESCRIPTION
When docker password env variable is present, and we are pushing to master (merging a PR), this will push a new docker image with auto-incrementing patch number.

It will use the latest non-alpha version to determine the next patch number to use and append `-alpha` to the version.

Example output:
```
Most recent release version: 0.0.0, most recent alpha: 0.0.0-alpha
Pushing alpha docker image with version 0.0.1-alpha
```