### PR TITLE
Expose fluentd config without ENV vars

### DIFF
--- a/deploy/helm/sumologic/conf/buffer.output.conf
+++ b/deploy/helm/sumologic/conf/buffer.output.conf
@@ -1,8 +1,8 @@
 <buffer>
   @type memory
   compress gzip
-  flush_interval "#{ENV['FLUSH_INTERVAL']}"
-  flush_thread_count "#{ENV['NUM_THREADS']}"
-  chunk_limit_size "#{ENV['CHUNK_LIMIT_SIZE']}"
-  total_limit_size "#{ENV['TOTAL_LIMIT_SIZE']}"
+  flush_interval {{ .Values.fluentd.buffer.flushInterval | quote }}
+  flush_thread_count {{ .Values.fluentd.buffer.numThreads | quote }}
+  chunk_limit_size {{ .Values.fluentd.buffer.chunkLimitSize | quote }}
+  total_limit_size {{ .Values.fluentd.buffer.totalLimitSize | quote }}
 </buffer>

--- a/deploy/helm/sumologic/conf/common.conf
+++ b/deploy/helm/sumologic/conf/common.conf
@@ -6,8 +6,8 @@
 <source>
   @type prometheus_output_monitor
 </source>
-{{- if .Values.sumologic.fluentdLogLevel }}
+{{- if .Values.fluentd.logLevel }}
 <system>
-  log_level {{ .Values.sumologic.fluentdLogLevel }}
+  log_level {{ .Values.fluentd.logLevel }}
 </system>
 {{- end }}

--- a/deploy/helm/sumologic/conf/events/events.conf
+++ b/deploy/helm/sumologic/conf/events/events.conf
@@ -27,15 +27,15 @@
   endpoint "#{ENV['SUMO_ENDPOINT_EVENTS']}"
   data_type logs
   disable_cookies true
-  verify_ssl "#{ENV['VERIFY_SSL']}"
-  proxy_uri "#{ENV['PROXY_URI']}"
+  verify_ssl {{ .Values.fluentd.verifySsl }}
+  proxy_uri {{ .Values.fluentd.proxyUri | quote }}
   <buffer>
     @type memory
     compress gzip
-    flush_interval "#{ENV['FLUSH_INTERVAL']}"
-    flush_thread_count "#{ENV['NUM_THREADS']}"
-    chunk_limit_size "#{ENV['CHUNK_LIMIT_SIZE']}"
-    total_limit_size "#{ENV['TOTAL_LIMIT_SIZE']}"
+    flush_interval {{ .Values.fluentd.buffer.flushInterval | quote }}
+    flush_thread_count {{ .Values.fluentd.buffer.numThreads | quote }}
+    chunk_limit_size {{ .Values.fluentd.buffer.chunkLimitSize | quote }}
+    total_limit_size {{ .Values.fluentd.buffer.totalLimitSize | quote }}
   </buffer>
 </match>
 {{- if .Values.sumologic.fluentdLogLevel }}

--- a/deploy/helm/sumologic/conf/events/events.conf
+++ b/deploy/helm/sumologic/conf/events/events.conf
@@ -1,5 +1,5 @@
-{{- if .Values.watchResourceEventsOverrides }}
-{{- range $name, $version := .Values.watchResourceEventsOverrides }}
+{{- if .Values.fluentd.events.watchResourceEventsOverrides }}
+{{- range $name, $version := .Values.fluentd.events.watchResourceEventsOverrides }}
 <source>
   @type events
   deploy_namespace {{ $.Release.Namespace }}
@@ -37,6 +37,7 @@
     chunk_limit_size {{ .Values.fluentd.buffer.chunkLimitSize | quote }}
     total_limit_size {{ .Values.fluentd.buffer.totalLimitSize | quote }}
   </buffer>
+{{- .Values.fluentd.events.output.extraConf | nindent 4 }}
 </match>
 {{- if .Values.fluentd.logLevel }}
 <system>

--- a/deploy/helm/sumologic/conf/events/events.conf
+++ b/deploy/helm/sumologic/conf/events/events.conf
@@ -38,8 +38,8 @@
     total_limit_size {{ .Values.fluentd.buffer.totalLimitSize | quote }}
   </buffer>
 </match>
-{{- if .Values.sumologic.fluentdLogLevel }}
+{{- if .Values.fluentd.logLevel }}
 <system>
-  log_level {{ .Values.sumologic.fluentdLogLevel }}
+  log_level {{ .Values.fluentd.logLevel }}
 </system>
 {{- end }}

--- a/deploy/helm/sumologic/conf/logs/logs.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.conf
@@ -12,3 +12,4 @@
 {{- if .Values.fluentd.logs.systemd.enabled }}
 @include logs.source.systemd.conf
 {{- end }}
+{{ .Values.fluentd.logs.extraLogs }}

--- a/deploy/helm/sumologic/conf/logs/logs.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.conf
@@ -12,4 +12,4 @@
 {{- if .Values.fluentd.logs.systemd.enabled }}
 @include logs.source.systemd.conf
 {{- end }}
-{{ .Values.fluentd.logs.extraLogs }}
+{{- .Values.fluentd.logs.extraLogs | nindent 2 }}

--- a/deploy/helm/sumologic/conf/logs/logs.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.conf
@@ -3,5 +3,12 @@
   port 24321
   bind 0.0.0.0
 </source>
+{{- if .Values.fluentd.logs.containers.enabled }}
 @include logs.source.containers.conf
+{{- end }}
+{{- if .Values.fluentd.logs.kubelet.enabled }}
+@include logs.source.kubelet.conf
+{{- end }}
+{{- if .Values.fluentd.logs.systemd.enabled }}
 @include logs.source.systemd.conf
+{{- end }}

--- a/deploy/helm/sumologic/conf/logs/logs.output.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.output.conf
@@ -1,6 +1,7 @@
 data_type logs
 log_key log
 endpoint "#{ENV['SUMO_ENDPOINT_LOGS']}"
-verify_ssl "#{ENV['VERIFY_SSL']}"
-proxy_uri "#{ENV['PROXY_URI']}"
+verify_ssl {{ .Values.fluentd.logs.output.verifySsl }}
+proxy_uri {{ .Values.fluentd.logs.output.proxyUri | quote }}
 @include buffer.output.conf
+{{ .Values.fluentd.logs.output.extraConf }}

--- a/deploy/helm/sumologic/conf/logs/logs.output.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.output.conf
@@ -4,4 +4,4 @@ endpoint "#{ENV['SUMO_ENDPOINT_LOGS']}"
 verify_ssl {{ .Values.fluentd.logs.output.verifySsl }}
 proxy_uri {{ .Values.fluentd.logs.output.proxyUri | quote }}
 @include buffer.output.conf
-{{ .Values.fluentd.logs.output.extraConf }}
+{{- .Values.fluentd.logs.output.extraConf | nindent 2 }}

--- a/deploy/helm/sumologic/conf/logs/logs.output.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.output.conf
@@ -1,7 +1,7 @@
 data_type logs
 log_key log
 endpoint "#{ENV['SUMO_ENDPOINT_LOGS']}"
-verify_ssl {{ .Values.fluentd.logs.output.verifySsl }}
-proxy_uri {{ .Values.fluentd.logs.output.proxyUri | quote }}
+verify_ssl {{ .Values.fluentd.verifySsl }}
+proxy_uri {{ .Values.fluentd.proxyUri | quote }}
 @include buffer.output.conf
 {{- .Values.fluentd.logs.output.extraConf | nindent 2 }}

--- a/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
@@ -169,6 +169,6 @@
   <match containers.**>
     @type sumologic
     @id sumologic.endpoint.logs
-{{ .Values.fluentd.logs.containers.outputConfig | indent 4 }}
+{{ .Values.fluentd.logs.containers.outputConf | indent 4 }}
   </match>
 </label>

--- a/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
@@ -62,15 +62,15 @@
   # }
   <filter containers.**>
     @type kubernetes_sumologic
-    source_name "#{ENV['SOURCE_NAME']}"
-    source_host "#{ENV['SOURCE_HOST']}"
-    source_category "#{ENV['SOURCE_CATEGORY']}"
-    source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-    source_category_replace_dash "#{ENV['SOURCE_CATEGORY_REPLACE_DASH']}"
-    exclude_namespace_regex "#{ENV['EXCLUDE_NAMESPACE_REGEX']}"
-    exclude_pod_regex "#{ENV['EXCLUDE_POD_REGEX']}"
-    exclude_container_regex "#{ENV['EXCLUDE_CONTAINER_REGEX']}"
-    exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
+    source_name {{ .Values.fluentd.logs.containers.sourceName | quote }}
+    source_host {{ .Values.fluentd.logs.containers.sourceHost | quote }}
+    source_category {{ .Values.fluentd.logs.containers.sourceCategory | quote }}
+    source_category_prefix {{ .Values.fluentd.logs.containers.sourceCategoryPrefix | quote }}
+    source_category_replace_dash {{ .Values.fluentd.logs.containers.sourceCategoryReplaceDash | quote }}
+    exclude_namespace_regex {{ .Values.fluentd.logs.containers.excludeNamespaceRegex | quote }}
+    exclude_pod_regex {{ .Values.fluentd.logs.containers.excludePodRegex | quote }}
+    exclude_container_regex {{ .Values.fluentd.logs.containers.excludeContainerRegex | quote }}
+    exclude_host_regex {{ .Values.fluentd.logs.containers.excludeHostRegex | quote }}
   </filter>
 ## Output from kubernetes_sumologic plugin
   # {
@@ -166,6 +166,8 @@
   #         }
   #     }
   # }
+
+{{- .Values.fluentd.logs.containers.extraPluginConf | nindent 4 }}
 
   <match containers.**>
     @type sumologic

--- a/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
@@ -1,8 +1,8 @@
 <filter containers.**>
   @type concat
   key log
-  multiline_start_regexp "#{ENV['MULTILINE_START_REGEXP']}"
-  separator "#{ENV['CONCAT_SEPARATOR']}"
+  multiline_start_regexp {{ .Values.fluentd.logs.containers.multilineStartRegexp | quote }}
+  separator {{ .Values.fluentd.logs.containers.concatSeparator | quote }}
   timeout_label @NORMAL
 </filter>
 <match containers.**>
@@ -15,15 +15,16 @@
     @log_level warn
     annotation_match ["sumologic\.com.*"]
     de_dot false
-    watch "#{ENV['K8S_METADATA_FILTER_WATCH']}"
-    ca_file "#{ENV['K8S_METADATA_FILTER_CA_FILE']}"
-    verify_ssl "#{ENV['K8S_METADATA_FILTER_VERIFY_SSL']}"
-    client_cert "#{ENV['K8S_METADATA_FILTER_CLIENT_CERT']}"
-    client_key "#{ENV['K8S_METADATA_FILTER_CLIENT_KEY']}"
-    bearer_token_file "#{ENV['K8S_METADATA_FILTER_BEARER_TOKEN_FILE']}"
-    cache_size "#{ENV['K8S_METADATA_FILTER_BEARER_CACHE_SIZE']}"
-    cache_ttl "#{ENV['K8S_METADATA_FILTER_BEARER_CACHE_TTL']}"
+    watch {{ .Values.fluentd.logs.containers.k8sMetadataFilter.watch | quote }}
+    ca_file {{ .Values.fluentd.logs.containers.k8sMetadataFilter.caFile | quote }}
+    verify_ssl {{ .Values.fluentd.logs.containers.k8sMetadataFilter.verifySsl | quote }}
+    client_cert {{ .Values.fluentd.logs.containers.k8sMetadataFilter.clientCert | quote }}
+    client_key {{ .Values.fluentd.logs.containers.k8sMetadataFilter.clientKey | quote }}
+    bearer_token_file {{ .Values.fluentd.logs.containers.k8sMetadataFilter.bearerTokenFile | quote }}
+    cache_size {{ .Values.fluentd.logs.containers.k8sMetadataFilter.bearerCacheSize | quote }}
+    cache_ttl {{ .Values.fluentd.logs.containers.k8sMetadataFilter.bearerCacheTtl | quote }}
     tag_to_kubernetes_name_regexp '.+?\.containers\.(?<pod_name>[^_]+)_(?<namespace>[^_]+)_(?<container_name>.+)-(?<docker_id>[a-z0-9]{64})\.log$'
+{{- .Values.fluentd.logs.containers.k8sMetadataFilter.extraConf | nindent 6 }}
   </filter>
   <filter containers.**>
     @type enhance_k8s_metadata
@@ -169,6 +170,6 @@
   <match containers.**>
     @type sumologic
     @id sumologic.endpoint.logs
-{{ .Values.fluentd.logs.containers.outputConf | indent 4 }}
+{{- .Values.fluentd.logs.containers.outputConf | nindent 6 }}
   </match>
 </label>

--- a/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
@@ -169,6 +169,6 @@
   <match containers.**>
     @type sumologic
     @id sumologic.endpoint.logs
-    @include logs.output.conf
+{{ .Values.fluentd.logs.containers.outputConfig | indent 4 }}
   </match>
 </label>

--- a/deploy/helm/sumologic/conf/logs/logs.source.kubelet.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.kubelet.conf
@@ -5,14 +5,15 @@
 <label @KUBELET>
   <filter host.kubelet.**>
     @type kubernetes_sumologic
-    source_category kubelet
-    source_name k8s_kubelet
-    source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-    exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
-    exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
-    exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
-    exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
+    source_category {{ .Values.fluentd.logs.kubelet.sourceCategory | quote }}
+    source_name {{ .Values.fluentd.logs.kubelet.sourceName | quote }}
+    source_category_prefix {{ .Values.fluentd.logs.kubelet.sourceCategoryPrefix | quote }}
+    exclude_facility_regex {{ .Values.fluentd.logs.kubelet.excludeFacilityRegex | quote }}
+    exclude_host_regex {{ .Values.fluentd.logs.kubelet.excludeHostRegex | quote }}
+    exclude_priority_regex {{ .Values.fluentd.logs.kubelet.excludePriorityRegex | quote }}
+    exclude_unit_regex {{ .Values.fluentd.logs.kubelet.excludeUnitRegex | quote }}
   </filter>
+{{- .Values.fluentd.logs.kubelet.extraPluginConf | nindent 4 }}
   <match host.kubelet.**>
     @type sumologic
     @id sumologic.endpoint.logs.kubelet

--- a/deploy/helm/sumologic/conf/logs/logs.source.kubelet.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.kubelet.conf
@@ -1,26 +1,21 @@
-<match host.**>
+<match host.kubelet.**>
   @type relabel
-  @label @SYSTEMD
+  @label @KUBELET
 </match>
-<label @SYSTEMD>
-  <filter host.**>
+<label @KUBELET>
+  <filter host.kubelet.**>
     @type kubernetes_sumologic
-    source_category system
+    source_category kubelet
+    source_name k8s_kubelet
     source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
     exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
     exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
     exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
     exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
   </filter>
-  <filter host.**>
-    @type record_modifier
-    <record>
-      _sumo_metadata ${record["_sumo_metadata"][:source] = tag_parts[1]; record["_sumo_metadata"]}
-    </record>
-  </filter>
-  <match host.**>
+  <match host.kubelet.**>
     @type sumologic
-    @id sumologic.endpoint.logs.systemd
-{{ .Values.fluentd.logs.systemd.outputConfig | indent 4 }}
+    @id sumologic.endpoint.logs.kubelet
+{{ .Values.fluentd.logs.kubelet.outputConfig | indent 4 }}
   </match>
 </label>

--- a/deploy/helm/sumologic/conf/logs/logs.source.kubelet.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.kubelet.conf
@@ -16,6 +16,6 @@
   <match host.kubelet.**>
     @type sumologic
     @id sumologic.endpoint.logs.kubelet
-{{ .Values.fluentd.logs.kubelet.outputConf | indent 4 }}
+{{- .Values.fluentd.logs.kubelet.outputConf | nindent 6 }}
   </match>
 </label>

--- a/deploy/helm/sumologic/conf/logs/logs.source.kubelet.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.kubelet.conf
@@ -16,6 +16,6 @@
   <match host.kubelet.**>
     @type sumologic
     @id sumologic.endpoint.logs.kubelet
-{{ .Values.fluentd.logs.kubelet.outputConfig | indent 4 }}
+{{ .Values.fluentd.logs.kubelet.outputConf | indent 4 }}
   </match>
 </label>

--- a/deploy/helm/sumologic/conf/logs/logs.source.systemd.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.systemd.conf
@@ -5,12 +5,12 @@
 <label @SYSTEMD>
   <filter host.**>
     @type kubernetes_sumologic
-    source_category system
-    source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-    exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
-    exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
-    exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
-    exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
+    source_category {{ .Values.fluentd.logs.systemd.sourceCategory | quote }}
+    source_category_prefix {{ .Values.fluentd.logs.systemd.sourceCategoryPrefix | quote }}
+    exclude_facility_regex {{ .Values.fluentd.logs.systemd.excludeFacilityRegex | quote }}
+    exclude_host_regex {{ .Values.fluentd.logs.systemd.excludeHostRegex | quote }}
+    exclude_priority_regex {{ .Values.fluentd.logs.systemd.excludePriorityRegex | quote }}
+    exclude_unit_regex {{ .Values.fluentd.logs.systemd.excludeUnitRegex | quote }}
   </filter>
   <filter host.**>
     @type record_modifier
@@ -18,6 +18,7 @@
       _sumo_metadata ${record["_sumo_metadata"][:source] = tag_parts[1]; record["_sumo_metadata"]}
     </record>
   </filter>
+{{- .Values.fluentd.logs.systemd.extraPluginConf | nindent 4 }}
   <match host.**>
     @type sumologic
     @id sumologic.endpoint.logs.systemd

--- a/deploy/helm/sumologic/conf/logs/logs.source.systemd.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.systemd.conf
@@ -21,6 +21,6 @@
   <match host.**>
     @type sumologic
     @id sumologic.endpoint.logs.systemd
-{{ .Values.fluentd.logs.systemd.outputConfig | indent 4 }}
+{{ .Values.fluentd.logs.systemd.outputConf | indent 4 }}
   </match>
 </label>

--- a/deploy/helm/sumologic/conf/logs/logs.source.systemd.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.systemd.conf
@@ -21,6 +21,6 @@
   <match host.**>
     @type sumologic
     @id sumologic.endpoint.logs.systemd
-{{ .Values.fluentd.logs.systemd.outputConf | indent 4 }}
+{{- .Values.fluentd.logs.systemd.outputConf | nindent 6 }}
   </match>
 </label>

--- a/deploy/helm/sumologic/conf/metrics/metrics.conf
+++ b/deploy/helm/sumologic/conf/metrics/metrics.conf
@@ -13,6 +13,7 @@
   <filter prometheus.metrics**>
     @type enhance_k8s_metadata
   </filter>
+{{- .Values.fluentd.metrics.extraPluginConf | nindent 4 }}
   <filter prometheus.metrics**>
     @type prometheus_format
     relabel container_name:container,pod_name:pod

--- a/deploy/helm/sumologic/conf/metrics/metrics.output.conf
+++ b/deploy/helm/sumologic/conf/metrics/metrics.output.conf
@@ -4,3 +4,4 @@ disable_cookies true
 verify_ssl {{ .Values.fluentd.verifySsl }}
 proxy_uri {{ .Values.fluentd.proxyUri | quote }}
 @include buffer.output.conf
+{{- .Values.fluentd.metrics.output.extraConf | nindent 2 }}

--- a/deploy/helm/sumologic/conf/metrics/metrics.output.conf
+++ b/deploy/helm/sumologic/conf/metrics/metrics.output.conf
@@ -1,4 +1,6 @@
 data_type metrics
 metric_data_format prometheus
 disable_cookies true
+verify_ssl {{ .Values.fluentd.verifySsl }}
+proxy_uri {{ .Values.fluentd.proxyUri | quote }}
 @include buffer.output.conf

--- a/deploy/helm/sumologic/templates/configmap.yaml
+++ b/deploy/helm/sumologic/templates/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
     {{ template "sumologic.labels.common" . }}
 data:
   fluent.conf: |-
-{{ .Values.fluentd.rawConfig | indent 4 }}
+{{- .Values.fluentd.rawConfig | nindent 4 }}
 {{- (tpl (.Files.Glob "conf/*.conf").AsConfig .) | nindent 2 }}
 {{- (tpl (.Files.Glob "conf/metrics/*.conf").AsConfig .) | nindent 2 }}
 {{- (tpl (.Files.Glob "conf/logs/*.conf").AsConfig .) | nindent 2 }}

--- a/deploy/helm/sumologic/templates/configmap.yaml
+++ b/deploy/helm/sumologic/templates/configmap.yaml
@@ -7,9 +7,7 @@ metadata:
     {{ template "sumologic.labels.common" . }}
 data:
   fluent.conf: |-
-    @include common.conf
-    @include metrics.conf
-    @include logs.conf
-  {{- (tpl (.Files.Glob "conf/*.conf").AsConfig .) | nindent 2 }}
-  {{- (tpl (.Files.Glob "conf/metrics/*.conf").AsConfig .) | nindent 2 }}
-  {{- (tpl (.Files.Glob "conf/logs/*.conf").AsConfig .) | nindent 2 }}
+{{ .Values.fluentd.rawConfig | indent 4 }}
+{{- (tpl (.Files.Glob "conf/*.conf").AsConfig .) | nindent 2 }}
+{{- (tpl (.Files.Glob "conf/metrics/*.conf").AsConfig .) | nindent 2 }}
+{{- (tpl (.Files.Glob "conf/logs/*.conf").AsConfig .) | nindent 2 }}

--- a/deploy/helm/sumologic/templates/deployment.yaml
+++ b/deploy/helm/sumologic/templates/deployment.yaml
@@ -100,11 +100,3 @@ spec:
             secretKeyRef:
               name: sumologic
               key: endpoint-logs
-        - name: FLUSH_INTERVAL
-          value: {{ .Values.sumologic.flushInterval | quote }}
-        - name: NUM_THREADS
-          value: {{ .Values.sumologic.numThreads | quote }}
-        - name: CHUNK_LIMIT_SIZE
-          value: {{ .Values.sumologic.chunkLimitSize | quote }}
-        - name: TOTAL_LIMIT_SIZE
-          value: {{ .Values.sumologic.totalLimitSize | quote }}

--- a/deploy/helm/sumologic/templates/deployment.yaml
+++ b/deploy/helm/sumologic/templates/deployment.yaml
@@ -108,16 +108,6 @@ spec:
           value: {{ .Values.sumologic.chunkLimitSize | quote }}
         - name: TOTAL_LIMIT_SIZE
           value: {{ .Values.sumologic.totalLimitSize | quote }}
-        - name: SOURCE_CATEGORY
-          value: {{ .Values.sumologic.sourceCategory | quote }}
-        - name: SOURCE_CATEGORY_PREFIX
-          value: {{ .Values.sumologic.sourceCategoryPrefix | quote }}
-        - name: SOURCE_CATEGORY_REPLACE_DASH
-          value: {{ .Values.sumologic.sourceCategoryReplaceDash | quote }}
-        - name: SOURCE_NAME
-          value: {{ .Values.sumologic.sourceName | quote }}
-        - name: VERIFY_SSL
-          value: {{ .Values.sumologic.verifySsl | quote }}
         - name: EXCLUDE_NAMESPACE_REGEX
           value: {{ .Values.sumologic.excludeNamespaceRegex | quote }}
         - name: EXCLUDE_CONTAINER_REGEX

--- a/deploy/helm/sumologic/templates/deployment.yaml
+++ b/deploy/helm/sumologic/templates/deployment.yaml
@@ -108,11 +108,3 @@ spec:
           value: {{ .Values.sumologic.chunkLimitSize | quote }}
         - name: TOTAL_LIMIT_SIZE
           value: {{ .Values.sumologic.totalLimitSize | quote }}
-        - name: EXCLUDE_NAMESPACE_REGEX
-          value: {{ .Values.sumologic.excludeNamespaceRegex | quote }}
-        - name: EXCLUDE_CONTAINER_REGEX
-          value: {{ .Values.sumologic.excludeContainerRegex | quote }}
-        - name: EXCLUDE_HOST_REGEX
-          value: {{ .Values.sumologic.excludeHostRegex | quote }}
-        - name: EXCLUDE_POD_REGEX
-          value: {{ .Values.sumologic.excludePodRegex | quote }}

--- a/deploy/helm/sumologic/templates/deployment.yaml
+++ b/deploy/helm/sumologic/templates/deployment.yaml
@@ -116,18 +116,6 @@ spec:
           value: {{ .Values.sumologic.sourceCategoryReplaceDash | quote }}
         - name: SOURCE_NAME
           value: {{ .Values.sumologic.sourceName | quote }}
-        - name: MULTILINE_START_REGEXP
-          value: {{ .Values.sumologic.multilineStartRegexp | quote }}
-        - name: CONCAT_SEPARATOR
-          value: {{ .Values.sumologic.concatSeparator | quote }}
-        - name: K8S_METADATA_FILTER_WATCH
-          value: {{ .Values.sumologic.k8sMetadataFilter.watch | quote }}
-        - name: K8S_METADATA_FILTER_VERIFY_SSL
-          value: {{ .Values.sumologic.k8sMetadataFilter.verifySsl | quote }}
-        - name: K8S_METADATA_FILTER_BEARER_CACHE_SIZE
-          value: {{ .Values.sumologic.k8sMetadataFilter.bearerCacheSize | quote }}
-        - name: K8S_METADATA_FILTER_BEARER_CACHE_TTL
-          value: {{ .Values.sumologic.k8sMetadataFilter.bearerCacheTtl | quote }}
         - name: VERIFY_SSL
           value: {{ .Values.sumologic.verifySsl | quote }}
         - name: EXCLUDE_NAMESPACE_REGEX

--- a/deploy/helm/sumologic/templates/events-configmap.yaml
+++ b/deploy/helm/sumologic/templates/events-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.sumologic.eventCollectionEnabled true }}
+{{- if eq .Values.fluentd.events.enabled true }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/deploy/helm/sumologic/templates/events-deployment.yaml
+++ b/deploy/helm/sumologic/templates/events-deployment.yaml
@@ -58,14 +58,4 @@ spec:
             secretKeyRef:
               name: sumologic
               key: endpoint-events
-        - name: VERIFY_SSL
-          value: {{ .Values.sumologic.verifySsl| quote }}
-        - name: FLUSH_INTERVAL
-          value: {{ .Values.sumologic.flushInterval | quote }}
-        - name: NUM_THREADS
-          value: {{ .Values.sumologic.numThreads | quote }}
-        - name: CHUNK_LIMIT_SIZE
-          value: {{ .Values.sumologic.chunkLimitSize | quote }}
-        - name: TOTAL_LIMIT_SIZE
-          value: {{ .Values.sumologic.totalLimitSize | quote }}
 {{- end }}

--- a/deploy/helm/sumologic/templates/events-deployment.yaml
+++ b/deploy/helm/sumologic/templates/events-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.sumologic.eventCollectionEnabled true }}
+{{- if eq .Values.fluentd.events.enabled true }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/deploy/helm/sumologic/templates/events-service.yaml
+++ b/deploy/helm/sumologic/templates/events-service.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.sumologic.eventCollectionEnabled true }}
+{{- if eq .Values.fluentd.events.enabled true }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -125,6 +125,13 @@ sumologic:
     ## ref: https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter#configuration
     bearerCacheTtl: "3600"
 
+## Configure fluentd
+fluentd:
+  rawConfig: |-
+    @include common.conf
+    @include metrics.conf
+    @include logs.conf
+
 ## Configure fluent-bit 
 ## ref: https://github.com/helm/charts/blob/master/stable/fluent-bit/values.yaml
 fluent-bit:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -72,13 +72,6 @@ sumologic:
   ## Used to replace - with another character.
   sourceCategoryReplaceDash: "/"
 
-  ## The regular expression for the "concat" plugin to use when merging multi-line messages
-  multilineStartRegexp: '/^\w{3} \d{1,2}, \d{4}/'
-
-  ## The character to use to delimit lines within the final concatenated message.
-  ## Most multi-line messages contain a newline at the end of each line
-  concatSeparator: ""
-
   ## Verify SumoLogic HTTPS certificates
   verifySsl: "true"
 
@@ -109,28 +102,13 @@ sumologic:
   #   pods: "v1"
   #   events: "events.k8s.io/v1beta1"
 
-  k8sMetadataFilter:
-    ## Option to control the enabling of metadata filter plugin watch.
-    ## ref: https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter#configuration
-    watch: "true"
-
-    ## Verify ssl certificate of sumologic endpoint.
-    verifySsl: "true"
-
-    ## Option to control the enabling of metadata filter plugin cache_size. 
-    ## ref: https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter#configuration
-    bearerCacheSize: "1000"
-
-    ## Option to control the enabling of metadata filter plugin cache_ttl. 
-    ## ref: https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter#configuration
-    bearerCacheTtl: "3600"
-
 ## Configure fluentd
 fluentd:
   rawConfig: |-
     @include common.conf
     @include metrics.conf
     @include logs.conf
+
   logs:
     ## Configuration for sumologic output plugin
     ## ref: https://github.com/SumoLogic/fluentd-output-sumologic
@@ -143,7 +121,7 @@ fluentd:
       ## Additional config parameters for sumologic output plugin
       extraConf: |-
 
-    ## Additional log config for custom log pipelines
+    ## Additional config for custom log pipelines
     ## ref: TODO: documentation for custom logs pipelines
     extraLogs: |-
 
@@ -152,11 +130,41 @@ fluentd:
       enabled: true
       outputConf: |-
         @include logs.output.conf
+
+      ## The regular expression for the "concat" plugin to use when merging multi-line messages
+      multilineStartRegexp: '/^\w{3} \d{1,2}, \d{4}/'
+
+      ## The character to use to delimit lines within the final concatenated message.
+      ## Most multi-line messages contain a newline at the end of each line
+      concatSeparator: ""
+
+      ## ref: https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter#configuration
+      k8sMetadataFilter:
+        ## Option to control the enabling of metadata filter plugin watch.
+        watch: "true"
+        ## path to CA file for Kubernetes server certificate validation
+        caFile: ""
+        ## Validate SSL certificates
+        verifySsl: "true"
+        ## Path to a client cert file to authenticate to the API server
+        clientCert: ""
+        ## Path to a client key file to authenticate to the API server
+        clientKey: ""
+        ## Path to a file containing the bearer token to use for authentication
+        bearerTokenFile: ""
+        ## Option to control the enabling of metadata filter plugin cache_size.
+        bearerCacheSize: "1000"
+        ## Option to control the enabling of metadata filter plugin cache_ttl.
+        bearerCacheTtl: "3600"
+        ## Additional config parameters for kubernetes_metadata filter plugin
+        extraConf: |-
+
     ## Kubelet log configuration
     kubelet:
       enabled: true
       outputConf: |-
         @include logs.output.conf
+
     ## Systemd log configuration
     systemd:
       enabled: true

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -60,18 +60,6 @@ sumologic:
 
   totalLimitSize: "128m"
 
-  ## Set the _sourceName metadata field in SumoLogic.
-  sourceName: "%{namespace}.%{pod}.%{container}"
-
-  ## Set the _sourceCategory metadata field in SumoLogic.
-  sourceCategory: "%{namespace}/%{pod_name}"
-
-  ## Set the prefix, for _sourceCategory metadata.
-  sourceCategoryPrefix: "kubernetes/"
-
-  ## Used to replace - with another character.
-  sourceCategoryReplaceDash: "/"
-
   ## Verify SumoLogic HTTPS certificates
   verifySsl: "true"
 
@@ -128,8 +116,40 @@ fluentd:
     ## Container log configuration
     containers:
       enabled: true
+
       outputConf: |-
         @include logs.output.conf
+
+      ## Set the _sourceName metadata field in Sumo Logic.
+      sourceName: "%{namespace}.%{pod}.%{container}"
+
+      ## Set the _sourceHost metadata field in Sumo Logic.
+      sourceHost: ""
+
+      ## Set the _sourceCategory metadata field in Sumo Logic.
+      sourceCategory: "%{namespace}/%{pod_name}"
+
+      ## Set the prefix, for _sourceCategory metadata.
+      sourceCategoryPrefix: "kubernetes/"
+
+      ## Used to replace - with another character.
+      sourceCategoryReplaceDash: "/"
+
+      ## A regular expression for containers.
+      ## Matching containers will be excluded from Sumo. The logs will still be sent to FluentD.
+      excludeContainerRegex: ""
+
+      ## A regular expression for hosts.
+      ## Matching hosts will be excluded from Sumo. The logs will still be sent to FluentD.
+      excludeHostRegex: ""
+
+      ## A regular expression for namespaces.
+      ## Matching namespaces will be excluded from Sumo. The logs will still be sent to FluentD.
+      excludeNamespaceRegex: ""
+
+      ## A regular expression for pods.
+      ## Matching pods will be excluded from Sumo. The logs will still be sent to FluentD.
+      excludePodRegex: ""
 
       ## The regular expression for the "concat" plugin to use when merging multi-line messages
       multilineStartRegexp: '/^\w{3} \d{1,2}, \d{4}/'
@@ -159,15 +179,20 @@ fluentd:
         ## Additional config parameters for kubernetes_metadata filter plugin
         extraConf: |-
 
+      ## To use additional filter plugins (ex: for text or json_merge log format)
+      extraPluginConf: |-
+
     ## Kubelet log configuration
     kubelet:
       enabled: true
+
       outputConf: |-
         @include logs.output.conf
 
     ## Systemd log configuration
     systemd:
       enabled: true
+
       outputConf: |-
         @include logs.output.conf
 

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -132,14 +132,32 @@ fluentd:
     @include metrics.conf
     @include logs.conf
   logs:
+    ## Configuration for sumologic output plugin
+    ## ref: https://github.com/SumoLogic/fluentd-output-sumologic
+    ## ref: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/master/deploy/helm/sumologic/conf/logs/logs.output.conf
+    output:
+      ## Verify SumoLogic HTTPS certificates
+      verifySsl: true
+      ## Proxy URI for sumologic output plugin
+      proxyUri: ""
+      ## Additional config parameters for sumologic output plugin
+      extraConf: |-
+
+    ## Additional log config for custom log pipelines
+    ## ref: TODO: documentation for custom logs pipelines
+    extraLogs: |-
+
+    ## Container log configuration
     containers:
       enabled: true
       outputConfig: |-
         @include logs.output.conf
+    ## Kubelet log configuration
     kubelet:
       enabled: true
       outputConfig: |-
         @include logs.output.conf
+    ## Systemd log configuration
     systemd:
       enabled: true
       outputConfig: |-

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -132,7 +132,7 @@ fluentd:
         ## path to CA file for Kubernetes server certificate validation
         caFile: ""
         ## Validate SSL certificates
-        verifySsl: "true"
+        verifySsl: true
         ## Path to a client cert file to authenticate to the API server
         clientCert: ""
         ## Path to a client key file to authenticate to the API server

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -188,6 +188,28 @@ fluentd:
 
       outputConf: |-
         @include logs.output.conf
+      
+      ## Set the _sourceName metadata field in Sumo Logic.
+      sourceName: "k8s_kubelet"
+      ## Set the _sourceCategory metadata field in Sumo Logic.
+      sourceCategory: "kubelet"
+      ## Set the prefix, for _sourceCategory metadata.
+      sourceCategoryPrefix: "kubernetes/"
+      ## A regular expression for facility.
+      ## Matching facility will be excluded from Sumo. The logs will still be sent to FluentD.
+      excludeFacilityRegex: ""
+      ## A regular expression for hosts.
+      ## Matching hosts will be excluded from Sumo. The logs will still be sent to FluentD.
+      excludeHostRegex: ""
+      ## A regular expression for priority.
+      ## Matching priority will be excluded from Sumo. The logs will still be sent to FluentD.
+      excludePriorityRegex: ""
+      ## A regular expression for unit.
+      ## Matching unit will be excluded from Sumo. The logs will still be sent to FluentD.
+      excludeUnitRegex: ""
+
+      ## To use additional filter plugins (ex: for text or json_merge log format)
+      extraPluginConf: |-
 
     ## Systemd log configuration
     systemd:
@@ -195,6 +217,26 @@ fluentd:
 
       outputConf: |-
         @include logs.output.conf
+
+      ## Set the _sourceCategory metadata field in Sumo Logic.
+      sourceCategory: "system"
+      ## Set the prefix, for _sourceCategory metadata.
+      sourceCategoryPrefix: "kubernetes/"
+      ## A regular expression for facility.
+      ## Matching facility will be excluded from Sumo. The logs will still be sent to FluentD.
+      excludeFacilityRegex: ""
+      ## A regular expression for hosts.
+      ## Matching hosts will be excluded from Sumo. The logs will still be sent to FluentD.
+      excludeHostRegex: ""
+      ## A regular expression for priority.
+      ## Matching priority will be excluded from Sumo. The logs will still be sent to FluentD.
+      excludePriorityRegex: ""
+      ## A regular expression for unit.
+      ## Matching unit will be excluded from Sumo. The logs will still be sent to FluentD.
+      excludeUnitRegex: ""
+
+      ## To use additional filter plugins (ex: for text or json_merge log format)
+      extraPluginConf: |-
 
 ## Configure fluent-bit 
 ## ref: https://github.com/helm/charts/blob/master/stable/fluent-bit/values.yaml

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -49,13 +49,6 @@ sumologic:
   # If enabled, collect K8s events
   eventCollectionEnabled: true
 
-  ## Verify SumoLogic HTTPS certificates
-  verifySsl: "true"
-
-  ## Sets the fluentd log level. The default log level, if not specified, is info.
-  ## ref: https://docs.fluentd.org/deployment/logging
-  # fluentdLogLevel: "debug"
-
   ## Override Kubernetes resource types you want to get events for from different Kubernetes
   ## API versions. The key represents the name of the resource type and the value represents
   ## the API version.
@@ -69,6 +62,10 @@ fluentd:
     @include common.conf
     @include metrics.conf
     @include logs.conf
+
+  ## Sets the fluentd log level. The default log level, if not specified, is info.
+  ## ref: https://docs.fluentd.org/deployment/logging
+  # logLevel: "debug"
 
   ## Verify SumoLogic HTTPS certificates
   verifySsl: true

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -49,35 +49,8 @@ sumologic:
   # If enabled, collect K8s events
   eventCollectionEnabled: true
 
-  ## How frequently to push logs to SumoLogic
-  ## ref: https://github.com/SumoLogic/fluentd-kubernetes-sumologic#options
-  flushInterval: "5s"
-
-  ## Increase number of http threads to Sumo. May be required in heavy logging clusters
-  numThreads: 4
-
-  chunkLimitSize: "100k"
-
-  totalLimitSize: "128m"
-
   ## Verify SumoLogic HTTPS certificates
   verifySsl: "true"
-
-  ## A regular expression for containers. 
-  ## Matching containers will be excluded from Sumo. The logs will still be sent to FluentD.
-  excludeContainerRegex: ""
-
-  ## A regular expression for hosts. 
-  ## Matching hosts will be excluded from Sumo. The logs will still be sent to FluentD.
-  excludeHostRegex: ""
-
-  ## A regular expression for namespaces. 
-  ## Matching namespaces will be excluded from Sumo. The logs will still be sent to FluentD.
-  excludeNamespaceRegex: ""
-
-  ## A regular expression for pods. 
-  ## Matching pods will be excluded from Sumo. The logs will still be sent to FluentD.
-  excludePodRegex: ""
 
   ## Sets the fluentd log level. The default log level, if not specified, is info.
   ## ref: https://docs.fluentd.org/deployment/logging
@@ -97,15 +70,25 @@ fluentd:
     @include metrics.conf
     @include logs.conf
 
+  ## Verify SumoLogic HTTPS certificates
+  verifySsl: true
+  ## Proxy URI for sumologic output plugin
+  proxyUri: ""
+
+  buffer:
+    ## How frequently to push logs to SumoLogic
+    ## ref: https://github.com/SumoLogic/fluentd-kubernetes-sumologic#options
+    flushInterval: "5s"
+    ## Increase number of http threads to Sumo. May be required in heavy logging clusters
+    numThreads: 4
+    chunkLimitSize: "100k"
+    totalLimitSize: "128m"
+
   logs:
     ## Configuration for sumologic output plugin
     ## ref: https://github.com/SumoLogic/fluentd-output-sumologic
     ## ref: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/master/deploy/helm/sumologic/conf/logs/logs.output.conf
     output:
-      ## Verify SumoLogic HTTPS certificates
-      verifySsl: true
-      ## Proxy URI for sumologic output plugin
-      proxyUri: ""
       ## Additional config parameters for sumologic output plugin
       extraConf: |-
 

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -150,17 +150,17 @@ fluentd:
     ## Container log configuration
     containers:
       enabled: true
-      outputConfig: |-
+      outputConf: |-
         @include logs.output.conf
     ## Kubelet log configuration
     kubelet:
       enabled: true
-      outputConfig: |-
+      outputConf: |-
         @include logs.output.conf
     ## Systemd log configuration
     systemd:
       enabled: true
-      outputConfig: |-
+      outputConf: |-
         @include logs.output.conf
 
 ## Configure fluent-bit 

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -131,6 +131,19 @@ fluentd:
     @include common.conf
     @include metrics.conf
     @include logs.conf
+  logs:
+    containers:
+      enabled: true
+      outputConfig: |-
+        @include logs.output.conf
+    kubelet:
+      enabled: true
+      outputConfig: |-
+        @include logs.output.conf
+    systemd:
+      enabled: true
+      outputConfig: |-
+        @include logs.output.conf
 
 ## Configure fluent-bit 
 ## ref: https://github.com/helm/charts/blob/master/stable/fluent-bit/values.yaml

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -46,16 +46,6 @@ sumologic:
   # Cluster name
   clusterName: "kubernetes"
 
-  # If enabled, collect K8s events
-  eventCollectionEnabled: true
-
-  ## Override Kubernetes resource types you want to get events for from different Kubernetes
-  ## API versions. The key represents the name of the resource type and the value represents
-  ## the API version.
-  # watchResourceEventsOverrides:
-  #   pods: "v1"
-  #   events: "events.k8s.io/v1beta1"
-
 ## Configure fluentd
 fluentd:
   rawConfig: |-
@@ -118,15 +108,12 @@ fluentd:
       ## A regular expression for containers.
       ## Matching containers will be excluded from Sumo. The logs will still be sent to FluentD.
       excludeContainerRegex: ""
-
       ## A regular expression for hosts.
       ## Matching hosts will be excluded from Sumo. The logs will still be sent to FluentD.
       excludeHostRegex: ""
-
       ## A regular expression for namespaces.
       ## Matching namespaces will be excluded from Sumo. The logs will still be sent to FluentD.
       excludeNamespaceRegex: ""
-
       ## A regular expression for pods.
       ## Matching pods will be excluded from Sumo. The logs will still be sent to FluentD.
       excludePodRegex: ""
@@ -188,7 +175,7 @@ fluentd:
       ## Matching unit will be excluded from Sumo. The logs will still be sent to FluentD.
       excludeUnitRegex: ""
 
-      ## To use additional filter plugins (ex: for text or json_merge log format)
+      ## To use additional filter plugins
       extraPluginConf: |-
 
     ## Systemd log configuration
@@ -215,8 +202,34 @@ fluentd:
       ## Matching unit will be excluded from Sumo. The logs will still be sent to FluentD.
       excludeUnitRegex: ""
 
-      ## To use additional filter plugins (ex: for text or json_merge log format)
+      ## To use additional filter plugins
       extraPluginConf: |-
+
+  metrics:
+    ## Configuration for sumologic output plugin
+    ## ref: https://github.com/SumoLogic/fluentd-output-sumologic
+    ## ref: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/master/deploy/helm/sumologic/conf/logs/logs.output.conf
+    output:
+      ## Additional config parameters for sumologic output plugin
+      extraConf: |-
+
+    ## To use additional filter plugins
+    extraPluginConf: |-
+
+  events:
+    # If enabled, collect K8s events
+    enabled: true
+
+    output:
+      ## Additional config parameters for sumologic output plugin
+      extraConf: |-
+
+    ## Override Kubernetes resource types you want to get events for from different Kubernetes
+    ## API versions. The key represents the name of the resource type and the value represents
+    ## the API version.
+    # watchResourceEventsOverrides:
+    #   pods: "v1"
+    #   events: "events.k8s.io/v1beta1"
 
 ## Configure fluent-bit 
 ## ref: https://github.com/helm/charts/blob/master/stable/fluent-bit/values.yaml

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -17,10 +17,10 @@ data:
     <buffer>
       @type memory
       compress gzip
-      flush_interval "#{ENV['FLUSH_INTERVAL']}"
-      flush_thread_count "#{ENV['NUM_THREADS']}"
-      chunk_limit_size "#{ENV['CHUNK_LIMIT_SIZE']}"
-      total_limit_size "#{ENV['TOTAL_LIMIT_SIZE']}"
+      flush_interval "5s"
+      flush_thread_count "4"
+      chunk_limit_size "100k"
+      total_limit_size "128m"
     </buffer>
   common.conf: |-
     <source>
@@ -48,6 +48,7 @@ data:
       <filter prometheus.metrics**>
         @type enhance_k8s_metadata
       </filter>
+      
       <filter prometheus.metrics**>
         @type prometheus_format
         relabel container_name:container,pod_name:pod
@@ -105,7 +106,10 @@ data:
     data_type metrics
     metric_data_format prometheus
     disable_cookies true
+    verify_ssl true
+    proxy_uri ""
     @include buffer.output.conf
+    
   
   logs.conf: |-
     <source>
@@ -114,20 +118,23 @@ data:
       bind 0.0.0.0
     </source>
     @include logs.source.containers.conf
+    @include logs.source.kubelet.conf
     @include logs.source.systemd.conf
-  logs.output.conf: |
+    
+  logs.output.conf: |-
     data_type logs
     log_key log
     endpoint "#{ENV['SUMO_ENDPOINT_LOGS']}"
-    verify_ssl "#{ENV['VERIFY_SSL']}"
-    proxy_uri "#{ENV['PROXY_URI']}"
+    verify_ssl true
+    proxy_uri ""
     @include buffer.output.conf
+    
   logs.source.containers.conf: |-
     <filter containers.**>
       @type concat
       key log
-      multiline_start_regexp "#{ENV['MULTILINE_START_REGEXP']}"
-      separator "#{ENV['CONCAT_SEPARATOR']}"
+      multiline_start_regexp "/^\\w{3} \\d{1,2}, \\d{4}/"
+      separator ""
       timeout_label @NORMAL
     </filter>
     <match containers.**>
@@ -140,15 +147,16 @@ data:
         @log_level warn
         annotation_match ["sumologic\.com.*"]
         de_dot false
-        watch "#{ENV['K8S_METADATA_FILTER_WATCH']}"
-        ca_file "#{ENV['K8S_METADATA_FILTER_CA_FILE']}"
-        verify_ssl "#{ENV['K8S_METADATA_FILTER_VERIFY_SSL']}"
-        client_cert "#{ENV['K8S_METADATA_FILTER_CLIENT_CERT']}"
-        client_key "#{ENV['K8S_METADATA_FILTER_CLIENT_KEY']}"
-        bearer_token_file "#{ENV['K8S_METADATA_FILTER_BEARER_TOKEN_FILE']}"
-        cache_size "#{ENV['K8S_METADATA_FILTER_BEARER_CACHE_SIZE']}"
-        cache_ttl "#{ENV['K8S_METADATA_FILTER_BEARER_CACHE_TTL']}"
+        watch "true"
+        ca_file ""
+        verify_ssl "true"
+        client_cert ""
+        client_key ""
+        bearer_token_file ""
+        cache_size "1000"
+        cache_ttl "3600"
         tag_to_kubernetes_name_regexp '.+?\.containers\.(?<pod_name>[^_]+)_(?<namespace>[^_]+)_(?<container_name>.+)-(?<docker_id>[a-z0-9]{64})\.log$'
+        
       </filter>
       <filter containers.**>
         @type enhance_k8s_metadata
@@ -186,15 +194,15 @@ data:
       # }
       <filter containers.**>
         @type kubernetes_sumologic
-        source_name "#{ENV['SOURCE_NAME']}"
-        source_host "#{ENV['SOURCE_HOST']}"
-        source_category "#{ENV['SOURCE_CATEGORY']}"
-        source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-        source_category_replace_dash "#{ENV['SOURCE_CATEGORY_REPLACE_DASH']}"
-        exclude_namespace_regex "#{ENV['EXCLUDE_NAMESPACE_REGEX']}"
-        exclude_pod_regex "#{ENV['EXCLUDE_POD_REGEX']}"
-        exclude_container_regex "#{ENV['EXCLUDE_CONTAINER_REGEX']}"
-        exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
+        source_name "%{namespace}.%{pod}.%{container}"
+        source_host ""
+        source_category "%{namespace}/%{pod_name}"
+        source_category_prefix "kubernetes/"
+        source_category_replace_dash "/"
+        exclude_namespace_regex ""
+        exclude_pod_regex ""
+        exclude_container_regex ""
+        exclude_host_regex ""
       </filter>
     ## Output from kubernetes_sumologic plugin
       # {
@@ -290,6 +298,7 @@ data:
       #         }
       #     }
       # }
+      
   
       <match containers.**>
         @type sumologic
@@ -297,7 +306,7 @@ data:
         @include logs.output.conf
       </match>
     </label>
-  logs.source.systemd.conf: |-
+  logs.source.kubelet.conf: |-
     <match host.kubelet.**>
       @type relabel
       @label @KUBELET
@@ -305,20 +314,22 @@ data:
     <label @KUBELET>
       <filter host.kubelet.**>
         @type kubernetes_sumologic
-        source_category kubelet
-        source_name k8s_kubelet
-        source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-        exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
-        exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
-        exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
-        exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
+        source_category "kubelet"
+        source_name "k8s_kubelet"
+        source_category_prefix "kubernetes/"
+        exclude_facility_regex ""
+        exclude_host_regex ""
+        exclude_priority_regex ""
+        exclude_unit_regex ""
       </filter>
+      
       <match host.kubelet.**>
         @type sumologic
         @id sumologic.endpoint.logs.kubelet
         @include logs.output.conf
       </match>
     </label>
+  logs.source.systemd.conf: |-
     <match host.**>
       @type relabel
       @label @SYSTEMD
@@ -326,12 +337,12 @@ data:
     <label @SYSTEMD>
       <filter host.**>
         @type kubernetes_sumologic
-        source_category system
-        source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
-        exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
-        exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
-        exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
-        exclude_unit_regex "#{ENV['EXCLUDE_UNIT_REGEX']}"
+        source_category "system"
+        source_category_prefix "kubernetes/"
+        exclude_facility_regex ""
+        exclude_host_regex ""
+        exclude_priority_regex ""
+        exclude_unit_regex ""
       </filter>
       <filter host.**>
         @type record_modifier
@@ -339,6 +350,7 @@ data:
           _sumo_metadata ${record["_sumo_metadata"][:source] = tag_parts[1]; record["_sumo_metadata"]}
         </record>
       </filter>
+      
       <match host.**>
         @type sumologic
         @id sumologic.endpoint.logs.systemd
@@ -379,16 +391,17 @@ data:
       endpoint "#{ENV['SUMO_ENDPOINT_EVENTS']}"
       data_type logs
       disable_cookies true
-      verify_ssl "#{ENV['VERIFY_SSL']}"
-      proxy_uri "#{ENV['PROXY_URI']}"
+      verify_ssl true
+      proxy_uri ""
       <buffer>
         @type memory
         compress gzip
-        flush_interval "#{ENV['FLUSH_INTERVAL']}"
-        flush_thread_count "#{ENV['NUM_THREADS']}"
-        chunk_limit_size "#{ENV['CHUNK_LIMIT_SIZE']}"
-        total_limit_size "#{ENV['TOTAL_LIMIT_SIZE']}"
+        flush_interval "5s"
+        flush_thread_count "4"
+        chunk_limit_size "100k"
+        total_limit_size "128m"
       </buffer>
+      
     </match>
   
 ---
@@ -599,44 +612,6 @@ spec:
             secretKeyRef:
               name: sumologic
               key: endpoint-logs
-        - name: FLUSH_INTERVAL
-          value: "5s"
-        - name: NUM_THREADS
-          value: "4"
-        - name: CHUNK_LIMIT_SIZE
-          value: "100k"
-        - name: TOTAL_LIMIT_SIZE
-          value: "128m"
-        - name: SOURCE_CATEGORY
-          value: "%{namespace}/%{pod_name}"
-        - name: SOURCE_CATEGORY_PREFIX
-          value: "kubernetes/"
-        - name: SOURCE_CATEGORY_REPLACE_DASH
-          value: "/"
-        - name: SOURCE_NAME
-          value: "%{namespace}.%{pod}.%{container}"
-        - name: MULTILINE_START_REGEXP
-          value: "/^\\w{3} \\d{1,2}, \\d{4}/"
-        - name: CONCAT_SEPARATOR
-          value: ""
-        - name: K8S_METADATA_FILTER_WATCH
-          value: "true"
-        - name: K8S_METADATA_FILTER_VERIFY_SSL
-          value: "true"
-        - name: K8S_METADATA_FILTER_BEARER_CACHE_SIZE
-          value: "1000"
-        - name: K8S_METADATA_FILTER_BEARER_CACHE_TTL
-          value: "3600"
-        - name: VERIFY_SSL
-          value: "true"
-        - name: EXCLUDE_NAMESPACE_REGEX
-          value: ""
-        - name: EXCLUDE_CONTAINER_REGEX
-          value: ""
-        - name: EXCLUDE_HOST_REGEX
-          value: ""
-        - name: EXCLUDE_POD_REGEX
-          value: ""
 ---
 # Source: sumologic/templates/events-deployment.yaml
 
@@ -705,13 +680,3 @@ spec:
             secretKeyRef:
               name: sumologic
               key: endpoint-events
-        - name: VERIFY_SSL
-          value: "true"
-        - name: FLUSH_INTERVAL
-          value: "5s"
-        - name: NUM_THREADS
-          value: "4"
-        - name: CHUNK_LIMIT_SIZE
-          value: "100k"
-        - name: TOTAL_LIMIT_SIZE
-          value: "128m"


### PR DESCRIPTION
###### Description

This PR was built with https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/232 as the base, we can address feedback from that one and merge before we merge this one.

The goal was to expose the Fluentd config to the user, while hopefully also making the `values.yaml` easier to use. We also want to get rid of the layer of indirection that was created with the ENV vars.

`values.yaml` will be the most interesting file to look at, hopefully the rest of it is just inserting the mustache syntax in the correct places to reflect what is in `values.yaml`.

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
