### PR TITLE
Parameterize buffer settings for Fluentd Logs/Metrics

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -43,7 +43,9 @@ RUN gem sources --clear-all \
 # Default settings for log collection
 ENV LOG_FORMAT "fields"
 ENV FLUSH_INTERVAL "5s"
-ENV NUM_THREADS "1"
+ENV NUM_THREADS "4"
+ENV CHUNK_LIMIT_SIZE "100k"
+ENV TOTAL_LIMIT_SIZE "128m"
 ENV SOURCE_CATEGORY "%{namespace}/%{pod_name}"
 ENV SOURCE_CATEGORY_PREFIX "kubernetes/"
 ENV SOURCE_CATEGORY_REPLACE_DASH "/"

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -90,6 +90,7 @@ data:
       data_type metrics
       metric_data_format prometheus
       disable_cookies true
+      @include buffer.output.conf
     </match>
     <match prometheus.datapoint.kubelet**>
       @type sumologic
@@ -97,6 +98,7 @@ data:
       data_type metrics
       metric_data_format prometheus
       disable_cookies true
+      @include buffer.output.conf
     </match>
     <match prometheus.datapoint.kube-controller-manager**>
       @type sumologic
@@ -104,6 +106,7 @@ data:
       data_type metrics
       metric_data_format prometheus
       disable_cookies true
+      @include buffer.output.conf
     </match>
     <match prometheus.datapoint.kube-scheduler**>
       @type sumologic
@@ -111,6 +114,7 @@ data:
       data_type metrics
       metric_data_format prometheus
       disable_cookies true
+      @include buffer.output.conf
     </match>
     <match prometheus.datapoint.kube-state**>
       @type sumologic
@@ -118,6 +122,7 @@ data:
       data_type metrics
       metric_data_format prometheus
       disable_cookies true
+      @include buffer.output.conf
     </match>
     <match prometheus.datapoint.node-exporter**>
       @type sumologic
@@ -125,6 +130,7 @@ data:
       data_type metrics
       metric_data_format prometheus
       disable_cookies true
+      @include buffer.output.conf
     </match>
     <match prometheus.datapoint**>
       @type sumologic
@@ -132,6 +138,7 @@ data:
       data_type metrics
       metric_data_format prometheus
       disable_cookies true
+      @include buffer.output.conf
     </match>
   logs.conf: |-
     <source>
@@ -260,13 +267,21 @@ data:
       endpoint "#{ENV['SUMO_ENDPOINT_LOGS']}"
       verify_ssl "#{ENV['VERIFY_SSL']}"
       log_format "#{ENV['LOG_FORMAT']}"
-      flush_interval "#{ENV['FLUSH_INTERVAL']}"
-      num_threads "#{ENV['NUM_THREADS']}"
-      open_timeout 60
       add_timestamp "#{ENV['ADD_TIMESTAMP']}"
       timestamp_key "#{ENV['TIMESTAMP_KEY']}"
       proxy_uri "#{ENV['PROXY_URI']}"
+      @include buffer.output.conf
     </match>
+  
+  buffer.output.conf: |-
+    <buffer>
+      @type memory
+      compress gzip
+      flush_interval "#{ENV['FLUSH_INTERVAL']}"
+      flush_thread_count "#{ENV['NUM_THREADS']}"
+      chunk_limit_size "#{ENV['CHUNK_LIMIT_SIZE']}"
+      total_limit_size "#{ENV['TOTAL_LIMIT_SIZE']}"
+    </buffer>
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -87,66 +87,51 @@ data:
     <match prometheus.datapoint.apiserver**>
       @type sumologic
       endpoint "#{ENV['SUMO_ENDPOINT_METRICS_APISERVER']}"
-      data_type metrics
-      metric_data_format prometheus
-      disable_cookies true
-      @include buffer.output.conf
+      @include metrics.output.conf
     </match>
     <match prometheus.datapoint.kubelet**>
       @type sumologic
       endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBELET']}"
-      data_type metrics
-      metric_data_format prometheus
-      disable_cookies true
-      @include buffer.output.conf
+      @include metrics.output.conf
     </match>
     <match prometheus.datapoint.kube-controller-manager**>
       @type sumologic
       endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBE_CONTROLLER_MANAGER']}"
-      data_type metrics
-      metric_data_format prometheus
-      disable_cookies true
-      @include buffer.output.conf
+      @include metrics.output.conf
     </match>
     <match prometheus.datapoint.kube-scheduler**>
       @type sumologic
       endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBE_SCHEDULER']}"
-      data_type metrics
-      metric_data_format prometheus
-      disable_cookies true
-      @include buffer.output.conf
+      @include metrics.output.conf
     </match>
     <match prometheus.datapoint.kube-state**>
       @type sumologic
       endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBE_STATE']}"
-      data_type metrics
-      metric_data_format prometheus
-      disable_cookies true
-      @include buffer.output.conf
+      @include metrics.output.conf
     </match>
     <match prometheus.datapoint.node-exporter**>
       @type sumologic
       endpoint "#{ENV['SUMO_ENDPOINT_METRICS_NODE_EXPORTER']}"
-      data_type metrics
-      metric_data_format prometheus
-      disable_cookies true
-      @include buffer.output.conf
+      @include metrics.output.conf
     </match>
     <match prometheus.datapoint**>
       @type sumologic
       endpoint "#{ENV['SUMO_ENDPOINT_METRICS']}"
-      data_type metrics
-      metric_data_format prometheus
-      disable_cookies true
-      @include buffer.output.conf
+      @include metrics.output.conf
     </match>
+
+  metrics.output.conf: |-
+    data_type metrics
+    metric_data_format prometheus
+    disable_cookies true
+    @include buffer.output.conf
+
   logs.conf: |-
     <source>
       @type forward
       port 24321
       bind 0.0.0.0
     </source>
-
     @include logs.source.containers.conf
     @include logs.source.systemd.conf
 
@@ -158,12 +143,10 @@ data:
       separator "#{ENV['CONCAT_SEPARATOR']}"
       timeout_label @NORMAL
     </filter>
-
     <match containers.**>
       @type relabel
       @label @NORMAL
     </match>
-
     <label @NORMAL>
       <filter containers.**>
         @type kubernetes_metadata
@@ -181,9 +164,12 @@ data:
         tag_to_kubernetes_name_regexp '.+?\.containers\.(?<pod_name>[^_]+)_(?<namespace>[^_]+)_(?<container_name>.+)-(?<docker_id>[a-z0-9]{64})\.log$'
         merge_json_log false
       </filter>
-
-      @include logs.enhanced.metadata.conf
-
+      <filter **>
+        @type enhance_k8s_metadata
+        in_namespace_path '$.kubernetes.namespace_name'
+        in_pod_path '$.kubernetes.pod_name'
+        data_type logs
+      </filter>
       <filter containers.**>
         @type kubernetes_sumologic
         source_name "#{ENV['SOURCE_NAME']}"
@@ -210,7 +196,6 @@ data:
       @type relabel
       @label @KUBELET
     </match>
-
     <label @KUBELET>
       <filter host.kubelet.**>
         @type kubernetes_sumologic
@@ -222,15 +207,12 @@ data:
         exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
         exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
       </filter>
-
       @include logs.output.conf
     </label>
-
     <match host.**>
       @type relabel
       @label @SYSTEMD
     </match>
-
     <label @SYSTEMD>
       <filter host.**>
         @type kubernetes_sumologic
@@ -241,28 +223,19 @@ data:
         exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
         exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
       </filter>
-
       <filter host.**>
         @type record_modifier
         <record>
           _sumo_metadata ${record["_sumo_metadata"][:source] = tag_parts[1]; record["_sumo_metadata"]}
         </record>
       </filter>
-
       @include logs.output.conf
     </label>
-
-  logs.enhanced.metadata.conf: |-
-    <filter **>
-      @type enhance_k8s_metadata
-      in_namespace_path '$.kubernetes.namespace_name'
-      in_pod_path '$.kubernetes.pod_name'
-      data_type logs
-    </filter>
 
   logs.output.conf: |-
     <match **>
       @type sumologic
+      data_type logs
       log_key log
       endpoint "#{ENV['SUMO_ENDPOINT_LOGS']}"
       verify_ssl "#{ENV['VERIFY_SSL']}"
@@ -406,6 +379,16 @@ data:
       endpoint "#{ENV['SUMO_ENDPOINT_EVENTS']}"
       data_type logs
       disable_cookies true
+      verify_ssl "#{ENV['VERIFY_SSL']}"
+      proxy_uri "#{ENV['PROXY_URI']}"
+      <buffer>
+      @type memory
+        compress gzip
+        flush_interval "#{ENV['FLUSH_INTERVAL']}"
+        flush_thread_count "#{ENV['NUM_THREADS']}"
+        chunk_limit_size "#{ENV['CHUNK_LIMIT_SIZE']}"
+        total_limit_size "#{ENV['TOTAL_LIMIT_SIZE']}"
+      </buffer>
     </match>
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
- Raise number of threads per output plugin to 4 threads to alleviate http bottleneck
- Apply same buffer configuration settings to both logs and metrics output plugins
- Specify `gzip` compression for fluentd to use internally when buffering to maximize amount of buffering we can do
- Parameterize chunk_limit_size (http payload size) with 100KB max, and total_limit_size (amount of memory used per plugin) with 128MB max

Tested bringing up Fluentd pods and ensured log and metric collection is working.