### PR TITLE
Update helm installation instructions in Non_Helm_Installation.md 

### DIFF
--- a/deploy/docs/Non_Helm_Installation.md
+++ b/deploy/docs/Non_Helm_Installation.md
@@ -35,7 +35,7 @@ kubectl config use-context DESIRED_CONTEXT_NAME
 
 *Note the following steps are one way to install Helm, but in order to ensure property security, please be sure to review the [Helm documentation.](https://helm.sh/docs/using_helm/#securing-your-helm-installation)*
 
-Download latest Helm 2 to generate the yaml files necessary to deploy by running
+Download the latest Helm 2 version to generate the yaml files necessary to deploy by running
 
 ```bash
 brew install helm@2

--- a/deploy/docs/Non_Helm_Installation.md
+++ b/deploy/docs/Non_Helm_Installation.md
@@ -35,11 +35,14 @@ kubectl config use-context DESIRED_CONTEXT_NAME
 
 *Note the following steps are one way to install Helm, but in order to ensure property security, please be sure to review the [Helm documentation.](https://helm.sh/docs/using_helm/#securing-your-helm-installation)*
 
-Download Helm to generate the yaml files necessary to deploy by running
+Download latest Helm 2 to generate the yaml files necessary to deploy by running
 
 ```bash
-brew install kubernetes-helm
+brew install helm@2
+export PATH="/usr/local/opt/helm@2/bin:$PATH"
 ```
+
+Reference: https://helm.sh/docs/intro/install/
 
 __NOTE__ These instructions assume that Prometheus is not already running on your Kubernetes cluster.
 


### PR DESCRIPTION
###### Description

The old instruction `brew install kubernetes-helm` downloads helm 3 which is not currently supported by us. 

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
