### PR TITLE
Cut release 0.10.0

### DIFF
--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.9.0"
+appVersion: "0.10.0"
 description: A Helm chart for collecting Kubernetes logs, metrics and events into Sumo Logic.
 name: sumologic
-version: 0.9.0
+version: 0.10.0

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: sumologic/kubernetes-fluentd
-  tag: 0.9.0
+  tag: 0.10.0
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -405,7 +405,7 @@ spec:
           name: collection-sumologic
       containers:
       - name: fluentd
-        image: sumologic/kubernetes-fluentd:0.9.0
+        image: sumologic/kubernetes-fluentd:0.10.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -567,7 +567,7 @@ spec:
           name: collection-sumologic-events
       containers:
       - name: fluentd-events
-        image: sumologic/kubernetes-fluentd:0.9.0
+        image: sumologic/kubernetes-fluentd:0.10.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:


### PR DESCRIPTION
###### Description

In preparation for cutting release 0.10.0

FYI: @maimaisie @lei-sumo @frankreno 

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
- [x] End-to-end tests are green with `v0.9.12-alpha`
