### PR TITLE
Use fully-qualified name for fluent-bit DNS resolution

### DIFF
--- a/deploy/helm/fluent-bit-overrides.yaml
+++ b/deploy/helm/fluent-bit-overrides.yaml
@@ -4,7 +4,8 @@ metrics:
 backend:
   type: forward
   forward:
-    host: collection-sumologic.sumologic.svc.cluster.local
+    # NOTE: Requires trailing "." for fully-qualified name resolution
+    host: collection-sumologic.sumologic.svc.cluster.local.
     port: 24321
     tls: "off"
     tls_verify: "on"

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -165,7 +165,8 @@ fluent-bit:
   backend:
     type: forward
     forward:
-      host: collection-sumologic.sumologic.svc.cluster.local
+      # NOTE: Requires trailing "." for fully-qualified name resolution
+      host: collection-sumologic.sumologic.svc.cluster.local.
       port: 24321
       tls: "off"
       tls_verify: "on"

--- a/deploy/kubernetes/setup-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/setup-sumologic.yaml.tmpl
@@ -263,3 +263,5 @@ spec:
           value: $SUMOLOGIC_ACCESSKEY
         - name: SUMOLOGIC_BASE_URL
           value: $SUMOLOGIC_BASE_URL
+        
+


### PR DESCRIPTION
###### Description

Noticed while investigating an issue around high rate of CoreDNS resolution, we should include a trailing dot (".") to ensure we do fully-qualified DNS resolution. This reduces the total rate of DNS resolution by a factor of 5 on my test cluster.

Reference: https://github.com/kubernetes/kubernetes/issues/56903#issuecomment-397404229

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
