### PR TITLE
Add NodeSelector and Tolerations to both deployments

### DIFF
--- a/deploy/helm/sumologic/templates/deployment.yaml
+++ b/deploy/helm/sumologic/templates/deployment.yaml
@@ -17,6 +17,14 @@ spec:
         {{ template "sumologic.labels.common" . }}
     spec:
       serviceAccountName: {{ template "sumologic.fullname" . }}
+{{- if .Values.deployment.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.deployment.nodeSelector | indent 8 }}
+{{- end -}}
+{{- if .Values.deployment.tolerations }}
+      tolerations:
+{{ toYaml .Values.deployment.tolerations | indent 8 }}
+{{- end -}}
       volumes:
       - name: pos-files
         hostPath:

--- a/deploy/helm/sumologic/templates/deployment.yaml
+++ b/deploy/helm/sumologic/templates/deployment.yaml
@@ -20,11 +20,11 @@ spec:
 {{- if .Values.deployment.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.deployment.nodeSelector | indent 8 }}
-{{- end -}}
+{{- end }}
 {{- if .Values.deployment.tolerations }}
       tolerations:
 {{ toYaml .Values.deployment.tolerations | indent 8 }}
-{{- end -}}
+{{- end }}
       volumes:
       - name: pos-files
         hostPath:

--- a/deploy/helm/sumologic/templates/events-deployment.yaml
+++ b/deploy/helm/sumologic/templates/events-deployment.yaml
@@ -17,6 +17,14 @@ spec:
         {{ template "sumologic.labels.common" . }}
     spec:
       serviceAccountName: {{ template "sumologic.fullname" . }}
+{{- if .Values.eventsDeployment.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.eventsDeployment.nodeSelector | indent 8 }}
+{{- end -}}
+{{- if .Values.eventsDeployment.tolerations }}
+      tolerations:
+{{ toYaml .Values.eventsDeployment.tolerations | indent 8 }}
+{{- end -}}
       volumes:
       - name: pos-files
         hostPath:

--- a/deploy/helm/sumologic/templates/events-deployment.yaml
+++ b/deploy/helm/sumologic/templates/events-deployment.yaml
@@ -20,11 +20,11 @@ spec:
 {{- if .Values.eventsDeployment.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.eventsDeployment.nodeSelector | indent 8 }}
-{{- end -}}
+{{- end }}
 {{- if .Values.eventsDeployment.tolerations }}
       tolerations:
 {{ toYaml .Values.eventsDeployment.tolerations | indent 8 }}
-{{- end -}}
+{{- end }}
       volumes:
       - name: pos-files
         hostPath:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -4,7 +4,6 @@ image:
   pullPolicy: IfNotPresent
 
 nameOverride: ""
-fullnameOverride: ""
 
 deployment:
   nodeSelector: {}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -7,6 +7,8 @@ nameOverride: ""
 fullnameOverride: ""
 
 deployment:
+  nodeSelector: {}
+  tolerations: {}
   replicaCount: 3
   resources:
     limits:
@@ -17,6 +19,8 @@ deployment:
       cpu: 0.5
 
 eventsDeployment:
+  nodeSelector: {}
+  tolerations: {}
   resources:
     limits:
       memory: 256Mi

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -394,7 +394,8 @@ spec:
         app: collection-sumologic
         
     spec:
-      serviceAccountName: collection-sumologicvolumes:
+      serviceAccountName: collection-sumologic
+      volumes:
       - name: pos-files
         hostPath:
           path: /var/run/fluentd-pos
@@ -555,7 +556,8 @@ spec:
         app: collection-sumologic-events
         
     spec:
-      serviceAccountName: collection-sumologicvolumes:
+      serviceAccountName: collection-sumologic
+      volumes:
       - name: pos-files
         hostPath:
           path: /var/run/fluentd-pos

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -394,8 +394,7 @@ spec:
         app: collection-sumologic
         
     spec:
-      serviceAccountName: collection-sumologic
-      volumes:
+      serviceAccountName: collection-sumologicvolumes:
       - name: pos-files
         hostPath:
           path: /var/run/fluentd-pos
@@ -556,8 +555,7 @@ spec:
         app: collection-sumologic-events
         
     spec:
-      serviceAccountName: collection-sumologic
-      volumes:
+      serviceAccountName: collection-sumologicvolumes:
       - name: pos-files
         hostPath:
           path: /var/run/fluentd-pos


### PR DESCRIPTION
###### Description

Adds `nodeSelector` and `tolerations` to both deployments, from https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/255

###### Testing performed

- [x] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
