### PR TITLE
Only pass in our own yamls to helm template cmd

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -66,7 +66,7 @@ ruby deploy/test/test_docker.rb
 if [ "$TRAVIS_BRANCH" != "master" ] && [ "$TRAVIS_EVENT_TYPE" == "push" ] && [ -n "$GITHUB_TOKEN" ]; then
   echo "Generating yaml from helm chart..."
   echo "# This file is auto-generated." > deploy/kubernetes/fluentd-sumologic.yaml.tmpl
-  sudo helm init --client-only
+  sudo helm init
   sudo helm dependency update
   sudo helm template deploy/helm/sumologic --namespace "\$NAMESPACE" --set dryRun=true >> deploy/kubernetes/fluentd-sumologic.yaml.tmpl
 
@@ -89,14 +89,14 @@ if [ "$TRAVIS_BRANCH" != "master" ] && [ "$TRAVIS_EVENT_TYPE" == "push" ] && [ -
     echo "Detected changes in 'values.yaml', generating file fluent-bit-overrides.yaml..."
     fluent_bit_start_linenum=`grep -n "fluent-bit:" deploy/helm/sumologic/values.yaml | head -n 1 | cut -d: -f1`
     fluent_bit_start_linenum=$(($fluent_bit_start_linenum + 2))
-    fluent_bit_end_linenum=`grep -n "## Confugure prometheus-operator" deploy/helm/sumologic/values.yaml | head -n 1 | cut -d: -f1`
+    fluent_bit_end_linenum=`grep -n "## Configure prometheus-operator" deploy/helm/sumologic/values.yaml | head -n 1 | cut -d: -f1`
     fluent_bit_end_linenum=$(($fluent_bit_end_linenum - 1))
     echo "Copy 'values.yaml' from line $fluent_bit_start_linenum to line $fluent_bit_end_linenum to 'fluent-bit-overrides.yaml'"
     echo "# This file is auto-generated." > deploy/helm/fluent-bit-overrides.yaml
     # Copy lines of fluent-bit section and remove indention from values.yaml
     sed -n "$fluent_bit_start_linenum,${fluent_bit_end_linenum}p" deploy/helm/sumologic/values.yaml | sed 's/  //' >> deploy/helm/fluent-bit-overrides.yaml
     # Remove release name from service name
-    sed -i 's/collection-sumologic/sumologic/' deploy/helm/fluent-bit-overrides.yaml
+    sed -i 's/collection-sumologic/fluentd/' deploy/helm/fluent-bit-overrides.yaml
 
     echo "Detected changes in 'values.yaml', generating file prometheus-overrides.yaml..."
     prometheus_start_linenum=`grep -n "prometheus-operator:" deploy/helm/sumologic/values.yaml | head -n 1 | cut -d: -f1`
@@ -106,7 +106,7 @@ if [ "$TRAVIS_BRANCH" != "master" ] && [ "$TRAVIS_EVENT_TYPE" == "push" ] && [ -
     # Copy lines of fluent-bit section and remove indention from values.yaml
     sed -n "$prometheus_start_linenum,$ p" deploy/helm/sumologic/values.yaml | sed 's/  //' >> deploy/helm/prometheus-overrides.yaml
     # Remove release name from service name
-    sed -i 's/collection-sumologic/sumologic/' deploy/helm/prometheus-overrides.yaml
+    sed -i 's/collection-sumologic/fluentd/' deploy/helm/prometheus-overrides.yaml
   else
     echo "No changes in 'values.yaml'."
   fi

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -72,7 +72,6 @@ if [ "$TRAVIS_BRANCH" != "master" ] && [ "$TRAVIS_EVENT_TYPE" == "push" ] && [ -
   cd ../../../
 
   with_files=`ls deploy/helm/sumologic/templates/*.yaml | sed 's#deploy/helm/sumologic/templates#-x templates#g' | sed 's/yaml/yaml \\\/g'`
-  echo "$with_files"
   eval 'sudo helm template deploy/helm/sumologic $with_files --namespace "\$NAMESPACE" --set dryRun=true >> deploy/kubernetes/fluentd-sumologic.yaml.tmpl'
 
   if [[ $(git diff deploy/kubernetes/fluentd-sumologic.yaml.tmpl) ]]; then
@@ -89,32 +88,32 @@ if [ "$TRAVIS_BRANCH" != "master" ] && [ "$TRAVIS_EVENT_TYPE" == "push" ] && [ -
       echo "No changes in 'fluentd-sumologic.yaml.tmpl'."
   fi
 
-  # # Generate override yaml file for chart dependencies if changes are made to values.yaml file
-  # if [[ $(git diff deploy/helm/sumologic/values.yaml) ]]; then
-  #   echo "Detected changes in 'values.yaml', generating file fluent-bit-overrides.yaml..."
-  #   fluent_bit_start_linenum=`grep -n "fluent-bit:" deploy/helm/sumologic/values.yaml | head -n 1 | cut -d: -f1`
-  #   fluent_bit_start_linenum=$(($fluent_bit_start_linenum + 2))
-  #   fluent_bit_end_linenum=`grep -n "## Configure prometheus-operator" deploy/helm/sumologic/values.yaml | head -n 1 | cut -d: -f1`
-  #   fluent_bit_end_linenum=$(($fluent_bit_end_linenum - 1))
-  #   echo "Copy 'values.yaml' from line $fluent_bit_start_linenum to line $fluent_bit_end_linenum to 'fluent-bit-overrides.yaml'"
-  #   echo "# This file is auto-generated." > deploy/helm/fluent-bit-overrides.yaml
-  #   # Copy lines of fluent-bit section and remove indention from values.yaml
-  #   sed -n "$fluent_bit_start_linenum,${fluent_bit_end_linenum}p" deploy/helm/sumologic/values.yaml | sed 's/  //' >> deploy/helm/fluent-bit-overrides.yaml
-  #   # Remove release name from service name
-  #   sed -i 's/collection-sumologic/fluentd/' deploy/helm/fluent-bit-overrides.yaml
+  # Generate override yaml file for chart dependencies if changes are made to values.yaml file
+  if git diff --name-only $TRAVIS_COMMIT_RANGE | grep -q -i "values.yaml"; then
+    echo "Detected changes in 'values.yaml', generating file fluent-bit-overrides.yaml..."
+    fluent_bit_start_linenum=`grep -n "fluent-bit:" deploy/helm/sumologic/values.yaml | head -n 1 | cut -d: -f1`
+    fluent_bit_start_linenum=$(($fluent_bit_start_linenum + 2))
+    fluent_bit_end_linenum=`grep -n "## Configure prometheus-operator" deploy/helm/sumologic/values.yaml | head -n 1 | cut -d: -f1`
+    fluent_bit_end_linenum=$(($fluent_bit_end_linenum - 1))
+    echo "Copy 'values.yaml' from line $fluent_bit_start_linenum to line $fluent_bit_end_linenum to 'fluent-bit-overrides.yaml'"
+    echo "# This file is auto-generated." > deploy/helm/fluent-bit-overrides.yaml
+    # Copy lines of fluent-bit section and remove indention from values.yaml
+    sed -n "$fluent_bit_start_linenum,${fluent_bit_end_linenum}p" deploy/helm/sumologic/values.yaml | sed 's/  //' >> deploy/helm/fluent-bit-overrides.yaml
+    # Remove release name from service name
+    sed -i 's/collection-sumologic/fluentd/' deploy/helm/fluent-bit-overrides.yaml
 
-  #   echo "Detected changes in 'values.yaml', generating file prometheus-overrides.yaml..."
-  #   prometheus_start_linenum=`grep -n "prometheus-operator:" deploy/helm/sumologic/values.yaml | head -n 1 | cut -d: -f1`
-  #   prometheus_start_linenum=$(($prometheus_start_linenum + 2))
-  #   echo "Copy 'values.yaml' from line $prometheus_start_linenum to end to 'prometheus-overrides.yaml'"
-  #   echo "# This file is auto-generated." > deploy/helm/prometheus-overrides.yaml
-  #   # Copy lines of fluent-bit section and remove indention from values.yaml
-  #   sed -n "$prometheus_start_linenum,$ p" deploy/helm/sumologic/values.yaml | sed 's/  //' >> deploy/helm/prometheus-overrides.yaml
-  #   # Remove release name from service name
-  #   sed -i 's/collection-sumologic/fluentd/' deploy/helm/prometheus-overrides.yaml
-  # else
-  #   echo "No changes in 'values.yaml'."
-  # fi
+    echo "Detected changes in 'values.yaml', generating file prometheus-overrides.yaml..."
+    prometheus_start_linenum=`grep -n "prometheus-operator:" deploy/helm/sumologic/values.yaml | head -n 1 | cut -d: -f1`
+    prometheus_start_linenum=$(($prometheus_start_linenum + 2))
+    echo "Copy 'values.yaml' from line $prometheus_start_linenum to end to 'prometheus-overrides.yaml'"
+    echo "# This file is auto-generated." > deploy/helm/prometheus-overrides.yaml
+    # Copy lines of fluent-bit section and remove indention from values.yaml
+    sed -n "$prometheus_start_linenum,$ p" deploy/helm/sumologic/values.yaml | sed 's/  //' >> deploy/helm/prometheus-overrides.yaml
+    # Remove release name from service name
+    sed -i 's/collection-sumologic/fluentd/' deploy/helm/prometheus-overrides.yaml
+  else
+    echo "No changes in 'values.yaml'."
+  fi
 fi
 
 if [ -n "$DOCKER_PASSWORD" ] && [ -n "$TRAVIS_TAG" ] && [[ $TRAVIS_TAG != *alpha* ]]; then

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -72,7 +72,7 @@ if [ "$TRAVIS_BRANCH" != "master" ] && [ "$TRAVIS_EVENT_TYPE" == "push" ] && [ -
   cd ../../../
 
   with_files=`ls deploy/helm/sumologic/templates/*.yaml | sed 's#deploy/helm/sumologic/templates#-x templates#g' | sed 's/yaml/yaml \\\/g'`
-  eval "helm template deploy/helm/sumologic --namespace "\$NAMESPACE" --set dryRun=true \ $with_files >> deploy/kubernetes/fluentd-sumologic.yaml.tmpl"
+  eval "sudo helm template deploy/helm/sumologic --namespace "\$NAMESPACE" --set dryRun=true \ $with_files >> deploy/kubernetes/fluentd-sumologic.yaml.tmpl"
 
   if [[ $(git diff deploy/kubernetes/fluentd-sumologic.yaml.tmpl) ]]; then
       echo "Detected changes in 'fluentd-sumologic.yaml.tmpl', committing the updated version to $TRAVIS_BRANCH..."

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -66,6 +66,7 @@ ruby deploy/test/test_docker.rb
 if [ "$TRAVIS_BRANCH" != "master" ] && [ "$TRAVIS_EVENT_TYPE" == "push" ] && [ -n "$GITHUB_TOKEN" ]; then
   echo "Generating yaml from helm chart..."
   echo "# This file is auto-generated." > deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+  sudo helm init --client-only
   sudo helm dependency update
   sudo helm template deploy/helm/sumologic --namespace "\$NAMESPACE" --set dryRun=true >> deploy/kubernetes/fluentd-sumologic.yaml.tmpl
 

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -73,7 +73,7 @@ if [ "$TRAVIS_BRANCH" != "master" ] && [ "$TRAVIS_EVENT_TYPE" == "push" ] && [ -
 
   with_files=`ls deploy/helm/sumologic/templates/*.yaml | sed 's#deploy/helm/sumologic/templates#-x templates#g' | sed 's/yaml/yaml \\\/g'`
   echo "$with_files"
-  eval "sudo helm template deploy/helm/sumologic --namespace "\$NAMESPACE" --set dryRun=true \ $with_files >> deploy/kubernetes/fluentd-sumologic.yaml.tmpl"
+  eval 'sudo helm template deploy/helm/sumologic $with_files --namespace "\$NAMESPACE" --set dryRun=true >> deploy/kubernetes/fluentd-sumologic.yaml.tmpl'
 
   if [[ $(git diff deploy/kubernetes/fluentd-sumologic.yaml.tmpl) ]]; then
       echo "Detected changes in 'fluentd-sumologic.yaml.tmpl', committing the updated version to $TRAVIS_BRANCH..."

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -72,6 +72,7 @@ if [ "$TRAVIS_BRANCH" != "master" ] && [ "$TRAVIS_EVENT_TYPE" == "push" ] && [ -
   cd ../../../
 
   with_files=`ls deploy/helm/sumologic/templates/*.yaml | sed 's#deploy/helm/sumologic/templates#-x templates#g' | sed 's/yaml/yaml \\\/g'`
+  echo "$with_files"
   eval "sudo helm template deploy/helm/sumologic --namespace "\$NAMESPACE" --set dryRun=true \ $with_files >> deploy/kubernetes/fluentd-sumologic.yaml.tmpl"
 
   if [[ $(git diff deploy/kubernetes/fluentd-sumologic.yaml.tmpl) ]]; then

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -8,28 +8,18 @@ if [ -n "$TRAVIS_COMMIT_RANGE" ] && [ "$TRAVIS_PULL_REQUEST" == false ] && [ "$T
     fi
   fi
   if git diff --name-only $TRAVIS_COMMIT_RANGE | grep -q -i "fluent-bit-overrides.yaml"; then
-  if git --no-pager show -s --format="%an" . | grep -v -q -i "travis"; then
-      echo "Detected manual changes 'fluent-bit-overrides.yaml', abort."
+    if git --no-pager show -s --format="%an" . | grep -v -q -i "travis"; then
+      echo "Detected manual changes in 'fluent-bit-overrides.yaml', abort."
       exit 1
     fi
   fi
   if git diff --name-only $TRAVIS_COMMIT_RANGE | grep -q -i "prometheus-overrides.yaml"; then
-  if git --no-pager show -s --format="%an" . | grep -v -q -i "travis"; then
-      echo "Detected manual changes 'prometheus-overrides.yaml', abort."
+    if git --no-pager show -s --format="%an" . | grep -v -q -i "travis"; then
+      echo "Detected manual changes in 'prometheus-overrides.yaml', abort."
       exit 1
     fi
   fi
 fi
-
-echo "Detected changes in 'values.yaml', generating file prometheus-overrides.yaml..."
-prometheus_start_linenum=`grep -n "prometheus-operator:" deploy/helm/sumologic/values.yaml | head -n 1 | cut -d: -f1`
-prometheus_start_linenum=$(($prometheus_start_linenum + 2))
-echo "Copy 'values.yaml' from line $prometheus_start_linenum to end to 'prometheus-overrides.yaml'"
-echo "# This file is auto-generated." > deploy/helm/prometheus-overrides.yaml
-# Copy lines of fluent-bit section and remove indention from values.yaml
-sed -n "$prometheus_start_linenum,$ p" deploy/helm/sumologic/values.yaml | sed 's/  //' >> deploy/helm/prometheus-overrides.yaml
-# Remove release names from service names
-sed -i -e 's/collection-sumologic/sumologic/' deploy/helm/prometheus-overrides.yaml
 
 VERSION="${TRAVIS_TAG:-0.0.0}"
 VERSION="${VERSION#v}"
@@ -76,6 +66,7 @@ ruby deploy/test/test_docker.rb
 if [ "$TRAVIS_BRANCH" != "master" ] && [ "$TRAVIS_EVENT_TYPE" == "push" ] && [ -n "$GITHUB_TOKEN" ]; then
   echo "Generating yaml from helm chart..."
   echo "# This file is auto-generated." > deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+  sudo helm dependency update
   sudo helm template deploy/helm/sumologic --namespace "\$NAMESPACE" --set dryRun=true >> deploy/kubernetes/fluentd-sumologic.yaml.tmpl
 
   if [[ $(git diff deploy/kubernetes/fluentd-sumologic.yaml.tmpl) ]]; then
@@ -114,7 +105,7 @@ if [ "$TRAVIS_BRANCH" != "master" ] && [ "$TRAVIS_EVENT_TYPE" == "push" ] && [ -
     # Copy lines of fluent-bit section and remove indention from values.yaml
     sed -n "$prometheus_start_linenum,$ p" deploy/helm/sumologic/values.yaml | sed 's/  //' >> deploy/helm/prometheus-overrides.yaml
     # Remove release name from service name
-    sed -i -e 's/collection-sumologic/sumologic/' deploy/helm/prometheus-overrides.yaml
+    sed -i 's/collection-sumologic/sumologic/' deploy/helm/prometheus-overrides.yaml
   else
     echo "No changes in 'values.yaml'."
   fi

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -204,7 +204,7 @@ fluent-bit:
 
     @INCLUDE fluent-bit-output.conf
 
-## Confugure prometheus-operator 
+## Configure prometheus-operator 
 ## ref: https://github.com/helm/charts/blob/master/stable/prometheus-operator/values.yaml
 prometheus-operator:
   enabled: true

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -117,7 +117,7 @@ fluent-bit:
   backend:
     type: forward
     forward:
-      host: fluentd
+      host: collection-sumologic.sumologic.svc.cluster.local
       port: 24321
       tls: "off"
       tls_verify: "on"
@@ -214,7 +214,7 @@ prometheus-operator:
     enabled: false
   prometheus:
     additionalServiceMonitors:
-      - name: fluentd
+      - name: collection-sumologic
         additionalLabels: 
           k8s-app: fluentd-sumologic
           release: prometheus-operator
@@ -226,7 +226,7 @@ prometheus-operator:
         selector:
             matchLabels:
               k8s-app: fluentd-sumologic
-      - name: fluentd-events
+      - name: collection-sumologic-events
         additionalLabels: 
           k8s-app: fluentd-sumologic-events
           release: prometheus-operator
@@ -244,92 +244,92 @@ prometheus-operator:
         cluster: kubernetes
       remoteWrite:
       # kube state metrics
-      - url: http://fluentd:9888/prometheus.metrics.state.statefulset
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.state.statefulset
         writeRelabelConfigs:
         - action: keep
           regex: kube-state-metrics;kube_statefulset_status_(?:observed_generation|replicas)
           sourceLabels: [job, __name__]
-      - url: http://fluentd:9888/prometheus.metrics.state.statefulset
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.state.statefulset
         writeRelabelConfigs:
         - action: keep
           regex: kube-state-metrics;kube_statefulset_(?:replicas|metadata_generation)
           sourceLabels: [job, __name__]
-      - url: http://fluentd:9888/prometheus.metrics.state.daemonset
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.state.daemonset
         writeRelabelConfigs:
         - action: keep
           regex: kube-state-metrics;kube_daemonset_status_(?:current_number_scheduled|desired_number_scheduled|number_misscheduled|number_unavailable)
           sourceLabels: [job, __name__]
-      - url: http://fluentd:9888/prometheus.metrics.state.daemonset
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.state.daemonset
         writeRelabelConfigs:
         - action: keep
           regex: kube-state-metrics;kube_daemonset_metadata_generation
           sourceLabels: [job, __name__]
-      - url: http://fluentd:9888/prometheus.metrics.state.deployment
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.state.deployment
         writeRelabelConfigs:
         - action: keep
           regex: kube-state-metrics;kube_deployment_(?:metadata_generation|spec_paused|spec_replicas|spec_strategy_rollingupdate_max_unavailable)
           sourceLabels: [job, __name__]
-      - url: http://fluentd:9888/prometheus.metrics.state.deployment
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.state.deployment
         writeRelabelConfigs:
         - action: keep
           regex: kube-state-metrics;kube_deployment_status_(?:replicas_available|observed_generation|replicas_unavailable)
           sourceLabels: [job, __name__]
-      - url: http://fluentd:9888/prometheus.metrics.state.node
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.state.node
         writeRelabelConfigs:
         - action: keep
           regex: kube-state-metrics;kube_node_(?:info|spec_unschedulable|status_allocatable|status_capacity|status_condition)
           sourceLabels: [job, __name__]
-      - url: http://fluentd:9888/prometheus.metrics.state.pod
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.state.pod
         writeRelabelConfigs:
         - action: keep
           regex: kube-state-metrics;kube_pod_container_(?:info|resource_requests|resource_limits|status_ready|status_terminated_reason|status_waiting_reason|status_restarts_total)
           sourceLabels: [job, __name__]
-      - url: http://fluentd:9888/prometheus.metrics.state.pod
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.state.pod
         writeRelabelConfigs:
         - action: keep
           regex: kube-state-metrics;kube_pod_status_phase
           sourceLabels: [job, __name__]
       # controller manager metrics
-      - url: http://fluentd:9888/prometheus.metrics.controller-manager
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.controller-manager
         writeRelabelConfigs:
         - action: keep
           regex: kubelet;cloudprovider_.*_api_request_duration_seconds.*
           sourceLabels: [job, __name__]
       # scheduler metrics
-      - url: http://fluentd:9888/prometheus.metrics.scheduler
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.scheduler
         writeRelabelConfigs:
         - action: keep
           regex: kube-scheduler;scheduler_(?:e2e_scheduling|binding|scheduling_algorithm)_latency_microseconds.*
           sourceLabels: [job, __name__]
       # api server metrics
-      - url: http://fluentd:9888/prometheus.metrics.apiserver
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.apiserver
         writeRelabelConfigs:
         - action: keep
           regex: apiserver;apiserver_request_(?:count|latencies.*)
           sourceLabels: [job, __name__]
-      - url: http://fluentd:9888/prometheus.metrics.apiserver
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.apiserver
         writeRelabelConfigs:
         - action: keep
           regex: apiserver;etcd_request_cache_(?:get|add)_latencies_summary.*
           sourceLabels: [job, __name__]
-      - url: http://fluentd:9888/prometheus.metrics.apiserver
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.apiserver
         writeRelabelConfigs:
         - action: keep
           regex: apiserver;etcd_helper_cache_(?:hit|miss)_count
           sourceLabels: [job, __name__]
       # kubelet metrics
-      - url: http://fluentd:9888/prometheus.metrics.kubelet
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.kubelet
         writeRelabelConfigs:
         - action: keep
           regex: kubelet;kubelet_docker_operations_(?:errors|latency_microseconds.*)
           sourceLabels: [job, __name__]
-      - url: http://fluentd:9888/prometheus.metrics.kubelet
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.kubelet
         writeRelabelConfigs:
         - action: keep
           regex: kubelet;kubelet_(running_container_count|running_pod_count|runtime_operations_latency_microseconds.*)
           sourceLabels: [job, __name__]
       # cadvisor container metrics
-      - url: http://fluentd:9888/prometheus.metrics.container
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.container
         writeRelabelConfigs:
         - action: drop
           regex: POD
@@ -340,7 +340,7 @@ prometheus-operator:
         - action: keep
           regex: kubelet;container_cpu_(?:load_average_10s|(?:system|usage|cfs_throttled)_seconds_total)
           sourceLabels: [job, __name__]
-      - url: http://fluentd:9888/prometheus.metrics.container
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.container
         writeRelabelConfigs:
         - action: drop
           regex: POD
@@ -351,7 +351,7 @@ prometheus-operator:
         - action: keep
           regex: kubelet;container_memory_(?:usage_bytes|swap|working_set_bytes)
           sourceLabels: [job, __name__]
-      - url: http://fluentd:9888/prometheus.metrics.container
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.container
         writeRelabelConfigs:
         - action: drop
           regex: POD
@@ -362,7 +362,7 @@ prometheus-operator:
         - action: keep
           regex: kubelet;container_spec_memory_(?:|swap_|reservation_)limit_bytes
           sourceLabels: [job, __name__]
-      - url: http://fluentd:9888/prometheus.metrics.container
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.container
         writeRelabelConfigs:
         - action: drop
           regex: POD
@@ -373,7 +373,7 @@ prometheus-operator:
         - action: keep
           regex: kubelet;container_spec_cpu_(?:|quota|period)
           sourceLabels: [job, __name__]
-      - url: http://fluentd:9888/prometheus.metrics.container
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.container
         writeRelabelConfigs:
         - action: drop
           regex: POD
@@ -384,7 +384,7 @@ prometheus-operator:
         - action: keep
           regex: kubelet;container_fs_(?:(?:usage|limit)_bytes|(?:reads|writes)_bytes_total)
           sourceLabels: [job, __name__]
-      - url: http://fluentd:9888/prometheus.metrics.container
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.container
         writeRelabelConfigs:
         - action: drop
           regex: POD
@@ -396,117 +396,117 @@ prometheus-operator:
           regex: kubelet;container_network_(?:receive|transmit)_(?:bytes|errors|packets_dropped)_total
           sourceLabels: [job, __name__]
       # node exporter metrics
-      - url: http://fluentd:9888/prometheus.metrics.node
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.node
         writeRelabelConfigs:
         - action: keep
           regex: node-exporter;node_load(?:1|5|15)
           sourceLabels: [job, __name__]
-      - url: http://fluentd:9888/prometheus.metrics.node
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.node
         writeRelabelConfigs:
         - action: keep
           regex: node-exporter;node_cpu_seconds_total
           sourceLabels: [job, __name__]
-      - url: http://fluentd:9888/prometheus.metrics.node
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.node
         writeRelabelConfigs:
         - action: keep
           regex: node-exporter;node_memory_(?:MemAvailable|MemTotal|Buffers|SwapCached|Cached|MemFree|SwapFree)_bytes
           sourceLabels: [job, __name__]
-      - url: http://fluentd:9888/prometheus.metrics.node
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.node
         writeRelabelConfigs:
         - action: keep
           regex: node-exporter;node_ipvs_(?:incoming|outgoing)_(?:bytes|packets)_total
           sourceLabels: [job, __name__]
-      - url: http://fluentd:9888/prometheus.metrics.node
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.node
         writeRelabelConfigs:
         - action: keep
           regex: node-exporter;node_disk_(?:(?:reads|writes)_completed|(?:read|written)_bytes)_total
           sourceLabels: [job, __name__]
-      - url: http://fluentd:9888/prometheus.metrics.node
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.node
         writeRelabelConfigs:
         - action: keep
           regex: node-exporter;node_filesystem_(?:avail|free|size)_bytes
           sourceLabels: [job, __name__]
-      - url: http://fluentd:9888/prometheus.metrics.node
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.node
         writeRelabelConfigs:
         - action: keep
           regex: node-exporter;node_filesystem_(?:files)
           sourceLabels: [job, __name__]
       # prometheus operator rules
-      - url: http://fluentd:9888/prometheus.metrics.operator.rule
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.operator.rule
         writeRelabelConfigs:
         - action: keep
           regex: apiserver;cluster_quantile:apiserver_request_latencies:histogram_quantile
           sourceLabels: [job, __name__]
-      - url: http://fluentd:9888/prometheus.metrics.operator.rule
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.operator.rule
         writeRelabelConfigs:
         - action: keep
           regex: instance:node_(?:cpu|filesystem_usage|network_receive_bytes|node_network_transmit_bytes):rate:sum
           sourceLabels: [__name__]
-      - url: http://fluentd:9888/prometheus.metrics.operator.rule
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.operator.rule
         writeRelabelConfigs:
         - action: keep
           regex: instance:node_cpu:ratio|cluster:node_cpu:sum_rate5m|cluster:node_cpu:ratio
           sourceLabels: [__name__]
-      - url: http://fluentd:9888/prometheus.metrics.operator.rule
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.operator.rule
         writeRelabelConfigs:
         - action: keep
           regex: cluster_quantile:scheduler_(?:e2e_scheduling|scheduling_algorithm|binding)_latency:histogram_quantile
           sourceLabels: [__name__]
-      - url: http://fluentd:9888/prometheus.metrics.operator.rule
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.operator.rule
         writeRelabelConfigs:
         - action: keep
           regex: 'node_namespace_pod:kube_pod_info:|:kube_pod_info_node_count:'
           sourceLabels: [__name__]
-      - url: http://fluentd:9888/prometheus.metrics.operator.rule
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.operator.rule
         writeRelabelConfigs:
         - action: keep
           regex: 'node:node_num_cpu:sum|:node_cpu_utilisation:avg1m|node:node_cpu_utilisation:avg1m|node:cluster_cpu_utilisation:ratio|:node_cpu_saturation_load1:|node:node_cpu_saturation_load1:'
           sourceLabels: [__name__]
-      - url: http://fluentd:9888/prometheus.metrics.operator.rule
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.operator.rule
         writeRelabelConfigs:
         - action: keep
           regex: ':node_memory_utilisation:|:node_memory_MemFreeCachedBuffers_bytes:sum|:node_memory_MemTotal_bytes:sum|node:node_memory_bytes_available:sum|node:node_memory_bytes_total:sum|node:node_memory_utilisation:ratio|node:cluster_memory_utilisation:ratio|:node_memory_swap_io_bytes:sum_rate|node:node_memory_utilisation:|node:node_memory_utilisation_2:|node:node_memory_swap_io_bytes:sum_rate'
           sourceLabels: [__name__]
-      - url: http://fluentd:9888/prometheus.metrics.operator.rule
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.operator.rule
         writeRelabelConfigs:
         - action: keep
           regex: ':node_disk_utilisation:avg_irate|node:node_disk_utilisation:avg_irate|:node_disk_saturation:avg_irate|node:node_disk_saturation:avg_irate'
           sourceLabels: [__name__]
-      - url: http://fluentd:9888/prometheus.metrics.operator.rule
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.operator.rule
         writeRelabelConfigs:
         - action: keep
           regex: 'node:node_filesystem_usage:|node:node_filesystem_avail:'
           sourceLabels: [__name__]
-      - url: http://fluentd:9888/prometheus.metrics.operator.rule
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.operator.rule
         writeRelabelConfigs:
         - action: keep
           regex: ':node_net_utilisation:sum_irate|node:node_net_utilisation:sum_irate|:node_net_saturation:sum_irate|node:node_net_saturation:sum_irate'
           sourceLabels: [__name__]
-      - url: http://fluentd:9888/prometheus.metrics.operator.rule
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.operator.rule
         writeRelabelConfigs:
         - action: keep
           regex: 'node:node_inodes_total:|node:node_inodes_free:'
           sourceLabels: [__name__]
       # up metrics
-      - url: http://fluentd:9888/prometheus.metrics
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics
         writeRelabelConfigs:
         - action: keep
           regex: up
           sourceLabels: [__name__]
       # prometheus remote write metrics
-      - url: http://fluentd:9888/prometheus.metrics
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics
         writeRelabelConfigs:
         - action: keep
           regex: 'prometheus_remote_storage_.*'
           sourceLabels: [__name__]
       # fluentd metrics
-      - url: http://fluentd:9888/prometheus.metrics
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics
         writeRelabelConfigs:
           - action: keep
             regex: 'fluentd_.*'
             sourceLabels: [__name__]
       # fluent-bit metrics
-      - url: http://fluentd:9888/prometheus.metrics
+      - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics
         writeRelabelConfigs:
           - action: keep
             regex: 'fluentbit.*'


### PR DESCRIPTION
###### Description

After adding dependencies into our helm chart, `helm template` will render not only our own yaml templates but also the yaml templates from all of the dependent charts. To render only our templates, we use the `-x` option for each .yaml file under `sumologic/templates` folder in the `helm template` command.

###### Testing performed

- [x] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
