### PR TITLE
remove log_format, attach fields by default

### DIFF
--- a/deploy/helm/sumologic/conf/logs/logs.output.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.output.conf
@@ -2,8 +2,5 @@ data_type logs
 log_key log
 endpoint "#{ENV['SUMO_ENDPOINT_LOGS']}"
 verify_ssl "#{ENV['VERIFY_SSL']}"
-log_format "#{ENV['LOG_FORMAT']}"
-add_timestamp "#{ENV['ADD_TIMESTAMP']}"
-timestamp_key "#{ENV['TIMESTAMP_KEY']}"
 proxy_uri "#{ENV['PROXY_URI']}"
 @include buffer.output.conf

--- a/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
@@ -25,7 +25,7 @@
     cache_ttl "#{ENV['K8S_METADATA_FILTER_BEARER_CACHE_TTL']}"
     tag_to_kubernetes_name_regexp '.+?\.containers\.(?<pod_name>[^_]+)_(?<namespace>[^_]+)_(?<container_name>.+)-(?<docker_id>[a-z0-9]{64})\.log$'
   </filter>
-  <filter **>
+  <filter containers.**>
     @type enhance_k8s_metadata
     in_namespace_path '$.kubernetes.namespace_name'
     in_pod_path '$.kubernetes.pod_name'
@@ -48,7 +48,19 @@
     exclude_container_regex "#{ENV['EXCLUDE_CONTAINER_REGEX']}"
     exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   </filter>
-  <match **>
+  # <filter containers.**>
+  #   @type record_modifier
+  #   <record>
+  #     message ${record["message"]["log"]}
+  #   </record>
+  # </filter>
+  # <filter containers.**>
+  #   @type record_modifier
+  #   <record>
+  #     message ${begin; record["message"].merge(JSON.parse(record["message"]["log"])).delete("log"); rescue JSON::ParserError; record["message"]; end}
+  #   </record>
+  # </filter>
+  <match containers.**>
     @type sumologic
     @id sumologic.endpoint.logs
     @include logs.output.conf

--- a/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
@@ -131,7 +131,7 @@
   # }
 
 ## For `json_merge` format, uncomment the following record_modifier section
-  # <filter containers.**> 
+  # <filter containers.**>
   #   @type record_modifier
   #   <record>
   #     message ${begin; record["message"].merge(JSON.parse(record["message"]["log"])).delete("log"); rescue JSON::ParserError; record["message"]; end}

--- a/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
@@ -35,11 +35,6 @@
     @type kubernetes_sumologic
     source_name "#{ENV['SOURCE_NAME']}"
     source_host "#{ENV['SOURCE_HOST']}"
-    log_format "#{ENV['LOG_FORMAT']}"
-    kubernetes_meta "#{ENV['KUBERNETES_META']}"
-    kubernetes_meta_reduce "#{ENV['KUBERNETES_META_REDUCE']}"
-    add_stream "#{ENV['ADD_STREAM']}"
-    add_time "#{ENV['ADD_TIME']}"
     source_category "#{ENV['SOURCE_CATEGORY']}"
     source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
     source_category_replace_dash "#{ENV['SOURCE_CATEGORY_REPLACE_DASH']}"

--- a/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
@@ -31,6 +31,34 @@
     in_pod_path '$.kubernetes.pod_name'
     data_type logs
   </filter>
+
+## Input to kubernetes_sumologic plugin
+  # {
+  #     "log" => "some message",
+  #     "stream" => "stdout",
+  #     "time" => "2019-10-11T04:45:38.046161188Z",
+  #     "docker" => {
+  #         "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
+  #     },
+  #     "kubernetes" => {
+  #         "container_name" => "log-format-labs",
+  #         "namespace_name" => "default",
+  #         "pod_name" => "log-format-labs-54575ccdb9-9d677",
+  #         "pod_id" => "170af806-c801-11e8-9009-025000000001",
+  #         "labels" => {
+  #             "pod-template-hash" => "1013177865",
+  #             "empty-value" => "",
+  #             "run" => "log-format-labs",
+  #             "null-value" => nil,
+  #         },
+  #         "namespace_labels" => {
+  #             "app" => "sumologic"
+  #         },
+  #         "host" => "docker-for-desktop",
+  #         "master_url" => "https =>//10.96.0.1 =>443/api",
+  #         "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
+  #     }
+  # }
   <filter containers.**>
     @type kubernetes_sumologic
     source_name "#{ENV['SOURCE_NAME']}"
@@ -43,18 +71,101 @@
     exclude_container_regex "#{ENV['EXCLUDE_CONTAINER_REGEX']}"
     exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   </filter>
+## Output from kubernetes_sumologic plugin
+  # {
+  #     "message" => {
+  #         "log" => "some message",
+  #         "stream" => "stdout",
+  #         "time" => "2019-10-11T04:45:38.046161188Z"
+  #     },
+  #     "_sumo_metadata" => {
+  #         :category => "kubernetes/default/log/format/labs",
+  #         :host => "",
+  #         :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
+  #         :fields => {
+  #           "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
+  #           "pod_labels_pod-template-hash" => "1013177865",
+  #           "pod_labels_run" => "log-format-labs",
+  #           "namespace_labels_app" => "sumologic",
+  #           "container" => "log-format-labs",
+  #           "namespace" => "default",
+  #           "pod" => "log-format-labs-54575ccdb9-9d677",
+  #           "pod_id" => "170af806-c801-11e8-9009-025000000001",
+  #           "host" => "docker-for-desktop",
+  #           "master_url" => "https =>//10.96.0.1 =>443/api",
+  #           "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
+  #           "node" => "docker-for-desktop"
+  #         }
+  #     }
+  # }
+
+## For `text` format, uncomment the following record_modifier section
   # <filter containers.**>
   #   @type record_modifier
   #   <record>
   #     message ${record["message"]["log"]}
   #   </record>
   # </filter>
-  # <filter containers.**>
+## Output from record_modifier plugin
+  # {
+  #     "message" => "some message",
+  #     "_sumo_metadata" => {
+  #         :category => "kubernetes/default/log/format/labs",
+  #         :host => "",
+  #         :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
+  #         :fields => {
+  #           "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
+  #           "pod_labels_pod-template-hash" => "1013177865",
+  #           "pod_labels_run" => "log-format-labs",
+  #           "namespace_labels_app" => "sumologic",
+  #           "container" => "log-format-labs",
+  #           "namespace" => "default",
+  #           "pod" => "log-format-labs-54575ccdb9-9d677",
+  #           "pod_id" => "170af806-c801-11e8-9009-025000000001",
+  #           "host" => "docker-for-desktop",
+  #           "master_url" => "https =>//10.96.0.1 =>443/api",
+  #           "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
+  #           "node" => "docker-for-desktop"
+  #         }
+  #     }
+  # }
+
+## For `json_merge` format, uncomment the following record_modifier section
+  # <filter containers.**> 
   #   @type record_modifier
   #   <record>
   #     message ${begin; record["message"].merge(JSON.parse(record["message"]["log"])).delete("log"); rescue JSON::ParserError; record["message"]; end}
   #   </record>
   # </filter>
+## Output from record_modifier plugin, where input "log" => "{\"foo\":\"bar\", \"a\":\"b\"}"
+  # {
+  #     "message" => {
+  #         "foo" => "bar",
+  #         "a" => "b",
+  #         "stream" => "stdout",
+  #         "time" => "2019-10-11T04:45:38.046161188Z"
+  #     },
+  #     "_sumo_metadata" => {
+  #         :category => "kubernetes/default/log/format/labs",
+  #         :host => "",
+  #         :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
+  #         :fields => {
+  #           "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
+  #           "pod_labels_pod-template-hash" => "1013177865",
+  #           "pod_labels_run" => "log-format-labs",
+  #           "namespace_labels_app" => "sumologic",
+  #           "container" => "log-format-labs",
+  #           "namespace" => "default",
+  #           "pod" => "log-format-labs-54575ccdb9-9d677",
+  #           "pod_id" => "170af806-c801-11e8-9009-025000000001",
+  #           "host" => "docker-for-desktop",
+  #           "master_url" => "https =>//10.96.0.1 =>443/api",
+  #           "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
+  #           "node" => "docker-for-desktop"
+  #         }
+  #     }
+  # }
+
   <match containers.**>
     @type sumologic
     @id sumologic.endpoint.logs

--- a/deploy/helm/sumologic/conf/logs/logs.source.systemd.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.systemd.conf
@@ -13,7 +13,7 @@
     exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
     exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
   </filter>
-  <match **>
+  <match host.kubelet.**>
     @type sumologic
     @id sumologic.endpoint.logs.kubelet
     @include logs.output.conf
@@ -39,7 +39,7 @@
       _sumo_metadata ${record["_sumo_metadata"][:source] = tag_parts[1]; record["_sumo_metadata"]}
     </record>
   </filter>
-  <match **>
+  <match host.**>
     @type sumologic
     @id sumologic.endpoint.logs.systemd
     @include logs.output.conf

--- a/deploy/helm/sumologic/templates/deployment.yaml
+++ b/deploy/helm/sumologic/templates/deployment.yaml
@@ -100,8 +100,6 @@ spec:
             secretKeyRef:
               name: sumologic
               key: endpoint-logs
-        - name: LOG_FORMAT
-          value: {{ .Values.sumologic.logFormat | quote }}
         - name: FLUSH_INTERVAL
           value: {{ .Values.sumologic.flushInterval | quote }}
         - name: NUM_THREADS
@@ -118,22 +116,10 @@ spec:
           value: {{ .Values.sumologic.sourceCategoryReplaceDash | quote }}
         - name: SOURCE_NAME
           value: {{ .Values.sumologic.sourceName | quote }}
-        - name: KUBERNETES_META
-          value: {{ .Values.sumologic.kubernetesMeta | quote }}
-        - name: KUBERNETES_META_REDUCE
-          value: {{ .Values.sumologic.kubernetesMetaReduce | quote }}
         - name: MULTILINE_START_REGEXP
           value: {{ .Values.sumologic.multilineStartRegexp | quote }}
         - name: CONCAT_SEPARATOR
           value: {{ .Values.sumologic.concatSeparator | quote }}
-        - name: ADD_TIMESTAMP
-          value: {{ .Values.sumologic.addTimestamp | quote }}
-        - name: TIMESTAMP_KEY
-          value: {{ .Values.sumologic.timestampKey | quote }}
-        - name: ADD_STREAM
-          value: {{ .Values.sumologic.addStream | quote }}
-        - name: ADD_TIME
-          value: {{ .Values.sumologic.addTime | quote }}
         - name: K8S_METADATA_FILTER_WATCH
           value: {{ .Values.sumologic.k8sMetadataFilter.watch | quote }}
         - name: K8S_METADATA_FILTER_VERIFY_SSL

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -49,9 +49,6 @@ sumologic:
   # If enabled, collect K8s events
   eventCollectionEnabled: true
 
-  ## Format to post logs into Sumo. json, json_merge, or text
-  logFormat: fields
-
   ## How frequently to push logs to SumoLogic
   ## ref: https://github.com/SumoLogic/fluentd-kubernetes-sumologic#options
   flushInterval: "5s"
@@ -75,32 +72,12 @@ sumologic:
   ## Used to replace - with another character.
   sourceCategoryReplaceDash: "/"
 
-  ## Include or exclude Kubernetes metadata such as namespace and pod_name if
-  ## using json log format.
-  kubernetesMeta: "true"
-
-  ## Reduces redundant Kubernetes metadata. 
-  ## ref: https://github.com/SumoLogic/fluentd-kubernetes-sumologic#reducing-kubernetes-metadata
-  kubernetesMetaReduce: "false"
-
   ## The regular expression for the "concat" plugin to use when merging multi-line messages
   multilineStartRegexp: '/^\w{3} \d{1,2}, \d{4}/'
 
   ## The character to use to delimit lines within the final concatenated message.
   ## Most multi-line messages contain a newline at the end of each line
   concatSeparator: ""
-
-  ## Option to control adding timestamp to logs. 
-  addTimestamp: "true"
-
-  ## Field name when add_timestamp is on.
-  timestampKey: "timestamp"
-
-  ## Option to control adding stream to logs.
-  addStream: "true"
-
-  ## Option to control adding time to logs.
-  addTime: "true"
 
   ## Verify SumoLogic HTTPS certificates
   verifySsl: "true"
@@ -120,7 +97,6 @@ sumologic:
   ## A regular expression for pods. 
   ## Matching pods will be excluded from Sumo. The logs will still be sent to FluentD.
   excludePodRegex: ""
-
 
   ## Sets the fluentd log level. The default log level, if not specified, is info.
   ## ref: https://docs.fluentd.org/deployment/logging

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -120,9 +120,6 @@ data:
     log_key log
     endpoint "#{ENV['SUMO_ENDPOINT_LOGS']}"
     verify_ssl "#{ENV['VERIFY_SSL']}"
-    log_format "#{ENV['LOG_FORMAT']}"
-    add_timestamp "#{ENV['ADD_TIMESTAMP']}"
-    timestamp_key "#{ENV['TIMESTAMP_KEY']}"
     proxy_uri "#{ENV['PROXY_URI']}"
     @include buffer.output.conf
   logs.source.containers.conf: |-
@@ -153,21 +150,44 @@ data:
         cache_ttl "#{ENV['K8S_METADATA_FILTER_BEARER_CACHE_TTL']}"
         tag_to_kubernetes_name_regexp '.+?\.containers\.(?<pod_name>[^_]+)_(?<namespace>[^_]+)_(?<container_name>.+)-(?<docker_id>[a-z0-9]{64})\.log$'
       </filter>
-      <filter **>
+      <filter containers.**>
         @type enhance_k8s_metadata
         in_namespace_path '$.kubernetes.namespace_name'
         in_pod_path '$.kubernetes.pod_name'
         data_type logs
       </filter>
+  
+    ## Input to kubernetes_sumologic plugin
+      # {
+      #     "log" => "some message",
+      #     "stream" => "stdout",
+      #     "time" => "2019-10-11T04:45:38.046161188Z",
+      #     "docker" => {
+      #         "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
+      #     },
+      #     "kubernetes" => {
+      #         "container_name" => "log-format-labs",
+      #         "namespace_name" => "default",
+      #         "pod_name" => "log-format-labs-54575ccdb9-9d677",
+      #         "pod_id" => "170af806-c801-11e8-9009-025000000001",
+      #         "labels" => {
+      #             "pod-template-hash" => "1013177865",
+      #             "empty-value" => "",
+      #             "run" => "log-format-labs",
+      #             "null-value" => nil,
+      #         },
+      #         "namespace_labels" => {
+      #             "app" => "sumologic"
+      #         },
+      #         "host" => "docker-for-desktop",
+      #         "master_url" => "https =>//10.96.0.1 =>443/api",
+      #         "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
+      #     }
+      # }
       <filter containers.**>
         @type kubernetes_sumologic
         source_name "#{ENV['SOURCE_NAME']}"
         source_host "#{ENV['SOURCE_HOST']}"
-        log_format "#{ENV['LOG_FORMAT']}"
-        kubernetes_meta "#{ENV['KUBERNETES_META']}"
-        kubernetes_meta_reduce "#{ENV['KUBERNETES_META_REDUCE']}"
-        add_stream "#{ENV['ADD_STREAM']}"
-        add_time "#{ENV['ADD_TIME']}"
         source_category "#{ENV['SOURCE_CATEGORY']}"
         source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
         source_category_replace_dash "#{ENV['SOURCE_CATEGORY_REPLACE_DASH']}"
@@ -176,7 +196,102 @@ data:
         exclude_container_regex "#{ENV['EXCLUDE_CONTAINER_REGEX']}"
         exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
       </filter>
-      <match **>
+    ## Output from kubernetes_sumologic plugin
+      # {
+      #     "message" => {
+      #         "log" => "some message",
+      #         "stream" => "stdout",
+      #         "time" => "2019-10-11T04:45:38.046161188Z"
+      #     },
+      #     "_sumo_metadata" => {
+      #         :category => "kubernetes/default/log/format/labs",
+      #         :host => "",
+      #         :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
+      #         :fields => {
+      #           "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
+      #           "pod_labels_pod-template-hash" => "1013177865",
+      #           "pod_labels_run" => "log-format-labs",
+      #           "namespace_labels_app" => "sumologic",
+      #           "container" => "log-format-labs",
+      #           "namespace" => "default",
+      #           "pod" => "log-format-labs-54575ccdb9-9d677",
+      #           "pod_id" => "170af806-c801-11e8-9009-025000000001",
+      #           "host" => "docker-for-desktop",
+      #           "master_url" => "https =>//10.96.0.1 =>443/api",
+      #           "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
+      #           "node" => "docker-for-desktop"
+      #         }
+      #     }
+      # }
+  
+    ## For `text` format, uncomment the following record_modifier section
+      # <filter containers.**>
+      #   @type record_modifier
+      #   <record>
+      #     message ${record["message"]["log"]}
+      #   </record>
+      # </filter>
+    ## Output from record_modifier plugin
+      # {
+      #     "message" => "some message",
+      #     "_sumo_metadata" => {
+      #         :category => "kubernetes/default/log/format/labs",
+      #         :host => "",
+      #         :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
+      #         :fields => {
+      #           "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
+      #           "pod_labels_pod-template-hash" => "1013177865",
+      #           "pod_labels_run" => "log-format-labs",
+      #           "namespace_labels_app" => "sumologic",
+      #           "container" => "log-format-labs",
+      #           "namespace" => "default",
+      #           "pod" => "log-format-labs-54575ccdb9-9d677",
+      #           "pod_id" => "170af806-c801-11e8-9009-025000000001",
+      #           "host" => "docker-for-desktop",
+      #           "master_url" => "https =>//10.96.0.1 =>443/api",
+      #           "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
+      #           "node" => "docker-for-desktop"
+      #         }
+      #     }
+      # }
+  
+    ## For `json_merge` format, uncomment the following record_modifier section
+      # <filter containers.**>
+      #   @type record_modifier
+      #   <record>
+      #     message ${begin; record["message"].merge(JSON.parse(record["message"]["log"])).delete("log"); rescue JSON::ParserError; record["message"]; end}
+      #   </record>
+      # </filter>
+    ## Output from record_modifier plugin, where input "log" => "{\"foo\":\"bar\", \"a\":\"b\"}"
+      # {
+      #     "message" => {
+      #         "foo" => "bar",
+      #         "a" => "b",
+      #         "stream" => "stdout",
+      #         "time" => "2019-10-11T04:45:38.046161188Z"
+      #     },
+      #     "_sumo_metadata" => {
+      #         :category => "kubernetes/default/log/format/labs",
+      #         :host => "",
+      #         :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
+      #         :fields => {
+      #           "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
+      #           "pod_labels_pod-template-hash" => "1013177865",
+      #           "pod_labels_run" => "log-format-labs",
+      #           "namespace_labels_app" => "sumologic",
+      #           "container" => "log-format-labs",
+      #           "namespace" => "default",
+      #           "pod" => "log-format-labs-54575ccdb9-9d677",
+      #           "pod_id" => "170af806-c801-11e8-9009-025000000001",
+      #           "host" => "docker-for-desktop",
+      #           "master_url" => "https =>//10.96.0.1 =>443/api",
+      #           "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
+      #           "node" => "docker-for-desktop"
+      #         }
+      #     }
+      # }
+  
+      <match containers.**>
         @type sumologic
         @id sumologic.endpoint.logs
         @include logs.output.conf
@@ -198,7 +313,7 @@ data:
         exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
         exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
       </filter>
-      <match **>
+      <match host.kubelet.**>
         @type sumologic
         @id sumologic.endpoint.logs.kubelet
         @include logs.output.conf
@@ -224,7 +339,7 @@ data:
           _sumo_metadata ${record["_sumo_metadata"][:source] = tag_parts[1]; record["_sumo_metadata"]}
         </record>
       </filter>
-      <match **>
+      <match host.**>
         @type sumologic
         @id sumologic.endpoint.logs.systemd
         @include logs.output.conf
@@ -484,8 +599,6 @@ spec:
             secretKeyRef:
               name: sumologic
               key: endpoint-logs
-        - name: LOG_FORMAT
-          value: "fields"
         - name: FLUSH_INTERVAL
           value: "5s"
         - name: NUM_THREADS
@@ -502,22 +615,10 @@ spec:
           value: "/"
         - name: SOURCE_NAME
           value: "%{namespace}.%{pod}.%{container}"
-        - name: KUBERNETES_META
-          value: "true"
-        - name: KUBERNETES_META_REDUCE
-          value: "false"
         - name: MULTILINE_START_REGEXP
           value: "/^\\w{3} \\d{1,2}, \\d{4}/"
         - name: CONCAT_SEPARATOR
           value: ""
-        - name: ADD_TIMESTAMP
-          value: "true"
-        - name: TIMESTAMP_KEY
-          value: "timestamp"
-        - name: ADD_STREAM
-          value: "true"
-        - name: ADD_TIME
-          value: "true"
         - name: K8S_METADATA_FILTER_WATCH
           value: "true"
         - name: K8S_METADATA_FILTER_VERIFY_SSL

--- a/fluent-plugin-kubernetes-sumologic/lib/fluent/plugin/filter_kubernetes_sumologic.rb
+++ b/fluent-plugin-kubernetes-sumologic/lib/fluent/plugin/filter_kubernetes_sumologic.rb
@@ -57,51 +57,44 @@ module Fluent::Plugin
     end
 
     def filter(tag, time, record)
+      log_fields = {}
+
       # Set the sumo metadata fields
       sumo_metadata = record["_sumo_metadata"] || {}
       record["_sumo_metadata"] = sumo_metadata
-      log_fields = {}
       sumo_metadata[:log_format] = @log_format
       sumo_metadata[:host] = @source_host if @source_host
       sumo_metadata[:source] = @source_name if @source_name
-
       unless @source_category.nil?
         sumo_metadata[:category] = @source_category.dup
         unless @source_category_prefix.nil?
           sumo_metadata[:category].prepend(@source_category_prefix)
         end
       end
+      sumo_metadata[:category].gsub!("-", @source_category_replace_dash)
 
+      # Check systemd exclude filters
       if record.key?("_SYSTEMD_UNIT") and not record.fetch("_SYSTEMD_UNIT").nil?
         unless @exclude_unit_regex.empty?
-          if Regexp.compile(@exclude_unit_regex).match(record["_SYSTEMD_UNIT"])
-            return nil
-          end
+          return nil if Regexp.compile(@exclude_unit_regex).match(record["_SYSTEMD_UNIT"])
         end
-
         unless @exclude_facility_regex.empty?
-          if Regexp.compile(@exclude_facility_regex).match(record["SYSLOG_FACILITY"])
-            return nil
-          end
+          return nil if Regexp.compile(@exclude_facility_regex).match(record["SYSLOG_FACILITY"])
         end
-
         unless @exclude_priority_regex.empty?
-          if Regexp.compile(@exclude_priority_regex).match(record["PRIORITY"])
-            return nil
-          end
+          return nil if Regexp.compile(@exclude_priority_regex).match(record["PRIORITY"])
         end
-
         unless @exclude_host_regex.empty?
-          if Regexp.compile(@exclude_host_regex).match(record["_HOSTNAME"])
-            return nil
-          end
+          return nil if Regexp.compile(@exclude_host_regex).match(record["_HOSTNAME"])
         end
       end
 
-      # Allow fields to be overridden by annotations
       if record.key?("kubernetes") and not record.fetch("kubernetes").nil?
         # Clone kubernetes hash so we don't override the cache
+        # Note (sam 10/9/19): this is a shallow copy; nested hashes can still be overriden
         kubernetes = record["kubernetes"].clone
+
+        # Populate k8s_metadata to use later in sumo_metadata
         k8s_metadata = {
             :namespace => kubernetes["namespace_name"],
             :pod => kubernetes["pod_name"],
@@ -109,8 +102,6 @@ module Fluent::Plugin
             :container => kubernetes["container_name"],
             :source_host => kubernetes["host"],
         }
-
-
         if kubernetes.has_key? "labels"
           kubernetes["labels"].each { |k, v| k8s_metadata["label:#{k}".to_sym] = v }
         end
@@ -119,34 +110,22 @@ module Fluent::Plugin
         end
         k8s_metadata.default = "undefined"
 
+        # Fetch annotations for config
         annotations = kubernetes.fetch("annotations", {})
-        if annotations["sumologic.com/include"] == "true"
-          include = true
-        else
-          include = false
-        end
 
-        unless @exclude_namespace_regex.empty?
-          if Regexp.compile(@exclude_namespace_regex).match(k8s_metadata[:namespace]) and not include
-            return nil
+        unless annotations["sumologic.com/include"] == "true"
+          # Check kubernetes exclude filters
+          unless @exclude_namespace_regex.empty?
+            return nil if Regexp.compile(@exclude_namespace_regex).match(k8s_metadata[:namespace])
           end
-        end
-
-        unless @exclude_pod_regex.empty?
-          if Regexp.compile(@exclude_pod_regex).match(k8s_metadata[:pod]) and not include
-            return nil
+          unless @exclude_pod_regex.empty?
+            return nil if Regexp.compile(@exclude_pod_regex).match(k8s_metadata[:pod])
           end
-        end
-
-        unless @exclude_container_regex.empty?
-          if Regexp.compile(@exclude_container_regex).match(k8s_metadata[:container]) and not include
-            return nil
+          unless @exclude_container_regex.empty?
+            return nil if Regexp.compile(@exclude_container_regex).match(k8s_metadata[:container])
           end
-        end
-
-        unless @exclude_host_regex.empty?
-          if Regexp.compile(@exclude_host_regex).match(k8s_metadata[:source_host]) and not include
-            return nil
+          unless @exclude_host_regex.empty?
+            return nil if Regexp.compile(@exclude_host_regex).match(k8s_metadata[:source_host])
           end
         end
 
@@ -158,23 +137,18 @@ module Fluent::Plugin
 
         sumo_metadata[:log_format] = annotations["sumologic.com/format"] if annotations["sumologic.com/format"]
 
-        if annotations["sumologic.com/sourceHost"].nil?
-          sumo_metadata[:host] = sumo_metadata[:host] % k8s_metadata
-        else
-          sumo_metadata[:host] = annotations["sumologic.com/sourceHost"] % k8s_metadata
+        unless annotations["sumologic.com/sourceHost"].nil?
+          sumo_metadata[:host] = annotations["sumologic.com/sourceHost"]
         end
-
-        if annotations["sumologic.com/sourceName"].nil?
-          sumo_metadata[:source] = sumo_metadata[:source] % k8s_metadata
-        else
-          sumo_metadata[:source] = annotations["sumologic.com/sourceName"] % k8s_metadata
+        unless annotations["sumologic.com/sourceName"].nil?
+          sumo_metadata[:source] = annotations["sumologic.com/sourceName"]
         end
-
-        if annotations["sumologic.com/sourceCategory"].nil?
-          sumo_metadata[:category] = sumo_metadata[:category] % k8s_metadata
-        else
-          sumo_metadata[:category] = (annotations["sumologic.com/sourceCategory"] % k8s_metadata).prepend(@source_category_prefix)
+        unless annotations["sumologic.com/sourceCategory"].nil?
+          sumo_metadata[:category] = annotations["sumologic.com/sourceCategory"].dup.prepend(@source_category_prefix)
         end
+        sumo_metadata[:host] = sumo_metadata[:host] % k8s_metadata
+        sumo_metadata[:source] = sumo_metadata[:source] % k8s_metadata
+        sumo_metadata[:category] = sumo_metadata[:category] % k8s_metadata
         sumo_metadata[:category].gsub!("-", @source_category_replace_dash)
 
         # Strip kubernetes metadata from json if disabled
@@ -198,10 +172,12 @@ module Fluent::Plugin
           record.delete("time")
         end
         # Strip sumologic.com annotations
+        # Note (sam 10/9/19): we're stripping from the copy, so this has no affect on output
         kubernetes.delete("annotations") if annotations
 
         if @log_format == "fields" and record.key?("docker") and not record.fetch("docker").nil?
           record["docker"].each {|k, v| log_fields[k] = v}
+          record.delete("docker")
         end
 
         if @log_format == "fields" and record.key?("kubernetes") and not record.fetch("kubernetes").nil?
@@ -218,13 +194,12 @@ module Fluent::Plugin
             log_fields[key] = kubernetes[key] unless kubernetes[key].nil?
           end
           log_fields["node"] = kubernetes["host"] unless kubernetes["host"].nil?
+          record.delete("kubernetes")
         end
       end
 
       if @log_format == "fields" and not log_fields.nil?
         sumo_metadata[:fields] = log_fields.select{|k,v| !(v.nil? || v.empty?)}.map{|k,v| "#{k}=#{v}"}.join(',')
-        record.delete("docker")
-        record.delete("kubernetes")
       end
       record
     end

--- a/fluent-plugin-kubernetes-sumologic/lib/fluent/plugin/filter_kubernetes_sumologic.rb
+++ b/fluent-plugin-kubernetes-sumologic/lib/fluent/plugin/filter_kubernetes_sumologic.rb
@@ -55,8 +55,7 @@ module Fluent::Plugin
       log_fields = {}
 
       # Set the sumo metadata fields
-      sumo_metadata = record["_sumo_metadata"] || {}
-      record["_sumo_metadata"] = sumo_metadata
+      sumo_metadata = record["_sumo_metadata"].clone || {}
       sumo_metadata[:host] = @source_host if @source_host
       sumo_metadata[:source] = @source_name if @source_name
       unless @source_category.nil?
@@ -170,7 +169,8 @@ module Fluent::Plugin
         record.delete("kubernetes")
       end
       sumo_metadata[:fields] = log_fields.select{|k,v| !(v.nil? || v.empty?)}.map{|k,v| "#{k}=#{v}"}.join(',')
-      record
+      record.delete("_sumo_metadata")
+      { "message" => record, "_sumo_metadata" => sumo_metadata }
     end
   end
 end

--- a/fluent-plugin-kubernetes-sumologic/lib/fluent/plugin/filter_kubernetes_sumologic.rb
+++ b/fluent-plugin-kubernetes-sumologic/lib/fluent/plugin/filter_kubernetes_sumologic.rb
@@ -154,10 +154,10 @@ module Fluent::Plugin
 
         # Populate log_fields with kubernetes metadata
         if kubernetes.has_key? "labels"
-          kubernetes["labels"].each { |k, v| log_fields["pod_labels_#{k}".to_sym] = v }
+          kubernetes["labels"].each { |k, v| log_fields["pod_labels_#{k}"] = v }
         end
         if kubernetes.has_key? "namespace_labels"
-          kubernetes["namespace_labels"].each { |k, v| log_fields["namespace_labels_#{k}".to_sym] = v }
+          kubernetes["namespace_labels"].each { |k, v| log_fields["namespace_labels_#{k}"] = v }
         end
         log_fields["container"] = kubernetes["container_name"] unless kubernetes["container_name"].nil?
         log_fields["namespace"] = kubernetes["namespace_name"] unless kubernetes["namespace_name"].nil?
@@ -168,7 +168,7 @@ module Fluent::Plugin
         log_fields["node"] = kubernetes["host"] unless kubernetes["host"].nil?
         record.delete("kubernetes")
       end
-      sumo_metadata[:fields] = log_fields.select{|k,v| !(v.nil? || v.empty?)}.map{|k,v| "#{k}=#{v}"}.join(',')
+      sumo_metadata[:fields] = log_fields.select{|k,v| !(v.nil? || v.empty?)}
       record.delete("_sumo_metadata")
       { "message" => record, "_sumo_metadata" => sumo_metadata }
     end

--- a/fluent-plugin-kubernetes-sumologic/test/plugin/test_filter_kubernetes_sumologic.rb
+++ b/fluent-plugin-kubernetes-sumologic/test/plugin/test_filter_kubernetes_sumologic.rb
@@ -56,9 +56,11 @@ class SumoContainerOutputTest < Test::Unit::TestCase
       d.feed("filter.test", time, input)
     end
     expected = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
+        "message" => {
+            "timestamp" => 1538677347823,
+            "log" => "some message",
+            "stream" => "stdout",
+        },
         "_sumo_metadata" => {
             :category => "kubernetes/default/log/format/labs",
             :host => "",
@@ -104,9 +106,11 @@ class SumoContainerOutputTest < Test::Unit::TestCase
       d.feed("filter.test", time, input)
     end
     expected = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
+        "message" => {
+            "timestamp" => 1538677347823,
+            "log" => "some message",
+            "stream" => "stdout",
+        },
         "_sumo_metadata" => {
             :category => "kubernetes/default/log/format/labs",
             :host => "",
@@ -149,9 +153,11 @@ class SumoContainerOutputTest < Test::Unit::TestCase
       d.feed("filter.test", time, input)
     end
     expected = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
+        "message" => {
+            "timestamp" => 1538677347823,
+            "log" => "some message",
+            "stream" => "stdout",
+        },
         "_sumo_metadata" => {
             :category => "kubernetes/default/log-format-labs",
             :host => "",
@@ -310,9 +316,11 @@ class SumoContainerOutputTest < Test::Unit::TestCase
       d.feed("filter.test", time, input)
     end
     expected = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
+        "message" => {
+            "timestamp" => 1538677347823,
+            "log" => "some message",
+            "stream" => "stdout",
+        },
         "_sumo_metadata" => {
             :category => "kubernetes/default/log/format/labs",
             :host => "foo",
@@ -356,9 +364,11 @@ class SumoContainerOutputTest < Test::Unit::TestCase
       d.feed("filter.test", time, input)
     end
     expected = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
+        "message" => {
+            "timestamp" => 1538677347823,
+            "log" => "some message",
+            "stream" => "stdout",
+        },
         "_sumo_metadata" => {
             :category => "kubernetes/default/log/format/labs",
             :host => "",
@@ -402,9 +412,11 @@ class SumoContainerOutputTest < Test::Unit::TestCase
       d.feed("filter.test", time, input)
     end
     expected = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
+        "message" => {
+            "timestamp" => 1538677347823,
+            "log" => "some message",
+            "stream" => "stdout",
+        },
         "_sumo_metadata" => {
             :category => "kubernetes/foo",
             :host => "",
@@ -447,9 +459,11 @@ class SumoContainerOutputTest < Test::Unit::TestCase
       d.feed("filter.test", time, input)
     end
     expected = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
+        "message" => {
+            "timestamp" => 1538677347823,
+            "log" => "some message",
+            "stream" => "stdout",
+        },
         "_sumo_metadata" => {
             :category => "kubernetes/default/log/format/labs/log/format/labs",
             :host => "",
@@ -492,9 +506,11 @@ class SumoContainerOutputTest < Test::Unit::TestCase
       d.feed("filter.test", time, input)
     end
     expected = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
+        "message" => {
+            "timestamp" => 1538677347823,
+            "log" => "some message",
+            "stream" => "stdout",
+        },
         "_sumo_metadata" => {
             :category => "kubernetes/default/log/format/labs",
             :host => "170af806-c801-11e8-9009-025000000001",
@@ -537,9 +553,11 @@ class SumoContainerOutputTest < Test::Unit::TestCase
       d.feed("filter.test", time, input)
     end
     expected = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
+        "message" => {
+            "timestamp" => 1538677347823,
+            "log" => "some message",
+            "stream" => "stdout",
+        },
         "_sumo_metadata" => {
             :category => "kubernetes/default/log/format/labs/undefined",
             :host => "",
@@ -628,9 +646,11 @@ class SumoContainerOutputTest < Test::Unit::TestCase
       d.feed("filter.test", time, input)
     end
     expected = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
+        "message" => {
+            "timestamp" => 1538677347823,
+            "log" => "some message",
+            "stream" => "stdout",
+        },
         "_sumo_metadata" => {
             :category => "kubernetes/default/log/format/labs",
             :host => "",
@@ -671,9 +691,11 @@ class SumoContainerOutputTest < Test::Unit::TestCase
       d.feed("filter.test", time, input)
     end
     expected = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
+        "message" => {
+            "timestamp" => 1538677347823,
+            "log" => "some message",
+            "stream" => "stdout",
+        },
         "_sumo_metadata" => {
             :category => "kubernetes/default/log/format/labs",
             :host => "",
@@ -714,9 +736,11 @@ class SumoContainerOutputTest < Test::Unit::TestCase
       d.feed("filter.test", time, input)
     end
     expected = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
+        "message" => {
+            "timestamp" => 1538677347823,
+            "log" => "some message",
+            "stream" => "stdout",
+        },
         "_sumo_metadata" => {
             :category => "kubernetes/default/log/format/labs/53575ccdb9",
             :host => "",

--- a/fluent-plugin-kubernetes-sumologic/test/plugin/test_filter_kubernetes_sumologic.rb
+++ b/fluent-plugin-kubernetes-sumologic/test/plugin/test_filter_kubernetes_sumologic.rb
@@ -44,164 +44,6 @@ class SumoContainerOutputTest < Test::Unit::TestCase
                 "pod-template-hash" => "1013177865",
                 "run" => "log-format-labs",
             },
-            "host" => "docker-for-desktop",
-            "master_url" => "https =>//10.96.0.1 =>443/api",
-            "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
-        },
-    }
-    d.run do
-      d.feed("filter.test", time, input)
-    end
-    expected = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
-        "docker" => {
-            "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
-        },
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "namespace_name" => "default",
-            "pod_name" => "log-format-labs-54575ccdb9-9d677",
-            "pod_id" => "170af806-c801-11e8-9009-025000000001",
-            "labels" => {
-                "pod-template-hash" => "1013177865",
-                "run" => "log-format-labs",
-            },
-            "host" => "docker-for-desktop",
-            "master_url" => "https =>//10.96.0.1 =>443/api",
-            "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
-        },
-        "_sumo_metadata" => {
-            :category => "kubernetes/default/log/format/labs",
-            :host => "",
-            :log_format => "json",
-            :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
-        },
-    }
-    assert_equal(1, d.filtered_records.size)
-    assert_equal(d.filtered_records[0], expected)
-  end
-
-  test "test_default_config_no_labels" do
-    conf = %{}
-    d = create_driver(conf)
-    time = @time
-    input = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
-        "docker" => {
-            "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
-        },
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "namespace_name" => "default",
-            "pod_name" => "log-format-labs-54575ccdb9-9d677",
-            "pod_id" => "170af806-c801-11e8-9009-025000000001",
-            "host" => "docker-for-desktop",
-            "master_url" => "https =>//10.96.0.1 =>443/api",
-            "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
-        },
-    }
-    d.run do
-      d.feed("filter.test", time, input)
-    end
-    expected = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
-        "docker" => {
-            "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
-        },
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "namespace_name" => "default",
-            "pod_name" => "log-format-labs-54575ccdb9-9d677",
-            "pod_id" => "170af806-c801-11e8-9009-025000000001",
-            "host" => "docker-for-desktop",
-            "master_url" => "https =>//10.96.0.1 =>443/api",
-            "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
-        },
-        "_sumo_metadata" => {
-            :category => "kubernetes/default/log/format/labs/54575ccdb9",
-            :host => "",
-            :log_format => "json",
-            :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
-        },
-    }
-    assert_equal(1, d.filtered_records.size)
-    assert_equal(d.filtered_records[0], expected)
-  end
-
-  test "test_fields_format" do
-    conf = %{
-	      log_format fields
-	    }
-    d = create_driver(conf)
-    time = @time
-    input = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
-        "docker" => {
-            "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
-        },
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "namespace_name" => "default",
-            "pod_name" => "log-format-labs-54575ccdb9-9d677",
-            "pod_id" => "170af806-c801-11e8-9009-025000000001",
-            "labels" => {
-                "pod-template-hash" => "1013177865",
-                "run" => "log-format-labs",
-            },
-            "host" => "docker-for-desktop",
-            "master_url" => "https =>//10.96.0.1 =>443/api",
-            "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
-        },
-    }
-    d.run do
-      d.feed("filter.test", time, input)
-    end
-    expected = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
-        "_sumo_metadata" => {
-            :category => "kubernetes/default/log/format/labs",
-            :host => "",
-            :log_format => "fields",
-            :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
-            :fields => "container_id=5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0,pod_labels_pod-template-hash=1013177865,pod_labels_run=log-format-labs,container=log-format-labs,namespace=default,pod=log-format-labs-54575ccdb9-9d677,pod_id=170af806-c801-11e8-9009-025000000001,host=docker-for-desktop,master_url=https =>//10.96.0.1 =>443/api,namespace_id=e8572415-9596-11e8-b28b-025000000001,node=docker-for-desktop"
-        },
-    }
-    assert_equal(1, d.filtered_records.size)
-    assert_equal(d.filtered_records[0], expected)
-  end
-
-  test "test_fields_namespace_labels" do
-    conf = %{
-	      log_format fields
-	    }
-    d = create_driver(conf)
-    time = @time
-    input = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
-        "docker" => {
-            "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
-        },
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "namespace_name" => "default",
-            "pod_name" => "log-format-labs-54575ccdb9-9d677",
-            "pod_id" => "170af806-c801-11e8-9009-025000000001",
-            "labels" => {
-                "pod-template-hash" => "1013177865",
-                "run" => "log-format-labs",
-            },
             "namespace_labels" => {
                 "app" => "sumologic"
             },
@@ -220,19 +62,16 @@ class SumoContainerOutputTest < Test::Unit::TestCase
         "_sumo_metadata" => {
             :category => "kubernetes/default/log/format/labs",
             :host => "",
-            :log_format => "fields",
             :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
             :fields => "container_id=5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0,pod_labels_pod-template-hash=1013177865,pod_labels_run=log-format-labs,namespace_labels_app=sumologic,container=log-format-labs,namespace=default,pod=log-format-labs-54575ccdb9-9d677,pod_id=170af806-c801-11e8-9009-025000000001,host=docker-for-desktop,master_url=https =>//10.96.0.1 =>443/api,namespace_id=e8572415-9596-11e8-b28b-025000000001,node=docker-for-desktop"
         },
     }
     assert_equal(1, d.filtered_records.size)
-    assert_equal(d.filtered_records[0], expected)
+    assert_equal(expected, d.filtered_records[0])
   end
 
-  test "test_fields_null_field_values" do
-    conf = %{
-	      log_format fields
-	    }
+  test "test_default_config_null_field_values" do
+    conf = %{}
     d = create_driver(conf)
     time = @time
     input = {
@@ -271,291 +110,12 @@ class SumoContainerOutputTest < Test::Unit::TestCase
         "_sumo_metadata" => {
             :category => "kubernetes/default/log/format/labs",
             :host => "",
-            :log_format => "fields",
             :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
             :fields => "container_id=5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0,pod_labels_pod-template-hash=1013177865,pod_labels_run=log-format-labs,namespace_labels_app=sumologic,container=log-format-labs,namespace=default,pod=log-format-labs-54575ccdb9-9d677,pod_id=170af806-c801-11e8-9009-025000000001,host=docker-for-desktop,master_url=https =>//10.96.0.1 =>443/api,namespace_id=e8572415-9596-11e8-b28b-025000000001,node=docker-for-desktop"
         },
     }
     assert_equal(1, d.filtered_records.size)
-    assert_equal(d.filtered_records[0], expected)
-  end
-
-  test "test_fields_format_no_timestamp" do
-    conf = %{
-	      log_format fields
-        add_stream false
-	    }
-    d = create_driver(conf)
-    time = @time
-    input = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
-        "docker" => {
-            "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
-        },
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "namespace_name" => "default",
-            "pod_name" => "log-format-labs-54575ccdb9-9d677",
-            "pod_id" => "170af806-c801-11e8-9009-025000000001",
-            "labels" => {
-                "pod-template-hash" => "1013177865",
-                "run" => "log-format-labs",
-            },
-            "host" => "docker-for-desktop",
-            "master_url" => "https =>//10.96.0.1 =>443/api",
-            "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
-        },
-    }
-    d.run do
-      d.feed("filter.test", time, input)
-    end
-    expected = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "_sumo_metadata" => {
-            :category => "kubernetes/default/log/format/labs",
-            :host => "",
-            :log_format => "fields",
-            :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
-            :fields => "container_id=5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0,pod_labels_pod-template-hash=1013177865,pod_labels_run=log-format-labs,container=log-format-labs,namespace=default,pod=log-format-labs-54575ccdb9-9d677,pod_id=170af806-c801-11e8-9009-025000000001,host=docker-for-desktop,master_url=https =>//10.96.0.1 =>443/api,namespace_id=e8572415-9596-11e8-b28b-025000000001,node=docker-for-desktop"
-        },
-    }
-    assert_equal(1, d.filtered_records.size)
-    assert_equal(d.filtered_records[0], expected)
-  end
-
-  test "test_no_k8s_labels" do
-    conf = %{}
-    d = create_driver(conf)
-    time = @time
-    input = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
-        "docker" => {
-            "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
-        },
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "namespace_name" => "default",
-            "pod_name" => "log-format-labs-54575ccdb9-9d677",
-            "pod_id" => "170af806-c801-11e8-9009-025000000001",
-            "host" => "docker-for-desktop",
-            "master_url" => "https =>//10.96.0.1 =>443/api",
-            "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
-        },
-    }
-    d.run do
-      d.feed("filter.test", time, input)
-    end
-    expected = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
-        "docker" => {
-            "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
-        },
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "namespace_name" => "default",
-            "pod_name" => "log-format-labs-54575ccdb9-9d677",
-            "pod_id" => "170af806-c801-11e8-9009-025000000001",
-            "host" => "docker-for-desktop",
-            "master_url" => "https =>//10.96.0.1 =>443/api",
-            "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
-        },
-        "_sumo_metadata" => {
-            :category => "kubernetes/default/log/format/labs/54575ccdb9",
-            :host => "",
-            :log_format => "json",
-            :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
-        },
-    }
-    assert_equal(1, d.filtered_records.size)
-    assert_equal(d.filtered_records[0], expected)
-  end
-
-  test "test_sourcecategory_prefix" do
-    conf = %{}
-    d = create_driver(conf)
-    time = @time
-    input = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
-        "docker" => {
-            "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
-        },
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "namespace_name" => "default",
-            "pod_name" => "log-format-labs-54575ccdb9-9d677",
-            "pod_id" => "170af806-c801-11e8-9009-025000000001",
-            "labels" => {
-                "pod-template-hash" => "1013177865",
-                "run" => "log-format-labs",
-            },
-            "host" => "docker-for-desktop",
-            "master_url" => "https =>//10.96.0.1 =>443/api",
-            "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
-        },
-    }
-    d.run do
-      d.feed("filter.test", time, input)
-    end
-    expected = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
-        "docker" => {
-            "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
-        },
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "namespace_name" => "default",
-            "pod_name" => "log-format-labs-54575ccdb9-9d677",
-            "pod_id" => "170af806-c801-11e8-9009-025000000001",
-            "labels" => {
-                "pod-template-hash" => "1013177865",
-                "run" => "log-format-labs",
-            },
-            "host" => "docker-for-desktop",
-            "master_url" => "https =>//10.96.0.1 =>443/api",
-            "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
-        },
-        "_sumo_metadata" => {
-            :category => "kubernetes/default/log/format/labs",
-            :host => "",
-            :log_format => "json",
-            :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
-        },
-    }
-    assert_equal(1, d.filtered_records.size)
-    assert_equal(d.filtered_records[0], expected)
-  end
-
-  test "test_add_stream" do
-    conf = %{
-      add_stream false
-    }
-    d = create_driver(conf)
-    time = @time
-    input = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
-        "docker" => {
-            "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
-        },
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "namespace_name" => "default",
-            "pod_name" => "log-format-labs-54575ccdb9-9d677",
-            "pod_id" => "170af806-c801-11e8-9009-025000000001",
-            "labels" => {
-                "pod-template-hash" => "1013177865",
-                "run" => "log-format-labs",
-            },
-            "host" => "docker-for-desktop",
-            "master_url" => "https =>//10.96.0.1 =>443/api",
-            "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
-        },
-    }
-    d.run do
-      d.feed("filter.test", time, input)
-    end
-    expected = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "docker" => {
-            "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
-        },
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "namespace_name" => "default",
-            "pod_name" => "log-format-labs-54575ccdb9-9d677",
-            "pod_id" => "170af806-c801-11e8-9009-025000000001",
-            "labels" => {
-                "pod-template-hash" => "1013177865",
-                "run" => "log-format-labs",
-            },
-            "host" => "docker-for-desktop",
-            "master_url" => "https =>//10.96.0.1 =>443/api",
-            "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
-        },
-        "_sumo_metadata" => {
-            :category => "kubernetes/default/log/format/labs",
-            :host => "",
-            :log_format => "json",
-            :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
-        },
-    }
-    assert_equal(1, d.filtered_records.size)
-    assert_equal(d.filtered_records[0], expected)
-  end
-
-  test "test_add_time" do
-    conf = %{
-      add_time false
-    }
-    d = create_driver(conf)
-    time = @time
-    input = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
-        "time" => time,
-        "docker" => {
-            "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
-        },
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "namespace_name" => "default",
-            "pod_name" => "log-format-labs-54575ccdb9-9d677",
-            "pod_id" => "170af806-c801-11e8-9009-025000000001",
-            "labels" => {
-                "pod-template-hash" => "1013177865",
-                "run" => "log-format-labs",
-            },
-            "host" => "docker-for-desktop",
-            "master_url" => "https =>//10.96.0.1 =>443/api",
-            "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
-        },
-    }
-    d.run do
-      d.feed("filter.test", time, input)
-    end
-    expected = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
-        "docker" => {
-            "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
-        },
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "namespace_name" => "default",
-            "pod_name" => "log-format-labs-54575ccdb9-9d677",
-            "pod_id" => "170af806-c801-11e8-9009-025000000001",
-            "labels" => {
-                "pod-template-hash" => "1013177865",
-                "run" => "log-format-labs",
-            },
-            "host" => "docker-for-desktop",
-            "master_url" => "https =>//10.96.0.1 =>443/api",
-            "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
-        },
-        "_sumo_metadata" => {
-            :category => "kubernetes/default/log/format/labs",
-            :host => "",
-            :log_format => "json",
-            :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
-        },
-    }
-    assert_equal(1, d.filtered_records.size)
-    assert_equal(d.filtered_records[0], expected)
+    assert_equal(expected, d.filtered_records[0])
   end
 
   test "test_sourcecategory_replace_dash" do
@@ -592,349 +152,15 @@ class SumoContainerOutputTest < Test::Unit::TestCase
         "timestamp" => 1538677347823,
         "log" => "some message",
         "stream" => "stdout",
-        "docker" => {
-            "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
-        },
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "namespace_name" => "default",
-            "pod_name" => "log-format-labs-54575ccdb9-9d677",
-            "pod_id" => "170af806-c801-11e8-9009-025000000001",
-            "labels" => {
-                "pod-template-hash" => "1013177865",
-                "run" => "log-format-labs",
-            },
-            "host" => "docker-for-desktop",
-            "master_url" => "https =>//10.96.0.1 =>443/api",
-            "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
-        },
         "_sumo_metadata" => {
             :category => "kubernetes/default/log-format-labs",
             :host => "",
-            :log_format => "json",
             :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
+            :fields => "container_id=5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0,pod_labels_pod-template-hash=1013177865,pod_labels_run=log-format-labs,container=log-format-labs,namespace=default,pod=log-format-labs-54575ccdb9-9d677,pod_id=170af806-c801-11e8-9009-025000000001,host=docker-for-desktop,master_url=https =>//10.96.0.1 =>443/api,namespace_id=e8572415-9596-11e8-b28b-025000000001,node=docker-for-desktop"
         },
     }
     assert_equal(1, d.filtered_records.size)
-    assert_equal(d.filtered_records[0], expected)
-  end
-
-  test "test_kubernetes_meta" do
-    conf = %{
-      kubernetes_meta false
-    }
-    d = create_driver(conf)
-    time = @time
-    input = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
-        "docker" => {
-            "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
-        },
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "namespace_name" => "default",
-            "pod_name" => "log-format-labs-54575ccdb9-9d677",
-            "pod_id" => "170af806-c801-11e8-9009-025000000001",
-            "labels" => {
-                "pod-template-hash" => "1013177865",
-                "run" => "log-format-labs",
-            },
-            "host" => "docker-for-desktop",
-            "master_url" => "https =>//10.96.0.1 =>443/api",
-            "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
-        },
-    }
-    d.run do
-      d.feed("filter.test", time, input)
-    end
-    expected = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
-        "_sumo_metadata" => {
-            :category => "kubernetes/default/log/format/labs",
-            :host => "",
-            :log_format => "json",
-            :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
-        },
-    }
-    assert_equal(1, d.filtered_records.size)
-    assert_equal(d.filtered_records[0], expected)
-  end
-
-  test "test_kubernetes_meta_reduce_via_annotation" do
-    conf = %{}
-    d = create_driver(conf)
-    time = @time
-    input = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
-        "docker" => {
-            "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
-        },
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "namespace_name" => "default",
-            "pod_name" => "log-format-labs-54575ccdb9-9d677",
-            "pod_id" => "170af806-c801-11e8-9009-025000000001",
-            "labels" => {
-                "pod-template-hash" => "1013177865",
-                "run" => "log-format-labs"
-            },
-            "annotations" => {
-                "sumologic.com/kubernetes_meta_reduce" => "true",
-            },
-            "host" => "docker-for-desktop",
-        },
-    }
-    d.run do
-      d.feed("filter.test", time, input)
-    end
-    expected = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "pod_name" => "log-format-labs-54575ccdb9-9d677",
-            "host" => "docker-for-desktop",
-            "namespace_name" => "default",
-        },
-        "_sumo_metadata" => {
-            :category => "kubernetes/default/log/format/labs",
-            :host => "",
-            :log_format => "json",
-            :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
-        },
-    }
-    assert_equal(1, d.filtered_records.size)
-    assert_equal(d.filtered_records[0], expected)
-  end
-
-  test "test_kubernetes_meta_reduce_via_conf" do
-    conf = %{
-      kubernetes_meta_reduce true
-    }
-    d = create_driver(conf)
-    time = @time
-    input = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
-        "docker" => {
-            "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
-        },
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "namespace_name" => "default",
-            "pod_name" => "log-format-labs-54575ccdb9-9d677",
-            "pod_id" => "170af806-c801-11e8-9009-025000000001",
-            "labels" => {
-                "pod-template-hash" => "1013177865",
-                "run" => "log-format-labs"
-            },
-            "host" => "docker-for-desktop",
-        },
-    }
-    d.run do
-      d.feed("filter.test", time, input)
-    end
-    expected = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "pod_name" => "log-format-labs-54575ccdb9-9d677",
-            "host" => "docker-for-desktop",
-            "namespace_name" => "default",
-        },
-        "_sumo_metadata" => {
-            :category => "kubernetes/default/log/format/labs",
-            :host => "",
-            :log_format => "json",
-            :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
-        },
-    }
-    assert_equal(1, d.filtered_records.size)
-    assert_equal(d.filtered_records[0], expected)
-  end
-
-  test "test_kubernetes_meta_reduce_via_annotation_and_conf" do
-    conf = %{
-      kubernetes_meta_reduce false
-    }
-    d = create_driver(conf)
-    time = @time
-    input = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
-        "docker" => {
-            "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
-        },
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "namespace_name" => "default",
-            "pod_name" => "log-format-labs-54575ccdb9-9d677",
-            "pod_id" => "170af806-c801-11e8-9009-025000000001",
-            "labels" => {
-                "pod-template-hash" => "1013177865",
-                "run" => "log-format-labs"
-            },
-            "annotations" => {
-                "sumologic.com/kubernetes_meta_reduce" => "true",
-            },
-            "host" => "docker-for-desktop",
-        },
-    }
-    d.run do
-      d.feed("filter.test", time, input)
-    end
-    expected = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "pod_name" => "log-format-labs-54575ccdb9-9d677",
-            "host" => "docker-for-desktop",
-            "namespace_name" => "default",
-        },
-        "_sumo_metadata" => {
-            :category => "kubernetes/default/log/format/labs",
-            :host => "",
-            :log_format => "json",
-            :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
-        },
-    }
-    assert_equal(1, d.filtered_records.size)
-    assert_equal(d.filtered_records[0], expected)
-  end
-
-  test "test_log_format_json_merge" do
-    conf = %{
-      log_format json_merge
-    }
-    d = create_driver(conf)
-    time = @time
-    input = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
-        "docker" => {
-            "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
-        },
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "namespace_name" => "default",
-            "pod_name" => "log-format-labs-54575ccdb9-9d677",
-            "pod_id" => "170af806-c801-11e8-9009-025000000001",
-            "labels" => {
-                "pod-template-hash" => "1013177865",
-                "run" => "log-format-labs",
-            },
-            "host" => "docker-for-desktop",
-            "master_url" => "https =>//10.96.0.1 =>443/api",
-            "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
-        },
-    }
-    d.run do
-      d.feed("filter.test", time, input)
-    end
-    expected = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
-        "docker" => {
-            "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
-        },
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "namespace_name" => "default",
-            "pod_name" => "log-format-labs-54575ccdb9-9d677",
-            "pod_id" => "170af806-c801-11e8-9009-025000000001",
-            "labels" => {
-                "pod-template-hash" => "1013177865",
-                "run" => "log-format-labs",
-            },
-            "host" => "docker-for-desktop",
-            "master_url" => "https =>//10.96.0.1 =>443/api",
-            "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
-        },
-        "_sumo_metadata" => {
-            :category => "kubernetes/default/log/format/labs",
-            :host => "",
-            :log_format => "json_merge",
-            :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
-        },
-    }
-    assert_equal(1, d.filtered_records.size)
-    assert_equal(d.filtered_records[0], expected)
-  end
-
-  test "test_log_format_text" do
-    conf = %{
-      log_format text
-    }
-    d = create_driver(conf)
-    time = @time
-    input = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
-        "docker" => {
-            "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
-        },
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "namespace_name" => "default",
-            "pod_name" => "log-format-labs-54575ccdb9-9d677",
-            "pod_id" => "170af806-c801-11e8-9009-025000000001",
-            "labels" => {
-                "pod-template-hash" => "1013177865",
-                "run" => "log-format-labs",
-            },
-            "host" => "docker-for-desktop",
-            "master_url" => "https =>//10.96.0.1 =>443/api",
-            "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
-        },
-    }
-    d.run do
-      d.feed("filter.test", time, input)
-    end
-    expected = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
-        "docker" => {
-            "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
-        },
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "namespace_name" => "default",
-            "pod_name" => "log-format-labs-54575ccdb9-9d677",
-            "pod_id" => "170af806-c801-11e8-9009-025000000001",
-            "labels" => {
-                "pod-template-hash" => "1013177865",
-                "run" => "log-format-labs",
-            },
-            "host" => "docker-for-desktop",
-            "master_url" => "https =>//10.96.0.1 =>443/api",
-            "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
-        },
-        "_sumo_metadata" => {
-            :category => "kubernetes/default/log/format/labs",
-            :host => "",
-            :log_format => "text",
-            :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
-        },
-    }
-    assert_equal(1, d.filtered_records.size)
-    assert_equal(d.filtered_records[0], expected)
+    assert_equal(expected, d.filtered_records[0])
   end
 
   test "test_exclude_pod_regex" do
@@ -1087,34 +313,15 @@ class SumoContainerOutputTest < Test::Unit::TestCase
         "timestamp" => 1538677347823,
         "log" => "some message",
         "stream" => "stdout",
-        "docker" => {
-            "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
-        },
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "namespace_name" => "default",
-            "pod_name" => "log-format-labs-54575ccdb9-9d677",
-            "pod_id" => "170af806-c801-11e8-9009-025000000001",
-            "labels" => {
-                "pod-template-hash" => "1013177865",
-                "run" => "log-format-labs",
-            },
-            "annotations" => {
-                "sumologic.com/sourceHost" => "foo",
-            },
-            "host" => "docker-for-desktop",
-            "master_url" => "https =>//10.96.0.1 =>443/api",
-            "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
-        },
         "_sumo_metadata" => {
             :category => "kubernetes/default/log/format/labs",
             :host => "foo",
-            :log_format => "json",
             :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
+            :fields => "container_id=5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0,pod_labels_pod-template-hash=1013177865,pod_labels_run=log-format-labs,container=log-format-labs,namespace=default,pod=log-format-labs-54575ccdb9-9d677,pod_id=170af806-c801-11e8-9009-025000000001,host=docker-for-desktop,master_url=https =>//10.96.0.1 =>443/api,namespace_id=e8572415-9596-11e8-b28b-025000000001,node=docker-for-desktop"
         },
     }
     assert_equal(1, d.filtered_records.size)
-    assert_equal(d.filtered_records[0], expected)
+    assert_equal(expected, d.filtered_records[0])
   end
 
   test "test_sourcename_annotation" do
@@ -1152,34 +359,15 @@ class SumoContainerOutputTest < Test::Unit::TestCase
         "timestamp" => 1538677347823,
         "log" => "some message",
         "stream" => "stdout",
-        "docker" => {
-            "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
-        },
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "namespace_name" => "default",
-            "pod_name" => "log-format-labs-54575ccdb9-9d677",
-            "pod_id" => "170af806-c801-11e8-9009-025000000001",
-            "labels" => {
-                "pod-template-hash" => "1013177865",
-                "run" => "log-format-labs",
-            },
-            "annotations" => {
-                "sumologic.com/sourceName" => "foo",
-            },
-            "host" => "docker-for-desktop",
-            "master_url" => "https =>//10.96.0.1 =>443/api",
-            "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
-        },
         "_sumo_metadata" => {
             :category => "kubernetes/default/log/format/labs",
             :host => "",
-            :log_format => "json",
             :source => "foo",
+            :fields => "container_id=5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0,pod_labels_pod-template-hash=1013177865,pod_labels_run=log-format-labs,container=log-format-labs,namespace=default,pod=log-format-labs-54575ccdb9-9d677,pod_id=170af806-c801-11e8-9009-025000000001,host=docker-for-desktop,master_url=https =>//10.96.0.1 =>443/api,namespace_id=e8572415-9596-11e8-b28b-025000000001,node=docker-for-desktop"
         },
     }
     assert_equal(1, d.filtered_records.size)
-    assert_equal(d.filtered_records[0], expected)
+    assert_equal(expected, d.filtered_records[0])
   end
 
   test "test_sourcecategory_annotation" do
@@ -1217,34 +405,15 @@ class SumoContainerOutputTest < Test::Unit::TestCase
         "timestamp" => 1538677347823,
         "log" => "some message",
         "stream" => "stdout",
-        "docker" => {
-            "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
-        },
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "namespace_name" => "default",
-            "pod_name" => "log-format-labs-54575ccdb9-9d677",
-            "pod_id" => "170af806-c801-11e8-9009-025000000001",
-            "labels" => {
-                "pod-template-hash" => "1013177865",
-                "run" => "log-format-labs",
-            },
-            "annotations" => {
-                "sumologic.com/sourceCategory" => "foo",
-            },
-            "host" => "docker-for-desktop",
-            "master_url" => "https =>//10.96.0.1 =>443/api",
-            "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
-        },
         "_sumo_metadata" => {
             :category => "kubernetes/foo",
             :host => "",
-            :log_format => "json",
             :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
+            :fields => "container_id=5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0,pod_labels_pod-template-hash=1013177865,pod_labels_run=log-format-labs,container=log-format-labs,namespace=default,pod=log-format-labs-54575ccdb9-9d677,pod_id=170af806-c801-11e8-9009-025000000001,host=docker-for-desktop,master_url=https =>//10.96.0.1 =>443/api,namespace_id=e8572415-9596-11e8-b28b-025000000001,node=docker-for-desktop"
         },
     }
     assert_equal(1, d.filtered_records.size)
-    assert_equal(d.filtered_records[0], expected)
+    assert_equal(expected, d.filtered_records[0])
   end
 
   test "test_sourcecategory_using_labels" do
@@ -1281,31 +450,15 @@ class SumoContainerOutputTest < Test::Unit::TestCase
         "timestamp" => 1538677347823,
         "log" => "some message",
         "stream" => "stdout",
-        "docker" => {
-            "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
-        },
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "namespace_name" => "default",
-            "pod_name" => "log-format-labs-54575ccdb9-9d677",
-            "pod_id" => "170af806-c801-11e8-9009-025000000001",
-            "labels" => {
-                "pod-template-hash" => "1013177865",
-                "run" => "log-format-labs",
-            },
-            "host" => "docker-for-desktop",
-            "master_url" => "https =>//10.96.0.1 =>443/api",
-            "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
-        },
         "_sumo_metadata" => {
             :category => "kubernetes/default/log/format/labs/log/format/labs",
             :host => "",
-            :log_format => "json",
             :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
+            :fields => "container_id=5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0,pod_labels_pod-template-hash=1013177865,pod_labels_run=log-format-labs,container=log-format-labs,namespace=default,pod=log-format-labs-54575ccdb9-9d677,pod_id=170af806-c801-11e8-9009-025000000001,host=docker-for-desktop,master_url=https =>//10.96.0.1 =>443/api,namespace_id=e8572415-9596-11e8-b28b-025000000001,node=docker-for-desktop"
         },
     }
     assert_equal(1, d.filtered_records.size)
-    assert_equal(d.filtered_records[0], expected)
+    assert_equal(expected, d.filtered_records[0])
   end
 
   test "test_sourcehost_using_pod_id" do
@@ -1342,31 +495,15 @@ class SumoContainerOutputTest < Test::Unit::TestCase
         "timestamp" => 1538677347823,
         "log" => "some message",
         "stream" => "stdout",
-        "docker" => {
-            "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
-        },
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "namespace_name" => "default",
-            "pod_name" => "log-format-labs-54575ccdb9-9d677",
-            "pod_id" => "170af806-c801-11e8-9009-025000000001",
-            "labels" => {
-                "pod-template-hash" => "1013177865",
-                "run" => "log-format-labs",
-            },
-            "host" => "docker-for-desktop",
-            "master_url" => "https =>//10.96.0.1 =>443/api",
-            "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
-        },
         "_sumo_metadata" => {
             :category => "kubernetes/default/log/format/labs",
             :host => "170af806-c801-11e8-9009-025000000001",
-            :log_format => "json",
             :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
+            :fields => "container_id=5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0,pod_labels_pod-template-hash=1013177865,pod_labels_run=log-format-labs,container=log-format-labs,namespace=default,pod=log-format-labs-54575ccdb9-9d677,pod_id=170af806-c801-11e8-9009-025000000001,host=docker-for-desktop,master_url=https =>//10.96.0.1 =>443/api,namespace_id=e8572415-9596-11e8-b28b-025000000001,node=docker-for-desktop"
         },
     }
     assert_equal(1, d.filtered_records.size)
-    assert_equal(d.filtered_records[0], expected)
+    assert_equal(expected, d.filtered_records[0])
   end
 
   test "test_undefined_labels" do
@@ -1403,31 +540,15 @@ class SumoContainerOutputTest < Test::Unit::TestCase
         "timestamp" => 1538677347823,
         "log" => "some message",
         "stream" => "stdout",
-        "docker" => {
-            "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
-        },
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "namespace_name" => "default",
-            "pod_name" => "log-format-labs-54575ccdb9-9d677",
-            "pod_id" => "170af806-c801-11e8-9009-025000000001",
-            "labels" => {
-                "pod-template-hash" => "1013177865",
-                "run" => "log-format-labs",
-            },
-            "host" => "docker-for-desktop",
-            "master_url" => "https =>//10.96.0.1 =>443/api",
-            "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
-        },
         "_sumo_metadata" => {
             :category => "kubernetes/default/log/format/labs/undefined",
             :host => "",
-            :log_format => "json",
             :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
+            :fields => "container_id=5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0,pod_labels_pod-template-hash=1013177865,pod_labels_run=log-format-labs,container=log-format-labs,namespace=default,pod=log-format-labs-54575ccdb9-9d677,pod_id=170af806-c801-11e8-9009-025000000001,host=docker-for-desktop,master_url=https =>//10.96.0.1 =>443/api,namespace_id=e8572415-9596-11e8-b28b-025000000001,node=docker-for-desktop"
         },
     }
     assert_equal(1, d.filtered_records.size)
-    assert_equal(d.filtered_records[0], expected)
+    assert_equal(expected, d.filtered_records[0])
   end
 
   test "test_exclude_systemd_unit_regex" do
@@ -1478,65 +599,6 @@ class SumoContainerOutputTest < Test::Unit::TestCase
     assert_equal(0, d.filtered_records.size)
   end
 
-  test "test_pre_1.8_dynamic_bit_removal" do
-    conf = %{}
-    d = create_driver(conf)
-    time = @time
-    input = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
-        "docker" => {
-            "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
-        },
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "namespace_name" => "default",
-            "pod_name" => "log-format-labs-1013177865-9d677",
-            "pod_id" => "170af806-c801-11e8-9009-025000000001",
-            "labels" => {
-                "pod-template-hash" => "1013177865",
-                "run" => "log-format-labs",
-            },
-            "host" => "docker-for-desktop",
-            "master_url" => "https =>//10.96.0.1 =>443/api",
-            "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
-        },
-    }
-    d.run do
-      d.feed("filter.test", time, input)
-    end
-    expected = {
-        "timestamp" => 1538677347823,
-        "log" => "some message",
-        "stream" => "stdout",
-        "docker" => {
-            "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
-        },
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "namespace_name" => "default",
-            "pod_name" => "log-format-labs-1013177865-9d677",
-            "pod_id" => "170af806-c801-11e8-9009-025000000001",
-            "labels" => {
-                "pod-template-hash" => "1013177865",
-                "run" => "log-format-labs",
-            },
-            "host" => "docker-for-desktop",
-            "master_url" => "https =>//10.96.0.1 =>443/api",
-            "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
-        },
-        "_sumo_metadata" => {
-            :category => "kubernetes/default/log/format/labs",
-            :host => "",
-            :log_format => "json",
-            :source => "default.log-format-labs-1013177865-9d677.log-format-labs",
-        },
-    }
-    assert_equal(1, d.filtered_records.size)
-    assert_equal(d.filtered_records[0], expected)
-  end
-
   test "test_1.8-1.11_dynamic_bit_removal" do
     conf = %{}
     d = create_driver(conf)
@@ -1569,31 +631,15 @@ class SumoContainerOutputTest < Test::Unit::TestCase
         "timestamp" => 1538677347823,
         "log" => "some message",
         "stream" => "stdout",
-        "docker" => {
-            "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
-        },
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "namespace_name" => "default",
-            "pod_name" => "log-format-labs-54575ccdb9-9d677",
-            "pod_id" => "170af806-c801-11e8-9009-025000000001",
-            "labels" => {
-                "pod-template-hash" => "1013177865",
-                "run" => "log-format-labs",
-            },
-            "host" => "docker-for-desktop",
-            "master_url" => "https =>//10.96.0.1 =>443/api",
-            "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
-        },
         "_sumo_metadata" => {
             :category => "kubernetes/default/log/format/labs",
             :host => "",
-            :log_format => "json",
             :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
+            :fields => "container_id=5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0,pod_labels_pod-template-hash=1013177865,pod_labels_run=log-format-labs,container=log-format-labs,namespace=default,pod=log-format-labs-54575ccdb9-9d677,pod_id=170af806-c801-11e8-9009-025000000001,host=docker-for-desktop,master_url=https =>//10.96.0.1 =>443/api,namespace_id=e8572415-9596-11e8-b28b-025000000001,node=docker-for-desktop"
         },
     }
     assert_equal(1, d.filtered_records.size)
-    assert_equal(d.filtered_records[0], expected)
+    assert_equal(expected, d.filtered_records[0])
   end
 
   test "test_post_1.11_dynamic_bit_removal" do
@@ -1628,31 +674,15 @@ class SumoContainerOutputTest < Test::Unit::TestCase
         "timestamp" => 1538677347823,
         "log" => "some message",
         "stream" => "stdout",
-        "docker" => {
-            "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
-        },
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "namespace_name" => "default",
-            "pod_name" => "log-format-labs-54575ccdb9-9d677",
-            "pod_id" => "170af806-c801-11e8-9009-025000000001",
-            "labels" => {
-                "pod-template-hash" => "54575ccdb9",
-                "run" => "log-format-labs",
-            },
-            "host" => "docker-for-desktop",
-            "master_url" => "https =>//10.96.0.1 =>443/api",
-            "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
-        },
         "_sumo_metadata" => {
             :category => "kubernetes/default/log/format/labs",
             :host => "",
-            :log_format => "json",
             :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
+            :fields => "container_id=5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0,pod_labels_pod-template-hash=54575ccdb9,pod_labels_run=log-format-labs,container=log-format-labs,namespace=default,pod=log-format-labs-54575ccdb9-9d677,pod_id=170af806-c801-11e8-9009-025000000001,host=docker-for-desktop,master_url=https =>//10.96.0.1 =>443/api,namespace_id=e8572415-9596-11e8-b28b-025000000001,node=docker-for-desktop"
         },
     }
     assert_equal(1, d.filtered_records.size)
-    assert_equal(d.filtered_records[0], expected)
+    assert_equal(expected, d.filtered_records[0])
   end
 
   test "test_mismatch_dynamic_bit_is_left" do
@@ -1672,7 +702,7 @@ class SumoContainerOutputTest < Test::Unit::TestCase
             "pod_name" => "log-format-labs-53575ccdb9-9d677",
             "pod_id" => "170af806-c801-11e8-9009-025000000001",
             "labels" => {
-                "pod-template-hash" => "54575ccdb9",
+                "pod-template-hash" => "1013177865",
                 "run" => "log-format-labs",
             },
             "host" => "docker-for-desktop",
@@ -1687,30 +717,14 @@ class SumoContainerOutputTest < Test::Unit::TestCase
         "timestamp" => 1538677347823,
         "log" => "some message",
         "stream" => "stdout",
-        "docker" => {
-            "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
-        },
-        "kubernetes" => {
-            "container_name" => "log-format-labs",
-            "namespace_name" => "default",
-            "pod_name" => "log-format-labs-53575ccdb9-9d677",
-            "pod_id" => "170af806-c801-11e8-9009-025000000001",
-            "labels" => {
-                "pod-template-hash" => "54575ccdb9",
-                "run" => "log-format-labs",
-            },
-            "host" => "docker-for-desktop",
-            "master_url" => "https =>//10.96.0.1 =>443/api",
-            "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
-        },
         "_sumo_metadata" => {
             :category => "kubernetes/default/log/format/labs/53575ccdb9",
             :host => "",
-            :log_format => "json",
             :source => "default.log-format-labs-53575ccdb9-9d677.log-format-labs",
+            :fields => "container_id=5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0,pod_labels_pod-template-hash=1013177865,pod_labels_run=log-format-labs,container=log-format-labs,namespace=default,pod=log-format-labs-53575ccdb9-9d677,pod_id=170af806-c801-11e8-9009-025000000001,host=docker-for-desktop,master_url=https =>//10.96.0.1 =>443/api,namespace_id=e8572415-9596-11e8-b28b-025000000001,node=docker-for-desktop"
         },
     }
     assert_equal(1, d.filtered_records.size)
-    assert_equal(d.filtered_records[0], expected)
+    assert_equal(expected, d.filtered_records[0])
   end
 end

--- a/fluent-plugin-kubernetes-sumologic/test/plugin/test_filter_kubernetes_sumologic.rb
+++ b/fluent-plugin-kubernetes-sumologic/test/plugin/test_filter_kubernetes_sumologic.rb
@@ -65,7 +65,20 @@ class SumoContainerOutputTest < Test::Unit::TestCase
             :category => "kubernetes/default/log/format/labs",
             :host => "",
             :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
-            :fields => "container_id=5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0,pod_labels_pod-template-hash=1013177865,pod_labels_run=log-format-labs,namespace_labels_app=sumologic,container=log-format-labs,namespace=default,pod=log-format-labs-54575ccdb9-9d677,pod_id=170af806-c801-11e8-9009-025000000001,host=docker-for-desktop,master_url=https =>//10.96.0.1 =>443/api,namespace_id=e8572415-9596-11e8-b28b-025000000001,node=docker-for-desktop"
+            :fields => {
+              "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
+              "pod_labels_pod-template-hash" => "1013177865",
+              "pod_labels_run" => "log-format-labs",
+              "namespace_labels_app" => "sumologic",
+              "container" => "log-format-labs",
+              "namespace" => "default",
+              "pod" => "log-format-labs-54575ccdb9-9d677",
+              "pod_id" => "170af806-c801-11e8-9009-025000000001",
+              "host" => "docker-for-desktop",
+              "master_url" => "https =>//10.96.0.1 =>443/api",
+              "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
+              "node" => "docker-for-desktop"
+            }
         },
     }
     assert_equal(1, d.filtered_records.size)
@@ -115,7 +128,20 @@ class SumoContainerOutputTest < Test::Unit::TestCase
             :category => "kubernetes/default/log/format/labs",
             :host => "",
             :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
-            :fields => "container_id=5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0,pod_labels_pod-template-hash=1013177865,pod_labels_run=log-format-labs,namespace_labels_app=sumologic,container=log-format-labs,namespace=default,pod=log-format-labs-54575ccdb9-9d677,pod_id=170af806-c801-11e8-9009-025000000001,host=docker-for-desktop,master_url=https =>//10.96.0.1 =>443/api,namespace_id=e8572415-9596-11e8-b28b-025000000001,node=docker-for-desktop"
+            :fields => {
+              "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
+              "pod_labels_pod-template-hash" => "1013177865",
+              "pod_labels_run" => "log-format-labs",
+              "namespace_labels_app" => "sumologic",
+              "container" => "log-format-labs",
+              "namespace" => "default",
+              "pod" => "log-format-labs-54575ccdb9-9d677",
+              "pod_id" => "170af806-c801-11e8-9009-025000000001",
+              "host" => "docker-for-desktop",
+              "master_url" => "https =>//10.96.0.1 =>443/api",
+              "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
+              "node" => "docker-for-desktop"
+            }
         },
     }
     assert_equal(1, d.filtered_records.size)
@@ -162,7 +188,19 @@ class SumoContainerOutputTest < Test::Unit::TestCase
             :category => "kubernetes/default/log-format-labs",
             :host => "",
             :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
-            :fields => "container_id=5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0,pod_labels_pod-template-hash=1013177865,pod_labels_run=log-format-labs,container=log-format-labs,namespace=default,pod=log-format-labs-54575ccdb9-9d677,pod_id=170af806-c801-11e8-9009-025000000001,host=docker-for-desktop,master_url=https =>//10.96.0.1 =>443/api,namespace_id=e8572415-9596-11e8-b28b-025000000001,node=docker-for-desktop"
+            :fields => {
+              "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
+              "pod_labels_pod-template-hash" => "1013177865",
+              "pod_labels_run" => "log-format-labs",
+              "container" => "log-format-labs",
+              "namespace" => "default",
+              "pod" => "log-format-labs-54575ccdb9-9d677",
+              "pod_id" => "170af806-c801-11e8-9009-025000000001",
+              "host" => "docker-for-desktop",
+              "master_url" => "https =>//10.96.0.1 =>443/api",
+              "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
+              "node" => "docker-for-desktop"
+            }
         },
     }
     assert_equal(1, d.filtered_records.size)
@@ -325,7 +363,19 @@ class SumoContainerOutputTest < Test::Unit::TestCase
             :category => "kubernetes/default/log/format/labs",
             :host => "foo",
             :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
-            :fields => "container_id=5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0,pod_labels_pod-template-hash=1013177865,pod_labels_run=log-format-labs,container=log-format-labs,namespace=default,pod=log-format-labs-54575ccdb9-9d677,pod_id=170af806-c801-11e8-9009-025000000001,host=docker-for-desktop,master_url=https =>//10.96.0.1 =>443/api,namespace_id=e8572415-9596-11e8-b28b-025000000001,node=docker-for-desktop"
+            :fields => {
+              "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
+              "pod_labels_pod-template-hash" => "1013177865",
+              "pod_labels_run" => "log-format-labs",
+              "container" => "log-format-labs",
+              "namespace" => "default",
+              "pod" => "log-format-labs-54575ccdb9-9d677",
+              "pod_id" => "170af806-c801-11e8-9009-025000000001",
+              "host" => "docker-for-desktop",
+              "master_url" => "https =>//10.96.0.1 =>443/api",
+              "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
+              "node" => "docker-for-desktop"
+            }
         },
     }
     assert_equal(1, d.filtered_records.size)
@@ -373,7 +423,19 @@ class SumoContainerOutputTest < Test::Unit::TestCase
             :category => "kubernetes/default/log/format/labs",
             :host => "",
             :source => "foo",
-            :fields => "container_id=5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0,pod_labels_pod-template-hash=1013177865,pod_labels_run=log-format-labs,container=log-format-labs,namespace=default,pod=log-format-labs-54575ccdb9-9d677,pod_id=170af806-c801-11e8-9009-025000000001,host=docker-for-desktop,master_url=https =>//10.96.0.1 =>443/api,namespace_id=e8572415-9596-11e8-b28b-025000000001,node=docker-for-desktop"
+            :fields => {
+              "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
+              "pod_labels_pod-template-hash" => "1013177865",
+              "pod_labels_run" => "log-format-labs",
+              "container" => "log-format-labs",
+              "namespace" => "default",
+              "pod" => "log-format-labs-54575ccdb9-9d677",
+              "pod_id" => "170af806-c801-11e8-9009-025000000001",
+              "host" => "docker-for-desktop",
+              "master_url" => "https =>//10.96.0.1 =>443/api",
+              "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
+              "node" => "docker-for-desktop"
+            }
         },
     }
     assert_equal(1, d.filtered_records.size)
@@ -421,7 +483,19 @@ class SumoContainerOutputTest < Test::Unit::TestCase
             :category => "kubernetes/foo",
             :host => "",
             :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
-            :fields => "container_id=5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0,pod_labels_pod-template-hash=1013177865,pod_labels_run=log-format-labs,container=log-format-labs,namespace=default,pod=log-format-labs-54575ccdb9-9d677,pod_id=170af806-c801-11e8-9009-025000000001,host=docker-for-desktop,master_url=https =>//10.96.0.1 =>443/api,namespace_id=e8572415-9596-11e8-b28b-025000000001,node=docker-for-desktop"
+            :fields => {
+              "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
+              "pod_labels_pod-template-hash" => "1013177865",
+              "pod_labels_run" => "log-format-labs",
+              "container" => "log-format-labs",
+              "namespace" => "default",
+              "pod" => "log-format-labs-54575ccdb9-9d677",
+              "pod_id" => "170af806-c801-11e8-9009-025000000001",
+              "host" => "docker-for-desktop",
+              "master_url" => "https =>//10.96.0.1 =>443/api",
+              "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
+              "node" => "docker-for-desktop"
+            }
         },
     }
     assert_equal(1, d.filtered_records.size)
@@ -468,7 +542,19 @@ class SumoContainerOutputTest < Test::Unit::TestCase
             :category => "kubernetes/default/log/format/labs/log/format/labs",
             :host => "",
             :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
-            :fields => "container_id=5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0,pod_labels_pod-template-hash=1013177865,pod_labels_run=log-format-labs,container=log-format-labs,namespace=default,pod=log-format-labs-54575ccdb9-9d677,pod_id=170af806-c801-11e8-9009-025000000001,host=docker-for-desktop,master_url=https =>//10.96.0.1 =>443/api,namespace_id=e8572415-9596-11e8-b28b-025000000001,node=docker-for-desktop"
+            :fields => {
+              "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
+              "pod_labels_pod-template-hash" => "1013177865",
+              "pod_labels_run" => "log-format-labs",
+              "container" => "log-format-labs",
+              "namespace" => "default",
+              "pod" => "log-format-labs-54575ccdb9-9d677",
+              "pod_id" => "170af806-c801-11e8-9009-025000000001",
+              "host" => "docker-for-desktop",
+              "master_url" => "https =>//10.96.0.1 =>443/api",
+              "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
+              "node" => "docker-for-desktop"
+            }
         },
     }
     assert_equal(1, d.filtered_records.size)
@@ -515,7 +601,19 @@ class SumoContainerOutputTest < Test::Unit::TestCase
             :category => "kubernetes/default/log/format/labs",
             :host => "170af806-c801-11e8-9009-025000000001",
             :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
-            :fields => "container_id=5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0,pod_labels_pod-template-hash=1013177865,pod_labels_run=log-format-labs,container=log-format-labs,namespace=default,pod=log-format-labs-54575ccdb9-9d677,pod_id=170af806-c801-11e8-9009-025000000001,host=docker-for-desktop,master_url=https =>//10.96.0.1 =>443/api,namespace_id=e8572415-9596-11e8-b28b-025000000001,node=docker-for-desktop"
+            :fields => {
+              "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
+              "pod_labels_pod-template-hash" => "1013177865",
+              "pod_labels_run" => "log-format-labs",
+              "container" => "log-format-labs",
+              "namespace" => "default",
+              "pod" => "log-format-labs-54575ccdb9-9d677",
+              "pod_id" => "170af806-c801-11e8-9009-025000000001",
+              "host" => "docker-for-desktop",
+              "master_url" => "https =>//10.96.0.1 =>443/api",
+              "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
+              "node" => "docker-for-desktop"
+            }
         },
     }
     assert_equal(1, d.filtered_records.size)
@@ -562,7 +660,19 @@ class SumoContainerOutputTest < Test::Unit::TestCase
             :category => "kubernetes/default/log/format/labs/undefined",
             :host => "",
             :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
-            :fields => "container_id=5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0,pod_labels_pod-template-hash=1013177865,pod_labels_run=log-format-labs,container=log-format-labs,namespace=default,pod=log-format-labs-54575ccdb9-9d677,pod_id=170af806-c801-11e8-9009-025000000001,host=docker-for-desktop,master_url=https =>//10.96.0.1 =>443/api,namespace_id=e8572415-9596-11e8-b28b-025000000001,node=docker-for-desktop"
+            :fields => {
+              "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
+              "pod_labels_pod-template-hash" => "1013177865",
+              "pod_labels_run" => "log-format-labs",
+              "container" => "log-format-labs",
+              "namespace" => "default",
+              "pod" => "log-format-labs-54575ccdb9-9d677",
+              "pod_id" => "170af806-c801-11e8-9009-025000000001",
+              "host" => "docker-for-desktop",
+              "master_url" => "https =>//10.96.0.1 =>443/api",
+              "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
+              "node" => "docker-for-desktop"
+            }
         },
     }
     assert_equal(1, d.filtered_records.size)
@@ -655,7 +765,19 @@ class SumoContainerOutputTest < Test::Unit::TestCase
             :category => "kubernetes/default/log/format/labs",
             :host => "",
             :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
-            :fields => "container_id=5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0,pod_labels_pod-template-hash=1013177865,pod_labels_run=log-format-labs,container=log-format-labs,namespace=default,pod=log-format-labs-54575ccdb9-9d677,pod_id=170af806-c801-11e8-9009-025000000001,host=docker-for-desktop,master_url=https =>//10.96.0.1 =>443/api,namespace_id=e8572415-9596-11e8-b28b-025000000001,node=docker-for-desktop"
+            :fields => {
+              "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
+              "pod_labels_pod-template-hash" => "1013177865",
+              "pod_labels_run" => "log-format-labs",
+              "container" => "log-format-labs",
+              "namespace" => "default",
+              "pod" => "log-format-labs-54575ccdb9-9d677",
+              "pod_id" => "170af806-c801-11e8-9009-025000000001",
+              "host" => "docker-for-desktop",
+              "master_url" => "https =>//10.96.0.1 =>443/api",
+              "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
+              "node" => "docker-for-desktop"
+            }
         },
     }
     assert_equal(1, d.filtered_records.size)
@@ -700,7 +822,19 @@ class SumoContainerOutputTest < Test::Unit::TestCase
             :category => "kubernetes/default/log/format/labs",
             :host => "",
             :source => "default.log-format-labs-54575ccdb9-9d677.log-format-labs",
-            :fields => "container_id=5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0,pod_labels_pod-template-hash=54575ccdb9,pod_labels_run=log-format-labs,container=log-format-labs,namespace=default,pod=log-format-labs-54575ccdb9-9d677,pod_id=170af806-c801-11e8-9009-025000000001,host=docker-for-desktop,master_url=https =>//10.96.0.1 =>443/api,namespace_id=e8572415-9596-11e8-b28b-025000000001,node=docker-for-desktop"
+            :fields => {
+              "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
+              "pod_labels_pod-template-hash" => "54575ccdb9",
+              "pod_labels_run" => "log-format-labs",
+              "container" => "log-format-labs",
+              "namespace" => "default",
+              "pod" => "log-format-labs-54575ccdb9-9d677",
+              "pod_id" => "170af806-c801-11e8-9009-025000000001",
+              "host" => "docker-for-desktop",
+              "master_url" => "https =>//10.96.0.1 =>443/api",
+              "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
+              "node" => "docker-for-desktop"
+            }
         },
     }
     assert_equal(1, d.filtered_records.size)
@@ -745,7 +879,19 @@ class SumoContainerOutputTest < Test::Unit::TestCase
             :category => "kubernetes/default/log/format/labs/53575ccdb9",
             :host => "",
             :source => "default.log-format-labs-53575ccdb9-9d677.log-format-labs",
-            :fields => "container_id=5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0,pod_labels_pod-template-hash=1013177865,pod_labels_run=log-format-labs,container=log-format-labs,namespace=default,pod=log-format-labs-53575ccdb9-9d677,pod_id=170af806-c801-11e8-9009-025000000001,host=docker-for-desktop,master_url=https =>//10.96.0.1 =>443/api,namespace_id=e8572415-9596-11e8-b28b-025000000001,node=docker-for-desktop"
+            :fields => {
+              "container_id" => "5c280b6ad5abec32e9af729295c20f60fbeadf3ba16fda2d121f87228e6822e0",
+              "pod_labels_pod-template-hash" => "1013177865",
+              "pod_labels_run" => "log-format-labs",
+              "container" => "log-format-labs",
+              "namespace" => "default",
+              "pod" => "log-format-labs-53575ccdb9-9d677",
+              "pod_id" => "170af806-c801-11e8-9009-025000000001",
+              "host" => "docker-for-desktop",
+              "master_url" => "https =>//10.96.0.1 =>443/api",
+              "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
+              "node" => "docker-for-desktop"
+            }
         },
     }
     assert_equal(1, d.filtered_records.size)


### PR DESCRIPTION
###### Description

I recommend reviewing commit by commit (maybe also with "hide whitespace changes"), hopefully that makes it easier to read the changes

By removing the `log_format` config, the filter plugin now always attaches the metadata as `_sumo_metadata.fields`.

We did get rid of `add_timestamp` in the output plugin, so the logs that come in no longer have `timestamp` (but still have `time`). We'll have to explicitly decide what we want to do by default to make those config changes in the fluentd yaml.

**TODO:** use `sumologic` output plugin version `2.0.0` in DockerFile when gem is released, once https://github.com/SumoLogic/fluentd-output-sumologic/pull/53 is merged

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
- [x] Tested with locally built `sumologic` output plugin to verify behaviour
