### PR TITLE
Fix Helm template naming in yaml files

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -77,7 +77,7 @@ if [ "$TRAVIS_BRANCH" != "master" ] && [ "$TRAVIS_EVENT_TYPE" == "push" ] && [ -
   cd ../../../
 
   with_files=`ls deploy/helm/sumologic/templates/*.yaml | sed 's#deploy/helm/sumologic/templates#-x templates#g' | sed 's/yaml/yaml \\\/g'`
-  eval 'sudo helm template deploy/helm/sumologic $with_files --namespace "\$NAMESPACE" --set dryRun=true >> deploy/kubernetes/fluentd-sumologic.yaml.tmpl'
+  eval 'sudo helm template deploy/helm/sumologic $with_files --namespace "\$NAMESPACE" --name collection --set dryRun=true >> deploy/kubernetes/fluentd-sumologic.yaml.tmpl'
 
   if [[ $(git diff deploy/kubernetes/fluentd-sumologic.yaml.tmpl) ]]; then
       echo "Detected changes in 'fluentd-sumologic.yaml.tmpl', committing the updated version to $TRAVIS_BRANCH..."
@@ -100,8 +100,6 @@ if [ "$TRAVIS_BRANCH" != "master" ] && [ "$TRAVIS_EVENT_TYPE" == "push" ] && [ -
   echo "# This file is auto-generated." > deploy/helm/fluent-bit-overrides.yaml
   # Copy lines of fluent-bit section and remove indention from values.yaml
   sed -n "$fluent_bit_start,${fluent_bit_end}p" deploy/helm/sumologic/values.yaml | sed 's/  //' >> deploy/helm/fluent-bit-overrides.yaml
-  # Remove release name from service name
-  sed -i 's/collection-sumologic/fluentd/' deploy/helm/fluent-bit-overrides.yaml
 
   prometheus_start=`grep -n "prometheus-operator:" deploy/helm/sumologic/values.yaml | head -n 1 | cut -d: -f1`
   prometheus_start=$(($prometheus_start + 2))
@@ -112,8 +110,6 @@ if [ "$TRAVIS_BRANCH" != "master" ] && [ "$TRAVIS_EVENT_TYPE" == "push" ] && [ -
   echo "# This file is auto-generated." > deploy/helm/prometheus-overrides.yaml
   # Copy lines of prometheus-operator section and remove indention from values.yaml
   sed -n "$prometheus_start,${prometheus_end}p" deploy/helm/sumologic/values.yaml | sed 's/  //' >> deploy/helm/prometheus-overrides.yaml
-  # Remove release name from service name
-  sed -i 's/collection-sumologic/fluentd/' deploy/helm/prometheus-overrides.yaml
 
   falco_start=`grep -n "falco:" deploy/helm/sumologic/values.yaml | head -n 1 | cut -d: -f1`
   falco_start=$(($falco_start + 2))

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -232,7 +232,7 @@ Before installing `prometheus-operator`, edit `prometheus-overrides.yaml` to def
 
 __NOTE__ It’s fine to change the value of the `cluster` field, but don’t change the field name (key).
 
-__NOTE__ If you plan to install Prometheus in a different namespace than you deployed FluentD to in Step 1, or you have an existing Prometheus you plan to apply our configuration to running in a different namespace,  please update the remote write API configuration to use the full service url. e.g. `http://fluentd.sumologic.svc.cluster.local:9888`.
+__NOTE__ If you plan to install Prometheus in a different namespace than you deployed FluentD to in Step 1, or you have an existing Prometheus you plan to apply our configuration to running in a different namespace,  please update the remote write API configuration to use the full service url. e.g. `http://collection-sumologic.sumologic.svc.cluster.local:9888`.
 
 You can also [Filter metrics](#filter-metrics) and [Trim and relabel metrics](#trim-and-relabel-metrics) in `prometheus-overrides.yaml`.
 

--- a/deploy/helm/fluent-bit-overrides.yaml
+++ b/deploy/helm/fluent-bit-overrides.yaml
@@ -4,7 +4,7 @@ metrics:
 backend:
   type: forward
   forward:
-    host: fluentd.sumologic.svc.cluster.local
+    host: collection-sumologic.sumologic.svc.cluster.local
     port: 24321
     tls: "off"
     tls_verify: "on"

--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -5,10 +5,9 @@ grafana:
   enabled: false
 prometheus:
   additionalServiceMonitors:
-    - name: fluentd
+    - name: collection-sumologic
       additionalLabels:
-        app: sumologic
-        release: collection
+        app: collection-sumologic
       endpoints:
       - port: metrics
       namespaceSelector:
@@ -16,11 +15,10 @@ prometheus:
         - sumologic
       selector:
         matchLabels:
-          app: fluentd
-    - name: fluentd-events
+          app: collection-sumologic
+    - name: collection-sumologic-events
       additionalLabels:
-        app: sumologic-events
-        release: collection
+        app: collection-sumologic-events
       endpoints:
         - port: metrics
       namespaceSelector:
@@ -28,11 +26,10 @@ prometheus:
           - sumologic
       selector:
         matchLabels:
-          app: fluentd-events
+          app: collection-sumologic-events
     - name: collection-fluent-bit
       additionalLabels:
-        app: fluent-bit
-        release: collection
+        app: collection-fluent-bit
       endpoints:
         - port: metrics
           path: /api/v1/metrics/prometheus
@@ -42,99 +39,98 @@ prometheus:
       selector:
         matchLabels:
           app: fluent-bit
-          release: collection
   prometheusSpec:
     externalLabels:
       # Set this to a value to distinguish between different k8s clusters
       cluster: kubernetes
     remoteWrite:
     # kube state metrics
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.state.statefulset
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.state.statefulset
       writeRelabelConfigs:
       - action: keep
         regex: kube-state-metrics;kube_statefulset_status_(?:observed_generation|replicas)
         sourceLabels: [job, __name__]
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.state.statefulset
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.state.statefulset
       writeRelabelConfigs:
       - action: keep
         regex: kube-state-metrics;kube_statefulset_(?:replicas|metadata_generation)
         sourceLabels: [job, __name__]
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.state.daemonset
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.state.daemonset
       writeRelabelConfigs:
       - action: keep
         regex: kube-state-metrics;kube_daemonset_status_(?:current_number_scheduled|desired_number_scheduled|number_misscheduled|number_unavailable)
         sourceLabels: [job, __name__]
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.state.daemonset
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.state.daemonset
       writeRelabelConfigs:
       - action: keep
         regex: kube-state-metrics;kube_daemonset_metadata_generation
         sourceLabels: [job, __name__]
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.state.deployment
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.state.deployment
       writeRelabelConfigs:
       - action: keep
         regex: kube-state-metrics;kube_deployment_(?:metadata_generation|spec_paused|spec_replicas|spec_strategy_rollingupdate_max_unavailable)
         sourceLabels: [job, __name__]
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.state.deployment
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.state.deployment
       writeRelabelConfigs:
       - action: keep
         regex: kube-state-metrics;kube_deployment_status_(?:replicas_available|observed_generation|replicas_unavailable)
         sourceLabels: [job, __name__]
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.state.node
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.state.node
       writeRelabelConfigs:
       - action: keep
         regex: kube-state-metrics;kube_node_(?:info|spec_unschedulable|status_allocatable|status_capacity|status_condition)
         sourceLabels: [job, __name__]
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.state.pod
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.state.pod
       writeRelabelConfigs:
       - action: keep
         regex: kube-state-metrics;kube_pod_container_(?:info|resource_requests|resource_limits|status_ready|status_terminated_reason|status_waiting_reason|status_restarts_total)
         sourceLabels: [job, __name__]
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.state.pod
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.state.pod
       writeRelabelConfigs:
       - action: keep
         regex: kube-state-metrics;kube_pod_status_phase
         sourceLabels: [job, __name__]
     # controller manager metrics
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.controller-manager
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.controller-manager
       writeRelabelConfigs:
       - action: keep
         regex: kubelet;cloudprovider_.*_api_request_duration_seconds.*
         sourceLabels: [job, __name__]
     # scheduler metrics
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.scheduler
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.scheduler
       writeRelabelConfigs:
       - action: keep
         regex: kube-scheduler;scheduler_(?:e2e_scheduling|binding|scheduling_algorithm)_latency_microseconds.*
         sourceLabels: [job, __name__]
     # api server metrics
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.apiserver
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.apiserver
       writeRelabelConfigs:
       - action: keep
         regex: apiserver;apiserver_request_(?:count|latencies.*)
         sourceLabels: [job, __name__]
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.apiserver
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.apiserver
       writeRelabelConfigs:
       - action: keep
         regex: apiserver;etcd_request_cache_(?:get|add)_latencies_summary.*
         sourceLabels: [job, __name__]
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.apiserver
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.apiserver
       writeRelabelConfigs:
       - action: keep
         regex: apiserver;etcd_helper_cache_(?:hit|miss)_count
         sourceLabels: [job, __name__]
     # kubelet metrics
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.kubelet
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.kubelet
       writeRelabelConfigs:
       - action: keep
         regex: kubelet;kubelet_docker_operations_(?:errors|latency_microseconds.*)
         sourceLabels: [job, __name__]
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.kubelet
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.kubelet
       writeRelabelConfigs:
       - action: keep
         regex: kubelet;kubelet_(running_container_count|running_pod_count|runtime_operations_latency_microseconds.*)
         sourceLabels: [job, __name__]
     # cadvisor container metrics
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.container
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.container
       writeRelabelConfigs:
       - action: drop
         regex: POD
@@ -145,7 +141,7 @@ prometheus:
       - action: keep
         regex: kubelet;container_cpu_(?:load_average_10s|(?:system|usage|cfs_throttled)_seconds_total)
         sourceLabels: [job, __name__]
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.container
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.container
       writeRelabelConfigs:
       - action: drop
         regex: POD
@@ -156,7 +152,7 @@ prometheus:
       - action: keep
         regex: kubelet;container_memory_(?:usage_bytes|swap|working_set_bytes)
         sourceLabels: [job, __name__]
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.container
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.container
       writeRelabelConfigs:
       - action: drop
         regex: POD
@@ -167,7 +163,7 @@ prometheus:
       - action: keep
         regex: kubelet;container_spec_memory_(?:|swap_|reservation_)limit_bytes
         sourceLabels: [job, __name__]
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.container
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.container
       writeRelabelConfigs:
       - action: drop
         regex: POD
@@ -178,7 +174,7 @@ prometheus:
       - action: keep
         regex: kubelet;container_spec_cpu_(?:|quota|period)
         sourceLabels: [job, __name__]
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.container
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.container
       writeRelabelConfigs:
       - action: drop
         regex: POD
@@ -189,7 +185,7 @@ prometheus:
       - action: keep
         regex: kubelet;container_fs_(?:(?:usage|limit)_bytes|(?:reads|writes)_bytes_total)
         sourceLabels: [job, __name__]
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.container
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.container
       writeRelabelConfigs:
       - action: drop
         regex: POD
@@ -201,117 +197,117 @@ prometheus:
         regex: kubelet;container_network_(?:receive|transmit)_(?:bytes|errors|packets_dropped)_total
         sourceLabels: [job, __name__]
     # node exporter metrics
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.node
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.node
       writeRelabelConfigs:
       - action: keep
         regex: node-exporter;node_load(?:1|5|15)
         sourceLabels: [job, __name__]
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.node
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.node
       writeRelabelConfigs:
       - action: keep
         regex: node-exporter;node_cpu_seconds_total
         sourceLabels: [job, __name__]
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.node
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.node
       writeRelabelConfigs:
       - action: keep
         regex: node-exporter;node_memory_(?:MemAvailable|MemTotal|Buffers|SwapCached|Cached|MemFree|SwapFree)_bytes
         sourceLabels: [job, __name__]
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.node
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.node
       writeRelabelConfigs:
       - action: keep
         regex: node-exporter;node_ipvs_(?:incoming|outgoing)_(?:bytes|packets)_total
         sourceLabels: [job, __name__]
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.node
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.node
       writeRelabelConfigs:
       - action: keep
         regex: node-exporter;node_disk_(?:(?:reads|writes)_completed|(?:read|written)_bytes)_total
         sourceLabels: [job, __name__]
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.node
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.node
       writeRelabelConfigs:
       - action: keep
         regex: node-exporter;node_filesystem_(?:avail|free|size)_bytes
         sourceLabels: [job, __name__]
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.node
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.node
       writeRelabelConfigs:
       - action: keep
         regex: node-exporter;node_filesystem_(?:files)
         sourceLabels: [job, __name__]
     # prometheus operator rules
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.operator.rule
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.operator.rule
       writeRelabelConfigs:
       - action: keep
         regex: apiserver;cluster_quantile:apiserver_request_latencies:histogram_quantile
         sourceLabels: [job, __name__]
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.operator.rule
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.operator.rule
       writeRelabelConfigs:
       - action: keep
         regex: instance:node_(?:cpu|filesystem_usage|network_receive_bytes|node_network_transmit_bytes):rate:sum
         sourceLabels: [__name__]
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.operator.rule
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.operator.rule
       writeRelabelConfigs:
       - action: keep
         regex: instance:node_cpu:ratio|cluster:node_cpu:sum_rate5m|cluster:node_cpu:ratio
         sourceLabels: [__name__]
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.operator.rule
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.operator.rule
       writeRelabelConfigs:
       - action: keep
         regex: cluster_quantile:scheduler_(?:e2e_scheduling|scheduling_algorithm|binding)_latency:histogram_quantile
         sourceLabels: [__name__]
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.operator.rule
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.operator.rule
       writeRelabelConfigs:
       - action: keep
         regex: 'node_namespace_pod:kube_pod_info:|:kube_pod_info_node_count:'
         sourceLabels: [__name__]
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.operator.rule
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.operator.rule
       writeRelabelConfigs:
       - action: keep
         regex: 'node:node_num_cpu:sum|:node_cpu_utilisation:avg1m|node:node_cpu_utilisation:avg1m|node:cluster_cpu_utilisation:ratio|:node_cpu_saturation_load1:|node:node_cpu_saturation_load1:'
         sourceLabels: [__name__]
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.operator.rule
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.operator.rule
       writeRelabelConfigs:
       - action: keep
         regex: ':node_memory_utilisation:|:node_memory_MemFreeCachedBuffers_bytes:sum|:node_memory_MemTotal_bytes:sum|node:node_memory_bytes_available:sum|node:node_memory_bytes_total:sum|node:node_memory_utilisation:ratio|node:cluster_memory_utilisation:ratio|:node_memory_swap_io_bytes:sum_rate|node:node_memory_utilisation:|node:node_memory_utilisation_2:|node:node_memory_swap_io_bytes:sum_rate'
         sourceLabels: [__name__]
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.operator.rule
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.operator.rule
       writeRelabelConfigs:
       - action: keep
         regex: ':node_disk_utilisation:avg_irate|node:node_disk_utilisation:avg_irate|:node_disk_saturation:avg_irate|node:node_disk_saturation:avg_irate'
         sourceLabels: [__name__]
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.operator.rule
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.operator.rule
       writeRelabelConfigs:
       - action: keep
         regex: 'node:node_filesystem_usage:|node:node_filesystem_avail:'
         sourceLabels: [__name__]
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.operator.rule
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.operator.rule
       writeRelabelConfigs:
       - action: keep
         regex: ':node_net_utilisation:sum_irate|node:node_net_utilisation:sum_irate|:node_net_saturation:sum_irate|node:node_net_saturation:sum_irate'
         sourceLabels: [__name__]
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics.operator.rule
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.operator.rule
       writeRelabelConfigs:
       - action: keep
         regex: 'node:node_inodes_total:|node:node_inodes_free:'
         sourceLabels: [__name__]
     # up metrics
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics
       writeRelabelConfigs:
       - action: keep
         regex: up
         sourceLabels: [__name__]
     # prometheus remote write metrics
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics
       writeRelabelConfigs:
       - action: keep
         regex: 'prometheus_remote_storage_.*'
         sourceLabels: [__name__]
     # fluentd metrics
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics
       writeRelabelConfigs:
         - action: keep
           regex: 'fluentd_.*'
           sourceLabels: [__name__]
     # fluent-bit metrics
-    - url: http://fluentd.sumologic.svc.cluster.local:9888/prometheus.metrics
+    - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics
       writeRelabelConfigs:
         - action: keep
           regex: 'fluentbit.*'

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -9,30 +9,24 @@ Expand the name of the chart.
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If dryRun=true, we use fixed value "fluentd".
 */}}
 {{- define "sumologic.fullname" -}}
-{{- if .Values.dryRun }}
-{{- printf "fluentd" }}
-{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end -}}
 {{- end -}}
 
 {{/*
 Create default fully qualified labels.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If dryRun=true, we use the Chart name "sumologic" and do not include labels specific to Helm.
 */}}
 {{- define "sumologic.labels.app" -}}
-{{- if .Values.dryRun }}
-{{- template "sumologic.name" . }}
-{{- else -}}
 {{- template "sumologic.fullname" . }}
 {{- end -}}
-{{- end -}}
 
+{{/*
+Create common labels used throughout the chart.
+If dryRun=true, we do not create any chart labels.
+*/}}
 {{- define "sumologic.labels.common" -}}
 {{- if .Values.dryRun -}}
 {{- else -}}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -218,8 +218,7 @@ prometheus-operator:
     additionalServiceMonitors:
       - name: collection-sumologic
         additionalLabels:
-          app: sumologic
-          release: collection
+          app: collection-sumologic
         endpoints:
         - port: metrics
         namespaceSelector:
@@ -230,8 +229,7 @@ prometheus-operator:
             app: collection-sumologic
       - name: collection-sumologic-events
         additionalLabels:
-          app: sumologic-events
-          release: collection
+          app: collection-sumologic-events
         endpoints:
           - port: metrics
         namespaceSelector:
@@ -242,8 +240,7 @@ prometheus-operator:
             app: collection-sumologic-events
       - name: collection-fluent-bit
         additionalLabels:
-          app: fluent-bit
-          release: collection
+          app: collection-fluent-bit
         endpoints:
           - port: metrics
             path: /api/v1/metrics/prometheus
@@ -253,7 +250,6 @@ prometheus-operator:
         selector:
           matchLabels:
             app: fluent-bit
-            release: collection
     prometheusSpec:
       externalLabels:
         # Set this to a value to distinguish between different k8s clusters

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -4,9 +4,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: fluentd
+  name: collection-sumologic
   labels:
-    app: sumologic
+    app: collection-sumologic
     
 data:
   fluent.conf: |-
@@ -241,9 +241,9 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: fluentd-events
+  name: collection-sumologic-events
   labels:
-    app: sumologic-events
+    app: collection-sumologic-events
     
 data:
   fluent.conf: |-
@@ -284,18 +284,18 @@ data:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: fluentd
+  name: collection-sumologic
   labels:
-    app: sumologic
+    app: collection-sumologic
     
 ---
 # Source: sumologic/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: fluentd
+  name: collection-sumologic
   labels:
-    app: sumologic
+    app: collection-sumologic
     
 rules:
 - apiGroups: ["", "apps", "extensions", "events.k8s.io"]
@@ -321,30 +321,30 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: fluentd
+  name: collection-sumologic
   labels:
-    app: sumologic
+    app: collection-sumologic
     
 subjects:
 - kind: ServiceAccount
   namespace: $NAMESPACE
-  name: fluentd
+  name: collection-sumologic
 roleRef:
   kind: ClusterRole
-  name: fluentd
+  name: collection-sumologic
   apiGroup: rbac.authorization.k8s.io
 ---
 # Source: sumologic/templates/events-service.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: fluentd-events
+  name: collection-sumologic-events
   labels:
-    app: sumologic-events
+    app: collection-sumologic-events
     
 spec:
   selector:
-    app: sumologic-events
+    app: collection-sumologic-events
   ports:
   - name: metrics
     port: 24231
@@ -356,13 +356,13 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: fluentd
+  name: collection-sumologic
   labels:
-    app: sumologic
+    app: collection-sumologic
     
 spec:
   selector:
-    app: sumologic
+    app: collection-sumologic
   ports:
   - name: prom-write
     port: 9888
@@ -382,22 +382,22 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: fluentd
+  name: collection-sumologic
   labels:
-    app: sumologic
+    app: collection-sumologic
     
 spec:
   selector:
     matchLabels:
-      app: sumologic
+      app: collection-sumologic
   replicas: 3
   template:
     metadata:
       labels:
-        app: sumologic
+        app: collection-sumologic
         
     spec:
-      serviceAccountName: fluentd
+      serviceAccountName: collection-sumologic
       volumes:
       - name: pos-files
         hostPath:
@@ -405,7 +405,7 @@ spec:
           type: ""
       - name: config-volume
         configMap:
-          name: fluentd
+          name: collection-sumologic
       containers:
       - name: fluentd
         image: sumologic/kubernetes-fluentd:0.3.0
@@ -536,21 +536,21 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: fluentd-events
+  name: collection-sumologic-events
   labels:
-    app: sumologic-events
+    app: collection-sumologic-events
     
 spec:
   selector:
     matchLabels:
-      app: sumologic-events
+      app: collection-sumologic-events
   template:
     metadata:
       labels:
-        app: sumologic-events
+        app: collection-sumologic-events
         
     spec:
-      serviceAccountName: fluentd
+      serviceAccountName: collection-sumologic
       volumes:
       - name: pos-files
         hostPath:
@@ -558,7 +558,7 @@ spec:
           type: ""
       - name: config-volume
         configMap:
-          name: fluentd-events
+          name: collection-sumologic-events
       containers:
       - name: fluentd-events
         image: sumologic/kubernetes-fluentd:0.3.0


### PR DESCRIPTION
###### Description

Fixes both Helm and YAML-based deployment by standardizing on `collection-sumologic` app labels (removing "fluentd" all together).

Also removes spurious `release: collection` in prometheus overrides, which was causing problems with YAML-based prometheus operator deployment.

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods via YAML files with Prometheus + FluentBit Helm
- [x] Redeploy fluentd and fluentd-events pods, Prometheus, Fluent-Bit via Helm
- [x] Confirm events, logs, and metrics (including fluentd and fluentbit) are coming in
