### PR TITLE
accesskey should be accessKey

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -35,7 +35,7 @@ sumologic:
   #accessId: ""
 
   # Sumo access key
-  #accesskey: ""
+  #accessKey: ""
 
   # Sumo API endpoint
   #endpoint: ""


### PR DESCRIPTION
###### Description

helm upgrade collection sumologic/sumologic -f values.yaml is failing.  The helm file [setup-job.yaml ](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/master/deploy/helm/sumologic/templates/setup/setup-job.yaml#L33)is looking for accessKey, but the [values.yaml](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/master/deploy/helm/sumologic/values.yaml#L38) is set to accesskey.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
