### PR TITLE
fix(metrics.conf): Missing operator.rule block.

### DIFF
--- a/deploy/helm/sumologic/conf/metrics/metrics.conf
+++ b/deploy/helm/sumologic/conf/metrics/metrics.conf
@@ -59,6 +59,12 @@
     endpoint "#{ENV['SUMO_ENDPOINT_METRICS_NODE_EXPORTER']}"
     @include metrics.output.conf
   </match>
+  <match prometheus.metrics.operator.rule**>
+    @type sumologic
+    @id sumologic.endpoint.metrics.operator.rule
+    endpoint "#{ENV['SUMO_ENDPOINT_METRICS']}"
+    @include metrics.output.conf
+  </match>
   <match prometheus.metrics**>
     @type sumologic
     @id sumologic.endpoint.metrics


### PR DESCRIPTION
Added the prometheus.metrics.operator.rule block so that the metrics from the operator rule are sent into sumo.

###### Description

Fill in your description here.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
