### PR TITLE
Add back and expose source category for events source

### DIFF
--- a/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
@@ -94,6 +94,7 @@ data:
 
     resource "sumologic_http_source" "events_source" {
         name         = local.events-source-name
+        category     = {{ if .Values.sumologic.eventsSourceCategory }}{{ .Values.sumologic.eventsSourceCategory }}{{- else}}{{ "${var.cluster_name}/${local.events-source-name}" }}{{- end}}
         collector_id = "${sumologic_collector.collector.id}"
     }
 

--- a/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
@@ -94,7 +94,7 @@ data:
 
     resource "sumologic_http_source" "events_source" {
         name         = local.events-source-name
-        category     = {{ if .Values.sumologic.eventsSourceCategory }}{{ .Values.sumologic.eventsSourceCategory }}{{- else}}{{ "${var.cluster_name}/${local.events-source-name}" }}{{- end}}
+        category     = {{ if .Values.sumologic.events.sourceCategory }}{{ .Values.sumologic.events.sourceCategory }}{{- else}}{{ "${var.cluster_name}/${local.events-source-name}" }}{{- end}}
         collector_id = "${sumologic_collector.collector.id}"
     }
 

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -85,8 +85,9 @@ sumologic:
   # If enabled, collect K8s events
   eventCollectionEnabled: true
 
-  # Source category for the Events source. Default: "{clusterName}/events"
-  #eventsSourceCategory: ""
+  events:
+    # Source category for the Events source. Default: "{clusterName}/events"
+    sourceCategory: ""
 
   ## Format to post logs into Sumo. json, json_merge, or text
   logFormat: fields

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -85,6 +85,9 @@ sumologic:
   # If enabled, collect K8s events
   eventCollectionEnabled: true
 
+  # Source category for the Events source. Default: "{clusterName}/events"
+  #eventsSourceCategory: ""
+
   ## Format to post logs into Sumo. json, json_merge, or text
   logFormat: fields
 

--- a/deploy/kubernetes/setup-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/setup-sumologic.yaml.tmpl
@@ -92,6 +92,7 @@ data:
 
     resource "sumologic_http_source" "events_source" {
         name         = local.events-source-name
+        category     = ${var.cluster_name}/${local.events-source-name}
         collector_id = "${sumologic_collector.collector.id}"
     }
 


### PR DESCRIPTION
###### Description

Since the events data doesn't go through metadata enrichment plugin currently, the source category for events source is just the default `http` after we removed static source category for all sources in #349. 

This PR adds it back just for events source and expose it in values.yaml file. Since after Sam's breaking change, [all events configuration fields](https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/330/files#diff-1afd7b203a6373f36b3fdb4d68d7ddb5R273) go under `events` I am adding it here in case this goes out in a minor release before the major one to avoid one more rename that customer needs to do when we do make the major release. 

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
- [x] Ran `helm template` to verify overwriting the field
