### PR TITLE
Re-add tiller-rbac.yaml

### DIFF
--- a/deploy/helm/tiller-rbac.yaml
+++ b/deploy/helm/tiller-rbac.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tiller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tiller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: tiller
+    namespace: kube-system


### PR DESCRIPTION
###### Description

Noticed that our jenkins jobs actually downloads this file, and without it I believe the helm installation fails.

I don't think this is enough to fix the jenkins job for helm since it's been failing for a few days, we'll have to keep investigating once this is merged

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
