### PR TITLE
Assign weight to pre-install hooks

### DIFF
--- a/deploy/helm/sumologic/templates/setup/setup-clusterrole.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-clusterrole.yaml
@@ -5,6 +5,7 @@ metadata:
   name:  {{ template "sumologic.fullname" . }}-setup
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
     app: {{ template "sumologic.labels.app" . }}

--- a/deploy/helm/sumologic/templates/setup/setup-clusterrolebinding.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-clusterrolebinding.yaml
@@ -5,6 +5,7 @@ metadata:
   name:  {{ template "sumologic.fullname" . }}-setup
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "2"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
     app: {{ template "sumologic.labels.app" . }}

--- a/deploy/helm/sumologic/templates/setup/setup-job.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-job.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "3"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
     app: {{ template "sumologic.labels.app" . }}

--- a/deploy/helm/sumologic/templates/setup/setup-serviceaccount.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-serviceaccount.yaml
@@ -5,6 +5,7 @@ metadata:
   name:  {{ template "sumologic.fullname" . }}-setup
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
     app: {{ template "sumologic.labels.app" . }}


### PR DESCRIPTION
###### Description

According to docs:

> Tiller sorts hooks by weight (assigning a weight of 0 by default) and by name for those hooks with the same weight in ascending order. Tiller then loads the hook with the lowest weight first (negative to positive)

So the service account should be assigned the lowest weight to get loaded first, and the job should be assigned the highest to get loaded last.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
