### PR TITLE
Remove source categories from source creation in terraform script

### DIFF
--- a/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
@@ -84,55 +84,46 @@ data:
 
     resource "sumologic_http_source" "default_metrics_source" {
         name         = local.default-metrics-source-name
-        category     = "${var.cluster_name}/${local.default-metrics-source-name}"
         collector_id = "${sumologic_collector.collector.id}"
     }
 
     resource "sumologic_http_source" "apiserver_metrics_source" {
         name         = local.apiserver-metrics-source-name
-        category     = "${var.cluster_name}/${local.apiserver-metrics-source-name}"
         collector_id = "${sumologic_collector.collector.id}"
     }
 
     resource "sumologic_http_source" "events_source" {
         name         = local.events-source-name
-        category     = "${var.cluster_name}/${local.events-source-name}"
         collector_id = "${sumologic_collector.collector.id}"
     }
 
     resource "sumologic_http_source" "kube_controller_manager_metrics_source" {
         name         = local.kube-controller-manager-metrics-source-name
-        category     = "${var.cluster_name}/${local.kube-controller-manager-metrics-source-name}"
         collector_id = "${sumologic_collector.collector.id}"
     }
 
     resource "sumologic_http_source" "kube_scheduler_metrics_source" {
         name         = local.kube-scheduler-metrics-source-name
-        category     = "${var.cluster_name}/${local.kube-scheduler-metrics-source-name}"
         collector_id = "${sumologic_collector.collector.id}"
     }
 
     resource "sumologic_http_source" "kube_state_metrics_source" {
         name         = local.kube-state-metrics-source-name
-        category     = "${var.cluster_name}/${local.kube-state-metrics-source-name}"
         collector_id = "${sumologic_collector.collector.id}"
     }
 
     resource "sumologic_http_source" "kubelet_metrics_source" {
         name         = local.kubelet-metrics-source-name
-        category     = "${var.cluster_name}/${local.kubelet-metrics-source-name}"
         collector_id = "${sumologic_collector.collector.id}"
     }
 
     resource "sumologic_http_source" "logs_source" {
         name         = local.logs-source-name
-        category     = "${var.cluster_name}/${local.logs-source-name}"
         collector_id = "${sumologic_collector.collector.id}"
     }
 
     resource "sumologic_http_source" "node_exporter_metrics_source" {
         name         = local.node-exporter-metrics-source-name
-        category     = "${var.cluster_name}/${local.node-exporter-metrics-source-name}"
         collector_id = "${sumologic_collector.collector.id}"
     }
 

--- a/deploy/kubernetes/setup-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/setup-sumologic.yaml.tmpl
@@ -82,55 +82,46 @@ data:
 
     resource "sumologic_http_source" "default_metrics_source" {
         name         = local.default-metrics-source-name
-        category     = "${var.cluster_name}/${local.default-metrics-source-name}"
         collector_id = "${sumologic_collector.collector.id}"
     }
 
     resource "sumologic_http_source" "apiserver_metrics_source" {
         name         = local.apiserver-metrics-source-name
-        category     = "${var.cluster_name}/${local.apiserver-metrics-source-name}"
         collector_id = "${sumologic_collector.collector.id}"
     }
 
     resource "sumologic_http_source" "events_source" {
         name         = local.events-source-name
-        category     = "${var.cluster_name}/${local.events-source-name}"
         collector_id = "${sumologic_collector.collector.id}"
     }
 
     resource "sumologic_http_source" "kube_controller_manager_metrics_source" {
         name         = local.kube-controller-manager-metrics-source-name
-        category     = "${var.cluster_name}/${local.kube-controller-manager-metrics-source-name}"
         collector_id = "${sumologic_collector.collector.id}"
     }
 
     resource "sumologic_http_source" "kube_scheduler_metrics_source" {
         name         = local.kube-scheduler-metrics-source-name
-        category     = "${var.cluster_name}/${local.kube-scheduler-metrics-source-name}"
         collector_id = "${sumologic_collector.collector.id}"
     }
 
     resource "sumologic_http_source" "kube_state_metrics_source" {
         name         = local.kube-state-metrics-source-name
-        category     = "${var.cluster_name}/${local.kube-state-metrics-source-name}"
         collector_id = "${sumologic_collector.collector.id}"
     }
 
     resource "sumologic_http_source" "kubelet_metrics_source" {
         name         = local.kubelet-metrics-source-name
-        category     = "${var.cluster_name}/${local.kubelet-metrics-source-name}"
         collector_id = "${sumologic_collector.collector.id}"
     }
 
     resource "sumologic_http_source" "logs_source" {
         name         = local.logs-source-name
-        category     = "${var.cluster_name}/${local.logs-source-name}"
         collector_id = "${sumologic_collector.collector.id}"
     }
 
     resource "sumologic_http_source" "node_exporter_metrics_source" {
         name         = local.node-exporter-metrics-source-name
-        category     = "${var.cluster_name}/${local.node-exporter-metrics-source-name}"
         collector_id = "${sumologic_collector.collector.id}"
     }
 


### PR DESCRIPTION
###### Description

The terraform script currently specifies the source category for each source to be `{cluster-name}/{source-name}` during source creation, however we did not used to specify source category when using the bash script. 

This change creates confusion to users running queries directly from UI by clicking the query icon next to the source category since it returns no results. The reason is because output plugin sends different source category through HTTP header and that takes precedence over the static source category.

###### Testing performed

- [x] ci/build.sh
- [x] Verify sources created no longer have predefined source categories through UI
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
