### PR TITLE
Improve fluentd liveness probe

### DIFF
--- a/deploy/helm/sumologic/conf/common.conf
+++ b/deploy/helm/sumologic/conf/common.conf
@@ -6,6 +6,11 @@
 <source>
   @type prometheus_output_monitor
 </source>
+<source>
+  @type http
+  port 9880
+  bind 0.0.0.0
+</source>
 {{- if .Values.sumologic.fluentdLogLevel }}
 <system>
   log_level {{ .Values.sumologic.fluentdLogLevel }}

--- a/deploy/helm/sumologic/conf/logs/logs.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.conf
@@ -3,10 +3,5 @@
   port 24321
   bind 0.0.0.0
 </source>
-<source>
-  @type http
-  port 9880
-  bind 0.0.0.0
-</source>
 @include logs.source.containers.conf
 @include logs.source.systemd.conf

--- a/deploy/helm/sumologic/conf/logs/logs.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.conf
@@ -3,5 +3,10 @@
   port 24321
   bind 0.0.0.0
 </source>
+<source>
+  @type http
+  port 9880
+  bind 0.0.0.0
+</source>
 @include logs.source.containers.conf
 @include logs.source.systemd.conf

--- a/deploy/helm/sumologic/templates/deployment.yaml
+++ b/deploy/helm/sumologic/templates/deployment.yaml
@@ -54,11 +54,9 @@ spec:
           periodSeconds: 30
           timeoutSeconds: 3
         readinessProbe:
-          exec:
-            command:
-            - "/bin/sh"
-            - "-c"
-            - "[ $(pgrep ruby | wc -l) -gt 0 ]"
+          httpGet:
+            path: /fluentd.pod.healthcheck?json=%7B%22log%22%3A+%22health+check%22%7D
+            port: 9880
           initialDelaySeconds: 30
           periodSeconds: 5
         volumeMounts:

--- a/deploy/helm/sumologic/templates/deployment.yaml
+++ b/deploy/helm/sumologic/templates/deployment.yaml
@@ -47,13 +47,12 @@ spec:
           containerPort: 24321
           protocol: TCP
         livenessProbe:
-          exec:
-            command:
-            - "/bin/sh"
-            - "-c"
-            - "[ $(pgrep ruby | wc -l) -gt 0 ]"
+          httpGet:
+            path: /fluentd.pod.healthcheck?json=%7B%22log%22%3A+%22health+check%22%7D
+            port: 9880
           initialDelaySeconds: 300
-          periodSeconds: 20
+          periodSeconds: 30
+          timeoutSeconds: 3
         readinessProbe:
           exec:
             command:

--- a/deploy/helm/sumologic/templates/events-deployment.yaml
+++ b/deploy/helm/sumologic/templates/events-deployment.yaml
@@ -45,19 +45,16 @@ spec:
         - name: pos-files
           mountPath: /mnt/pos/
         livenessProbe:
-          exec:
-            command:
-            - "/bin/sh"
-            - "-c"
-            - "[ $(pgrep ruby | wc -l) -gt 0 ]"
+          httpGet:
+            path: /fluentd.pod.healthcheck?json=%7B%22log%22%3A+%22health+check%22%7D
+            port: 9880
           initialDelaySeconds: 300
-          periodSeconds: 20
+          periodSeconds: 30
+          timeoutSeconds: 3
         readinessProbe:
-          exec:
-            command:
-            - "/bin/sh"
-            - "-c"
-            - "[ $(pgrep ruby | wc -l) -gt 0 ]"
+          httpGet:
+            path: /fluentd.pod.healthcheck?json=%7B%22log%22%3A+%22health+check%22%7D
+            port: 9880
           initialDelaySeconds: 30
           periodSeconds: 5
         env:

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -627,19 +627,16 @@ spec:
         - name: pos-files
           mountPath: /mnt/pos/
         livenessProbe:
-          exec:
-            command:
-            - "/bin/sh"
-            - "-c"
-            - "[ $(pgrep ruby | wc -l) -gt 0 ]"
+          httpGet:
+            path: /fluentd.pod.healthcheck?json=%7B%22log%22%3A+%22health+check%22%7D
+            port: 9880
           initialDelaySeconds: 300
-          periodSeconds: 20
+          periodSeconds: 30
+          timeoutSeconds: 3
         readinessProbe:
-          exec:
-            command:
-            - "/bin/sh"
-            - "-c"
-            - "[ $(pgrep ruby | wc -l) -gt 0 ]"
+          httpGet:
+            path: /fluentd.pod.healthcheck?json=%7B%22log%22%3A+%22health+check%22%7D
+            port: 9880
           initialDelaySeconds: 30
           periodSeconds: 5
         env:

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -142,6 +142,11 @@ data:
       port 24321
       bind 0.0.0.0
     </source>
+    <source>
+      @type http
+      port 9880
+      bind 0.0.0.0
+    </source>
     @include logs.source.containers.conf
     @include logs.source.systemd.conf
   logs.output.conf: |-
@@ -469,13 +474,12 @@ spec:
           containerPort: 24321
           protocol: TCP
         livenessProbe:
-          exec:
-            command:
-            - "/bin/sh"
-            - "-c"
-            - "[ $(pgrep ruby | wc -l) -gt 0 ]"
+          httpGet:
+            path: /fluentd.pod.healthcheck?json=%7B%22log%22%3A+%22health+check%22%7D
+            port: 9880
           initialDelaySeconds: 300
-          periodSeconds: 20
+          periodSeconds: 30
+          timeoutSeconds: 3
         readinessProbe:
           exec:
             command:


### PR DESCRIPTION
###### Description

Add new liveness probe to fluentd deployment. 
```
httpGet:
    path: /fluentd.pod.healthcheck?json=%7B%22log%22%3A+%22health+check%22%7D
    port: 9880
```
The rationale is that if Fluentd can accept log messages, it must be healthy.
The endpoint itself results in a new fluentd tag `fluentd.pod-healthcheck`
The query parameter in the URL defines a URL-encoded JSON object that looks like this:
{"log": "health check"}


###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
