### PR TITLE
Include buffer.output.conf for events configmap

### DIFF
--- a/deploy/helm/sumologic/templates/events-configmap.yaml
+++ b/deploy/helm/sumologic/templates/events-configmap.yaml
@@ -10,4 +10,5 @@ data:
   fluent.conf: |-
     @include events.conf
   {{- (tpl (.Files.Glob "conf/events/*.conf").AsConfig .) | nindent 2 }}
+  {{- (tpl (.Files.Glob "conf/buffer.output.conf").AsConfig .) | nindent 2 }}
 {{- end }}

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -315,6 +315,13 @@ data:
       </buffer>
     </match>
   
+  buffer.output.conf: |-
+    compress gzip
+    flush_interval "#{ENV['FLUSH_INTERVAL']}"
+    flush_thread_count "#{ENV['NUM_THREADS']}"
+    chunk_limit_size "#{ENV['CHUNK_LIMIT_SIZE']}"
+    total_limit_size "#{ENV['TOTAL_LIMIT_SIZE']}"
+  
 ---
 # Source: sumologic/templates/serviceaccount.yaml
 apiVersion: v1


### PR DESCRIPTION
###### Description

Include buffer.output.conf for events configmap

###### Testing performed

- [x] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
