### PR TITLE
SUMO-115364 Handle exceptions thrwon from kubeclient calls

### DIFF
--- a/fluent-plugin-events/lib/fluent/plugin/in_events.rb
+++ b/fluent-plugin-events/lib/fluent/plugin/in_events.rb
@@ -119,6 +119,8 @@ module Fluent
             log.debug "Closing watch stream"
           end
         end
+      rescue => e
+        log.error "Got exception #{e} watching for resource #{resource_name}. Skipping."
       end
 
       def create_config_map
@@ -126,6 +128,8 @@ module Fluent
         @clients['v1'].public_send("create_config_map", @configmap).tap do |map|
           log.debug "Created config map: #{map}"
         end
+      rescue => e
+        log.error "Got exception #{e} creating config map. Skipping."
       end
 
       def patch_config_map
@@ -133,6 +137,8 @@ module Fluent
         @clients['v1'].public_send("patch_config_map", "fluentd-config-resource-version", {data: { "resource-version-#{resource_name}": "#{@resource_version}"}}, @deploy_namespace).tap do |map|
           log.debug "Patched config map for #{@resource_name}: #{map}"
         end
+      rescue => e
+        log.error "Got exception #{e} patching config map. Skipping."
       end
 
       def initialize_resource_version
@@ -152,6 +158,8 @@ module Fluent
           end
         rescue Kubeclient::ResourceNotFoundError
           create_config_map
+        rescue => e
+          log.error "Got exception #{e} getting config map #{resource}. Skipping."
         end
       end
 
@@ -167,6 +175,8 @@ module Fluent
         end
 
         @resource_version = resource_version
+      rescue => e
+        log.error "Got exception #{e} pulling resource version #{resource_version} for resource #{resource_name}. Skipping."
       end
 
       def normalize_param

--- a/fluent-plugin-events/lib/fluent/plugin/in_events.rb
+++ b/fluent-plugin-events/lib/fluent/plugin/in_events.rb
@@ -159,7 +159,7 @@ module Fluent
         rescue Kubeclient::ResourceNotFoundError
           create_config_map
         rescue => e
-          log.error "Got exception #{e} getting config map #{resource}. Skipping."
+          log.error "Got exception #{e} getting config map. Skipping."
         end
       end
 

--- a/fluent-plugin-events/test/helper.rb
+++ b/fluent-plugin-events/test/helper.rb
@@ -63,11 +63,34 @@ def mock_patch_config_map(rv)
     .returns(object.to_json)
 end
 
+def mock_create_config_map_execution(configmap)
+  Kubeclient::Client.any_instance.stubs(:public_send)
+    .with("create_config_map", configmap)
+    .raises(StandardError.new 'Error occurred when creating config map.')
+end
+
 def mock_patch_config_map_exception(rv)
   Kubeclient::Client.any_instance.stubs(:public_send)
     .with("patch_config_map", "fluentd-config-resource-version",
     {data: { "resource-version-events": rv.to_s}}, 'sumologic')
-    .raises()
+    .raises(StandardError.new 'Error occurred when patching config map.')
+end
+
+def mock_get_config_map_exception
+  Kubeclient::Client.any_instance.stubs(:public_send)
+    .with("get_config_map", "fluentd-config-resource-version", "sumologic")
+    .raises(StandardError.new 'Error occurred when getting config map.')
+end
+
+def mock_get_events_exception
+  Kubeclient::Client.any_instance.stubs(:public_send).with("get_events", {:as=>:raw})
+    .raises(StandardError.new 'Error occurred when getting events.')
+end
+
+def mock_watch_events_exception
+  Kubeclient::Client.any_instance.stubs(:public_send)
+    .with("watch_events", {:as=>:raw, :field_selector=>nil, :label_selector=>nil, :namespace=>nil, :resource_version=>nil, :timeout_seconds=>360})
+    .raises(StandardError.new 'Error occurred when watching events.')
 end
 
 def get_watch_resources_count_by_type_selector(type_selector, file_name)

--- a/fluent-plugin-events/test/helper.rb
+++ b/fluent-plugin-events/test/helper.rb
@@ -63,6 +63,13 @@ def mock_patch_config_map(rv)
     .returns(object.to_json)
 end
 
+def mock_patch_config_map_exception(rv)
+  Kubeclient::Client.any_instance.stubs(:public_send)
+    .with("patch_config_map", "fluentd-config-resource-version",
+    {data: { "resource-version-events": rv.to_s}}, 'sumologic')
+    .raises()
+end
+
 def get_watch_resources_count_by_type_selector(type_selector, file_name)
   text = File.read(test_resource(file_name))
   objects = text.split(/\n+/).map {|line| JSON.parse(line)}

--- a/fluent-plugin-events/test/plugin/test_in_events.rb
+++ b/fluent-plugin-events/test/plugin/test_in_events.rb
@@ -24,18 +24,22 @@ class EventsInputTest < Test::Unit::TestCase
     driver = Fluent::Test::Driver::Input.new(Fluent::Plugin::EventsInput).configure(conf)
   end
 
+  def configure_test_driver(config = %([]))
+    driver = create_driver(config).instance
+    connect_kubernetes_with_api_version(driver)
+    driver.instance_variable_set(:@clients, @clients)
+    driver
+  end
+
   def connect_kubernetes_with_api_version(driver)
     @api_version = driver.instance_variable_get(:@api_version)
     connect_kubernetes
   end
 
   test 'pull_resource_version correctly from eventlist' do
-    config = %([])
-    driver = create_driver(config).instance
-    connect_kubernetes_with_api_version(driver)
-    driver.instance_variable_set(:@clients, @clients)
-
+    driver = configure_test_driver()
     mock_get_events('api_list_events_v1.json')
+
     resource_version = driver.pull_resource_version
     assert_equal '2346293', resource_version
   end
@@ -44,22 +48,17 @@ class EventsInputTest < Test::Unit::TestCase
     config = %([
       api_version "events.k8s.io/v1beta1"
     ])
-    driver = create_driver(config).instance
-    connect_kubernetes_with_api_version(driver)
-    driver.instance_variable_set(:@clients, @clients)
-
+    driver = configure_test_driver(config)
     mock_get_events('api_list_events_v1beta1.json')
+
     resource_version = driver.pull_resource_version
     assert_equal '2721303', resource_version
   end
 
   test 'initialize_resource_version correctly for different resources' do
-    config = %([])
-    driver = create_driver(config).instance
-    connect_kubernetes_with_api_version(driver)
-    driver.instance_variable_set(:@clients, @clients)
-
+    driver = configure_test_driver()
     mock_get_config_map
+
     resource = driver.initialize_resource_version
     assert_equal 'dummy-events-rv', resource.data['resource-version-events']
     assert_equal 'dummy-pods-rv', resource.data['resource-version-pods']
@@ -70,11 +69,9 @@ class EventsInputTest < Test::Unit::TestCase
     config = %([
       api_version "events.k8s.io/v1beta1"
     ])
-    driver = create_driver(config).instance
-    connect_kubernetes_with_api_version(driver)
-    driver.instance_variable_set(:@clients, @clients)
-
+    driver = configure_test_driver(config)
     mock_get_config_map
+
     resource = driver.initialize_resource_version
     assert_equal 'dummy-events-rv', resource.data['resource-version-events']
     assert_equal 'dummy-pods-rv', resource.data['resource-version-pods']
@@ -82,10 +79,7 @@ class EventsInputTest < Test::Unit::TestCase
   end
 
   test 'watch_events with default type_selector' do
-    config = %([])
-    driver = create_driver(config).instance
-    connect_kubernetes_with_api_version(driver)
-    driver.instance_variable_set(:@clients, @clients)
+    driver = configure_test_driver()
     mock_watch_events('api_watch_events_v1.txt')
 
     selected_events_count = get_watch_resources_count_by_type_selector(["ADDED", "MODIFIED"],
@@ -102,9 +96,7 @@ class EventsInputTest < Test::Unit::TestCase
     config = %([
       type_selector ["ADDED", "MODIFIED", "DELETED"]
     ])
-    driver = create_driver(config).instance
-    connect_kubernetes_with_api_version(driver)
-    driver.instance_variable_set(:@clients, @clients)
+    driver = configure_test_driver(config)
     mock_watch_events('api_watch_events_v1.txt')
 
     selected_events_count = get_watch_resources_count_by_type_selector(["ADDED", "MODIFIED", "DELETED"],
@@ -140,9 +132,7 @@ class EventsInputTest < Test::Unit::TestCase
     config = %([
       resource_name "services"
     ])
-    driver = create_driver(config).instance
-    connect_kubernetes_with_api_version(driver)
-    driver.instance_variable_set(:@clients, @clients)
+    driver = configure_test_driver(config)
     mock_watch_services
 
     selected_services_count = get_watch_resources_count_by_type_selector(["ADDED", "MODIFIED"],
@@ -158,9 +148,7 @@ class EventsInputTest < Test::Unit::TestCase
     config = %([
       api_version "events.k8s.io/v1beta1"
     ])
-    driver = create_driver(config).instance
-    connect_kubernetes_with_api_version(driver)
-    driver.instance_variable_set(:@clients, @clients)
+    driver = configure_test_driver(config)
     mock_watch_events('api_watch_events_v1beta1.txt')
 
     selected_events_count = get_watch_resources_count_by_type_selector(["ADDED", "MODIFIED"],
@@ -173,78 +161,55 @@ class EventsInputTest < Test::Unit::TestCase
   end
 
   test 'no events are ingested with too old resource version error' do
-    config = %([])
-    driver = create_driver(config).instance
-    connect_kubernetes_with_api_version(driver)
-    driver.instance_variable_set(:@clients, @clients)
+    driver = configure_test_driver()
     driver.instance_variable_set(:@last_recreated, 0)
-
     mock_get_events('api_list_events_v1.json')
     mock_patch_config_map(2346293)
     mock_watch_events('api_watch_events_error_v1.txt')
+
     driver.router.expects(:emit).never.with(anything, anything, anything)
-    
     driver.start_monitor
   end
 
-  sub_test_case 'exception from kubeclient will not interrupt execution of start monitor' do
+  sub_test_case 'appropriately handle exceptions thrown from kubeclient' do
     test 'exception from kubeclient call in create_config_map' do
-      config = %([])
-      driver = create_driver(config).instance
-      connect_kubernetes_with_api_version(driver)
-      driver.instance_variable_set(:@clients, @clients)
-      driver.instance_variable_set(:@last_recreated, 0)
-
+      driver = configure_test_driver(%([]))
       mock_get_config_map
+
       driver.initialize_resource_version
       mock_create_config_map_execution(driver.instance_variable_get(:@configmap))
       assert_nothing_raised { driver.create_config_map }
     end
 
     test 'exception from kubeclient call in patch_config_map' do
-      config = %([])
-      driver = create_driver(config).instance
-      connect_kubernetes_with_api_version(driver)
-      driver.instance_variable_set(:@clients, @clients)
+      driver = configure_test_driver(%([]))
       driver.instance_variable_set(:@last_recreated, 0)
-  
       mock_get_events('api_list_events_v1.json')
       mock_watch_events('api_watch_events_v1.txt')
       mock_patch_config_map_exception(2346293)
+
       assert_nothing_raised { driver.start_monitor }
     end
 
     test 'exception from kubeclient call in initialize_resource_version' do
-      config = %([])
-      driver = create_driver(config).instance
-      connect_kubernetes_with_api_version(driver)
-      driver.instance_variable_set(:@clients, @clients)
-      driver.instance_variable_set(:@last_recreated, 0)
-
+      driver = configure_test_driver(%([]))
       mock_get_config_map_exception
+
       assert_nothing_raised { driver.initialize_resource_version }
     end
 
     test 'exception from kubeclient call in pull_resource_version' do
-      config = %([])
-      driver = create_driver(config).instance
-      connect_kubernetes_with_api_version(driver)
-      driver.instance_variable_set(:@clients, @clients)
-      driver.instance_variable_set(:@last_recreated, 0)
-
+      driver = configure_test_driver(%([]))
       mock_get_events_exception
+
       assert_nothing_raised { driver.pull_resource_version }
     end
 
     test 'exception from kubclient call in start_watcher_thread' do
-      config = %([])
-      driver = create_driver(config).instance
-      connect_kubernetes_with_api_version(driver)
-      driver.instance_variable_set(:@clients, @clients)
-      driver.instance_variable_set(:@last_recreated, 0)
-      
+      driver = configure_test_driver(%([]))
       mock_watch_events_exception
-      assert_nothing_raised { driver.start_watcher_thread}
+
+      assert_nothing_raised { driver.start_watcher_thread }
     end
   end
 end

--- a/fluent-plugin-events/test/plugin/test_in_events.rb
+++ b/fluent-plugin-events/test/plugin/test_in_events.rb
@@ -173,7 +173,7 @@ class EventsInputTest < Test::Unit::TestCase
 
   sub_test_case 'appropriately handle exceptions thrown from kubeclient' do
     test 'exception from kubeclient call in create_config_map' do
-      driver = configure_test_driver(%([]))
+      driver = configure_test_driver()
       mock_get_config_map
 
       driver.initialize_resource_version
@@ -182,7 +182,7 @@ class EventsInputTest < Test::Unit::TestCase
     end
 
     test 'exception from kubeclient call in patch_config_map' do
-      driver = configure_test_driver(%([]))
+      driver = configure_test_driver()
       driver.instance_variable_set(:@last_recreated, 0)
       mock_get_events('api_list_events_v1.json')
       mock_watch_events('api_watch_events_v1.txt')
@@ -192,21 +192,21 @@ class EventsInputTest < Test::Unit::TestCase
     end
 
     test 'exception from kubeclient call in initialize_resource_version' do
-      driver = configure_test_driver(%([]))
+      driver = configure_test_driver()
       mock_get_config_map_exception
 
       assert_nothing_raised { driver.initialize_resource_version }
     end
 
     test 'exception from kubeclient call in pull_resource_version' do
-      driver = configure_test_driver(%([]))
+      driver = configure_test_driver()
       mock_get_events_exception
 
       assert_nothing_raised { driver.pull_resource_version }
     end
 
     test 'exception from kubclient call in start_watcher_thread' do
-      driver = configure_test_driver(%([]))
+      driver = configure_test_driver()
       mock_watch_events_exception
 
       assert_nothing_raised { driver.start_watcher_thread }

--- a/fluent-plugin-events/test/plugin/test_in_events.rb
+++ b/fluent-plugin-events/test/plugin/test_in_events.rb
@@ -186,4 +186,17 @@ class EventsInputTest < Test::Unit::TestCase
     
     driver.start_monitor
   end
+
+  test 'exception thrown from kubeclient will not interrupt execution of start_monitor' do
+    config = %([])
+    driver = create_driver(config).instance
+    connect_kubernetes_with_api_version(driver)
+    driver.instance_variable_set(:@clients, @clients)
+    driver.instance_variable_set(:@last_recreated, 0)
+
+    mock_get_events('api_list_events_v1.json')
+    mock_watch_events('api_watch_events_v1.txt')
+    mock_patch_config_map_exception(2346293)
+    assert_nothing_raised { driver.start_monitor}
+  end
 end


### PR DESCRIPTION
Since we are using `timer_execute` for `start_monitor`, any exceptions thrown from the method will cause the timer detached.

We are going to add exceptions handling for all methods that have kubeclient calls in events plugin, including following methods:
```
start_watcher_thread
create_config_map
patch_config_map
initialize_resource_version
pull_resource_version
```
We will only rescue possible errors and then log the error so that we can know errors from which method they throw. For all other methods except for `start_watch_thread`, we don't want errors from kubeclient blocks the thread of watching, so we just log the error and ignore it. For `start_watcher_thread`, we need `timer_execute` continues working so exceptions will be swallowed and timer won't be detached in this case.