### PR TITLE
Fix service monitor

### DIFF
--- a/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
@@ -79,7 +79,6 @@ module Fluent
           metadata['service'] = {'service' => service.sort!.join('_')} if !(service.nil? || service.empty?)
 
           ['pod_labels', 'owners', 'service'].each do |metadata_type|
-          # ['pod_labels', 'owners'].each do |metadata_type|
             attachment = metadata[metadata_type]
             if attachment.nil? || attachment.empty?
               log.trace "Cannot get #{metadata_type} for pod #{namespace_name}::#{pod_name}, skip."

--- a/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
@@ -50,7 +50,7 @@ module Fluent
 
       def start
         super
-        # start_service_monitor
+        start_service_monitor
       end
 
       def filter(tag, time, record)
@@ -75,11 +75,11 @@ module Fluent
             record.delete('service')
           end
           metadata = get_pod_metadata(namespace_name, pod_name)
-          # service = @pods_to_services[pod_name]
-          # metadata['service'] = {'service' => service.sort!.join('_')} if !(service.nil? || service.empty?)
+          service = @pods_to_services[pod_name]
+          metadata['service'] = {'service' => service.sort!.join('_')} if !(service.nil? || service.empty?)
 
-          # ['pod_labels', 'owners', 'service'].each do |metadata_type|
-          ['pod_labels', 'owners'].each do |metadata_type|
+          ['pod_labels', 'owners', 'service'].each do |metadata_type|
+          # ['pod_labels', 'owners'].each do |metadata_type|
             attachment = metadata[metadata_type]
             if attachment.nil? || attachment.empty?
               log.trace "Cannot get #{metadata_type} for pod #{namespace_name}::#{pod_name}, skip."

--- a/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
@@ -66,9 +66,9 @@ module Fluent
         @in_namespace_ac.each { |ac| namespace_name ||= ac.call(record) }
         @in_pod_ac.each { |ac| pod_name ||= ac.call(record) }
         if namespace_name.nil?
-          log.debug "Record doesn't have [#{@in_namespace_path}] field"
+          log.trace "Record doesn't have [#{@in_namespace_path}] field"
         elsif pod_name.nil?
-          log.debug "Record doesn't have [#{@in_pod_path}] field"
+          log.trace "Record doesn't have [#{@in_pod_path}] field"
         else
           if record.key? 'service'
             record['prometheus_service'] = record['service']
@@ -82,7 +82,7 @@ module Fluent
           ['pod_labels', 'owners'].each do |metadata_type|
             attachment = metadata[metadata_type]
             if attachment.nil? || attachment.empty?
-              log.debug "Cannot get #{metadata_type} for pod #{namespace_name}::#{pod_name}, skip."
+              log.trace "Cannot get #{metadata_type} for pod #{namespace_name}::#{pod_name}, skip."
             else
               case @data_type
               when 'logs'

--- a/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/connector.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/connector.rb
@@ -36,7 +36,11 @@ module SumoLogic
           ver,
           ssl_options: ssl_options,
           auth_options: auth_options,
-          as: :parsed
+          as: :parsed,
+          timeouts: {
+            open: 5,
+            read: 5
+          }
         )
         client.api_valid?
         client

--- a/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/service_monitor.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/service_monitor.rb
@@ -52,7 +52,7 @@ module SumoLogic
                 event = JSON.parse(event)
                 handle_service_event(event)
               rescue => e
-                log.error "Got exception #{e} parsing entity #{entity}. Skipping."
+                log.error "Got exception #{e} parsing event #{event}. Skipping."
               end
             end
             log.info "Closing watch stream"


### PR DESCRIPTION
We had this running on 15 Fluentd replicas over the last ~3.5 days and none of the replicas have yet to get stuck.

Ryan concurrently ran a test with calling `get_endpoints` in a tight loop over the weekend, and found this time that none of the replicas got stuck. We're not sure what changed, but it seems like `get_endpoints` may be working now? 🤞 