### PR TITLE
Automate helm chart release in setup.sh

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -54,6 +54,7 @@ ruby deploy/test/test_docker.rb
 if [ "$TRAVIS_BRANCH" != "master" ] && [ "$TRAVIS_EVENT_TYPE" == "push" ] && [ -n "$GITHUB_TOKEN" ]; then
   echo "Generating yaml from helm chart..."
   echo "# This file is auto-generated." > deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+  sumo helm init --client-only
   sudo helm template deploy/helm/sumologic --namespace "\$NAMESPACE" --set dryRun=true >> deploy/kubernetes/fluentd-sumologic.yaml.tmpl
 
   if [[ $(git diff deploy/kubernetes/fluentd-sumologic.yaml.tmpl) ]]; then

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -79,6 +79,7 @@ if [ "$TRAVIS_BRANCH" != "master" ] && [ "$TRAVIS_EVENT_TYPE" == "push" ] && [ -
   git fetch origin-repo
   git checkout gh-pages
   sudo helm repo index ./ --url https://sumologic.github.io/sumologic-kubernetes-collection/
+  git status
   git commit -a -m "Push new Helm Chart release $VERSION"
   git push --quiet origin-repo gh-pages
 fi

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -70,8 +70,17 @@ if [ "$TRAVIS_BRANCH" != "master" ] && [ "$TRAVIS_EVENT_TYPE" == "push" ] && [ -
   else
       echo "No changes in 'fluentd-sumologic.yaml.tmpl'."
   fi
+fi
+
+if [ -n "$DOCKER_PASSWORD" ] && [ -n "$TRAVIS_TAG" ] && [[ $TRAVIS_TAG != *alpha* ]]; then
+  echo "Tagging docker image $DOCKER_TAG:local with $DOCKER_TAG:$VERSION..."
+  docker tag $DOCKER_TAG:local $DOCKER_TAG:$VERSION
+  echo "Pushing docker image $DOCKER_TAG:$VERSION..."
+  echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+  docker push $DOCKER_TAG:$VERSION
 
   # Push new helm release
+  sudo helm init --client-only
   sudo helm package deploy/helm/sumologic --version=$VERSION
   git config --global user.email "travis@travis-ci.org"
   git config --global user.name "Travis CI"
@@ -82,15 +91,6 @@ if [ "$TRAVIS_BRANCH" != "master" ] && [ "$TRAVIS_EVENT_TYPE" == "push" ] && [ -
   git add -A
   git commit -m "Push new Helm Chart release $VERSION"
   git push --quiet origin-repo gh-pages
-fi
-
-if [ -n "$DOCKER_PASSWORD" ] && [ -n "$TRAVIS_TAG" ] && [[ $TRAVIS_TAG != *alpha* ]]; then
-  echo "Tagging docker image $DOCKER_TAG:local with $DOCKER_TAG:$VERSION..."
-  docker tag $DOCKER_TAG:local $DOCKER_TAG:$VERSION
-  echo "Pushing docker image $DOCKER_TAG:$VERSION..."
-  echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-  docker push $DOCKER_TAG:$VERSION
-
 
 elif [ -n "$DOCKER_PASSWORD" ] && [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_EVENT_TYPE" == "push" ]; then
   # Major.minor.patch version format

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -54,7 +54,7 @@ ruby deploy/test/test_docker.rb
 if [ "$TRAVIS_BRANCH" != "master" ] && [ "$TRAVIS_EVENT_TYPE" == "push" ] && [ -n "$GITHUB_TOKEN" ]; then
   echo "Generating yaml from helm chart..."
   echo "# This file is auto-generated." > deploy/kubernetes/fluentd-sumologic.yaml.tmpl
-  sumo helm init --client-only
+  sudo helm init --client-only
   sudo helm template deploy/helm/sumologic --namespace "\$NAMESPACE" --set dryRun=true >> deploy/kubernetes/fluentd-sumologic.yaml.tmpl
 
   if [[ $(git diff deploy/kubernetes/fluentd-sumologic.yaml.tmpl) ]]; then

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -79,8 +79,8 @@ if [ "$TRAVIS_BRANCH" != "master" ] && [ "$TRAVIS_EVENT_TYPE" == "push" ] && [ -
   git fetch origin-repo
   git checkout gh-pages
   sudo helm repo index ./ --url https://sumologic.github.io/sumologic-kubernetes-collection/
-  git status
-  git commit -a -m "Push new Helm Chart release $VERSION"
+  git add -A
+  git commit -m "Push new Helm Chart release $VERSION"
   git push --quiet origin-repo gh-pages
 fi
 


### PR DESCRIPTION
###### Description

When a new tag is created, `setup.sh` should create a new docker release as well as a new helm chart release and pushes the packaged helm chart with the new version to Github Pages.

We need to do some refactoring work on the setup script as it becomes longer and has more repeated code. But we can do it at once after Yuting merges the overrides auto generation.

###### Testing performed

- [x] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
