### PR TITLE
Move fluent-bit INPUT config to overrides yaml

### DIFF
--- a/deploy/helm/fluent-bit-overrides.yaml
+++ b/deploy/helm/fluent-bit-overrides.yaml
@@ -22,70 +22,75 @@ tolerations:
     operator: Exists
 
 input:
-  tail:
-    memBufLimit: 5MB
-    parser: docker
-    path: /var/log/containers/*.log
   systemd:
     enabled: true
-    filters:
-      systemdUnit:
-        - addon-config.service
-        - addon-run.service
-        - cfn-etcd-environment.service
-        - cfn-signal.service
-        - clean-ca-certificates.service
-        - containerd.service
-        - coreos-metadata.service
-        - coreos-setup-environment.service
-        - coreos-tmpfiles.service
-        - dbus.service
-        - docker.service
-        - efs.service
-        - etcd-member.service
-        - etcd.service
-        - etcd2.service
-        - etcd3.service
-        - etcdadm-check.service
-        - etcdadm-reconfigure.service
-        - etcdadm-save.service
-        - etcdadm-update-status.service
-        - flanneld.service
-        - format-etcd2-volume.service
-        - kube-node-taint-and-uncordon.service
-        - kubelet.service
-        - ldconfig.service
-        - locksmithd.service
-        - logrotate.service
-        - lvm2-monitor.service
-        - mdmon.service
-        - nfs-idmapd.service
-        - nfs-mountd.service
-        - nfs-server.service
-        - nfs-utils.service
-        - node-problem-detector.service
-        - ntp.service
-        - oem-cloudinit.service
-        - rkt-gc.service
-        - rkt-metadata.service
-        - rpc-idmapd.service
-        - rpc-mountd.service
-        - rpc-statd.service
-        - rpcbind.service
-        - set-aws-environment.service
-        - system-cloudinit.service
-        - systemd-timesyncd.service
-        - update-ca-certificates.service
-        - user-cloudinit.service
-        - var-lib-etcd2.service
-    maxEntries: 1000
-    readFromTail: true
-    tag: host.*
-
-filter:
-  kubeTag: containers
 
 rawConfig: |-
   @INCLUDE fluent-bit-service.conf
-  @INCLUDE fluent-bit-input.conf
+
+  [INPUT]
+    Name             tail
+    Path             /var/log/containers/*.log
+    Parser           docker
+    Tag              containers.*
+    Refresh_Interval 1
+    Rotate_Wait      60
+    Mem_Buf_Limit    5MB
+    Skip_Long_Lines  On
+    DB               /tail-db/tail-containers-state.db
+    DB.Sync          Normal
+  [INPUT]
+    Name            systemd
+    Tag             host.*
+    Systemd_Filter  _SYSTEMD_UNIT=addon-config.service
+    Systemd_Filter  _SYSTEMD_UNIT=addon-run.service
+    Systemd_Filter  _SYSTEMD_UNIT=cfn-etcd-environment.service
+    Systemd_Filter  _SYSTEMD_UNIT=cfn-signal.service
+    Systemd_Filter  _SYSTEMD_UNIT=clean-ca-certificates.service
+    Systemd_Filter  _SYSTEMD_UNIT=containerd.service
+    Systemd_Filter  _SYSTEMD_UNIT=coreos-metadata.service
+    Systemd_Filter  _SYSTEMD_UNIT=coreos-setup-environment.service
+    Systemd_Filter  _SYSTEMD_UNIT=coreos-tmpfiles.service
+    Systemd_Filter  _SYSTEMD_UNIT=dbus.service
+    Systemd_Filter  _SYSTEMD_UNIT=docker.service
+    Systemd_Filter  _SYSTEMD_UNIT=efs.service
+    Systemd_Filter  _SYSTEMD_UNIT=etcd-member.service
+    Systemd_Filter  _SYSTEMD_UNIT=etcd.service
+    Systemd_Filter  _SYSTEMD_UNIT=etcd2.service
+    Systemd_Filter  _SYSTEMD_UNIT=etcd3.service
+    Systemd_Filter  _SYSTEMD_UNIT=etcdadm-check.service
+    Systemd_Filter  _SYSTEMD_UNIT=etcdadm-reconfigure.service
+    Systemd_Filter  _SYSTEMD_UNIT=etcdadm-save.service
+    Systemd_Filter  _SYSTEMD_UNIT=etcdadm-update-status.service
+    Systemd_Filter  _SYSTEMD_UNIT=flanneld.service
+    Systemd_Filter  _SYSTEMD_UNIT=format-etcd2-volume.service
+    Systemd_Filter  _SYSTEMD_UNIT=kube-node-taint-and-uncordon.service
+    Systemd_Filter  _SYSTEMD_UNIT=kubelet.service
+    Systemd_Filter  _SYSTEMD_UNIT=ldconfig.service
+    Systemd_Filter  _SYSTEMD_UNIT=locksmithd.service
+    Systemd_Filter  _SYSTEMD_UNIT=logrotate.service
+    Systemd_Filter  _SYSTEMD_UNIT=lvm2-monitor.service
+    Systemd_Filter  _SYSTEMD_UNIT=mdmon.service
+    Systemd_Filter  _SYSTEMD_UNIT=nfs-idmapd.service
+    Systemd_Filter  _SYSTEMD_UNIT=nfs-mountd.service
+    Systemd_Filter  _SYSTEMD_UNIT=nfs-server.service
+    Systemd_Filter  _SYSTEMD_UNIT=nfs-utils.service
+    Systemd_Filter  _SYSTEMD_UNIT=node-problem-detector.service
+    Systemd_Filter  _SYSTEMD_UNIT=ntp.service
+    Systemd_Filter  _SYSTEMD_UNIT=oem-cloudinit.service
+    Systemd_Filter  _SYSTEMD_UNIT=rkt-gc.service
+    Systemd_Filter  _SYSTEMD_UNIT=rkt-metadata.service
+    Systemd_Filter  _SYSTEMD_UNIT=rpc-idmapd.service
+    Systemd_Filter  _SYSTEMD_UNIT=rpc-mountd.service
+    Systemd_Filter  _SYSTEMD_UNIT=rpc-statd.service
+    Systemd_Filter  _SYSTEMD_UNIT=rpcbind.service
+    Systemd_Filter  _SYSTEMD_UNIT=set-aws-environment.service
+    Systemd_Filter  _SYSTEMD_UNIT=system-cloudinit.service
+    Systemd_Filter  _SYSTEMD_UNIT=systemd-timesyncd.service
+    Systemd_Filter  _SYSTEMD_UNIT=update-ca-certificates.service
+    Systemd_Filter  _SYSTEMD_UNIT=user-cloudinit.service
+    Systemd_Filter  _SYSTEMD_UNIT=var-lib-etcd2.service
+    Max_Entries     1000
+    Read_From_Tail  true
+
   @INCLUDE fluent-bit-output.conf


### PR DESCRIPTION
###### Description

Since the OOB fluent-bit helm chart does not expose configs for `Refresh_Interval` and `Rotate_Wait`, we decided to expose the `[INPUT]` config for fluent-bit explicitly in the overrides yaml file.

For reference, this was the helm chart's `[INPUT]` [config](https://github.com/helm/charts/blob/master/stable/fluent-bit/templates/config.yaml). We need to keep `.Values.input.systemd.enabled` and `.Values. trackOffsets` in our overrides since they are used [here](https://github.com/helm/charts/blob/master/stable/fluent-bit/templates/daemonset.yaml).

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
