### PR TITLE
Cut release 0.11.0

### DIFF
--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.10.0"
+appVersion: "0.11.0"
 description: A Helm chart for collecting Kubernetes logs, metrics and events into Sumo Logic.
 name: sumologic
-version: 0.10.0
+version: 0.11.0

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: sumologic/kubernetes-fluentd
-  tag: 0.10.0
+  tag: 0.11.0
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -405,7 +405,7 @@ spec:
           name: collection-sumologic
       containers:
       - name: fluentd
-        image: sumologic/kubernetes-fluentd:0.10.0
+        image: sumologic/kubernetes-fluentd:0.11.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -567,7 +567,7 @@ spec:
           name: collection-sumologic-events
       containers:
       - name: fluentd-events
-        image: sumologic/kubernetes-fluentd:0.10.0
+        image: sumologic/kubernetes-fluentd:0.11.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/deploy/kubernetes/setup-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/setup-sumologic.yaml.tmpl
@@ -249,7 +249,7 @@ spec:
           defaultMode: 0777
       containers:
       - name: setup
-        image: sumologic/kubernetes-fluentd:0.10.0
+        image: sumologic/kubernetes-fluentd:0.11.0
         imagePullPolicy: IfNotPresent
         command: ["/etc/terraform/setup.sh"]
         volumeMounts:


### PR DESCRIPTION
###### Description

To prepare v0.11.0

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
