### PR TITLE
Skip generated yaml check for TRAVIS_TAG builds

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -22,8 +22,8 @@ if [ -n "$GITHUB_TOKEN" ]; then
   git checkout $TRAVIS_BRANCH
 fi
 
-# Check for invalid changes to generated yaml files
-if [ -n "$GITHUB_TOKEN" ] && [ "$TRAVIS_PULL_REQUEST" == false ] && [ "$TRAVIS_BRANCH" != "master" ] && [ "$TRAVIS_EVENT_TYPE" == "push" ]; then
+# Check for invalid changes to generated yaml files (non-Tag builds)
+if [ -n "$GITHUB_TOKEN" ] && [ -z "$TRAVIS_TAG" ] && [ "$TRAVIS_PULL_REQUEST" == false ] && [ "$TRAVIS_BRANCH" != "master" ] && [ "$TRAVIS_EVENT_TYPE" == "push" ]; then
   # Check most recent commit author. If non-Travis, check for changes made to generated files
   recent_author=`git log origin-repo/master..HEAD --format="%an" | grep -m1 ""`
   if echo $recent_author | grep -v -q -i "travis"; then


### PR DESCRIPTION
###### Description

I saw that https://travis-ci.org/SumoLogic/sumologic-kubernetes-collection/builds/589711994 failed due to trying to check `git log` for a Tag build.  We can skip the generated yaml check all together for Tag builds, so that it doesn't fail when we cut a new release.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
