### PR TITLE
Pin patch version of helm dependencies

### DIFF
--- a/deploy/helm/sumologic/requirements.yaml
+++ b/deploy/helm/sumologic/requirements.yaml
@@ -1,13 +1,13 @@
 dependencies:
   - name: fluent-bit
-    version: ~2.4.0
+    version: 2.4.4
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: fluent-bit.enabled
   - name: prometheus-operator
-    version: ~6.2.0
+    version: 6.2.1
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: prometheus-operator.enabled
   - name: falco
-    version: ~1.0.0
+    version: 1.0.5
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: falco.enabled


### PR DESCRIPTION
###### Description

We want to pin the stable versions that have been tested, including the patch version.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
