### PR TITLE
Modify regexes to match both deprecated and new metrics in 1.16

### DIFF
--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -74,13 +74,13 @@ prometheus:
       - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.apiserver
         writeRelabelConfigs:
           - action: keep
-            regex: apiserver;(?:apiserver_request_count|apiserver_request_latencies.*|etcd_request_cache_get_latencies_summary.*|etcd_request_cache_add_latencies_summary.*|etcd_helper_cache_hit_count|etcd_helper_cache_miss_count)
+            regex: apiserver;(?:apiserver_request_(?:count|total)|apiserver_request_(?:latencies|duration_seconds).*|etcd_request_cache_get_(?:latencies_summary|duration_seconds).*|etcd_request_cache_add_(?:latencies_summary|duration_seconds).*|etcd_helper_cache_hit_(?:count|total)|etcd_helper_cache_miss_(?:count|total))
             sourceLabels: [job, __name__]
       # kubelet metrics
       - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.kubelet
         writeRelabelConfigs:
           - action: keep
-            regex: kubelet;(?:kubelet_docker_operations_errors|kubelet_docker_operations_latency_microseconds|kubelet_running_container_count|kubelet_running_pod_count|kubelet_runtime_operations_latency_microseconds.*)
+            regex: kubelet;(?:kubelet_docker_operations_errors.*|kubelet_docker_operations_(?:latency_micro|duration_)seconds.*|kubelet_running_container_count|kubelet_running_pod_count|kubelet_runtime_operations_(?:latency_micro|duration_)seconds.*)
             sourceLabels: [job, __name__]
       # cadvisor container metrics
       - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.container

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -386,7 +386,7 @@ prometheus-operator:
         - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.apiserver
           writeRelabelConfigs:
             - action: keep
-              regex: apiserver;(?:apiserver_request_(?:count|total)|apiserver_request_latenc(?:ies|y_seconds).*|etcd_request_cache_get_latenc(?:ies_summary|y_seconds).*|etcd_request_cache_add_latenc(?:ies_summary|y_seconds).*|etcd_helper_cache_hit_(?:count|total)|etcd_helper_cache_miss_(?:count|total))
+              regex: apiserver;(?:apiserver_request_(?:count|total)|apiserver_request_(?:latencies|duration_seconds).*|etcd_request_cache_get_(?:latencies_summary|duration_seconds).*|etcd_request_cache_add_(?:latencies_summary|duration_seconds).*|etcd_helper_cache_hit_(?:count|total)|etcd_helper_cache_miss_(?:count|total))
               sourceLabels: [job, __name__]
         # kubelet metrics
         - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.kubelet

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -386,13 +386,13 @@ prometheus-operator:
         - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.apiserver
           writeRelabelConfigs:
             - action: keep
-              regex: apiserver;(?:apiserver_request_count|apiserver_request_latencies.*|etcd_request_cache_get_latencies_summary.*|etcd_request_cache_add_latencies_summary.*|etcd_helper_cache_hit_count|etcd_helper_cache_miss_count)
+              regex: apiserver;(?:apiserver_request_(?:count|total)|apiserver_request_latenc(?:ies|y_seconds).*|etcd_request_cache_get_latenc(?:ies_summary|y_seconds).*|etcd_request_cache_add_latenc(?:ies_summary|y_seconds).*|etcd_helper_cache_hit_(?:count|total)|etcd_helper_cache_miss_(?:count|total))
               sourceLabels: [job, __name__]
         # kubelet metrics
         - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.kubelet
           writeRelabelConfigs:
             - action: keep
-              regex: kubelet;(?:kubelet_docker_operations_errors|kubelet_docker_operations_latency_microseconds|kubelet_running_container_count|kubelet_running_pod_count|kubelet_runtime_operations_latency_microseconds.*)
+              regex: kubelet;(?:kubelet_docker_operations_errors.*|kubelet_docker_operations_(?:latency_micro|duration_)seconds.*|kubelet_running_container_count|kubelet_running_pod_count|kubelet_runtime_operations_(?:latency_micro|duration_)seconds.*)
               sourceLabels: [job, __name__]
         # cadvisor container metrics
         - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.container

--- a/deploy/kubernetes/kube-prometheus-sumo-logic-mixin.libsonnet
+++ b/deploy/kubernetes/kube-prometheus-sumo-logic-mixin.libsonnet
@@ -49,7 +49,7 @@
         writeRelabelConfigs: [
           {
             action: "keep",
-            regex: "apiserver;(?:apiserver_request_count|apiserver_request_latencies.*|etcd_request_cache_get_latencies_summary.*|etcd_request_cache_add_latencies_summary.*|etcd_helper_cache_hit_count|etcd_helper_cache_miss_count)",
+            regex: "apiserver;(?:apiserver_request_(?:count|total)|apiserver_request_(?:latencies|duration_seconds).*|etcd_request_cache_get_(?:latencies_summary|duration_seconds).*|etcd_request_cache_add_(?:latencies_summary|duration_seconds).*|etcd_helper_cache_hit_(?:count|total)|etcd_helper_cache_miss_(?:count|total))",
             sourceLabels: [
               "job",
               "__name__"
@@ -62,7 +62,7 @@
         writeRelabelConfigs: [
           {
             action: "keep",
-            regex: "kubelet;(?:kubelet_docker_operations_errors|kubelet_docker_operations_latency_microseconds|kubelet_running_container_count|kubelet_running_pod_count|kubelet_runtime_operations_latency_microseconds.*)",
+            regex: "kubelet;(?:kubelet_docker_operations_errors.*|kubelet_docker_operations_(?:latency_micro|duration_)seconds.*|kubelet_running_container_count|kubelet_running_pod_count|kubelet_runtime_operations_(?:latency_micro|duration_)seconds.*)",
             sourceLabels: [
               "job",
               "__name__"


### PR DESCRIPTION
###### Description

**Deprecated apiserver metrics:**
`apiserver_request_count` -> `apiserver_request_total`
`apiserver_request_latencies_summary` -> `apiserver_request_duration_seconds`
`etcd_request_cache_get_latencies_summary` -> `etcd_request_cache_get_duration_seconds`
`etcd_request_cache_add_latencies_summary` -> `etcd_request_cache_add_duration_seconds`
`etcd_helper_cache_hit_count` -> `etcd_helper_cache_hit_total`
`etcd_helper_cache_miss_count` -> `etcd_helper_cache_miss_total`

(Verified the apiserver metrics are coming in 1.16, but the etcd ones are not, I think all of these 4 etcd metrics got removed in 1.17 but not sure why they are not showing up in 1.16 either)

**Deprecated kubelet metrics:**
`kubelet_runtime_operations_latency_microseconds` -> `kubelet_runtime_operations_duration_seconds`
`kubelet_docker_operations_latency_microseconds` -> `kubelet_docker_operations_duration_seconds`
`kubelet_docker_operations_errors` -> `kubelet_docker_operations_errors_total`

(Verified all of the old and new kubelet metrics are coming in 1.16)

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
