### PR TITLE
revert readiness probe for events deployment

### DIFF
--- a/deploy/helm/sumologic/templates/events-deployment.yaml
+++ b/deploy/helm/sumologic/templates/events-deployment.yaml
@@ -45,16 +45,19 @@ spec:
         - name: pos-files
           mountPath: /mnt/pos/
         livenessProbe:
-          httpGet:
-            path: /fluentd.pod.healthcheck?json=%7B%22log%22%3A+%22health+check%22%7D
-            port: 9880
+          exec:
+            command:
+            - "/bin/sh"
+            - "-c"
+            - "[ $(pgrep ruby | wc -l) -gt 0 ]"
           initialDelaySeconds: 300
-          periodSeconds: 30
-          timeoutSeconds: 3
+          periodSeconds: 20
         readinessProbe:
-          httpGet:
-            path: /fluentd.pod.healthcheck?json=%7B%22log%22%3A+%22health+check%22%7D
-            port: 9880
+          exec:
+            command:
+            - "/bin/sh"
+            - "-c"
+            - "[ $(pgrep ruby | wc -l) -gt 0 ]"
           initialDelaySeconds: 30
           periodSeconds: 5
         env:

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -633,16 +633,19 @@ spec:
         - name: pos-files
           mountPath: /mnt/pos/
         livenessProbe:
-          httpGet:
-            path: /fluentd.pod.healthcheck?json=%7B%22log%22%3A+%22health+check%22%7D
-            port: 9880
+          exec:
+            command:
+            - "/bin/sh"
+            - "-c"
+            - "[ $(pgrep ruby | wc -l) -gt 0 ]"
           initialDelaySeconds: 300
-          periodSeconds: 30
-          timeoutSeconds: 3
+          periodSeconds: 20
         readinessProbe:
-          httpGet:
-            path: /fluentd.pod.healthcheck?json=%7B%22log%22%3A+%22health+check%22%7D
-            port: 9880
+          exec:
+            command:
+            - "/bin/sh"
+            - "-c"
+            - "[ $(pgrep ruby | wc -l) -gt 0 ]"
           initialDelaySeconds: 30
           periodSeconds: 5
         env:


### PR DESCRIPTION
###### Description

Reverting the readiness probe for events deployment.

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
