### PR TITLE
Prometheus fix for k8s 1.16 

### DIFF
--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -85,15 +85,15 @@ prometheus:
       # cadvisor container metrics
       - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.container
         writeRelabelConfigs:
+          - action: labelmap
+            regex: container_name
+            replacement: container
           - action: drop
             regex: POD
             sourceLabels: [container]
-          - action: drop
-            regex: POD
-            sourceLabels: [container_name]
           - action: keep
             regex: kubelet;.+;(?:container_cpu_load_average_10s|container_cpu_system_seconds_total|container_cpu_usage_seconds_total|container_cpu_cfs_throttled_seconds_total|container_memory_usage_bytes|container_memory_swap|container_memory_working_set_bytes|container_spec_memory_limit_bytes|container_spec_memory_swap_limit_bytes|container_spec_memory_reservation_limit_bytes|container_spec_cpu_quota|container_spec_cpu_period|container_fs_usage_bytes|container_fs_limit_bytes|container_fs_reads_bytes_total|container_fs_writes_bytes_total|)
-            sourceLabels: [job,container_name,__name__]
+            sourceLabels: [job,container,__name__]
       # cadvisor aggregate container metrics
       - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.container
         writeRelabelConfigs:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -399,8 +399,7 @@ prometheus-operator:
           writeRelabelConfigs:
             - action: labelmap
               regex: container_name
-              replacement: ${1}
-              targetLabel: container
+              replacement: container
             - action: drop
               regex: POD
               sourceLabels: [container]

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -397,15 +397,16 @@ prometheus-operator:
         # cadvisor container metrics
         - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.container
           writeRelabelConfigs:
+            - action: labelmap
+              regex: .*
+              replacement: ${1}
+              targetLabel: container
             - action: drop
               regex: POD
               sourceLabels: [container]
-            - action: drop
-              regex: POD
-              sourceLabels: [container_name]
             - action: keep
               regex: kubelet;.+;(?:container_cpu_load_average_10s|container_cpu_system_seconds_total|container_cpu_usage_seconds_total|container_cpu_cfs_throttled_seconds_total|container_memory_usage_bytes|container_memory_swap|container_memory_working_set_bytes|container_spec_memory_limit_bytes|container_spec_memory_swap_limit_bytes|container_spec_memory_reservation_limit_bytes|container_spec_cpu_quota|container_spec_cpu_period|container_fs_usage_bytes|container_fs_limit_bytes|container_fs_reads_bytes_total|container_fs_writes_bytes_total|)
-              sourceLabels: [job,container_name,__name__]
+              sourceLabels: [job,container,__name__]
         # cadvisor aggregate container metrics
         - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.container
           writeRelabelConfigs:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -398,7 +398,7 @@ prometheus-operator:
         - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.container
           writeRelabelConfigs:
             - action: labelmap
-              regex: .*
+              regex: container_name
               replacement: ${1}
               targetLabel: container
             - action: drop

--- a/deploy/kubernetes/kube-prometheus-sumo-logic-mixin.libsonnet
+++ b/deploy/kubernetes/kube-prometheus-sumo-logic-mixin.libsonnet
@@ -74,6 +74,11 @@
         url: $._config.sumologicCollectorSvc + "prometheus.metrics.container",
         writeRelabelConfigs: [
           {
+            action: "labelmap",
+            regex: "container_name",
+            replacement: "container"
+          },
+          {
             action: "drop",
             regex: "POD",
             sourceLabels: [
@@ -81,18 +86,11 @@
             ]
           },
           {
-            action: "drop",
-            regex: "POD",
-            sourceLabels: [
-              "container_name"
-            ]
-          },
-          {
             action: "keep",
             regex: "kubelet;.+;(?:container_cpu_load_average_10s|container_cpu_system_seconds_total|container_cpu_usage_seconds_total|container_cpu_cfs_throttled_seconds_total|container_memory_usage_bytes|container_memory_swap|container_memory_working_set_bytes|container_spec_memory_limit_bytes|container_spec_memory_swap_limit_bytes|container_spec_memory_reservation_limit_bytes|container_spec_cpu_quota|container_spec_cpu_period|container_fs_usage_bytes|container_fs_limit_bytes|container_fs_reads_bytes_total|container_fs_writes_bytes_total|)",
             sourceLabels: [
               "job",
-              "container_name",
+              "container",
               "__name__"
             ]
           }


### PR DESCRIPTION
###### Description

Relabel metrics metadata "container_name" to "container" for k8s 1.16

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
