### PR TITLE
Fix Container Metrics Routing

### DIFF
--- a/deploy/helm/sumologic/conf/metrics/metrics.conf
+++ b/deploy/helm/sumologic/conf/metrics/metrics.conf
@@ -29,6 +29,12 @@
     endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBELET']}"
     @include metrics.output.conf
   </match>
+  <match prometheus.metrics.container**>
+    @type sumologic
+    @id sumologic.endpoint.metrics.container
+    endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBELET']}"
+    @include metrics.output.conf
+  </match>
   <match prometheus.metrics.controller-manager**>
     @type sumologic
     @id sumologic.endpoint.metrics.kube.controller.manager

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -64,6 +64,12 @@ data:
         endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBELET']}"
         @include metrics.output.conf
       </match>
+      <match prometheus.metrics.container**>
+        @type sumologic
+        @id sumologic.endpoint.metrics.container
+        endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBELET']}"
+        @include metrics.output.conf
+      </match>
       <match prometheus.metrics.controller-manager**>
         @type sumologic
         @id sumologic.endpoint.metrics.kube.controller.manager


### PR DESCRIPTION
Ensure container metrics get routed to Kubelet source and not to default-metrics.