### PR TITLE
Cut 0.5.0 release

### DIFF
--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.4.0"
+appVersion: "0.5.0"
 description: A Helm chart for collecting Kubernetes logs, metrics and events into Sumo Logic.
 name: sumologic
-version: 0.4.0
+version: 0.5.0

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: sumologic/kubernetes-fluentd
-  tag: 0.4.0
+  tag: 0.5.0
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -398,7 +398,7 @@ spec:
           name: collection-sumologic
       containers:
       - name: fluentd
-        image: sumologic/kubernetes-fluentd:0.4.0
+        image: sumologic/kubernetes-fluentd:0.5.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -551,7 +551,7 @@ spec:
           name: collection-sumologic-events
       containers:
       - name: fluentd-events
-        image: sumologic/kubernetes-fluentd:0.4.0
+        image: sumologic/kubernetes-fluentd:0.5.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:


### PR DESCRIPTION
###### Description

Cut 0.5.0 release. The URL changes in README will be in a separate PR after CI builds the 0.5.0 image and helm chart. (Otherwise customers will get 404 not found if we change it before the actual release is made. I'll update the release process doc as well)

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
