### PR TITLE
Change events deployment readiness probe

### DIFF
--- a/deploy/helm/sumologic/conf/events/events.conf
+++ b/deploy/helm/sumologic/conf/events/events.conf
@@ -21,6 +21,11 @@
 <source>
   @type prometheus_output_monitor
 </source>
+<source>
+  @type http
+  port 9880
+  bind 0.0.0.0
+</source>
 <match kubernetes.**>
   @type sumologic
   @id sumologic.endpoint.events

--- a/deploy/helm/sumologic/templates/events-deployment.yaml
+++ b/deploy/helm/sumologic/templates/events-deployment.yaml
@@ -45,19 +45,16 @@ spec:
         - name: pos-files
           mountPath: /mnt/pos/
         livenessProbe:
-          exec:
-            command:
-            - "/bin/sh"
-            - "-c"
-            - "[ $(pgrep ruby | wc -l) -gt 0 ]"
+          httpGet:
+            path: /fluentd.pod.healthcheck?json=%7B%22log%22%3A+%22health+check%22%7D
+            port: 9880
           initialDelaySeconds: 300
-          periodSeconds: 20
+          periodSeconds: 30
+          timeoutSeconds: 3
         readinessProbe:
-          exec:
-            command:
-            - "/bin/sh"
-            - "-c"
-            - "[ $(pgrep ruby | wc -l) -gt 0 ]"
+          httpGet:
+            path: /fluentd.pod.healthcheck?json=%7B%22log%22%3A+%22health+check%22%7D
+            port: 9880
           initialDelaySeconds: 30
           periodSeconds: 5
         env:

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -309,6 +309,11 @@ data:
     <source>
       @type prometheus_output_monitor
     </source>
+    <source>
+      @type http
+      port 9880
+      bind 0.0.0.0
+    </source>
     <match kubernetes.**>
       @type sumologic
       @id sumologic.endpoint.events
@@ -633,19 +638,16 @@ spec:
         - name: pos-files
           mountPath: /mnt/pos/
         livenessProbe:
-          exec:
-            command:
-            - "/bin/sh"
-            - "-c"
-            - "[ $(pgrep ruby | wc -l) -gt 0 ]"
+          httpGet:
+            path: /fluentd.pod.healthcheck?json=%7B%22log%22%3A+%22health+check%22%7D
+            port: 9880
           initialDelaySeconds: 300
-          periodSeconds: 20
+          periodSeconds: 30
+          timeoutSeconds: 3
         readinessProbe:
-          exec:
-            command:
-            - "/bin/sh"
-            - "-c"
-            - "[ $(pgrep ruby | wc -l) -gt 0 ]"
+          httpGet:
+            path: /fluentd.pod.healthcheck?json=%7B%22log%22%3A+%22health+check%22%7D
+            port: 9880
           initialDelaySeconds: 30
           periodSeconds: 5
         env:


### PR DESCRIPTION
###### Description

This PR adds the http source to `events.conf` and changes the readiness/liveness probes for the events deployment.

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
