### PR TITLE
Increase fluent-bit flush interval to lessen DNS load

### DIFF
--- a/deploy/helm/fluent-bit-overrides.yaml
+++ b/deploy/helm/fluent-bit-overrides.yaml
@@ -1,4 +1,6 @@
 # This file is auto-generated.
+service:
+  flush: 5
 metrics:
   enabled: true
 backend:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -187,6 +187,8 @@ sumologic:
 ## ref: https://github.com/helm/charts/blob/master/stable/fluent-bit/values.yaml
 fluent-bit:
   enabled: true
+  service:
+    flush: 5
   metrics:
     enabled: true
   backend:


### PR DESCRIPTION
###### Description

From the CoreDNS investigation, we are using the default fluent-bit flush interval of 1s, which leads to DNS lookup per flush. We can increase the flush interval to lessen the DNS lookups, and also the number of network calls from fluent-bit to fluentd.

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
