### PR TITLE
#293 facilitate gitops better through sourced secrets in setup Chart

### DIFF
--- a/deploy/helm/sumologic/templates/setup/setup-job.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-job.yaml
@@ -29,6 +29,10 @@ spec:
         volumeMounts:
         - name: setup
           mountPath: /etc/terraform
+        {{- if .Values.sumologic.envFromSecret }}
+        envFrom:
+          - {{ .Values.sumologic.envFromSecret }}
+        {{ else }}
         env:
         - name: SUMOLOGIC_ACCESSID
           value: {{ required "A valid .Values.sumologic.accessId entry required!" .Values.sumologic.accessId }}
@@ -36,4 +40,6 @@ spec:
           value: {{ required "A valid .Values.sumologic.accessKey entry required!" .Values.sumologic.accessKey }}
         - name: SUMOLOGIC_BASE_URL
           value: {{ .Values.sumologic.endpoint }}
+        {{ end }}
+
 {{- end }}

--- a/deploy/helm/sumologic/templates/setup/setup-job.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-job.yaml
@@ -41,5 +41,4 @@ spec:
         - name: SUMOLOGIC_BASE_URL
           value: {{ .Values.sumologic.endpoint }}
         {{ end }}
-
 {{- end }}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -34,6 +34,9 @@ sumologic:
   # If enabled, a pre-install hook will create Collector and Sources in Sumo Logic
   setupEnabled: true
 
+  # If enabled, accessId and accessKey will be sourced from Secret Name given
+  # envFromSecret: accessCredentials
+
   # Sumo access ID
   #accessId: ""
 


### PR DESCRIPTION
facilitate gitops better through sourced secrets in setup Chart

###### Description

Change the source of the config for the setup job to a secret for better facilitating helm dependency in git

###### Testing performed

Not sure if these are 100% necessary as this is just a config change to the chart

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
