### PR TITLE
Bump version of Fluentd Output plugin to support fields

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN gem install fluent-plugin-s3
 RUN gem install fluent-plugin-systemd -v 1.0.2 \
        && gem install fluent-plugin-record-modifier -v 2.0.1 \
        && gem install fluent-plugin-kubernetes_metadata_filter -v 2.2.0 \
-       && gem install fluent-plugin-sumologic_output -v 1.5.0 \
+       && gem install fluent-plugin-sumologic_output -v 1.6.0 \
        && gem install fluent-plugin-concat -v 2.4.0 \
        && gem install fluent-plugin-rewrite-tag-filter -v 2.2.0 \
        && gem install fluent-plugin-prometheus -v 1.6.1


### PR DESCRIPTION
###### Description

We should have the Kubernetes collection start using this version of the output plugin: https://github.com/SumoLogic/fluentd-output-sumologic/releases/tag/1.6.0

###### Testing performed

- [x] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
