### PR TITLE
Drop labels with empty values

### DIFF
--- a/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
@@ -93,6 +93,8 @@ module Fluent
               end
             end
           end
+
+          record['kubernetes']['labels'].select!{|k,v| !(v.nil? || v.empty?)} if @data_type == 'logs'
         end
       end
 


### PR DESCRIPTION
###### Description

Sumo backend can't accept fields with empty values, so we drop those pod labels with empty values here

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
- [x] Confirm logs with pod labels with empty values get those labels removed
