### PR TITLE
Use empty endpoint URL by default for redirection

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -96,7 +96,7 @@ if [ -n "$GITHUB_TOKEN" ] && [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]; then
   echo "# This file is auto-generated." > deploy/kubernetes/setup-sumologic.yaml.tmpl
 
   with_files=`ls deploy/helm/sumologic/templates/setup/*.yaml | sed 's#deploy/helm/sumologic/templates#-x templates#g' | sed 's/yaml/yaml \\\/g'`
-  eval 'sudo helm template deploy/helm/sumologic $with_files --namespace "\$NAMESPACE" --name collection --set dryRun=true >> deploy/kubernetes/setup-sumologic.yaml.tmpl --set sumologic.endpoint="\$SUMOLOGIC_BASE_URL" --set sumologic.accessId="\$SUMOLOGIC_ACCESSID" --set sumologic.accessKey="\$SUMOLOGIC_ACCESSKEY" --set sumologic.collectorName="\$COLLECTOR_NAME" --set sumologic.clusterName="\$CLUSTER_NAME"'
+  eval 'sudo helm template deploy/helm/sumologic $with_files --namespace "\$NAMESPACE" --name collection --set dryRun=true >> deploy/kubernetes/setup-sumologic.yaml.tmpl --set sumologic.accessId="\$SUMOLOGIC_ACCESSID" --set sumologic.accessKey="\$SUMOLOGIC_ACCESSKEY" --set sumologic.collectorName="\$COLLECTOR_NAME" --set sumologic.clusterName="\$CLUSTER_NAME"'
   if [[ $(git diff deploy/kubernetes/setup-sumologic.yaml.tmpl) ]]; then
       echo "Detected changes in 'setup-sumologic.yaml.tmpl', committing the updated version to $TRAVIS_PULL_REQUEST_BRANCH..."
       git add deploy/kubernetes/setup-sumologic.yaml.tmpl

--- a/deploy/helm/sumologic/templates/setup/setup-job.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-job.yaml
@@ -37,7 +37,7 @@ spec:
           value: {{ required "A valid .Values.sumologic.accessId entry required!" .Values.sumologic.accessId }}
         - name: SUMOLOGIC_ACCESSKEY
           value: {{ required "A valid .Values.sumologic.accessKey entry required!" .Values.sumologic.accessKey }}
-        # - name: SUMOLOGIC_BASE_URL
-        #  value: {{ .Values.sumologic.endpoint }}
+        - name: SUMOLOGIC_BASE_URL
+          value: {{ .Values.sumologic.endpoint }}
         {{ end }}
 {{- end }}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -43,9 +43,9 @@ sumologic:
   # Sumo access key
   #accessKey: ""
 
-  # Sumo API endpoint
+  # Sumo API endpoint; Leave blank for automatic endpoint discovery and redirection
   # ref: https://help.sumologic.com/APIs/General-API-Information/Sumo-Logic-Endpoints-and-Firewall-Security
-  #endpoint: ""
+  endpoint: ""
 
   # Collector name
   #collectorName: ""

--- a/deploy/kubernetes/setup-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/setup-sumologic.yaml.tmpl
@@ -269,7 +269,7 @@ spec:
           value: $SUMOLOGIC_ACCESSID
         - name: SUMOLOGIC_ACCESSKEY
           value: $SUMOLOGIC_ACCESSKEY
-        # - name: SUMOLOGIC_BASE_URL
-        #  value: $SUMOLOGIC_BASE_URL
+        - name: SUMOLOGIC_BASE_URL
+          value: $SUMOLOGIC_BASE_URL
         
 

--- a/deploy/kubernetes/setup-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/setup-sumologic.yaml.tmpl
@@ -270,6 +270,6 @@ spec:
         - name: SUMOLOGIC_ACCESSKEY
           value: $SUMOLOGIC_ACCESSKEY
         - name: SUMOLOGIC_BASE_URL
-          value: $SUMOLOGIC_BASE_URL
+          value: 
         
 


### PR DESCRIPTION
###### Description

We decided to use empty string for the `endpoint` config param so by default it will do auto URL redirection unless the user overrides it. This will work for both helm and non-helm installations. 

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
