### PR TITLE
Pin gem dependency versions; Fix metadata version string

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -11,11 +11,11 @@ RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev libsnappy-dev" \
 COPY gems/fluent-plugin*.gem ./
 
 # Fluentd plugin dependencies
-RUN gem install concurrent-ruby \
-       && gem install google-protobuf \
-       && gem install kubeclient \
-       && gem install lru_redux \
-       && gem install snappy
+RUN gem install concurrent-ruby -v 1.1.5 \
+       && gem install google-protobuf -v 3.9.2 \
+       && gem install kubeclient -v 4.5.0 \
+       && gem install lru_redux -v 1.1.0 \
+       && gem install snappy -v 0.0.17
 
 # FluentD plugins to allow customers to forward data if needed to various cloud providers
 RUN gem install fluent-plugin-s3

--- a/fluent-plugin-enhance-k8s-metadata/fluent-plugin-enhance-k8s-metadata.gemspec
+++ b/fluent-plugin-enhance-k8s-metadata/fluent-plugin-enhance-k8s-metadata.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.1'
   spec.add_runtime_dependency 'fluentd', ['>= 0.14.10', '< 2']
-  spec.add_runtime_dependency 'kubeclient', '~> 4.4.0'
+  spec.add_runtime_dependency 'kubeclient', '~> 4.4'
   spec.add_runtime_dependency 'lru_redux', '~> 1.1.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'


### PR DESCRIPTION
###### Description

Root issue for the problem:
```
ERROR:  Could not find a valid gem 'kubeclient' (~> 4.4.0) (required by 'fluent-plugin-enhance-k8s-metadata' (>= 0)) in any repository
```
was that in our metadata plugin we were defining required version as `~>4.4.0` which only applies to `>= 4.4.0` and `< 4.5`.  Overnight `kubeclient` released a `4.5.0` version which now fails the required version check.

This PR fixes that issue, and also pins our external gem dependency versions to avoid surprises since otherwise our CI could randomly start failing at any time as projects release new major versions.

###### Testing performed

- [x] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
