### PR TITLE
using include statement vs template for better yaml support

### DIFF
--- a/deploy/helm/sumologic/templates/clusterrole.yaml
+++ b/deploy/helm/sumologic/templates/clusterrole.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "sumologic.fullname" . }}
   labels:
     app: {{ template "sumologic.labels.app" . }}
-    {{ template "sumologic.labels.common" . }}
+    {{- include "sumologic.labels.common" . | nindent 4 }}
 rules:
 - apiGroups: ["", "apps", "extensions", "events.k8s.io"]
   resources:

--- a/deploy/helm/sumologic/templates/clusterrolebinding.yaml
+++ b/deploy/helm/sumologic/templates/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "sumologic.fullname" . }}
   labels:
     app: {{ template "sumologic.labels.app" . }}
-    {{ template "sumologic.labels.common" . }}
+    {{- include "sumologic.labels.common" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
   namespace: {{ .Release.Namespace }}

--- a/deploy/helm/sumologic/templates/configmap.yaml
+++ b/deploy/helm/sumologic/templates/configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "sumologic.fullname" . }}
   labels:
     app: {{ template "sumologic.labels.app" . }}
-    {{ template "sumologic.labels.common" . }}
+    {{- include "sumologic.labels.common" . | nindent 4 }}
 data:
   fluent.conf: |-
     @include common.conf

--- a/deploy/helm/sumologic/templates/deployment.yaml
+++ b/deploy/helm/sumologic/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "sumologic.fullname" . }}
   labels:
     app: {{ template "sumologic.labels.app" . }}
-    {{ template "sumologic.labels.common" . }}
+    {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -14,7 +14,7 @@ spec:
     metadata:
       labels:
         app: {{ template "sumologic.labels.app" . }}
-        {{ template "sumologic.labels.common" . }}
+        {{- include "sumologic.labels.common" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "sumologic.fullname" . }}
 {{- if .Values.deployment.nodeSelector }}

--- a/deploy/helm/sumologic/templates/events-configmap.yaml
+++ b/deploy/helm/sumologic/templates/events-configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ printf "%s-events" (include "sumologic.fullname" .) }}
   labels:
     app: {{ printf "%s-events" (include "sumologic.labels.app" .) }}
-    {{ template "sumologic.labels.common" . }}
+    {{- include "sumologic.labels.common" . | nindent 4 }}
 data:
   fluent.conf: |-
     @include events.conf

--- a/deploy/helm/sumologic/templates/events-deployment.yaml
+++ b/deploy/helm/sumologic/templates/events-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ printf "%s-events" (include "sumologic.fullname" .) }}
   labels:
     app: {{ printf "%s-events" (include "sumologic.labels.app" .) }}
-    {{ template "sumologic.labels.common" . }}
+    {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -14,7 +14,7 @@ spec:
     metadata:
       labels:
         app: {{ printf "%s-events" (include "sumologic.labels.app" .) }}
-        {{ template "sumologic.labels.common" . }}
+        {{- include "sumologic.labels.common" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "sumologic.fullname" . }}
 {{- if .Values.eventsDeployment.nodeSelector }}

--- a/deploy/helm/sumologic/templates/events-service.yaml
+++ b/deploy/helm/sumologic/templates/events-service.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ printf "%s-events" (include "sumologic.fullname" .) }}
   labels:
     app: {{ printf "%s-events" (include "sumologic.labels.app" .) }}
-    {{ template "sumologic.labels.common" . }}
+    {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:
     app: {{ printf "%s-events" (include "sumologic.labels.app" .) }}

--- a/deploy/helm/sumologic/templates/service.yaml
+++ b/deploy/helm/sumologic/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "sumologic.fullname" . }}
   labels:
     app: {{ template "sumologic.labels.app" . }}
-    {{ template "sumologic.labels.common" . }}
+    {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:
     app: {{ template "sumologic.labels.app" . }}

--- a/deploy/helm/sumologic/templates/serviceaccount.yaml
+++ b/deploy/helm/sumologic/templates/serviceaccount.yaml
@@ -4,4 +4,4 @@ metadata:
   name: {{ template "sumologic.fullname" . }}
   labels:
     app: {{ template "sumologic.labels.app" . }}
-    {{ template "sumologic.labels.common" . }}
+    {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/setup/setup-clusterrole.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-clusterrole.yaml
@@ -9,7 +9,7 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
     app: {{ template "sumologic.labels.app" . }}
-    {{ template "sumologic.labels.common" . }}
+    {{- include "sumologic.labels.common" . | nindent 4 }}
 rules:
   - apiGroups:
       - ""

--- a/deploy/helm/sumologic/templates/setup/setup-clusterrolebinding.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-clusterrolebinding.yaml
@@ -9,7 +9,7 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
     app: {{ template "sumologic.labels.app" . }}
-    {{ template "sumologic.labels.common" . }}
+    {{- include "sumologic.labels.common" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/deploy/helm/sumologic/templates/setup/setup-job.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-job.yaml
@@ -10,7 +10,7 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
     app: {{ template "sumologic.labels.app" . }}
-    {{ template "sumologic.labels.common" . }}
+    {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   template:
     spec:

--- a/deploy/helm/sumologic/templates/setup/setup-serviceaccount.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-serviceaccount.yaml
@@ -9,5 +9,5 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
     app: {{ template "sumologic.labels.app" . }}
-    {{ template "sumologic.labels.common" . }}
+    {{- include "sumologic.labels.common" . | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
###### Description

#263 

Based on the following DOC, included is preferred for multiline template
https://helm.sh/docs/chart_template_guide/#the-include-function

The new generated yamls are now much better

```
# Source: sumologic/templates/events-deployment.yaml

apiVersion: apps/v1
kind: Deployment
metadata:
  name: release-name-sumologic-events
  labels:
    app: release-name-sumologic-events
    chart: "sumologic-0.10.0"
    release: "release-name"
    heritage: "Tiller"
spec:
  selector:
    matchLabels:
      app: release-name-sumologic-events
  template:
    metadata:
      labels:
        app: release-name-sumologic-events
        chart: "sumologic-0.10.0"
        release: "release-name"
        heritage: "Tiller"
    spec:
``` 
```
# Source: sumologic/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: release-name-sumologic
  labels:
    app: release-name-sumologic
    chart: "sumologic-0.10.0"
    release: "release-name"
    heritage: "Tiller"
spec:
  selector:
    matchLabels:
      app: release-name-sumologic
  replicas: 3
  template:
    metadata:
      labels:
        app: release-name-sumologic
        chart: "sumologic-0.10.0"
        release: "release-name"
        heritage: "Tiller"
    spec:
```

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
