### PR TITLE
Add missing double quotes

### DIFF
--- a/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
@@ -94,7 +94,7 @@ data:
 
     resource "sumologic_http_source" "events_source" {
         name         = local.events-source-name
-        category     = {{ if .Values.sumologic.events.sourceCategory }}{{ .Values.sumologic.events.sourceCategory }}{{- else}}{{ "${var.cluster_name}/${local.events-source-name}" }}{{- end}}
+        category     = {{ if .Values.sumologic.events.sourceCategory }}{{ .Values.sumologic.events.sourceCategory }}{{- else}}{{ "\"${var.cluster_name}/${local.events-source-name}\"" }}{{- end}}
         collector_id = "${sumologic_collector.collector.id}"
     }
 

--- a/deploy/kubernetes/setup-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/setup-sumologic.yaml.tmpl
@@ -92,6 +92,7 @@ data:
 
     resource "sumologic_http_source" "events_source" {
         name         = local.events-source-name
+        category     = "${var.cluster_name}/${local.events-source-name}"
         collector_id = "${sumologic_collector.collector.id}"
     }
 


### PR DESCRIPTION
###### Description

TF complains about missing double quotes in rendered source category for events source.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
