### PR TITLE
enable fluent-bit metrics collection

### DIFF
--- a/deploy/helm/fluent-bit-overrides.yaml
+++ b/deploy/helm/fluent-bit-overrides.yaml
@@ -1,3 +1,10 @@
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    additionalLabels:
+      release: prometheus-operator
+
 backend:
   type: forward
   forward:

--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -264,3 +264,9 @@ prometheus:
       - action: keep
         regex: 'prometheus_remote_storage_.*'
         sourceLabels: [__name__]
+      # fluent-bit metrics
+    - url: http://fluentd:9888/prometheus.metrics
+      writeRelabelConfigs:
+        - action: keep
+          regex: 'fluentbit.*'
+          sourceLabels: [__name__]


### PR DESCRIPTION
This PR enables Fluent-Bit metrics, creates a serviceMonitor with the appropriate label so Prometheus discovers, and then adds the appropriate remote write configuration.