### PR TITLE
Update Helm requirement to 2.12+

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -36,7 +36,7 @@ The diagram below illustrates the components of the Kubernetes collection soluti
 Name | Version
 -------- | -----
 K8s | 1.10+
-Helm | 2.11+
+Helm | 2.12+
 
 ## Support Matrix
 


### PR DESCRIPTION
###### Description

The prometheus operator requires Helm version 2.12+ now, so we need to update the docs to reflect this

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
