### PR TITLE
Fix setup.sh bash script issues

### DIFF
--- a/deploy/kubernetes/setup.sh
+++ b/deploy/kubernetes/setup.sh
@@ -84,7 +84,7 @@ if [ -z $CLUSTER_NAME ]; then
   fi
 fi
 
-if [ -z $NAMESPACE]; then
+if [ -z $NAMESPACE ]; then
   if [ -z $SUMO_NAMESPACE ]
   then
     NAMESPACE="sumologic"
@@ -118,7 +118,7 @@ else
 fi
 
 set +e
-kubectl describe namespace $NAMESPACE &>/dev/null
+kubectl get namespace $NAMESPACE &>/dev/null
 retVal=$?
 set -e
 if [ $retVal -ne 0 ]; then


### PR DESCRIPTION
Fixes https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/98
- `kubectl get` doesn't have the same issue with substring matches that `kubectl describe` has:
```
k8s $ kubectl get namespace sumol
Error from server (NotFound): namespaces "sumol" not found
k8s $ echo $?
1
k8s $ kubectl get namespace sumologic
NAME        STATUS   AGE
sumologic   Active   12d
k8s $ echo $?
0
```

Fixes https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/97