### PR TITLE
Fix alpha helm chart installation

### DIFF
--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -1,12 +1,14 @@
 # This file is auto-generated.
-prometheusOperator:
-  admissionWebhooks:
-    enabled: false
 alertmanager:
   enabled: false
 grafana:
   enabled: false
   defaultDashboardsEnabled: false
+prometheusOperator:
+  admissionWebhooks:
+    enabled: false
+  tlsProxy:
+    enabled: false
 prometheus:
   additionalServiceMonitors:
     - name: collection-sumologic

--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -1,4 +1,7 @@
 # This file is auto-generated.
+prometheusOperator:
+  admissionWebhooks:
+    enabled: false
 alertmanager:
   enabled: false
 grafana:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -286,14 +286,16 @@ grafana:
   enabled: false
 prometheus-operator:
   enabled: true
-  prometheusOperator:
-    admissionWebhooks:
-      enabled: false
   alertmanager:
     enabled: false
   grafana:
     enabled: false
     defaultDashboardsEnabled: false
+  prometheusOperator:
+    admissionWebhooks:
+      enabled: false
+    tlsProxy:
+      enabled: false
   prometheus:
     additionalServiceMonitors:
       - name: collection-sumologic

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -35,7 +35,7 @@ sumologic:
   setupEnabled: true
 
   # If enabled, accessId and accessKey will be sourced from Secret Name given
-  # envFromSecret: sumo-api-secret
+  #envFromSecret: sumo-api-secret
 
   # Sumo access ID
   #accessId: ""
@@ -47,38 +47,38 @@ sumologic:
   # ref: https://help.sumologic.com/APIs/General-API-Information/Sumo-Logic-Endpoints-and-Firewall-Security
   #endpoint: ""
 
-  setup:
-    clusterRole:
-      annotations:
-        helm.sh/hook: pre-install
-        helm.sh/hook-weight: 1
-        helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
-    clusterRoleBinding:
-      annotations:
-        helm.sh/hook: pre-install
-        helm.sh/hook-weight: 2
-        helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
-    configMap:
-      annotations:
-        helm.sh/hook: pre-install
-        helm.sh/hook-weight: 2
-        helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
-    job:
-      annotations:
-        helm.sh/hook: pre-install
-        helm.sh/hook-weight: 3
-        helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
-    serviceAccount:
-      annotations:
-        helm.sh/hook: pre-install
-        helm.sh/hook-weight: 0
-        helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
-
   # Collector name
   #collectorName: ""
 
   # Cluster name
   clusterName: "kubernetes"
+
+  setup:
+    clusterRole:
+      annotations:
+        helm.sh/hook: pre-install
+        helm.sh/hook-weight: "1"
+        helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    clusterRoleBinding:
+      annotations:
+        helm.sh/hook: pre-install
+        helm.sh/hook-weight: "2"
+        helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    configMap:
+      annotations:
+        helm.sh/hook: pre-install
+        helm.sh/hook-weight: "2"
+        helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    job:
+      annotations:
+        helm.sh/hook: pre-install
+        helm.sh/hook-weight: "3"
+        helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    serviceAccount:
+      annotations:
+        helm.sh/hook: pre-install
+        helm.sh/hook-weight: "0"
+        helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 
   # If enabled, collect K8s events
   eventCollectionEnabled: true
@@ -286,6 +286,9 @@ grafana:
   enabled: false
 prometheus-operator:
   enabled: true
+  prometheusOperator:
+    admissionWebhooks:
+      enabled: false
   alertmanager:
     enabled: false
   grafana:

--- a/deploy/kubernetes/setup-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/setup-sumologic.yaml.tmpl
@@ -7,9 +7,10 @@ kind: ConfigMap
 metadata:
   name:  collection-sumologic-setup
   annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "2"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "2"
+    
   labels:
     app: collection-sumologic
     
@@ -174,12 +175,14 @@ kind: ServiceAccount
 metadata:
   name:  collection-sumologic-setup
   annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "0"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "0"
+    
   labels:
     app: collection-sumologic
     
+
 ---
 # Source: sumologic/templates/setup/setup-clusterrole.yaml
 
@@ -188,9 +191,10 @@ kind: ClusterRole
 metadata:
   name:  collection-sumologic-setup
   annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "1"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "1"
+    
   labels:
     app: collection-sumologic
     
@@ -201,6 +205,7 @@ rules:
       - secrets
       - namespaces
     verbs: ["get", "create", "describe", "patch"]
+
 ---
 # Source: sumologic/templates/setup/setup-clusterrolebinding.yaml
 
@@ -209,9 +214,10 @@ kind: ClusterRoleBinding
 metadata:
   name:  collection-sumologic-setup
   annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "2"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "2"
+    
   labels:
     app: collection-sumologic
     
@@ -223,6 +229,7 @@ subjects:
   - kind: ServiceAccount
     name: collection-sumologic-setup
     namespace: $NAMESPACE
+
 ---
 # Source: sumologic/templates/setup/setup-job.yaml
 
@@ -232,9 +239,10 @@ metadata:
   name: collection-sumologic-setup
   namespace: $NAMESPACE
   annotations:
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "3"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "3"
+    
   labels:
     app: collection-sumologic
     


### PR DESCRIPTION
###### Description

A few fixes based on the failing automation tests:

1. New prometheus operator version introduced in https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/299 seems to have added this admission webhook step that fails our helm installation. Since we're not using admission webhooks, we can disable this by setting `prometheus-operator.prometheusOperator.admissionWebhooks.enabled=false`.

2. Disables `tlsProxy` in the new prometheus operator version as well since this was failing to start prometheus when enabled.

3. Helm hook weights seem to expect string values, not numbers, so changing these back to strings after they were changed to numbers in https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/302

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
