### PR TITLE
Tolerate any NoScheule taint regardless of key

### DIFF
--- a/deploy/helm/fluent-bit-overrides.yaml
+++ b/deploy/helm/fluent-bit-overrides.yaml
@@ -18,8 +18,8 @@ backend:
 trackOffsets: true
 
 tolerations:
-  - key: node-role.kubernetes.io/master
-    effect: NoSchedule
+  - effect: NoSchedule
+    operator: Exists
 
 input:
   tail:


### PR DESCRIPTION
Fixes https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/84

Tested only by redeploying fluentbit operator with these overrides and ensuring log collection works.