### PR TITLE
Re-add wget dependency for setup.sh script

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -53,6 +53,7 @@ RUN runDeps="sudo libsnappy-dev" \
  && apt-get install -y gnupg \
  && apt-get install -y curl \
  && apt-get install -y jq \
+ && apt-get install -y wget \
  && apt-get install -y unzip
 
  # Install kubectl (to be removed once we switch to Terraform)


### PR DESCRIPTION
###### Description

`wget` dependency was removed in https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/248 but we still need this while we have the `setup.sh` script since it depends on it.

FYI: @maimaisie 

###### Testing performed

- [x] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
