### PR TITLE
SUMO-117261: Skip using TRAVIS_COMMIT_RANGE for yaml detection

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ "$TRAVIS_PULL_REQUEST" == false ] && [ "$TRAVIS_BRANCH" != "master" ] && [ "$TRAVIS_EVENT_TYPE" == "push" ]; then
-  changes=`git diff master...$TRAVIS_BRANCH | grep -i "fluentd-sumologic.yaml.tmpl\|fluent-bit-overrides.yaml\|prometheus-overrides.yaml\|falco-overrides.yaml"`
+  changes=`git diff master...$TRAVIS_BRANCH --name-only | grep -i "fluentd-sumologic.yaml.tmpl\|fluent-bit-overrides.yaml\|prometheus-overrides.yaml\|falco-overrides.yaml"`
   if [ -n "$changes" ]; then
     if git --no-pager show -s --format="%an" . | grep -v -q -i "travis"; then
       echo "Aborting due to manual changes detected in the following generated files: $changes"


### PR DESCRIPTION
###### Description

Recommend using "Hide whitespace changes" since most of this is just indent change.

Rather than using  `TRAVIS_COMMIT_RANGE` which is empty on initial commit, we can `git diff master...$TRAVIS_BRANCH` to detect manual changes to the yaml files.

Rather than checking for changes made to `values.yaml`, we can always generate the new files and commit them if there is a difference.

###### Testing performed

- [x] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
- [x] Tested initial commit with no yaml changes
- [x] Tested initial commit with changes in values.yaml for our template as well as overrides
- [x] Tested initial commit incorrectly making changes to overrides and ensure it failed
