### PR TITLE
Switch to Debian fluentd Dockerfile

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -3,8 +3,7 @@ FROM fluent/fluentd:v1.6.3-debian-1.0
 # Use root account to use apt
 USER root
 
-# below RUN includes plugin as examples elasticsearch is not required
-# you may customize including plugins as you wish
+# Build dependencies
 RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev libsnappy-dev" \
  && apt-get update \
  && apt-get install -y --no-install-recommends $buildDeps

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,16 +1,18 @@
-FROM fluent/fluentd:v1.6.3-1.0
+FROM fluent/fluentd:v1.6.3-debian-1.0
 
-# Use root account to use apk
+# Use root account to use apt
 USER root
+
+# below RUN includes plugin as examples elasticsearch is not required
+# you may customize including plugins as you wish
+RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev libsnappy-dev" \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends $buildDeps
 
 COPY gems/fluent-plugin*.gem ./
 
-RUN apk add --no-cache libexecinfo libexecinfo-dev
-
-RUN apk add --no-cache snappy g++ snappy-dev
-
-RUN apk add --no-cache --update --virtual .build-deps sudo build-base ruby-dev \
-       && gem install concurrent-ruby \
+# Fluentd plugin dependencies
+RUN gem install concurrent-ruby \
        && gem install google-protobuf \
        && gem install kubeclient \
        && gem install lru_redux \
@@ -40,14 +42,15 @@ RUN gem install fluent-plugin-prometheus-format \
        && gem install fluent-plugin-protobuf \
        && gem install fluent-plugin-events
 
-RUN gem sources --clear-all \
-       && apk del .build-deps \
-       && rm -rf /home/fluent/.gem/ruby/2.5.0/cache/*.gem \
-       && rm -f ./*.gem
-
-RUN mkdir -p /fluentd/conf.d
+RUN sudo gem sources --clear-all \
+ && SUDO_FORCE_REMOVE=yes \
+    apt-get purge -y --auto-remove \
+                  -o APT::AutoRemove::RecommendsImportant=false \
+                  $buildDeps \
+ && rm -rf /var/lib/apt/lists/* \
+ && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem
 
 COPY ./fluent.conf /fluentd/etc/
-COPY entrypoint.sh /bin/
+COPY ./entrypoint.sh /bin/
 
 USER fluent

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -326,17 +326,17 @@ spec:
         livenessProbe:
           exec:
             command:
-            - "/bin/sh"
+            - "/bin/bash"
             - "-c"
-            - "[[ $( pgrep ruby | wc -l)  == 2 ]]"
+            - "[[ $( pgrep ruby | wc -l)  > 0 ]]"
           initialDelaySeconds: 300
           periodSeconds: 20
         readinessProbe:
           exec:
             command:
-            - "/bin/sh"
+            - "/bin/bash"
             - "-c"
-            - "[[ $( pgrep ruby | wc -l)  == 2 ]]"
+            - "[[ $( pgrep ruby | wc -l)  > 0 ]]"
           initialDelaySeconds: 30
           periodSeconds: 5
         volumeMounts:
@@ -511,17 +511,17 @@ spec:
         livenessProbe:
           exec:
             command:
-            - "/bin/sh"
+            - "/bin/bash"
             - "-c"
-            - "[[ $( pgrep ruby | wc -l)  == 2 ]]"
+            - "[[ $( pgrep ruby | wc -l)  > 0 ]]"
           initialDelaySeconds: 300
           periodSeconds: 20
         readinessProbe:
           exec:
             command:
-            - "/bin/sh"
+            - "/bin/bash"
             - "-c"
-            - "[[ $( pgrep ruby | wc -l)  == 2 ]]"
+            - "[[ $( pgrep ruby | wc -l)  > 0 ]]"
           initialDelaySeconds: 30
           periodSeconds: 5
         env:

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -326,17 +326,17 @@ spec:
         livenessProbe:
           exec:
             command:
-            - "/bin/bash"
+            - "/bin/sh"
             - "-c"
-            - "[[ $( pgrep ruby | wc -l)  > 0 ]]"
+            - "[ $(pgrep ruby | wc -l) -gt 0 ]"
           initialDelaySeconds: 300
           periodSeconds: 20
         readinessProbe:
           exec:
             command:
-            - "/bin/bash"
+            - "/bin/sh"
             - "-c"
-            - "[[ $( pgrep ruby | wc -l)  > 0 ]]"
+            - "[ $(pgrep ruby | wc -l) -gt 0 ]"
           initialDelaySeconds: 30
           periodSeconds: 5
         volumeMounts:
@@ -511,17 +511,17 @@ spec:
         livenessProbe:
           exec:
             command:
-            - "/bin/bash"
+            - "/bin/sh"
             - "-c"
-            - "[[ $( pgrep ruby | wc -l)  > 0 ]]"
+            - "[ $(pgrep ruby | wc -l) -gt 0 ]"
           initialDelaySeconds: 300
           periodSeconds: 20
         readinessProbe:
           exec:
             command:
-            - "/bin/bash"
+            - "/bin/sh"
             - "-c"
-            - "[[ $( pgrep ruby | wc -l)  > 0 ]]"
+            - "[ $(pgrep ruby | wc -l) -gt 0 ]"
           initialDelaySeconds: 30
           periodSeconds: 5
         env:


### PR DESCRIPTION
The [fluentd-kubernetes](https://github.com/fluent/fluentd-kubernetes-daemonset) daemonset has deprecated using Alpine as their base image, and also says

> The following repository expose images based on Alpine Linux and Debian. For production environments we strongly suggest to use Debian images.

This PR changes our fluentd Docker image to be based on Debian.

Testing performed:
- ci/build.sh
- Redeploy fluentd and fluentd-events pods
- Confirm events logs and normal logs and metrics are still coming in