### PR TITLE
Add monitoring for FluentD plugins

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -24,7 +24,7 @@ RUN gem install fluent-plugin-s3 -v 1.1.4 \
        && gem install fluent-plugin-sumologic_output -v 1.5.0 \
        && gem install fluent-plugin-concat -v 2.3.0 \
        && gem install fluent-plugin-rewrite-tag-filter -v 2.1.0 \
-       && gem install fluent-plugin-prometheus -v 1.1.0 \
+       && gem install fluent-plugin-prometheus -v 1.4.0 \
        && gem install fluent-plugin-kubernetes_sumologic -v 2.4.1
 
 # FluentD plugins from this repository

--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -264,3 +264,9 @@ prometheus:
       - action: keep
         regex: 'prometheus_remote_storage_.*'
         sourceLabels: [__name__]
+    # self-ingest Fluentd metrics
+    - url: http://fluentd:9888/prometheus.metrics
+      writeRelabelConfigs:
+        - action: keep
+          regex: 'fluentd_*'
+          sourceLabels: [__name__]

--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -16,6 +16,18 @@ prometheus:
       selector:
           matchLabels:
             k8s-app: fluentd-sumologic
+    - name: fluentd-events
+      additionalLabels: 
+        k8s-app: fluentd-sumologic-events
+        release: prometheus-operator
+      endpoints:
+      - port: metrics
+      namespaceSelector:
+        matchNames:
+        - sumologic
+      selector:
+          matchLabels:
+            k8s-app: fluentd-sumologic-events
   prometheusSpec:
     externalLabels:
       # Set this to a value to distinguish between different k8s clusters

--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -3,6 +3,19 @@ alertmanager:
 grafana:
   enabled: false
 prometheus:
+  additionalServiceMonitors:
+    - name: fluentd
+      additionalLabels: 
+        k8s-app: fluentd-sumologic
+        release: prometheus-operator
+      endpoints:
+      - port: metrics
+      namespaceSelector:
+        matchNames:
+        - sumologic
+      selector:
+          matchLabels:
+            k8s-app: fluentd-sumologic
   prometheusSpec:
     externalLabels:
       # Set this to a value to distinguish between different k8s clusters
@@ -268,5 +281,5 @@ prometheus:
     - url: http://fluentd:9888/prometheus.metrics
       writeRelabelConfigs:
         - action: keep
-          regex: 'fluentd_*'
+          regex: 'fluentd_.*'
           sourceLabels: [__name__]

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -57,6 +57,8 @@ data:
   common.conf: |-
     <source>
       @type prometheus
+      metrics_path /metrics
+      port 24231
     </source>
     <source>
       @type monitor_agent
@@ -339,7 +341,7 @@ spec:
             - "/bin/sh"
             - "-c"
             - "[[ $( pgrep ruby | wc -l)  == 2 ]]"
-          initialDelaySeconds: 45
+          initialDelaySeconds: 30
           periodSeconds: 5
         volumeMounts:
         - name: config-volume
@@ -538,22 +540,8 @@ spec:
     port: 24321
     targetPort: 24321
     protocol: TCP
----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  labels:
-    k8s-app: fluentd-sumologic
-    release: prometheus-operator
-  name: fluentd
-  namespace: sumologic
-spec:
-  endpoints:
-    port: metrics
-  namespaceSelector:
-    matchNames:
-    - sumologic
-  selector:
-    matchLabels:
-      k8s-app: fluentd-sumologic
+  - name: metrics
+    port: 24231
+    targetPort: 24231
+    protocol: TCP
 ---

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -51,8 +51,15 @@ metadata:
   name: fluentd-config
 data:
   fluent.conf: |-
+    @include common.conf
     @include metrics.conf
     @include logs.conf
+  common.conf: |-
+    <source>
+      @type monitor_agent
+      bind 0.0.0.0
+      port 24220
+    </source>
   metrics.conf: |-
     <source>
       @type http
@@ -86,36 +93,43 @@ data:
     </filter>
     <match prometheus.datapoint.apiserver**>
       @type sumologic
+      @id sumologic.endpoint.metrics.apiserver
       endpoint "#{ENV['SUMO_ENDPOINT_METRICS_APISERVER']}"
       @include metrics.output.conf
     </match>
     <match prometheus.datapoint.kubelet**>
       @type sumologic
+      @id sumologic.endpoint.metrics.kubelet
       endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBELET']}"
       @include metrics.output.conf
     </match>
     <match prometheus.datapoint.kube-controller-manager**>
       @type sumologic
+      @id sumologic.endpoint.metrics.kube.controller.manager
       endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBE_CONTROLLER_MANAGER']}"
       @include metrics.output.conf
     </match>
     <match prometheus.datapoint.kube-scheduler**>
       @type sumologic
+      @id sumologic.endpoint.metrics.kube.scheduler
       endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBE_SCHEDULER']}"
       @include metrics.output.conf
     </match>
     <match prometheus.datapoint.kube-state**>
       @type sumologic
+      @id sumologic.endpoint.metrics.kube.state
       endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBE_STATE']}"
       @include metrics.output.conf
     </match>
     <match prometheus.datapoint.node-exporter**>
       @type sumologic
+      @id sumologic.endpoint.metrics.node.exporter
       endpoint "#{ENV['SUMO_ENDPOINT_METRICS_NODE_EXPORTER']}"
       @include metrics.output.conf
     </match>
     <match prometheus.datapoint**>
       @type sumologic
+      @id sumologic.endpoint.metrics
       endpoint "#{ENV['SUMO_ENDPOINT_METRICS']}"
       @include metrics.output.conf
     </match>
@@ -187,8 +201,11 @@ data:
         exclude_container_regex "#{ENV['EXCLUDE_CONTAINER_REGEX']}"
         exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
       </filter>
-
-      @include logs.output.conf
+      <match **>
+        @type sumologic
+        @id sumologic.endpoint.logs
+        @include logs.output.conf
+      </match>
     </label>
 
   logs.source.systemd.conf: |-
@@ -207,7 +224,11 @@ data:
         exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
         exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
       </filter>
-      @include logs.output.conf
+      <match **>
+        @type sumologic
+        @id sumologic.endpoint.logs.kubelet
+        @include logs.output.conf
+      </match>
     </label>
     <match host.**>
       @type relabel
@@ -229,22 +250,23 @@ data:
           _sumo_metadata ${record["_sumo_metadata"][:source] = tag_parts[1]; record["_sumo_metadata"]}
         </record>
       </filter>
-      @include logs.output.conf
+      <match **>
+        @type sumologic
+        @id sumologic.endpoint.logs.systemd
+        @include logs.output.conf
+      </match>
     </label>
 
   logs.output.conf: |-
-    <match **>
-      @type sumologic
-      data_type logs
-      log_key log
-      endpoint "#{ENV['SUMO_ENDPOINT_LOGS']}"
-      verify_ssl "#{ENV['VERIFY_SSL']}"
-      log_format "#{ENV['LOG_FORMAT']}"
-      add_timestamp "#{ENV['ADD_TIMESTAMP']}"
-      timestamp_key "#{ENV['TIMESTAMP_KEY']}"
-      proxy_uri "#{ENV['PROXY_URI']}"
-      @include buffer.output.conf
-    </match>
+    data_type logs
+    log_key log
+    endpoint "#{ENV['SUMO_ENDPOINT_LOGS']}"
+    verify_ssl "#{ENV['VERIFY_SSL']}"
+    log_format "#{ENV['LOG_FORMAT']}"
+    add_timestamp "#{ENV['ADD_TIMESTAMP']}"
+    timestamp_key "#{ENV['TIMESTAMP_KEY']}"
+    proxy_uri "#{ENV['PROXY_URI']}"
+    @include buffer.output.conf
   
   buffer.output.conf: |-
     <buffer>
@@ -416,6 +438,7 @@ data:
   events.conf: |-
     <source>
       @type events
+      @id sumologic.endpoint.events
       deploy_namespace $NAMESPACE
     </source>
     <match kubernetes.**>
@@ -426,7 +449,7 @@ data:
       verify_ssl "#{ENV['VERIFY_SSL']}"
       proxy_uri "#{ENV['PROXY_URI']}"
       <buffer>
-      @type memory
+        @type memory
         compress gzip
         flush_interval "#{ENV['FLUSH_INTERVAL']}"
         flush_thread_count "#{ENV['NUM_THREADS']}"

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -61,9 +61,6 @@ data:
       port 24231
     </source>
     <source>
-      @type monitor_agent
-    </source>
-    <source>
       @type prometheus_output_monitor
     </source>
   metrics.conf: |-
@@ -443,12 +440,20 @@ data:
     @include events.conf
   events.conf: |-
     <source>
+      @type prometheus
+      metrics_path /metrics
+      port 24231
+    </source>
+    <source>
+      @type prometheus_output_monitor
+    </source>
+    <source>
       @type events
-      @id sumologic.endpoint.events
       deploy_namespace $NAMESPACE
     </source>
     <match kubernetes.**>
       @type sumologic
+      @id sumologic.endpoint.events
       endpoint "#{ENV['SUMO_ENDPOINT_EVENTS']}"
       data_type logs
       disable_cookies true
@@ -504,6 +509,22 @@ spec:
           mountPath: /fluentd/etc/
         - name: pos-files
           mountPath: /mnt/pos/
+        livenessProbe:
+          exec:
+            command:
+            - "/bin/sh"
+            - "-c"
+            - "[[ $( pgrep ruby | wc -l)  == 2 ]]"
+          initialDelaySeconds: 300
+          periodSeconds: 20
+        readinessProbe:
+          exec:
+            command:
+            - "/bin/sh"
+            - "-c"
+            - "[[ $( pgrep ruby | wc -l)  == 2 ]]"
+          initialDelaySeconds: 30
+          periodSeconds: 5
         env:
         - name: SUMO_ENDPOINT_EVENTS
           valueFrom:
@@ -520,7 +541,6 @@ spec:
           value: "100k"
         - name: TOTAL_LIMIT_SIZE
           value: "128m"
-
 ---
 apiVersion: v1
 kind: Service
@@ -540,6 +560,21 @@ spec:
     port: 24321
     targetPort: 24321
     protocol: TCP
+  - name: metrics
+    port: 24231
+    targetPort: 24231
+    protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: fluentd-events
+  labels:
+    k8s-app: fluentd-sumologic-events
+spec:
+  selector:
+    k8s-app: fluentd-sumologic-events
+  ports:
   - name: metrics
     port: 24231
     targetPort: 24231

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -56,9 +56,13 @@ data:
     @include logs.conf
   common.conf: |-
     <source>
+      @type prometheus
+    </source>
+    <source>
       @type monitor_agent
-      bind 0.0.0.0
-      port 24220
+    </source>
+    <source>
+      @type prometheus_output_monitor
     </source>
   metrics.conf: |-
     <source>
@@ -534,4 +538,22 @@ spec:
     port: 24321
     targetPort: 24321
     protocol: TCP
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: fluentd-sumologic
+    release: prometheus-operator
+  name: fluentd
+  namespace: sumologic
+spec:
+  endpoints:
+    port: metrics
+  namespaceSelector:
+    matchNames:
+    - sumologic
+  selector:
+    matchLabels:
+      k8s-app: fluentd-sumologic
 ---

--- a/fluent-plugin-protobuf/lib/fluent/plugin/parser_protobuf.rb
+++ b/fluent-plugin-protobuf/lib/fluent/plugin/parser_protobuf.rb
@@ -4,6 +4,8 @@ require 'snappy'
 require_relative '../../types_pb'
 require_relative '../../remote_pb'
 
+WriteRequest = Prometheus::WriteRequest
+
 module Fluent
   module Plugin
     # fluentd parser plugin to parse Prometheus metrics into timeseries events.
@@ -14,7 +16,7 @@ module Fluent
 
       def parse(text)
         inflated = Snappy.inflate(text)
-        decoded = Prometheus::WriteRequest.decode(inflated)
+        decoded = WriteRequest.decode(inflated)
         log.trace "protobuf::parse - in: (#{text.bytesize}/#{inflated.bytesize}), out: #{decoded.timeseries.length}"
         record = {}
         record[KEY_TIMESERIES] = decoded.timeseries


### PR DESCRIPTION
Exposes Prometheus metrics (currently just output plugin metrics) for fluentd and fluentd-events deployments.
![Screen Shot 2019-07-31 at 5 11 50 PM](https://user-images.githubusercontent.com/3904453/62256490-513eca00-b3b6-11e9-9457-e820f1514951.png)
