### PR TITLE
Move Dockerfile env variables to yaml file to avoid drift

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -40,30 +40,6 @@ RUN gem sources --clear-all \
        && rm -rf /home/fluent/.gem/ruby/2.5.0/cache/*.gem \
        && rm -f ./*.gem
 
-# Default settings for log collection
-ENV LOG_FORMAT "fields"
-ENV FLUSH_INTERVAL "5s"
-ENV NUM_THREADS "4"
-ENV CHUNK_LIMIT_SIZE "100k"
-ENV TOTAL_LIMIT_SIZE "128m"
-ENV SOURCE_CATEGORY "%{namespace}/%{pod_name}"
-ENV SOURCE_CATEGORY_PREFIX "kubernetes/"
-ENV SOURCE_CATEGORY_REPLACE_DASH "/"
-ENV SOURCE_NAME "%{namespace}.%{pod}.%{container}"
-ENV KUBERNETES_META "true"
-ENV KUBERNETES_META_REDUCE "false"
-ENV MULTILINE_START_REGEXP "/^\w{3} \d{1,2}, \d{4}/"
-ENV CONCAT_SEPARATOR ""
-ENV ADD_TIMESTAMP "true"
-ENV TIMESTAMP_KEY "timestamp"
-ENV ADD_STREAM "true"
-ENV ADD_TIME "true"
-ENV K8S_METADATA_FILTER_WATCH "true"
-ENV K8S_METADATA_FILTER_VERIFY_SSL "true"
-ENV K8S_METADATA_FILTER_BEARER_CACHE_SIZE "1000"
-ENV K8S_METADATA_FILTER_BEARER_CACHE_TTL "3600"
-ENV VERIFY_SSL "true"
-
 RUN mkdir -p /fluentd/conf.d
 
 COPY ./fluent.conf /fluentd/etc/

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -361,6 +361,50 @@ spec:
             secretKeyRef:
               name: sumologic
               key: endpoint-logs
+        - name: LOG_FORMAT
+          value: "fields"
+        - name: FLUSH_INTERVAL
+          value: "5s"
+        - name: NUM_THREADS
+          value: "4"
+        - name: CHUNK_LIMIT_SIZE
+          value: "100k"
+        - name: TOTAL_LIMIT_SIZE
+          value: "128m"
+        - name: SOURCE_CATEGORY
+          value: "%{namespace}/%{pod_name}"
+        - name: SOURCE_CATEGORY_PREFIX
+          value: "kubernetes/"
+        - name: SOURCE_CATEGORY_REPLACE_DASH
+          value: "/"
+        - name: SOURCE_NAME
+          value: "%{namespace}.%{pod}.%{container}"
+        - name: KUBERNETES_META
+          value: "true"
+        - name: KUBERNETES_META_REDUCE
+          value: "false"
+        - name: MULTILINE_START_REGEXP
+          value: "/^\w{3} \d{1,2}, \d{4}/"
+        - name: CONCAT_SEPARATOR
+          value: ""
+        - name: ADD_TIMESTAMP
+          value: "true"
+        - name: TIMESTAMP_KEY
+          value: "timestamp"
+        - name: ADD_STREAM
+          value: "true"
+        - name: ADD_TIME
+          value: "true"
+        - name: K8S_METADATA_FILTER_WATCH
+          value: "true"
+        - name: K8S_METADATA_FILTER_VERIFY_SSL
+          value: "true"
+        - name: K8S_METADATA_FILTER_BEARER_CACHE_SIZE
+          value: "1000"
+        - name: K8S_METADATA_FILTER_BEARER_CACHE_TTL
+          value: "3600"
+        - name: VERIFY_SSL
+          value: "true"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -437,6 +481,17 @@ spec:
             secretKeyRef:
               name: sumologic
               key: endpoint-events
+        - name: VERIFY_SSL
+          value: "true"
+        - name: FLUSH_INTERVAL
+          value: "5s"
+        - name: NUM_THREADS
+          value: "4"
+        - name: CHUNK_LIMIT_SIZE
+          value: "100k"
+        - name: TOTAL_LIMIT_SIZE
+          value: "128m"
+
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -384,7 +384,7 @@ spec:
         - name: KUBERNETES_META_REDUCE
           value: "false"
         - name: MULTILINE_START_REGEXP
-          value: "/^\w{3} \d{1,2}, \d{4}/"
+          value: "/^\\w{3} \\d{1,2}, \\d{4}/"
         - name: CONCAT_SEPARATOR
           value: ""
         - name: ADD_TIMESTAMP


### PR DESCRIPTION
We currently have an issue where customers can use the latest yaml file from master branch (e.g. from setup.sh script) but it can reference environment variables in newer docker images so they won't get the default value.

To avoid drift, we would like to centralize this configuration in the yaml file itself.