### PR TITLE
Add log lines; Force CI yaml generation

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -157,6 +157,7 @@ if [ -n "$DOCKER_PASSWORD" ] && [ -n "$TRAVIS_TAG" ] && [[ $TRAVIS_TAG != *alpha
   docker push $DOCKER_TAG:$VERSION
 
   # Push new helm release
+  echo "Pushing new Helm Chart release $VERSION"
   git checkout -- .
   sudo helm init --client-only
   sudo helm package deploy/helm/sumologic --dependency-update --version=$VERSION --app-version=$VERSION
@@ -193,6 +194,7 @@ elif [ -n "$DOCKER_PASSWORD" ] && [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS
   git push --tags --quiet --set-upstream origin-repo master
 
   # Push new alpha helm release
+  echo "Pushing new alpha Helm Chart release $new_alpha"
   git checkout -- .
   sudo helm init --client-only
   sudo helm package deploy/helm/sumologic --dependency-update --version=$new_alpha --app-version=$new_alpha

--- a/deploy/kubernetes/setup-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/setup-sumologic.yaml.tmpl
@@ -165,6 +165,7 @@ data:
 
       type = "Opaque"
     }
+
 ---
 # Source: sumologic/templates/setup/setup-serviceaccount.yaml
 


### PR DESCRIPTION
###### Description

Unfortunately our CI still can't push to PRs from forked repos, so this PR is really just to get the CI to generate the yaml.

But at the same time, add a couple log lines I wanted to see yesterday.

###### Testing performed

- [x] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
