### PR TITLE
Update helm installation/upgrade notes on collector name

### DIFF
--- a/deploy/helm/sumologic/templates/NOTES.txt
+++ b/deploy/helm/sumologic/templates/NOTES.txt
@@ -1,6 +1,6 @@
 Thank you for installing {{ .Chart.Name }}. 
 
-A Collector with the name {{ default "kubernetes-<TIMESTAMP>" .Values.sumologic.collectorName }} has been created in your Sumo Logic account.
+A Collector with the name {{ .Values.sumologic.collectorName | default .Values.sumologic.clusterName | quote }} has been created in your Sumo Logic account.
 
 Check the release status by running:
   kubectl --namespace {{ .Release.Namespace }} get pods -l "release={{ .Release.Name }}"


### PR DESCRIPTION
###### Description

Notes should use `collectorName` if supplied, if not use `clusterName` which has a default value of `kubernetes`.

###### Testing performed

- [ ] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
- [x] Verify installation notes use `collectorName` or `clusterName` config params
