### PR TITLE
Update promethues pod name in doc

### DIFF
--- a/deploy/docs/Non_Helm_Installation.md
+++ b/deploy/docs/Non_Helm_Installation.md
@@ -218,7 +218,7 @@ $ kubectl apply -f prometheus.yaml
 Verify `prometheus-operator` is running:
 
 ```sh
-kubectl -n sumologic logs prometheus-prometheus-operator-prometheus-0 prometheus -f
+kubectl -n sumologic logs prometheus-collection-prometheus-oper-prometheus-0 prometheus -f
 ```
 
 At this point setup is complete and metrics data is being sent to Sumo Logic.


### PR DESCRIPTION
###### Description

The non-helm documentation refers to incorrect prometheus pod name to check the status of prometheus-operator. This PR updates the doc with the correct pod name.

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
