### PR TITLE
Add setup as pre-upgrade hook

### DIFF
--- a/deploy/helm/sumologic/templates/setup/setup-clusterrole.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-clusterrole.yaml
@@ -4,7 +4,7 @@ kind: ClusterRole
 metadata:
   name:  {{ template "sumologic.fullname" . }}-setup
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:

--- a/deploy/helm/sumologic/templates/setup/setup-clusterrolebinding.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-clusterrolebinding.yaml
@@ -4,7 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   name:  {{ template "sumologic.fullname" . }}-setup
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "2"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:

--- a/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name:  {{ template "sumologic.fullname" . }}-setup
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "2"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:

--- a/deploy/helm/sumologic/templates/setup/setup-job.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-job.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "sumologic.fullname" . }}-setup
   namespace: {{ .Release.Namespace }}
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "3"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:

--- a/deploy/helm/sumologic/templates/setup/setup-serviceaccount.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-serviceaccount.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   name:  {{ template "sumologic.fullname" . }}-setup
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:


### PR DESCRIPTION
###### Description

Adding setup job and RBAC resources as pre-upgrade hooks

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
- [x] Verify `helm upgrade collection maisie-charts/sumologic --reuse-values` succeeds after pushing new chart with a new source added in the terraform file
- [x] Verify new source is created in Sumo and a new entry for the URL is added in the existing secret

