### PR TITLE
Add a note for helm 3 support

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -53,6 +53,8 @@ K8s with AKS | 1.12.8
 Helm | 2.14.13 (Linux)
 kubectl | 1.15.0
 
+NOTE: Helm 3 is currently not supported.
+
 The following matrix displays the tested package versions for our Helm chart.
 
 Sumo Logic Helm Chart | Prometheus Operator | Fluent Bit | Falco


### PR DESCRIPTION
###### Description

Helm 3 was released recently and has become default version for homebrew for installs. Adding a note in the support matrix since there is currently some issues in our solution with Helm 3.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
