### PR TITLE
fix labels, disable Fluent-Bit Helm Chart serviceMonitor, use Prometheus Operator additionalServiceMonitors to work around expectation that Prometheus Operator is already installed.

### DIFF
--- a/deploy/helm/fluent-bit-overrides.yaml
+++ b/deploy/helm/fluent-bit-overrides.yaml
@@ -1,10 +1,6 @@
 # This file is auto-generated.
 metrics:
   enabled: true
-  serviceMonitor:
-    enabled: true
-    additionalLabels:
-      release: prometheus-operator
 backend:
   type: forward
   forward:

--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -6,29 +6,43 @@ grafana:
 prometheus:
   additionalServiceMonitors:
     - name: fluentd
-      additionalLabels: 
+      additionalLabels:
         app: sumologic
-        release: prometheus-operator
+        release: collection
       endpoints:
       - port: metrics
       namespaceSelector:
         matchNames:
         - sumologic
       selector:
-          matchLabels:
-            app: sumologic
+        matchLabels:
+          app: fluentd
     - name: fluentd-events
-      additionalLabels: 
+      additionalLabels:
         app: sumologic-events
-        release: prometheus-operator
+        release: collection
       endpoints:
-      - port: metrics
+        - port: metrics
       namespaceSelector:
         matchNames:
-        - sumologic
+          - sumologic
       selector:
-          matchLabels:
-            app: sumologic-events
+        matchLabels:
+          app: fluentd-events
+    - name: collection-fluent-bit
+      additionalLabels:
+        app: fluent-bit
+        release: collection
+      endpoints:
+        - port: metrics
+          path: /api/v1/metrics/prometheus
+      namespaceSelector:
+        matchNames:
+          - sumologic
+      selector:
+        matchLabels:
+          app: fluent-bit
+          release: collection
   prometheusSpec:
     externalLabels:
       # Set this to a value to distinguish between different k8s clusters

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -25,6 +25,7 @@ eventsDeployment:
       memory: 256Mi
       cpu: "100m"
 
+
 sumologic:
 
   ## Format to post logs into Sumo. json, json_merge, or text

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -8,7 +8,7 @@ fullnameOverride: ""
 
 deployment:
   replicaCount: 3
-  resources: 
+  resources:
     limits:
       memory: 1Gi
       cpu: 1
@@ -17,7 +17,7 @@ deployment:
       cpu: 0.5
 
 eventsDeployment:
-  resources: 
+  resources:
     limits:
       memory: 256Mi
       cpu: "100m"
@@ -33,20 +33,20 @@ sumologic:
   ## How frequently to push logs to SumoLogic
   ## ref: https://github.com/SumoLogic/fluentd-kubernetes-sumologic#options
   flushInterval: "5s"
-  
+
   ## Increase number of http threads to Sumo. May be required in heavy logging clusters
   numThreads: 4
 
   chunkLimitSize: "100k"
-  
+
   totalLimitSize: "128m"
-  
+
   ## Set the _sourceName metadata field in SumoLogic.
   sourceName: "%{namespace}.%{pod}.%{container}"
 
   ## Set the _sourceCategory metadata field in SumoLogic.
   sourceCategory: "%{namespace}/%{pod_name}"
-  
+
   ## Set the prefix, for _sourceCategory metadata.
   sourceCategoryPrefix: "kubernetes/"
 
@@ -60,7 +60,7 @@ sumologic:
   ## Reduces redundant Kubernetes metadata. 
   ## ref: https://github.com/SumoLogic/fluentd-kubernetes-sumologic#reducing-kubernetes-metadata
   kubernetesMetaReduce: "false"
-  
+
   ## The regular expression for the "concat" plugin to use when merging multi-line messages
   multilineStartRegexp: '/^\w{3} \d{1,2}, \d{4}/'
 
@@ -116,10 +116,6 @@ fluent-bit:
   enabled: true
   metrics:
     enabled: true
-    serviceMonitor:
-      enabled: true
-      additionalLabels:
-        release: prometheus-operator
   backend:
     type: forward
     forward:
@@ -210,7 +206,7 @@ fluent-bit:
 
     @INCLUDE fluent-bit-output.conf
 
-## Configure prometheus-operator 
+## Configure prometheus-operator
 ## ref: https://github.com/helm/charts/blob/master/stable/prometheus-operator/values.yaml
 prometheus-operator:
   enabled: true
@@ -221,29 +217,43 @@ prometheus-operator:
   prometheus:
     additionalServiceMonitors:
       - name: collection-sumologic
-        additionalLabels: 
+        additionalLabels:
           app: sumologic
-          release: prometheus-operator
+          release: collection
         endpoints:
         - port: metrics
         namespaceSelector:
           matchNames:
           - sumologic
         selector:
-            matchLabels:
-              app: sumologic
+          matchLabels:
+            app: collection-sumologic
       - name: collection-sumologic-events
-        additionalLabels: 
+        additionalLabels:
           app: sumologic-events
-          release: prometheus-operator
+          release: collection
         endpoints:
-        - port: metrics
+          - port: metrics
         namespaceSelector:
           matchNames:
-          - sumologic
+            - sumologic
         selector:
-            matchLabels:
-              app: sumologic-events
+          matchLabels:
+            app: collection-sumologic-events
+      - name: collection-fluent-bit
+        additionalLabels:
+          app: fluent-bit
+          release: collection
+        endpoints:
+          - port: metrics
+            path: /api/v1/metrics/prometheus
+        namespaceSelector:
+          matchNames:
+            - sumologic
+        selector:
+          matchLabels:
+            app: fluent-bit
+            release: collection
     prometheusSpec:
       externalLabels:
         # Set this to a value to distinguish between different k8s clusters

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -25,7 +25,6 @@ eventsDeployment:
       memory: 256Mi
       cpu: "100m"
 
-
 sumologic:
 
   ## Format to post logs into Sumo. json, json_merge, or text


### PR DESCRIPTION
fix labels, disable Fluent-Bit Helm Chart serviceMonitor, use Prometheus Operator additionalServiceMonitors to work around expectation that Prometheus Operator is already installed.