### PR TITLE
disable metrics-server dependency by default

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -193,7 +193,7 @@ sumologic:
 ## Configure metrics-server
 ## ref: https://github.com/helm/charts/blob/master/stable/metrics-server/values.yaml
 metrics-server:
-  enabled: true
+  enabled: false
   args:
     - --kubelet-insecure-tls
     - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname


### PR DESCRIPTION
###### Description

This PR disabled the `metrics-server` helm chart dependency by default. 
`metrics-server` is only required for the `fluentd` HPA , which is disabled by default, so we are also defaulting this dependency to `false`.

It is primarily done to cover the scenario, where the user already has `metrics-server` installed in the k8s cluster, then our helm install command would fail with the error : 

```Error: release collection failed: apiservices.apiregistration.k8s.io "v1beta1.metrics.k8s.io" already exists```

Now, if the user wants to enable autoscaling for fluentd they will have to do the following steps:
1. Enable `metrics-server` dependency 
Note: if `metrics-server` is already installed , this step is not required

2.Enable autoscaling for fluentd

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
- [x] Installed metrics server before running the `helm install` command and verified that helm install and upgrade are successful