### PR TITLE
Remove symlinks to legacy helm override files

### DIFF
--- a/deploy/fluent-bit/overrides.yaml
+++ b/deploy/fluent-bit/overrides.yaml
@@ -1,1 +1,0 @@
-../helm/fluent-bit-overrides.yaml

--- a/deploy/helm/overrides.yaml
+++ b/deploy/helm/overrides.yaml
@@ -1,1 +1,0 @@
-prometheus-overrides.yaml


### PR DESCRIPTION
###### Description

We previously added these symlinks for old versions of the setup script that downloaded the resources directly, but since Github doesn't actually resolve the symlink (they would only get the filename as the contents of the symlink), we might as well clean these up.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
