### PR TITLE
SUMO-117711: Prevent Grafana from deploying with Helm collection chart

### DIFF
--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -3,6 +3,7 @@ alertmanager:
   enabled: false
 grafana:
   enabled: false
+  defaultDashboardsEnabled: false
 prometheus:
   additionalServiceMonitors:
     - name: collection-sumologic

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -214,6 +214,7 @@ prometheus-operator:
     enabled: false
   grafana:
     enabled: false
+    defaultDashboardsEnabled: false
   prometheus:
     additionalServiceMonitors:
       - name: collection-sumologic


### PR DESCRIPTION
###### Description

I saw this other property is evaluated in some templates, and setting both to `false` seems to prevent deploying Grafana when using Helm collection chart.

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods with Helm custom override:
`helm install sumologic/sumologic --name collection --namespace sumologic --no-crd-hook -f prometheus-overrides.yaml`
- [x] Confirm events, logs, and metrics are coming in
