### PR TITLE
Update steps for installing side Prometheus

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -245,16 +245,19 @@ Update your Prometheus configuration file’s `remote_write` section, as per the
 When installing our Helm Chart it is possible to have more than one Prometheus server running in the same cluster. You can deploy our solution more than once in the same cluster or in a cluster with an existing Prometheus server. To use a different port number than the default 9100 set the following fields for the Prometheus node exporter when installing our Helm Chart. For example:
 
 ```
---set prometheus-node-exporter.service.port=9200 --set prometheus-node-exporter.service.targetPort=9200
+--set prometheus-operator.prometheus-node-exporter.service.port=9200 --set prometheus-operator.prometheus-node-exporter.service.targetPort=9200
 ```
 
-Or add the following section to your override values.yaml:
+Or add the following to the `prometheus-operator` section of the override `values.yaml`:
 
 ```
-prometheus-node-exporter:
-  service:
-    port: 9200
-    targetPort: 9200
+prometheus-operator:
+  ...
+  prometheus-node-exporter:
+    service:
+      port: 9200
+      targetPort: 9200
+  ...
 ```
 
 ### Uninstalling the Chart


### PR DESCRIPTION
###### Description

Since our overrides file puts all prometheus operator config under `prometheus-operator`, we need to specify this to prevent confusion
