### PR TITLE
Bump Dockerfile Sumo TF provider to 2.0.0

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -72,7 +72,7 @@ RUN mkdir /tmp/terraform && \
     rm -rf /tmp/terraform
 
 # Install sumologic provider and Kubernetes provider
-ENV SUMO_PROVIDER_VERSION 1.3.0
+ENV SUMO_PROVIDER_VERSION 2.0.0
 ENV KUBERNETES_PROVIDER_VERSION 1.9.0
 RUN mkdir -p /terraform && \
     cd /terraform && \

--- a/deploy/helm/sumologic/templates/setup/setup-job.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-job.yaml
@@ -35,5 +35,5 @@ spec:
         - name: SUMOLOGIC_ACCESSKEY
           value: {{ required "A valid .Values.sumologic.accessKey entry required!" .Values.sumologic.accessKey }}
         - name: SUMOLOGIC_BASE_URL
-          value: {{ required "A valid .Values.sumologic.endpoint entry required!" .Values.sumologic.endpoint }}
+          value: {{ .Values.sumologic.endpoint }}
 {{- end }}

--- a/deploy/kubernetes/setup-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/setup-sumologic.yaml.tmpl
@@ -7,7 +7,7 @@ kind: ConfigMap
 metadata:
   name:  collection-sumologic-setup
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "2"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
@@ -173,7 +173,7 @@ kind: ServiceAccount
 metadata:
   name:  collection-sumologic-setup
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
@@ -187,7 +187,7 @@ kind: ClusterRole
 metadata:
   name:  collection-sumologic-setup
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
@@ -208,7 +208,7 @@ kind: ClusterRoleBinding
 metadata:
   name:  collection-sumologic-setup
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "2"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
@@ -231,7 +231,7 @@ metadata:
   name: collection-sumologic-setup
   namespace: $NAMESPACE
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "3"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:


### PR DESCRIPTION
###### Description

With the new TF provider, we no longer require specifying endpoint URL since it will try to follow the 301 redirection response to the correct deployment.

###### Testing performed

- [x] ci/build.sh
- [x] Local helm chart install with local built Docker image, specifying US2 access key/id but *not* specifying endpoint URL, verified the TF Provider automatically redirected and created collector and sources on US2 🎉 
- [x] Confirm events, logs, and metrics are coming in
