### PR TITLE
fix filter plugin error with kubernetes_meta_reduce

### DIFF
--- a/fluent-plugin-kubernetes-sumologic/lib/fluent/plugin/filter_kubernetes_sumologic.rb
+++ b/fluent-plugin-kubernetes-sumologic/lib/fluent/plugin/filter_kubernetes_sumologic.rb
@@ -158,12 +158,14 @@ module Fluent::Plugin
         end
         if annotations["sumologic.com/kubernetes_meta_reduce"] == "true" || annotations["sumologic.com/kubernetes_meta_reduce"].nil? && @kubernetes_meta_reduce == true
           record.delete("docker")
-          record["kubernetes"].delete("pod_id")
-          record["kubernetes"].delete("namespace_id")
-          record["kubernetes"].delete("labels")
-          record["kubernetes"].delete("namespace_labels")
-          record["kubernetes"].delete("master_url")
-          record["kubernetes"].delete("annotations")
+          if record.key?("kubernetes") and not record.fetch("kubernetes").nil?
+            record["kubernetes"].delete("pod_id")
+            record["kubernetes"].delete("namespace_id")
+            record["kubernetes"].delete("labels")
+            record["kubernetes"].delete("namespace_labels")
+            record["kubernetes"].delete("master_url")
+            record["kubernetes"].delete("annotations")
+          end
         end
         if @add_stream == false
           record.delete("stream")


### PR DESCRIPTION
###### Description

Unfortunately we found that if `kubernetes_meta` is set to `false` and `kubernetes_meta_reduce` is set to `true` at the same time, this plugin tries to delete keys from `record["kubernetes"]`, which has been deleted previously and is therefore nil.

At the very least this spams fluentd logs with the error, which is self collected and creates a nasty loop.

At worst, we believe this may have caused container logs to be dropped due to the unhandled error in this plugin. We should confirm that behavior, and in general handle errors more gracefully in all of our plugins to ensure this sort of issue does not occur again.

###### Testing performed

- [x] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
