### PR TITLE
Convert more absolute URLs to Relative URLs in Docs

### DIFF
--- a/deploy/docs/Installation_with_Helm.md
+++ b/deploy/docs/Installation_with_Helm.md
@@ -32,9 +32,9 @@ The Helm chart installation requires three parameter overrides:
 
 These steps require that no Prometheus exists. If you already have Prometheus installed select from the following options:
 
-- [How to install if you have an existing Prometheus operator](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/master/deploy/docs/existingPrometheusDoc.md) 
-- [How to install if you have standalone Prometheus](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/master/deploy/docs/standAlonePrometheus.md) 
-- [How to install our Prometheus side by side with your existing Prometheus](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/master/deploy/docs/SideBySidePrometheus.md)
+- [How to install if you have an existing Prometheus operator](./existingPrometheusDoc.md) 
+- [How to install if you have standalone Prometheus](./standAlonePrometheus.md) 
+- [How to install our Prometheus side by side with your existing Prometheus](./SideBySidePrometheus.md)
 
 To install the chart, first add the `sumologic` private repo:
 

--- a/deploy/docs/Non_Helm_Installation.md
+++ b/deploy/docs/Non_Helm_Installation.md
@@ -167,7 +167,7 @@ curl https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection
 sed 's/\$NAMESPACE'"/sumologic/g" >> fluentd-sumologic.yaml
 ```
 
-Next, customize the provided YAML file. Our [plugin](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/master/fluent-plugin-events/README.md#fluent-plugin-events) allows you to configure fields for events. Once done run the following command to apply the `fluentd-sumologic.yaml` manifest.
+Next, customize the provided YAML file. Our [plugin](../../fluent-plugin-events/README.md#fluent-plugin-events) allows you to configure fields for events. Once done run the following command to apply the `fluentd-sumologic.yaml` manifest.
 
 ```sh
 kubectl -n sumologic apply -f fluentd-sumologic.yaml

--- a/deploy/docs/Troubleshoot_Collection.md
+++ b/deploy/docs/Troubleshoot_Collection.md
@@ -255,7 +255,7 @@ helm install stable/prometheus-operator --name prometheus-operator --namespace s
 
 ### Missing `kube-controller-manager` or `kube-scheduler` metrics
 
-There’s an issue with backwards compatibility in the current version of the prometheus-operator helm chart that requires us to override the selectors for kube-scheduler and kube-controller-manager in order to see metrics from them. If you are not seeing metrics from these two targets, try running the commands in the "Configure Prometheus" section [here](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/master/deploy/docs/Non_Helm_Installation.md#missing-metrics-for-controller-manager-or-scheduler).
+There’s an issue with backwards compatibility in the current version of the prometheus-operator helm chart that requires us to override the selectors for kube-scheduler and kube-controller-manager in order to see metrics from them. If you are not seeing metrics from these two targets, try running the commands in the "Configure Prometheus" section [here](./Non_Helm_Installation.md#missing-metrics-for-controller-manager-or-scheduler).
 
 ### Rancher
 

--- a/deploy/docs/additional_prometheus_configuration.md
+++ b/deploy/docs/additional_prometheus_configuration.md
@@ -21,7 +21,7 @@ You can supply any label you like. You can query Prometheus to see a complete li
 
 You can specify relabeling, and additional inclusion or exclusion options in `fluentd-sumologic.yaml`.
 
-The options you can use are described [here](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/master/fluent-plugin-prometheus-format).
+The options you can use are described [here](../../fluent-plugin-prometheus-format/README.md).
 
 Make your edits in the `<filter>` stanza in the ConfigMap section of `fluentd-sumologic.yaml`.
 


### PR DESCRIPTION
###### Description

Replaces absolute links with relative links so that historical docs will be preserved with working links when new releases are made (new tags).

###### Testing performed

- [x] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
