### PR TITLE
Update Travis CI to support PR push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,6 @@ before_install:
   - sudo apt install snapd
   - sudo snap install helm --classic
 script: bash ci/build.sh
+branches:
+  only:
+  - master


### PR DESCRIPTION
###### Description

1. Only pushing to master (merging a PR) will run CI with `push` event type
2. Otherwise, all PRs will run CI with `pull_request` event type. In this case we look at `TRAVIS_PULL_REQUEST_BRANCH` in order to detect changes made to generated files, or changes that need to be committed for generated files.

FYI: @maimaisie 

###### Testing performed

- [x] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
- [x] Test making invalid change and verifying it fails
- [x] Test making valid change and verify it commits the generated yaml files
- [x] Test making subsequent valid change and verify it commits the updated generated files