### PR TITLE
Update labels in prometheus-overrides.yaml

### DIFF
--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -6,7 +6,7 @@ prometheus:
   additionalServiceMonitors:
     - name: fluentd
       additionalLabels: 
-        k8s-app: fluentd-sumologic
+        app: sumologic
         release: prometheus-operator
       endpoints:
       - port: metrics
@@ -15,10 +15,10 @@ prometheus:
         - sumologic
       selector:
           matchLabels:
-            k8s-app: fluentd-sumologic
+            app: sumologic
     - name: fluentd-events
       additionalLabels: 
-        k8s-app: fluentd-sumologic-events
+        app: sumologic-events
         release: prometheus-operator
       endpoints:
       - port: metrics
@@ -27,7 +27,7 @@ prometheus:
         - sumologic
       selector:
           matchLabels:
-            k8s-app: fluentd-sumologic-events
+            app: sumologic-events
   prometheusSpec:
     externalLabels:
       # Set this to a value to distinguish between different k8s clusters


### PR DESCRIPTION
###### Description

After we use helm to generate `fluentd-sumologic.yaml.tmpl`, we now use different labels than our previous ones. 
`k8s-app: fluentd-sumologic` => `app: sumologic`
`k8s-app: fluentd-sumologic-events` => `app: sumologic-events`

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
