### PR TITLE
Bump fluent-plugin-prometheus version to fix breaking change from prometheus-client

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -30,7 +30,7 @@ RUN gem install fluent-plugin-systemd -v 1.0.2 \
        && gem install fluent-plugin-sumologic_output -v 1.5.0 \
        && gem install fluent-plugin-concat -v 2.4.0 \
        && gem install fluent-plugin-rewrite-tag-filter -v 2.2.0 \
-       && gem install fluent-plugin-prometheus -v 1.5.0
+       && gem install fluent-plugin-prometheus -v 1.6.1
 
 # FluentD plugins from this repository
 RUN gem install --local fluent-plugin-prometheus-format \


### PR DESCRIPTION
###### Description

The `fluent-plugin-prometheus` gem has a dependency on `prometheus-client` which recently introduced a breaking change in their latest release, describe in https://github.com/fluent/fluent-plugin-prometheus/issues/119. `fluent-plugin-prometheus` made a new release 1.6.1 to use a version lower than the latest. To unblock our release we should try this new version and verify it doesn't create other issues.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
