### PR TITLE
Modify the default multiline regex to be more flexible

### DIFF
--- a/deploy/helm/fluent-bit-overrides.yaml
+++ b/deploy/helm/fluent-bit-overrides.yaml
@@ -26,10 +26,10 @@ input:
 
 parsers:
   enabled: true
-  # This regex matches the first line of a multiline log starting with a date of the format : "2019-11-17 07:14:12"
+  # This regex matches the first line of a multiline log starting with a date of the format :  "2019-11-17 07:14:12" or "2019-11-17T07:14:12"
   regex:
     - name: multi_line
-      regex: (?<log>^{"log":"\d{4}-\d{1,2}-\d{1,2} \d{2}:\d{2}:\d{2}.*)
+      regex: (?<log>^{"log":"\d{4}-\d{1,2}-\d{1,2}.\d{2}:\d{2}:\d{2}.*)
     
 rawConfig: |-
   @INCLUDE fluent-bit-service.conf

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -248,10 +248,10 @@ fluent-bit:
 
   parsers:
     enabled: true
-    # This regex matches the first line of a multiline log starting with a date of the format : "2019-11-17 07:14:12"
+    # This regex matches the first line of a multiline log starting with a date of the format :  "2019-11-17 07:14:12" or "2019-11-17T07:14:12"
     regex:
       - name: multi_line
-        regex: (?<log>^{"log":"\d{4}-\d{1,2}-\d{1,2} \d{2}:\d{2}:\d{2}.*)
+        regex: (?<log>^{"log":"\d{4}-\d{1,2}-\d{1,2}.\d{2}:\d{2}:\d{2}.*)
       
   rawConfig: |-
     @INCLUDE fluent-bit-service.conf


### PR DESCRIPTION


###### Description

Modify the default multiline regex to be more flexible to be more flexible with datetime format. 
This regex matches the first line of a multiline log starting with a date of the format :  `"2019-11-17 07:14:12"` or `"2019-11-17T07:14:12"`

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
