### PR TITLE
check exact secret name in setup script

### DIFF
--- a/deploy/docker/setup/setup.sh
+++ b/deploy/docker/setup/setup.sh
@@ -153,7 +153,7 @@ fi
 
 set +e
 echo "Checking for secret 'sumologic'..."
-kubectl -n $NAMESPACE describe secret sumologic &>/dev/null
+kubectl -n $NAMESPACE describe secret/sumologic &>/dev/null
 retVal=$?
 set -e
 if [ $retVal -eq 0 ]; then


### PR DESCRIPTION
###### Description

`kubectl describe secret sumologic` will return results if you have any secret whose name starts with `sumologic`

so if you have any secret named `sumologic.*`, the setup script will fail. On the other hand, `kubectl describe secret/sumologic` will only return results for an exact match on a secret named `sumologic`.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
