### PR TITLE
Change default fluentd log level to ERROR

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -149,9 +149,9 @@ sumologic:
   excludePodRegex: ""
 
 
-  ## Sets the fluentd log level. The default log level, if not specified, is info.
+  ## Sets the fluentd log level. The default log level, if not specified, is error.
   ## ref: https://docs.fluentd.org/deployment/logging
-  # fluentdLogLevel: "debug"
+  fluentdLogLevel: "error"
 
   ## Override Kubernetes resource types you want to get events for from different Kubernetes
   ## API versions. The key represents the name of the resource type and the value represents

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -33,6 +33,9 @@ data:
       port 9880
       bind 0.0.0.0
     </source>
+    <system>
+      log_level error
+    </system>
   
   metrics.conf: |-
     <source>
@@ -319,6 +322,9 @@ data:
         @include buffer.output.conf
       </buffer>
     </match>
+    <system>
+      log_level error
+    </system>
   
   buffer.output.conf: |-
     compress gzip


### PR DESCRIPTION
###### Description

Following SEs and @frankreno's suggestion, change default fluentd log level to `error` to reduce verbose logging especially when customer is throttled.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
