### PR TITLE
Bump versions of plugins used in Dockerfile

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -16,6 +16,11 @@ RUN apk add --no-cache --update --virtual .build-deps sudo build-base ruby-dev \
        && gem install lru_redux \
        && gem install snappy
 
+# FluentD plugins to allow customers to forward data if needed to various cloud platforms
+RUN gem install fluent-plugin-s3 \
+       && gem install fluent-plugin-google-cloud \
+       && gem install fluent-plugin-azure-storage-append-blob
+
 # FluentD plugins from RubyGems
 RUN gem install fluent-plugin-systemd -v 1.0.2 \
        && gem install fluent-plugin-record-modifier -v 2.0.1 \

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluent/fluentd:v1.6.2-1.0
+FROM fluent/fluentd:v1.6.3-1.0
 
 # Use root account to use apk
 USER root
@@ -17,14 +17,13 @@ RUN apk add --no-cache --update --virtual .build-deps sudo build-base ruby-dev \
        && gem install snappy
 
 # FluentD plugins from RubyGems
-RUN gem install fluent-plugin-s3 -v 1.1.4 \
-       && gem install fluent-plugin-systemd -v 0.3.1 \
-       && gem install fluent-plugin-record-modifier \
-       && gem install fluent-plugin-kubernetes_metadata_filter -v 1.0.2 \
+RUN gem install fluent-plugin-systemd -v 1.0.2 \
+       && gem install fluent-plugin-record-modifier -v 2.0.1 \
+       && gem install fluent-plugin-kubernetes_metadata_filter -v 2.2.0 \
        && gem install fluent-plugin-sumologic_output -v 1.5.0 \
-       && gem install fluent-plugin-concat -v 2.3.0 \
-       && gem install fluent-plugin-rewrite-tag-filter -v 2.1.0 \
-       && gem install fluent-plugin-prometheus -v 1.4.0 \
+       && gem install fluent-plugin-concat -v 2.4.0 \
+       && gem install fluent-plugin-rewrite-tag-filter -v 2.2.0 \
+       && gem install fluent-plugin-prometheus -v 1.5.0 \
        && gem install fluent-plugin-kubernetes_sumologic -v 2.4.2
 
 # FluentD plugins from this repository

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -16,10 +16,11 @@ RUN apk add --no-cache --update --virtual .build-deps sudo build-base ruby-dev \
        && gem install lru_redux \
        && gem install snappy
 
-# FluentD plugins to allow customers to forward data if needed to various cloud platforms
-RUN gem install fluent-plugin-s3 \
-       && gem install fluent-plugin-google-cloud \
-       && gem install fluent-plugin-azure-storage-append-blob
+# FluentD plugins to allow customers to forward data if needed to various cloud providers
+RUN gem install fluent-plugin-s3
+       # TODO: Support additional cloud providers
+       # && gem install fluent-plugin-google-cloud \
+       # && gem install fluent-plugin-azure-storage-append-blob
 
 # FluentD plugins from RubyGems
 RUN gem install fluent-plugin-systemd -v 1.0.2 \

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -179,7 +179,6 @@ data:
         cache_size "#{ENV['K8S_METADATA_FILTER_BEARER_CACHE_SIZE']}"
         cache_ttl "#{ENV['K8S_METADATA_FILTER_BEARER_CACHE_TTL']}"
         tag_to_kubernetes_name_regexp '.+?\.containers\.(?<pod_name>[^_]+)_(?<namespace>[^_]+)_(?<container_name>.+)-(?<docker_id>[a-z0-9]{64})\.log$'
-        merge_json_log false
       </filter>
       <filter **>
         @type enhance_k8s_metadata

--- a/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/reader.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/reader.rb
@@ -113,7 +113,7 @@ module SumoLogic
           nil
         end
       rescue Kubeclient::ResourceNotFoundError => e
-        log.error e
+        log.warn e
         nil
       end
     end

--- a/fluent-plugin-events/lib/fluent/plugin/in_events.rb
+++ b/fluent-plugin-events/lib/fluent/plugin/in_events.rb
@@ -111,7 +111,7 @@ module Fluent
               end
 
               if (!rv)
-                log.error "Resource version #{rv} expired, waiting for stream to be recreated with more recent version."
+                log.warn "Resource version #{rv} expired, waiting for stream to be recreated with more recent version."
                 break
               end
             end


### PR DESCRIPTION
Noticed several of our fluentd plugin gems are out of date, and one is not being used.

Testing performed:
- ci/build.sh
- Redeploy fluentd and fluentd-events pods
- Confirm events logs and normal logs and metrics are still coming in

FYI: @lei-sumo @frankreno 