### PR TITLE
Use Github token to push tags

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -70,8 +70,11 @@ elif [ -n "$DOCKER_PASSWORD" ] && [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS
   docker push $DOCKER_TAG:$new_alpha
 
   echo "Tagging git with v$new_alpha..."
+  git config --global user.email "travis@travis-ci.org"
+  git config --global user.name "Travis CI"
+  git remote add origin-repo https://${GITHUB_TOKEN}@github.com/SumoLogic/sumologic-kubernetes-collection.git > /dev/null 2>&1
   git tag -a "v$new_alpha" -m "Bump version to v$new_alpha"
-  git push --tags origin master
+  git push --tags --quiet --set-upstream origin-repo master
 else
   echo "Skip Docker pushing"
 fi


### PR DESCRIPTION
```
Tagging git with v0.0.5-alpha...
remote: Invalid username or password.
fatal: Authentication failed for 'https://github.com/SumoLogic/sumologic-kubernetes-collection.git/'
The command "bash ci/build.sh" exited with 128.
```

This adds authentication from a Github token env variable I added to Travis settings.