### PR TITLE
expose cache params for enhance_k8s_metadata plugin

### DIFF
--- a/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
@@ -15,6 +15,8 @@
 <label @NORMAL>
   <filter containers.**>
     @type kubernetes_metadata
+    cache_size  {{ .Values.sumologic.k8sMetadataFilter.cacheSize }}
+    cache_ttl  {{ .Values.sumologic.k8sMetadataFilter.cacheTtl }}
     @log_level warn
     annotation_match ["sumologic\.com.*"]
     de_dot false

--- a/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
@@ -32,6 +32,8 @@
   </filter>
   <filter **>
     @type enhance_k8s_metadata
+    cache_size  {{ .Values.sumologic.k8sMetadataFilter.cacheSize }}
+    cache_ttl  {{ .Values.sumologic.k8sMetadataFilter.cacheTtl }}
     in_namespace_path '$.kubernetes.namespace_name'
     in_pod_path '$.kubernetes.pod_name'
     data_type logs

--- a/deploy/helm/sumologic/conf/metrics/metrics.conf
+++ b/deploy/helm/sumologic/conf/metrics/metrics.conf
@@ -12,8 +12,8 @@
 <label @DATAPOINT>
   <filter prometheus.metrics**>
     @type enhance_k8s_metadata
-    cache_size  {{ .Values.sumologic.k8sMetadataFilter.bearerCacheSize }}
-    cache_ttl  {{ .Values.sumologic.k8sMetadataFilter.bearerCacheTtl }}
+    cache_size  {{ .Values.sumologic.k8sMetadataFilter.cacheSize }}
+    cache_ttl  {{ .Values.sumologic.k8sMetadataFilter.cacheTtl }}
   </filter>
   <filter prometheus.metrics**>
     @type prometheus_format

--- a/deploy/helm/sumologic/conf/metrics/metrics.conf
+++ b/deploy/helm/sumologic/conf/metrics/metrics.conf
@@ -12,6 +12,8 @@
 <label @DATAPOINT>
   <filter prometheus.metrics**>
     @type enhance_k8s_metadata
+    cache_size  {{ .Values.sumologic.k8sMetadataFilter.bearerCacheSize }}
+    cache_ttl  {{ .Values.sumologic.k8sMetadataFilter.bearerCacheTtl }}
   </filter>
   <filter prometheus.metrics**>
     @type prometheus_format

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -145,9 +145,9 @@ spec:
           value: {{ .Values.sumologic.k8sMetadataFilter.watch | quote }}
         - name: K8S_METADATA_FILTER_VERIFY_SSL
           value: {{ .Values.sumologic.k8sMetadataFilter.verifySsl | quote }}
-        - name: K8S_METADATA_FILTER_BEARER_CACHE_SIZE
+        - name: K8S_METADATA_FILTER_CACHE_SIZE
           value: {{ .Values.sumologic.k8sMetadataFilter.cacheSize | quote }}
-        - name: K8S_METADATA_FILTER_BEARER_CACHE_TTL
+        - name: K8S_METADATA_FILTER_CACHE_TTL
           value: {{ .Values.sumologic.k8sMetadataFilter.cacheTtl | quote }}
         - name: VERIFY_SSL
           value: {{ .Values.sumologic.verifySsl | quote }}

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -146,9 +146,9 @@ spec:
         - name: K8S_METADATA_FILTER_VERIFY_SSL
           value: {{ .Values.sumologic.k8sMetadataFilter.verifySsl | quote }}
         - name: K8S_METADATA_FILTER_BEARER_CACHE_SIZE
-          value: {{ .Values.sumologic.k8sMetadataFilter.bearerCacheSize | quote }}
+          value: {{ .Values.sumologic.k8sMetadataFilter.cacheSize | quote }}
         - name: K8S_METADATA_FILTER_BEARER_CACHE_TTL
-          value: {{ .Values.sumologic.k8sMetadataFilter.bearerCacheTtl | quote }}
+          value: {{ .Values.sumologic.k8sMetadataFilter.cacheTtl | quote }}
         - name: VERIFY_SSL
           value: {{ .Values.sumologic.verifySsl | quote }}
         - name: EXCLUDE_NAMESPACE_REGEX

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -202,7 +202,7 @@ sumologic:
 
     ## Option to control the enabling of metadata filter plugin cache_size. 
     ## ref: https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter#configuration
-    bearerCacheSize: "1000"
+    bearerCacheSize: "10000"
 
     ## Option to control the enabling of metadata filter plugin cache_ttl. 
     ## ref: https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter#configuration

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -202,11 +202,11 @@ sumologic:
 
     ## Option to control the enabling of metadata filter plugin cache_size. 
     ## ref: https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter#configuration
-    bearerCacheSize: "10000"
+    cacheSize: "10000"
 
-    ## Option to control the enabling of metadata filter plugin cache_ttl. 
+    ## Option to control the enabling of metadata filter plugin cache_ttl (in seconds). 
     ## ref: https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter#configuration
-    bearerCacheTtl: "3600"
+    cacheTtl: "3600"
 
 
 ## Configure metrics-server

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -206,6 +206,8 @@ data:
       </filter>
       <filter **>
         @type enhance_k8s_metadata
+        cache_size  10000
+        cache_ttl  3600
         in_namespace_path '$.kubernetes.namespace_name'
         in_pod_path '$.kubernetes.pod_name'
         data_type logs
@@ -673,9 +675,9 @@ spec:
           value: "true"
         - name: K8S_METADATA_FILTER_VERIFY_SSL
           value: "true"
-        - name: K8S_METADATA_FILTER_BEARER_CACHE_SIZE
+        - name: K8S_METADATA_FILTER_CACHE_SIZE
           value: "10000"
-        - name: K8S_METADATA_FILTER_BEARER_CACHE_TTL
+        - name: K8S_METADATA_FILTER_CACHE_TTL
           value: "3600"
         - name: VERIFY_SSL
           value: "true"


### PR DESCRIPTION


###### Description

Expose cache params for enhance_k8s_metadata plugin and change default cache size to 10000

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
