### PR TITLE
Bump falco chart version to 1.0.8 for EKS fix

### DIFF
--- a/deploy/helm/sumologic/requirements.yaml
+++ b/deploy/helm/sumologic/requirements.yaml
@@ -8,6 +8,6 @@ dependencies:
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: prometheus-operator.enabled
   - name: falco
-    version: 1.0.5
+    version: 1.0.8
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: falco.enabled


### PR DESCRIPTION
###### Description

Bump falco chart version to 1.0.8 for EKS fix

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
