### PR TITLE
Fix labels for k8s health check metrics and use versioned overrides yaml files

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -224,7 +224,7 @@ This manifest binds the default `cluster-admin` ClusterRole in your Kubernetes c
 Download the Prometheus Operator `prometheus-overrides.yaml` from GitHub:
 
 ```sh
-curl -LJO https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/master/deploy/helm/prometheus-overrides.yaml
+curl -LJO https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.1.0/deploy/helm/prometheus-overrides.yaml
 ```
 
 Before installing `prometheus-operator`, edit `prometheus-overrides.yaml` to define a unique cluster identifier. The default value of the `cluster` field in the `externalLabels` section of `prometheus-overrides.yaml` is `kubernetes`. If you will be deploying the metric collection solution on multiple Kubernetes clusters, you will want to use a unique identifier for each. For example, you might use “Dev”, “Prod”, and so on.
@@ -393,7 +393,7 @@ In this step, you will deploy FluentBit to forward logs to Fluentd.
 Download the FluentBit `fluent-bit-overrides.yaml` from GitHub:
 
 ```sh
-curl -LJO https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/master/deploy/helm/fluent-bit-overrides.yaml
+curl -LJO https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.1.0/deploy/helm/fluent-bit-overrides.yaml
 ```
 
 Install `fluent-bit` using Helm:

--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -7,7 +7,7 @@ prometheus:
   additionalServiceMonitors:
     - name: fluentd
       additionalLabels: 
-        k8s-app: fluentd-sumologic
+        app: sumologic
         release: prometheus-operator
       endpoints:
       - port: metrics
@@ -16,10 +16,10 @@ prometheus:
         - sumologic
       selector:
           matchLabels:
-            k8s-app: fluentd-sumologic
+            app: sumologic
     - name: fluentd-events
       additionalLabels: 
-        k8s-app: fluentd-sumologic-events
+        app: sumologic-events
         release: prometheus-operator
       endpoints:
       - port: metrics
@@ -28,7 +28,7 @@ prometheus:
         - sumologic
       selector:
           matchLabels:
-            k8s-app: fluentd-sumologic-events
+            app: sumologic-events
   prometheusSpec:
     externalLabels:
       # Set this to a value to distinguish between different k8s clusters

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -222,7 +222,7 @@ prometheus-operator:
     additionalServiceMonitors:
       - name: collection-sumologic
         additionalLabels: 
-          k8s-app: fluentd-sumologic
+          app: sumologic
           release: prometheus-operator
         endpoints:
         - port: metrics
@@ -231,10 +231,10 @@ prometheus-operator:
           - sumologic
         selector:
             matchLabels:
-              k8s-app: fluentd-sumologic
+              app: sumologic
       - name: collection-sumologic-events
         additionalLabels: 
-          k8s-app: fluentd-sumologic-events
+          app: sumologic-events
           release: prometheus-operator
         endpoints:
         - port: metrics
@@ -243,7 +243,7 @@ prometheus-operator:
           - sumologic
         selector:
             matchLabels:
-              k8s-app: fluentd-sumologic-events
+              app: sumologic-events
     prometheusSpec:
       externalLabels:
         # Set this to a value to distinguish between different k8s clusters


### PR DESCRIPTION
###### Description

Health check metrics are broken because the values.yaml contains the old labels "k8s-app=fluentd-sumologic". If we change it, we also need to update the README to instruct users to download versioned overrides yamls. I don't think manually updating the version in the URLs is scalable but I also don't know if just telling users to change the URL with the latest version is sufficient?

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
