### PR TITLE
Adding support for NodeSelector and Tolerations

### DIFF
--- a/deploy/helm/sumologic/templates/deployment.yaml
+++ b/deploy/helm/sumologic/templates/deployment.yaml
@@ -17,6 +17,10 @@ spec:
         {{ template "sumologic.labels.common" . }}
     spec:
       serviceAccountName: {{ template "sumologic.fullname" . }}
+{{- if .Values.deployment.nodeSelector }}
+	    nodeSelector:
+{{ toYaml .Values.deployment.nodeSelector | indent 8 }}
+{{- end -}}
       volumes:
       - name: pos-files
         hostPath:

--- a/deploy/helm/sumologic/templates/deployment.yaml
+++ b/deploy/helm/sumologic/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       serviceAccountName: {{ template "sumologic.fullname" . }}
 {{- if .Values.deployment.nodeSelector }}
-	    nodeSelector:
+      nodeSelector:
 {{ toYaml .Values.deployment.nodeSelector | indent 8 }}
 {{- end -}}
       volumes:

--- a/deploy/helm/sumologic/templates/deployment.yaml
+++ b/deploy/helm/sumologic/templates/deployment.yaml
@@ -21,6 +21,10 @@ spec:
       nodeSelector:
 {{ toYaml .Values.deployment.nodeSelector | indent 8 }}
 {{- end -}}
+{{- if .Values.deployment.tolerations }}
+      tolerations:
+{{ toYaml .Values.deployment.tolerations | indent 8 }}
+{{- end -}}
       volumes:
       - name: pos-files
         hostPath:

--- a/deploy/helm/sumologic/templates/deployment.yaml
+++ b/deploy/helm/sumologic/templates/deployment.yaml
@@ -20,11 +20,11 @@ spec:
 {{- if .Values.deployment.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.deployment.nodeSelector | indent 8 }}
-{{- end -}}
+{{- end }}
 {{- if .Values.deployment.tolerations }}
       tolerations:
 {{ toYaml .Values.deployment.tolerations | indent 8 }}
-{{- end -}}
+{{- end }}
       volumes:
       - name: pos-files
         hostPath:

--- a/deploy/helm/sumologic/templates/events-deployment.yaml
+++ b/deploy/helm/sumologic/templates/events-deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       serviceAccountName: {{ template "sumologic.fullname" . }}
 {{- if .Values.eventsDeployment.nodeSelector }}
-	    nodeSelector:
+      nodeSelector:
 {{ toYaml .Values.eventsDeployment.nodeSelector | indent 8 }}
 {{- end -}}
       volumes:

--- a/deploy/helm/sumologic/templates/events-deployment.yaml
+++ b/deploy/helm/sumologic/templates/events-deployment.yaml
@@ -20,11 +20,11 @@ spec:
 {{- if .Values.eventsDeployment.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.eventsDeployment.nodeSelector | indent 8 }}
-{{- end -}}
+{{- end }}
 {{- if .Values.eventsDeployment.tolerations }}
       tolerations:
 {{ toYaml .Values.eventsDeployment.tolerations | indent 8 }}
-{{- end -}}
+{{- end }}
       volumes:
       - name: pos-files
         hostPath:

--- a/deploy/helm/sumologic/templates/events-deployment.yaml
+++ b/deploy/helm/sumologic/templates/events-deployment.yaml
@@ -21,6 +21,10 @@ spec:
       nodeSelector:
 {{ toYaml .Values.eventsDeployment.nodeSelector | indent 8 }}
 {{- end -}}
+{{- if .Values.deployment.tolerations }}
+      tolerations:
+{{ toYaml .Values.deployment.tolerations | indent 8 }}
+{{- end -}}
       volumes:
       - name: pos-files
         hostPath:

--- a/deploy/helm/sumologic/templates/events-deployment.yaml
+++ b/deploy/helm/sumologic/templates/events-deployment.yaml
@@ -21,9 +21,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.eventsDeployment.nodeSelector | indent 8 }}
 {{- end -}}
-{{- if .Values.deployment.tolerations }}
+{{- if .Values.eventsDeployment.tolerations }}
       tolerations:
-{{ toYaml .Values.deployment.tolerations | indent 8 }}
+{{ toYaml .Values.eventsDeployment.tolerations | indent 8 }}
 {{- end -}}
       volumes:
       - name: pos-files

--- a/deploy/helm/sumologic/templates/events-deployment.yaml
+++ b/deploy/helm/sumologic/templates/events-deployment.yaml
@@ -17,6 +17,10 @@ spec:
         {{ template "sumologic.labels.common" . }}
     spec:
       serviceAccountName: {{ template "sumologic.fullname" . }}
+{{- if .Values.eventsDeployment.nodeSelector }}
+	    nodeSelector:
+{{ toYaml .Values.eventsDeployment.nodeSelector | indent 8 }}
+{{- end -}}
       volumes:
       - name: pos-files
         hostPath:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -4,9 +4,9 @@ image:
   pullPolicy: IfNotPresent
 
 nameOverride: ""
-fullnameOverride: ""
 
 deployment:
+  nodeSelector: {}
   replicaCount: 3
   resources:
     limits:
@@ -17,6 +17,7 @@ deployment:
       cpu: 0.5
 
 eventsDeployment:
+  nodeSelector: {}
   resources:
     limits:
       memory: 256Mi

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -7,6 +7,7 @@ nameOverride: ""
 
 deployment:
   nodeSelector: {}
+  tolerations: {}
   replicaCount: 3
   resources:
     limits:
@@ -18,6 +19,7 @@ deployment:
 
 eventsDeployment:
   nodeSelector: {}
+  tolerations: {}
   resources:
     limits:
       memory: 256Mi


### PR DESCRIPTION
###### Description

Both Deployment and EventDepoyment don't support configuring NodeSelector, in hybrid clusters (windows+linux), this is a must. 

###### Testing performed

- [X ] ci/build.sh
 --- No support for OSX
 ```
 11:39 $ ci/build.sh 
Starting build process in: /Users/sylvain_boily/git/djsly/sumologic-kubernetes-collection with version tag: 0.0.0
Building gem fluent-plugin-carbon-v2 version 0.0.0 in /Users/sylvain_boily/git/djsly/sumologic-kubernetes-collection/fluent-plugin-carbon-v2 ...
Install bundler...
ci/build.sh: /usr/local/bin/bundle: /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/bin/ruby: bad interpreter: No such file or directory
Script error on line 39
```
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
