### PR TITLE
Clarify usage of envFromSecret to specify env variables needed

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -35,6 +35,8 @@ sumologic:
   setupEnabled: true
 
   # If enabled, accessId and accessKey will be sourced from Secret Name given
+  # Be sure to include at least the following env variables in your secret
+  # (1) SUMOLOGIC_ACCESSID, (2) SUMOLOGIC_ACCESSKEY
   #envFromSecret: sumo-api-secret
 
   # Sumo access ID


### PR DESCRIPTION
###### Description

It's not clear how to use `envFromSecret` based on https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/352 so this PR adds a comment explaining the two env variables we require to be added to the secret used.

###### Testing performed

- [x] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
