### PR TITLE
Add Alpha Release Guide to Docs

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -6,13 +6,14 @@ This page has instructions for collecting Kubernetes logs, metrics, and events; 
   - [Solution overview](#solution-overview)
   - [Minimum Requirements](#minimum-requirements)
   - [Support Matrix](#support-matrix)
-  - [Installation with Helm](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/master/deploy/docs/Installation_with_Helm.md)
-  - [Upgrading with Helm](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/master/deploy/docs/Upgrading_with_Helm.md) 
-  - [Non Helm Installation](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/master/deploy/docs/Non_Helm_Installation.md) 
-  - [Adding Additional FluentD Plugins](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/master/deploy/docs/Additional_Fluentd_Plugins.md)
-- [Migration Steps](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/master/deploy/docs/Migration_Steps.md)
-- [Troubleshooting Collection](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/master/deploy/docs/Troubleshoot_Collection.md)
-- [Monitoring the Monitoring](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/master/deploy/docs/monitoring-lag.md)
+  - [Installation with Helm](./docs/Installation_with_Helm.md)
+  - [Upgrading with Helm](./docs/Upgrading_with_Helm.md) 
+  - [Non Helm Installation](./docs/Non_Helm_Installation.md) 
+  - [Adding Additional FluentD Plugins](./docs/Additional_Fluentd_Plugins.md)
+  - [Alpha Releases](./docs/Alpha_Release_Guide.md)
+- [Migration Steps](./docs/Migration_Steps.md)
+- [Troubleshooting Collection](./docs/Troubleshoot_Collection.md)
+- [Monitoring the Monitoring](./docs/monitoring-lag.md)
 
 ## Solution overview
 

--- a/deploy/docs/Alpha_Release_Guide.md
+++ b/deploy/docs/Alpha_Release_Guide.md
@@ -1,0 +1,42 @@
+# Alpha Releases
+
+| DISCLAIMER |
+| --- |
+| We recommend testing alpha releases on non-production clusters. These releases are generated continuously from contributions to this repo and may not be fully tested. |
+
+
+As part of our [Travis CI script](../../ci/build.sh), we release an alpha Docker image as well as an alpha Helm chart release.
+
+## Versioning
+Release Type | Version Scheme | Example
+-------- | ----- | -----
+Major Release | `major.0.0` | `2.0.0`
+Minor Release | `major.minor.0` | `0.11.0`
+Alpha Release | `major.minor.patch-alpha` | `0.11.3-alpha`
+
+You can find a list of all releases in the Github repo's [Releases](https://github.com/SumoLogic/sumologic-kubernetes-collection/releases) section. You can find a list of all Docker images in the [Docker tags](https://hub.docker.com/repository/docker/sumologic/kubernetes-fluentd/tags) section.
+
+## Using an alpha release
+
+### Helm installation
+
+Follow the [Helm installation guide](./Installation_with_Helm.md), but override both the Helm chart version and the Docker image version.
+
+```
+helm repo update
+helm install sumologic/sumologic --name collection --namespace sumologic ... --version=0.11.3-alpha --set image.tag="0.11.3-alpha"
+```
+
+### Non-helm installation
+
+Follow the [non-Helm installation guide](./Non_Helm_Installation.md), but modify the .yaml template to use an alpha Docker image for both log and event deployments, e.g.
+
+```
+- name: fluentd
+  image: sumologic/kubernetes-fluentd:0.11.3-alpha
+```
+
+```
+- name: fluentd-events
+  image: sumologic/kubernetes-fluentd:0.11.3-alpha
+```


### PR DESCRIPTION
###### Description

Adds documentation on how to find and use an Alpha docker image and Alpha helm chart release, geared toward customers that want to run alpha builds, such as customers contributing PRs to our repo.

###### Testing performed

N/A