### PR TITLE
Add help doc link for API endpoint

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -41,6 +41,7 @@ sumologic:
   #accessKey: ""
 
   # Sumo API endpoint
+  # ref: https://help.sumologic.com/APIs/General-API-Information/Sumo-Logic-Endpoints-and-Firewall-Security
   #endpoint: ""
 
   # Collector name


### PR DESCRIPTION
As per request, we're updating the comment in the `values.yaml` file to help make it clearer that it is the API endpoint used here
