### PR TITLE
[breaking change] Add pre-upgrade hook for setup

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -56,27 +56,27 @@ sumologic:
   setup:
     clusterRole:
       annotations:
-        helm.sh/hook: pre-install
+        helm.sh/hook: pre-install,pre-upgrade
         helm.sh/hook-weight: "1"
         helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
     clusterRoleBinding:
       annotations:
-        helm.sh/hook: pre-install
+        helm.sh/hook: pre-install,pre-upgrade
         helm.sh/hook-weight: "2"
         helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
     configMap:
       annotations:
-        helm.sh/hook: pre-install
+        helm.sh/hook: pre-install,pre-upgrade
         helm.sh/hook-weight: "2"
         helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
     job:
       annotations:
-        helm.sh/hook: pre-install
+        helm.sh/hook: pre-install,pre-upgrade
         helm.sh/hook-weight: "3"
         helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
     serviceAccount:
       annotations:
-        helm.sh/hook: pre-install
+        helm.sh/hook: pre-install,pre-upgrade
         helm.sh/hook-weight: "0"
         helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 

--- a/deploy/kubernetes/setup-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/setup-sumologic.yaml.tmpl
@@ -7,7 +7,7 @@ kind: ConfigMap
 metadata:
   name:  collection-sumologic-setup
   annotations:
-    helm.sh/hook: pre-install
+    helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
     helm.sh/hook-weight: "2"
     
@@ -175,7 +175,7 @@ kind: ServiceAccount
 metadata:
   name:  collection-sumologic-setup
   annotations:
-    helm.sh/hook: pre-install
+    helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
     helm.sh/hook-weight: "0"
     
@@ -191,7 +191,7 @@ kind: ClusterRole
 metadata:
   name:  collection-sumologic-setup
   annotations:
-    helm.sh/hook: pre-install
+    helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
     helm.sh/hook-weight: "1"
     
@@ -214,7 +214,7 @@ kind: ClusterRoleBinding
 metadata:
   name:  collection-sumologic-setup
   annotations:
-    helm.sh/hook: pre-install
+    helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
     helm.sh/hook-weight: "2"
     
@@ -239,7 +239,7 @@ metadata:
   name: collection-sumologic-setup
   namespace: $NAMESPACE
   annotations:
-    helm.sh/hook: pre-install
+    helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
     helm.sh/hook-weight: "3"
     


### PR DESCRIPTION
###### Description

Revert #288 since we have confirmed that upgrading from non-TF chart to TF chart with setup running in pre-upgrade will potentially create a new collector (breaking change). 

Will update CHANGELOG in #333.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
