### PR TITLE
Get rid of unstaged changes before switching to gh-pages branch

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -141,6 +141,7 @@ if [ -n "$DOCKER_PASSWORD" ] && [ -n "$TRAVIS_TAG" ] && [[ $TRAVIS_TAG != *alpha
   docker push $DOCKER_TAG:$VERSION
 
   # Push new helm release
+  git checkout -- .
   sudo helm init --client-only
   sudo helm package deploy/helm/sumologic --version=$VERSION
   git fetch origin-repo


### PR DESCRIPTION
###### Description

Fix for broken Travis build on new release https://travis-ci.org/SumoLogic/sumologic-kubernetes-collection/builds/578495759#L1778

`git checkout -- .` should throw away the gemspec changes.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
