### PR TITLE
Customizable annotations for setup resources

### DIFF
--- a/deploy/helm/sumologic/templates/setup/setup-clusterrole.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-clusterrole.yaml
@@ -3,10 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name:  {{ template "sumologic.fullname" . }}-setup
-  {{- if .Values.sumologic.setup.clusterRole.annotations  }}
   annotations:
 {{ toYaml .Values.sumologic.setup.clusterRole.annotations | indent 4 }}
-  {{- end }}
   labels:
     app: {{ template "sumologic.labels.app" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/setup/setup-clusterrole.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-clusterrole.yaml
@@ -1,12 +1,12 @@
-{{- if .Values.sumologic.setupEnabled }}
+{{- if .Values.sumologic.setup }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name:  {{ template "sumologic.fullname" . }}-setup
+  {{- if .Values.sumologic.setup.clusterRole.annotations  }}
   annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "1"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+{{ toYaml .Values.sumologic.setup.clusterRole.annotations | indent 4 }}
+  {{- end }}
   labels:
     app: {{ template "sumologic.labels.app" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/setup/setup-clusterrole.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.sumologic.setup }}
+{{- if .Values.sumologic.setupEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/deploy/helm/sumologic/templates/setup/setup-clusterrolebinding.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-clusterrolebinding.yaml
@@ -1,12 +1,12 @@
-{{- if .Values.sumologic.setupEnabled }}
+{{- if .Values.sumologic.setup }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name:  {{ template "sumologic.fullname" . }}-setup
+  {{- if .Values.sumologic.setup.clusterRoleBinding.annotations  }}
   annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "2"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+{{ toYaml .Values.sumologic.setup.clusterRoleBinding.annotations | indent 4 }}
+  {{- end }}
   labels:
     app: {{ template "sumologic.labels.app" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/setup/setup-clusterrolebinding.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.sumologic.setup }}
+{{- if .Values.sumologic.setupEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/deploy/helm/sumologic/templates/setup/setup-clusterrolebinding.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-clusterrolebinding.yaml
@@ -3,10 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name:  {{ template "sumologic.fullname" . }}-setup
-  {{- if .Values.sumologic.setup.clusterRoleBinding.annotations  }}
   annotations:
 {{ toYaml .Values.sumologic.setup.clusterRoleBinding.annotations | indent 4 }}
-  {{- end }}
   labels:
     app: {{ template "sumologic.labels.app" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.sumologic.setup }}
+{{- if .Values.sumologic.setupEnabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
@@ -1,12 +1,12 @@
-{{- if .Values.sumologic.setupEnabled }}
+{{- if .Values.sumologic.setup }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name:  {{ template "sumologic.fullname" . }}-setup
+  {{- if .Values.sumologic.setup.configMap.annotations  }}
   annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "2"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+{{ toYaml .Values.sumologic.setup.configMap.annotations | indent 4 }}
+  {{- end }}
   labels:
     app: {{ template "sumologic.labels.app" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
@@ -3,10 +3,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name:  {{ template "sumologic.fullname" . }}-setup
-  {{- if .Values.sumologic.setup.configMap.annotations  }}
   annotations:
 {{ toYaml .Values.sumologic.setup.configMap.annotations | indent 4 }}
-  {{- end }}
   labels:
     app: {{ template "sumologic.labels.app" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/setup/setup-job.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-job.yaml
@@ -42,4 +42,4 @@ spec:
         - name: SUMOLOGIC_BASE_URL
           value: {{ .Values.sumologic.setup.job.endpoint }}
         {{ end }}
-{{- end}}
+{{- end }}

--- a/deploy/helm/sumologic/templates/setup/setup-job.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-job.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.sumologic.setup }}
+{{- if .Values.sumologic.setupEnabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -29,17 +29,17 @@ spec:
         volumeMounts:
         - name: setup
           mountPath: /etc/terraform
-        {{- if .Values.sumologic.setup.job.envFromSecret }}
+        {{- if .Values.sumologic.envFromSecret }}
         envFrom:
         - secretRef:
-            name: {{ .Values.sumologic.setup.job.envFromSecret }}
+            name: {{ .Values.sumologic.envFromSecret }}
         {{ else }}
         env:
         - name: SUMOLOGIC_ACCESSID
-          value: {{ required "A valid .Values.sumologic.accessId entry required!" .Values.sumologic.setup.job.accessId }}
+          value: {{ required "A valid .Values.sumologic.accessId entry required!" .Values.sumologic.accessId }}
         - name: SUMOLOGIC_ACCESSKEY
-          value: {{ required "A valid .Values.sumologic.accessKey entry required!" .Values.sumologic.setup.job.accessKey }}
+          value: {{ required "A valid .Values.sumologic.accessKey entry required!" .Values.sumologic.accessKey }}
         - name: SUMOLOGIC_BASE_URL
-          value: {{ .Values.sumologic.setup.job.endpoint }}
+          value: {{ .Values.sumologic.endpoint }}
         {{ end }}
 {{- end }}

--- a/deploy/helm/sumologic/templates/setup/setup-job.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-job.yaml
@@ -1,13 +1,13 @@
-{{- if .Values.sumologic.setupEnabled }}
+{{- if .Values.sumologic.setup }}
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "sumologic.fullname" . }}-setup
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.sumologic.setup.job.annotations  }}
   annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "3"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+{{ toYaml .Values.sumologic.setup.job.annotations | indent 4 }}
+  {{- end }}
   labels:
     app: {{ template "sumologic.labels.app" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
@@ -29,17 +29,17 @@ spec:
         volumeMounts:
         - name: setup
           mountPath: /etc/terraform
-        {{- if .Values.sumologic.envFromSecret }}
+        {{- if .Values.sumologic.setup.job.envFromSecret }}
         envFrom:
         - secretRef:
-            name: {{ .Values.sumologic.envFromSecret }}
+            name: {{ .Values.sumologic.setup.job.envFromSecret }}
         {{ else }}
         env:
         - name: SUMOLOGIC_ACCESSID
-          value: {{ required "A valid .Values.sumologic.accessId entry required!" .Values.sumologic.accessId }}
+          value: {{ required "A valid .Values.sumologic.accessId entry required!" .Values.sumologic.setup.job.accessId }}
         - name: SUMOLOGIC_ACCESSKEY
-          value: {{ required "A valid .Values.sumologic.accessKey entry required!" .Values.sumologic.accessKey }}
+          value: {{ required "A valid .Values.sumologic.accessKey entry required!" .Values.sumologic.setup.job.accessKey }}
         - name: SUMOLOGIC_BASE_URL
-          value: {{ .Values.sumologic.endpoint }}
-        {{ end }}
-{{- end }}
+          value: {{ .Values.sumologic.setup.job.endpoint }}
+        {{- end }}
+{{- end}}

--- a/deploy/helm/sumologic/templates/setup/setup-job.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-job.yaml
@@ -41,5 +41,5 @@ spec:
           value: {{ required "A valid .Values.sumologic.accessKey entry required!" .Values.sumologic.setup.job.accessKey }}
         - name: SUMOLOGIC_BASE_URL
           value: {{ .Values.sumologic.setup.job.endpoint }}
-        {{- end }}
+        {{ end }}
 {{- end}}

--- a/deploy/helm/sumologic/templates/setup/setup-job.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-job.yaml
@@ -4,10 +4,8 @@ kind: Job
 metadata:
   name: {{ template "sumologic.fullname" . }}-setup
   namespace: {{ .Release.Namespace }}
-  {{- if .Values.sumologic.setup.job.annotations  }}
   annotations:
 {{ toYaml .Values.sumologic.setup.job.annotations | indent 4 }}
-  {{- end }}
   labels:
     app: {{ template "sumologic.labels.app" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/setup/setup-serviceaccount.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-serviceaccount.yaml
@@ -1,12 +1,12 @@
-{{- if .Values.sumologic.setupEnabled }}
+{{- if .Values.sumologic.setup }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name:  {{ template "sumologic.fullname" . }}-setup
+  {{- if .Values.sumologic.setup.serviceAccount.annotations  }}
   annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "0"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+{{ toYaml .Values.sumologic.setup.serviceAccount.annotations | indent 4 }}
+  {{- end }}
   labels:
     app: {{ template "sumologic.labels.app" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/setup/setup-serviceaccount.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.sumologic.setup }}
+{{- if .Values.sumologic.setupEnabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/deploy/helm/sumologic/templates/setup/setup-serviceaccount.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-serviceaccount.yaml
@@ -3,10 +3,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name:  {{ template "sumologic.fullname" . }}-setup
-  {{- if .Values.sumologic.setup.serviceAccount.annotations  }}
   annotations:
 {{ toYaml .Values.sumologic.setup.serviceAccount.annotations | indent 4 }}
-  {{- end }}
   labels:
     app: {{ template "sumologic.labels.app" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -40,6 +40,9 @@ sumologic:
   # Sumo access ID
   #accessId: ""
 
+  # Sumo access key
+  #accessKey: ""
+
   # Sumo API endpoint
   # ref: https://help.sumologic.com/APIs/General-API-Information/Sumo-Logic-Endpoints-and-Firewall-Security
   #endpoint: ""

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -68,7 +68,7 @@ sumologic:
         helm.sh/hook: pre-install
         helm.sh/hook-weight: 3
         helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
-    serviceaccount:
+    serviceAccount:
       annotations:
         helm.sh/hook: pre-install
         helm.sh/hook-weight: 0

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -30,18 +30,20 @@ eventsDeployment:
 
 sumologic:
   ## Setup
-  #envFromSecret: sumo-api-secret
+
+  # If enabled, a pre-install hook will create Collector and Sources in Sumo Logic
+  setupEnabled: true
+
+  # If enabled, accessId and accessKey will be sourced from Secret Name given
+  # envFromSecret: sumo-api-secret
 
   # Sumo access ID
   #accessId: ""
 
-  # Sumo access key
-  #accessKey: ""
-
   # Sumo API endpoint
   # ref: https://help.sumologic.com/APIs/General-API-Information/Sumo-Logic-Endpoints-and-Firewall-Security
   #endpoint: ""
-  setupEnabled:
+
   setup:
     clusterRole:
       annotations:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -30,22 +30,43 @@ eventsDeployment:
 
 sumologic:
   ## Setup
+  setup:
+    clusterRole:
+      annotations:
+        helm.sh/hook: pre-install
+        helm.sh/hook-weight: 1
+        helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    clusterRoleBinding:
+      annotations:
+        helm.sh/hook: pre-install
+        helm.sh/hook-weight: 2
+        helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    configMap:
+      annotations:
+        helm.sh/hook: pre-install
+        helm.sh/hook-weight: 2
+        helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    job:
+      #envFromSecret: sumo-api-secret
 
-  # If enabled, a pre-install hook will create Collector and Sources in Sumo Logic
-  setupEnabled: true
+      # Sumo access ID
+      #accessId: ""
 
-  # If enabled, accessId and accessKey will be sourced from Secret Name given
-  # envFromSecret: accessCredentials
+      # Sumo access key
+      #accessKey: ""
 
-  # Sumo access ID
-  #accessId: ""
-
-  # Sumo access key
-  #accessKey: ""
-
-  # Sumo API endpoint
-  # ref: https://help.sumologic.com/APIs/General-API-Information/Sumo-Logic-Endpoints-and-Firewall-Security
-  #endpoint: ""
+      # Sumo API endpoint
+      # ref: https://help.sumologic.com/APIs/General-API-Information/Sumo-Logic-Endpoints-and-Firewall-Security
+      #endpoint: ""
+      annotations:
+        helm.sh/hook: pre-install
+        helm.sh/hook-weight: 3
+        helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    serviceaccount:
+      annotations:
+        helm.sh/hook: pre-install
+        helm.sh/hook-weight: 0
+        helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 
   # Collector name
   #collectorName: ""

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -30,6 +30,18 @@ eventsDeployment:
 
 sumologic:
   ## Setup
+  #envFromSecret: sumo-api-secret
+
+  # Sumo access ID
+  #accessId: ""
+
+  # Sumo access key
+  #accessKey: ""
+
+  # Sumo API endpoint
+  # ref: https://help.sumologic.com/APIs/General-API-Information/Sumo-Logic-Endpoints-and-Firewall-Security
+  #endpoint: ""
+  setupEnabled:
   setup:
     clusterRole:
       annotations:
@@ -47,17 +59,6 @@ sumologic:
         helm.sh/hook-weight: 2
         helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
     job:
-      #envFromSecret: sumo-api-secret
-
-      # Sumo access ID
-      #accessId: ""
-
-      # Sumo access key
-      #accessKey: ""
-
-      # Sumo API endpoint
-      # ref: https://help.sumologic.com/APIs/General-API-Information/Sumo-Logic-Endpoints-and-Firewall-Security
-      #endpoint: ""
       annotations:
         helm.sh/hook: pre-install
         helm.sh/hook-weight: 3


### PR DESCRIPTION
###### Description

I think that the ability to customize the annotations for helm hooks is important enough to move it out into the values to make it override-able. I also fixed some of the formatting around setup in the values to make it expandable in the future.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
