### PR TITLE
Update setup.sh to use Terraform

### DIFF
--- a/deploy/helm/sumologic/templates/setup/setup-clusterrole.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-clusterrole.yaml
@@ -16,5 +16,5 @@ rules:
     resources:
       - secrets
       - namespaces
-    verbs: ["get", "create", "describe"]
+    verbs: ["get", "create", "describe", "patch"]
 {{- end }}

--- a/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
@@ -1,0 +1,143 @@
+{{- if .Values.sumologic.setupEnabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name:  {{ template "sumologic.fullname" . }}-setup
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    app: {{ template "sumologic.labels.app" . }}
+    {{ template "sumologic.labels.common" . }}
+data:
+  setup.sh: |-
+    #!/bin/sh
+
+    mkdir /test
+    cp /etc/terraform/* /test/
+    cd /test
+    terraform init
+
+    terraform import -config=/test kubernetes_namespace.sumologic_collection_namespace {{ .Release.Namespace }}
+    terraform import -config=/test kubernetes_secret.sumologic_collection_secret {{ .Release.Namespace }}/sumologic
+
+    terraform apply -auto-approve
+  sumo-k8s.tf: |-
+    variable "cluster_name" {
+      type  = string
+      default = "{{ .Values.sumologic.clusterName }}"
+    }
+
+    variable "namespace_name" {
+      type  = string
+      default = "{{ .Release.Namespace }}"
+    }
+
+    locals {
+      default-metrics-source-name                 = "(default-metrics)"
+      apiserver-metrics-source-name               = "apiserver-metrics"
+      events-source-name                          = "events"
+      kube-controller-manager-metrics-source-name = "kube-controller-manager-metrics"
+      kube-scheduler-metrics-source-name          = "kube-scheduler-metrics"
+      kube-state-metrics-source-name              = "kube-state-metrics"
+      kubelet-metrics-source-name                 = "kubelet-metrics"
+      logs-source-name                            = "logs"
+      node-exporter-metrics-source-name           = "node-exporter-metrics"
+    }
+
+    provider "sumologic" {}
+
+    resource "sumologic_collector" "collector" {
+        name  = var.cluster_name
+        fields  = {
+          cluster = var.cluster_name
+        }
+    }
+
+    resource "sumologic_http_source" "default_metrics_source" {
+        name         = local.default-metrics-source-name
+        category     = "${var.cluster_name}/${local.default-metrics-source-name}"
+        collector_id = "${sumologic_collector.collector.id}"
+    }
+
+    resource "sumologic_http_source" "apiserver_metrics_source" {
+        name         = local.apiserver-metrics-source-name
+        category     = "${var.cluster_name}/${local.apiserver-metrics-source-name}"
+        collector_id = "${sumologic_collector.collector.id}"
+    }
+
+    resource "sumologic_http_source" "events_source" {
+        name         = local.events-source-name
+        category     = "${var.cluster_name}/${local.events-source-name}"
+        collector_id = "${sumologic_collector.collector.id}"
+    }
+
+    resource "sumologic_http_source" "kube_controller_manager_metrics_source" {
+        name         = local.kube-controller-manager-metrics-source-name
+        category     = "${var.cluster_name}/${local.kube-controller-manager-metrics-source-name}"
+        collector_id = "${sumologic_collector.collector.id}"
+    }
+
+    resource "sumologic_http_source" "kube_scheduler_metrics_source" {
+        name         = local.kube-scheduler-metrics-source-name
+        category     = "${var.cluster_name}/${local.kube-scheduler-metrics-source-name}"
+        collector_id = "${sumologic_collector.collector.id}"
+    }
+
+    resource "sumologic_http_source" "kube_state_metrics_source" {
+        name         = local.kube-state-metrics-source-name
+        category     = "${var.cluster_name}/${local.kube-state-metrics-source-name}"
+        collector_id = "${sumologic_collector.collector.id}"
+    }
+
+    resource "sumologic_http_source" "kubelet_metrics_source" {
+        name         = local.kubelet-metrics-source-name
+        category     = "${var.cluster_name}/${local.kubelet-metrics-source-name}"
+        collector_id = "${sumologic_collector.collector.id}"
+    }
+
+    resource "sumologic_http_source" "logs_source" {
+        name         = local.logs-source-name
+        category     = "${var.cluster_name}/${local.logs-source-name}"
+        collector_id = "${sumologic_collector.collector.id}"
+    }
+
+    resource "sumologic_http_source" "node_exporter_metrics_source" {
+        name         = local.node-exporter-metrics-source-name
+        category     = "${var.cluster_name}/${local.node-exporter-metrics-source-name}"
+        collector_id = "${sumologic_collector.collector.id}"
+    }
+
+    provider "kubernetes" {
+      host = "http://localhost:8001"
+    }
+
+    resource "kubernetes_namespace" "sumologic_collection_namespace" {
+      metadata {
+        name = var.namespace_name
+      }
+    }
+
+    resource "kubernetes_secret" "sumologic_collection_secret" {
+      metadata {
+        name = "sumologic"
+        namespace = var.namespace_name
+      }
+
+      data = {
+        endpoint-events                           = "${sumologic_http_source.events_source.url}"
+        endpoint-logs                             = "${sumologic_http_source.logs_source.url}"
+        endpoint-metrics                          = "${sumologic_http_source.default_metrics_source.url}"
+        endpoint-metrics-apiserver                = "${sumologic_http_source.apiserver_metrics_source.url}"
+        endpoint-metrics-kube-controller-manager  = "${sumologic_http_source.kube_controller_manager_metrics_source.url}"
+        endpoint-metrics-kube-scheduler           = "${sumologic_http_source.kube_scheduler_metrics_source.url}"
+        endpoint-metrics-kube-state               = "${sumologic_http_source.kube_state_metrics_source.url}"
+        endpoint-metrics-kubelet                  = "${sumologic_http_source.kubelet_metrics_source.url}"
+        endpoint-metrics-node-exporter            = "${sumologic_http_source.node_exporter_metrics_source.url}"
+      }
+
+      type = "Opaque"
+    }
+
+{{- end }}

--- a/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
@@ -136,7 +136,9 @@ data:
     }
 
     provider "kubernetes" {
-      host = "http://localhost:8001"
+      host                    = "https://kubernetes.default.svc"
+      token                   = "${file("/var/run/secrets/kubernetes.io/serviceaccount/token")}"
+      cluster_ca_certificate  = "${file("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")}"
     }
 
     resource "kubernetes_namespace" "sumologic_collection_namespace" {

--- a/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
@@ -13,14 +13,28 @@ metadata:
 data:
   setup.sh: |-
     #!/bin/sh
+    cp /etc/terraform/sumo-k8s.tf /terraform
+    cd /terraform
 
-    mkdir /test
-    cp /etc/terraform/* /test/
-    cd /test
+    COLLECTOR_NAME={{- if .Values.sumologic.collectorName }}{{ .Values.sumologic.collectorName }}{{- else}}{{ .Values.sumologic.clusterName }}{{- end}}
+
     terraform init
 
-    terraform import -config=/test kubernetes_namespace.sumologic_collection_namespace {{ .Release.Namespace }}
-    terraform import -config=/test kubernetes_secret.sumologic_collection_secret {{ .Release.Namespace }}/sumologic
+    # Sumo Collector and HTTP sources
+    terraform import sumologic_collector.collector "$COLLECTOR_NAME"
+    terraform import sumologic_http_source.default_metrics_source "$COLLECTOR_NAME/(default-metrics)"
+    terraform import sumologic_http_source.apiserver_metrics_source "$COLLECTOR_NAME/apiserver-metrics"
+    terraform import sumologic_http_source.events_source "$COLLECTOR_NAME/events"
+    terraform import sumologic_http_source.kube_controller_manager_metrics_source "$COLLECTOR_NAME/kube-controller-manager-metrics"
+    terraform import sumologic_http_source.kube_scheduler_metrics_source "$COLLECTOR_NAME/kube-scheduler-metrics"
+    terraform import sumologic_http_source.kube_state_metrics_source "$COLLECTOR_NAME/kube-state-metrics"
+    terraform import sumologic_http_source.kubelet_metrics_source "$COLLECTOR_NAME/kubelet-metrics"
+    terraform import sumologic_http_source.logs_source "$COLLECTOR_NAME/logs"
+    terraform import sumologic_http_source.node_exporter_metrics_source "$COLLECTOR_NAME/node-exporter-metrics"
+
+    # Kubernetes Namespace and Secret
+    terraform import kubernetes_namespace.sumologic_collection_namespace {{ .Release.Namespace }}
+    terraform import kubernetes_secret.sumologic_collection_secret {{ .Release.Namespace }}/sumologic
 
     terraform apply -auto-approve
   sumo-k8s.tf: |-
@@ -28,6 +42,18 @@ data:
       type  = string
       default = "{{ .Values.sumologic.clusterName }}"
     }
+
+    {{- if .Values.sumologic.collectorName }}
+    variable "collector_name" {
+      type  = string
+      default = "{{ .Values.sumologic.collectorName }}"
+    }
+    {{- else }}
+    variable "collector_name" {
+      type  = string
+      default = "{{ .Values.sumologic.clusterName }}"
+    }
+    {{- end }}
 
     variable "namespace_name" {
       type  = string
@@ -49,7 +75,7 @@ data:
     provider "sumologic" {}
 
     resource "sumologic_collector" "collector" {
-        name  = var.cluster_name
+        name  = var.collector_name
         fields  = {
           cluster = var.cluster_name
         }

--- a/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
@@ -16,6 +16,9 @@ data:
     cp /etc/terraform/sumo-k8s.tf /terraform
     cd /terraform
 
+    # Fix URL to remove "v1" or "v1/"
+    export SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL%v1*}
+
     COLLECTOR_NAME={{- if .Values.sumologic.collectorName }}{{ .Values.sumologic.collectorName }}{{- else}}{{ .Values.sumologic.clusterName }}{{- end}}
 
     terraform init

--- a/deploy/helm/sumologic/templates/setup/setup-job.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-job.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   template:
     spec:
-      restartPolicy: OnFailure
+      restartPolicy: Never
       serviceAccountName: {{ template "sumologic.fullname" . }}-setup
       volumes:
       - name: setup
@@ -27,11 +27,9 @@ spec:
         command: ["/kubectl"]
         args: ["proxy", "-p", "8001"]
       - name: setup
-        image: test1:latest
-        imagePullPolicy: Never
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["/etc/terraform/setup.sh"]
-        securityContext:
-          runAsUser: 0
         volumeMounts:
         - name: setup
           mountPath: /etc/terraform
@@ -40,6 +38,6 @@ spec:
           value: {{ required "A valid .Values.sumologic.accessId entry required!" .Values.sumologic.accessId }}
         - name: SUMOLOGIC_ACCESSKEY
           value: {{ required "A valid .Values.sumologic.accessKey entry required!" .Values.sumologic.accessKey }}
-        - name: SUMOLOGIC_ENVIRONMENT
-          value: us2
+        - name: SUMOLOGIC_BASE_URL
+          value: {{ required "A valid .Values.sumologic.endpoint entry required!" .Values.sumologic.endpoint }}
 {{- end }}

--- a/deploy/helm/sumologic/templates/setup/setup-job.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-job.yaml
@@ -16,19 +16,30 @@ spec:
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ template "sumologic.fullname" . }}-setup
-      containers:
+      volumes:
       - name: setup
-        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        command: ["/usr/bin/setup.sh", 
-          "-n", "{{ .Release.Namespace }}", 
-          "-k", "{{ .Values.sumologic.clusterName }}", 
-          {{- if .Values.sumologic.collectorName }}
-          "-c", "{{ .Values.sumologic.collectorName }}",
-          {{- end }}
-          "-d", "false", 
-          "-y", "false", 
-          '{{ required "A valid .Values.sumologic.endpoint entry required!" .Values.sumologic.endpoint }}',
-          '{{ required "A valid .Values.sumologic.accessId entry required!" .Values.sumologic.accessId }}', 
-          '{{ required "A valid .Values.sumologic.accessKey entry required!" .Values.sumologic.accessKey }}']
+        configMap:
+          name: {{ template "sumologic.fullname" . }}-setup
+          defaultMode: 0777
+      containers:
+      - name:  kubectl
+        image: gcr.io/google_containers/kubectl:v1.0.7
+        command: ["/kubectl"]
+        args: ["proxy", "-p", "8001"]
+      - name: setup
+        image: test1:latest
+        imagePullPolicy: Never
+        command: ["/etc/terraform/setup.sh"]
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+        - name: setup
+          mountPath: /etc/terraform
+        env:
+        - name: SUMOLOGIC_ACCESSID
+          value: {{ required "A valid .Values.sumologic.accessId entry required!" .Values.sumologic.accessId }}
+        - name: SUMOLOGIC_ACCESSKEY
+          value: {{ required "A valid .Values.sumologic.accessKey entry required!" .Values.sumologic.accessKey }}
+        - name: SUMOLOGIC_ENVIRONMENT
+          value: us2
 {{- end }}

--- a/deploy/helm/sumologic/templates/setup/setup-job.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-job.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   template:
     spec:
-      restartPolicy: Never
+      restartPolicy: OnFailure
       serviceAccountName: {{ template "sumologic.fullname" . }}-setup
       volumes:
       - name: setup
@@ -22,10 +22,6 @@ spec:
           name: {{ template "sumologic.fullname" . }}-setup
           defaultMode: 0777
       containers:
-      - name:  kubectl
-        image: gcr.io/google_containers/kubectl:v1.0.7
-        command: ["/kubectl"]
-        args: ["proxy", "-p", "8001"]
       - name: setup
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}


### PR DESCRIPTION
###### Description

Adds Terraform-based setup for Sumo collector and HTTP sources, as well as Kubernetes namespace and secret.

Requires https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/248 to be merged, and a Helm chart release (minor version, non-alpha) so that the docker image contains the required dependencies.

~~Do not merge until we have a Helm chart release with the updated Dockerfile~~
Dockerfile changes are in Helm chart release 0.10.0

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
