### PR TITLE
Fix fluentd log level parameter

### DIFF
--- a/deploy/helm/sumologic/conf/common.conf
+++ b/deploy/helm/sumologic/conf/common.conf
@@ -6,3 +6,8 @@
 <source>
   @type prometheus_output_monitor
 </source>
+{{- if .Values.sumologic.fluentdLogLevel }}
+<system>
+  log_level {{ .Values.sumologic.fluentdLogLevel }}
+</system>
+{{- end }}

--- a/deploy/helm/sumologic/conf/events/events.conf
+++ b/deploy/helm/sumologic/conf/events/events.conf
@@ -38,8 +38,8 @@
     total_limit_size "#{ENV['TOTAL_LIMIT_SIZE']}"
   </buffer>
 </match>
-{{- if .Values.fluentdLogLevel }}
+{{- if .Values.sumologic.fluentdLogLevel }}
 <system>
-  log_level {{ .Values.fluentdLogLevel }}
+  log_level {{ .Values.sumologic.fluentdLogLevel }}
 </system>
 {{- end }}

--- a/deploy/helm/sumologic/conf/logs/logs.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.conf
@@ -5,8 +5,3 @@
 </source>
 @include logs.source.containers.conf
 @include logs.source.systemd.conf
-{{- if .Values.fluentdLogLevel }}
-<system>
-  log_level {{ .Values.fluentdLogLevel }}
-</system>
-{{- end }}

--- a/deploy/helm/sumologic/conf/metrics/metrics.conf
+++ b/deploy/helm/sumologic/conf/metrics/metrics.conf
@@ -66,8 +66,3 @@
     @include metrics.output.conf
   </match>
 </label>
-{{- if .Values.fluentdLogLevel }}
-<system>
-  log_level {{ .Values.fluentdLogLevel }}
-</system>
-{{- end }}


### PR DESCRIPTION
###### Description

The first issue is we were incorrectly accessing `fluentdLogLevel` in the templates, we should be using `.Values.sumologic.fluentdLogLevel` instead of `.Values.fluentdLogLevel`. The second issue that Sam noticed was fluentd could not start if the `<system>` block is defined twice. The fix for that is to have `<system>` block defined once in the logs and metrics config map (in common.conf) and once in the events config map.

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
- [x] Confirm debug logs are present in the pods