### PR TITLE
Add async cache and expose refresh interval in values.yaml

### DIFF
--- a/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
@@ -32,6 +32,7 @@
     @type enhance_k8s_metadata
     cache_size  "#{ENV['K8S_METADATA_FILTER_CACHE_SIZE']}"
     cache_ttl  "#{ENV['K8S_METADATA_FILTER_CACHE_TTL']}"
+    cache_refresh "#{ENV['K8S_METADATA_FILTER_CACHE_REFRESH']}"
     in_namespace_path '$.kubernetes.namespace_name'
     in_pod_path '$.kubernetes.pod_name'
     data_type logs

--- a/deploy/helm/sumologic/conf/metrics/metrics.conf
+++ b/deploy/helm/sumologic/conf/metrics/metrics.conf
@@ -14,6 +14,7 @@
     @type enhance_k8s_metadata
     cache_size  "#{ENV['K8S_METADATA_FILTER_CACHE_SIZE']}"
     cache_ttl  "#{ENV['K8S_METADATA_FILTER_CACHE_TTL']}"
+    cache_refresh "#{ENV['K8S_METADATA_FILTER_CACHE_REFRESH']}"
   </filter>
   <filter prometheus.metrics**>
     @type prometheus_format

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -149,6 +149,8 @@ spec:
           value: {{ .Values.sumologic.k8sMetadataFilter.cacheSize | quote }}
         - name: K8S_METADATA_FILTER_CACHE_TTL
           value: {{ .Values.sumologic.k8sMetadataFilter.cacheTtl | quote }}
+        - name: K8S_METADATA_FILTER_CACHE_REFRESH
+          value: {{ .Values.sumologic.k8sMetadataFilter.cacheRefresh | quote }}
         - name: VERIFY_SSL
           value: {{ .Values.sumologic.verifySsl | quote }}
         - name: EXCLUDE_NAMESPACE_REGEX

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -212,6 +212,7 @@ sumologic:
     ## ref: https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter#configuration
     cacheTtl: "3600"
 
+    cacheRefresh: "600"
 
 ## Configure metrics-server
 ## ref: https://github.com/helm/charts/blob/master/stable/metrics-server/values.yaml

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -212,6 +212,7 @@ sumologic:
     ## ref: https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter#configuration
     cacheTtl: "3600"
 
+    ## Option to control the interval at which metadata cache is asynchronously refreshed (in seconds).
     cacheRefresh: "600"
 
 ## Configure metrics-server

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -54,6 +54,7 @@ data:
         @type enhance_k8s_metadata
         cache_size  "#{ENV['K8S_METADATA_FILTER_CACHE_SIZE']}"
         cache_ttl  "#{ENV['K8S_METADATA_FILTER_CACHE_TTL']}"
+        cache_refresh "#{ENV['K8S_METADATA_FILTER_CACHE_REFRESH']}"
       </filter>
       <filter prometheus.metrics**>
         @type prometheus_format
@@ -206,6 +207,7 @@ data:
         @type enhance_k8s_metadata
         cache_size  "#{ENV['K8S_METADATA_FILTER_CACHE_SIZE']}"
         cache_ttl  "#{ENV['K8S_METADATA_FILTER_CACHE_TTL']}"
+        cache_refresh "#{ENV['K8S_METADATA_FILTER_CACHE_REFRESH']}"
         in_namespace_path '$.kubernetes.namespace_name'
         in_pod_path '$.kubernetes.pod_name'
         data_type logs
@@ -677,6 +679,8 @@ spec:
           value: "10000"
         - name: K8S_METADATA_FILTER_CACHE_TTL
           value: "3600"
+        - name: K8S_METADATA_FILTER_CACHE_REFRESH
+          value: "600"
         - name: VERIFY_SSL
           value: "true"
         - name: EXCLUDE_NAMESPACE_REGEX

--- a/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
@@ -130,13 +130,7 @@ module Fluent
               namespace_name = split[0]
               pod_name = split[1]
               metadata = fetch_pod_metadata(namespace_name, pod_name)
-
-              if !metadata.nil? && !metadata.empty?
-                @cache[entry[0]] = metadata
-              else
-                log.info "Deleting entry for key #{entry[0]}"
-                @cache.delete(entry[0])
-              end
+              @cache[entry[0]] = metadata unless metadata.empty?
             rescue => e
               log.error "Cannot refresh metadata for entry #{entry}: #{e}"
             end

--- a/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
@@ -38,12 +38,14 @@ module Fluent
 
       config_param :cache_size, :integer, default: 1000
       config_param :cache_ttl, :integer, default: 60 * 60
+      config_param :cache_refresh, :integer, default: 60 * 10
 
       def configure(conf)
         super
         normalize_param
         connect_kubernetes
         init_cache
+        start_cache_timer
         @in_namespace_ac = @in_namespace_path.map { |path| record_accessor_create(path) }
         @in_pod_ac = @in_pod_path.map { |path| record_accessor_create(path) }
       end
@@ -113,7 +115,33 @@ module Fluent
         log.debug "bearer_token_file: '#{@bearer_token_file}', exist: #{File.exist?(@bearer_token_file)}"
 
         @cache_ttl = :none if @cache_ttl <= 0
-        log.info "cache_ttl: #{cache_ttl}, cache_size: #{@cache_size}"
+        log.info "cache_ttl: #{@cache_ttl}, cache_size: #{@cache_size}, cache_refresh: #{@cache_refresh}"
+      end
+
+      def start_cache_timer
+        timer_execute(:"cache_refresher", @cache_refresh) {
+          entries = @cache.to_a
+          log.info "Refreshing metadata for #{entries.count} entries"
+
+          entries.each { |entry|
+            begin
+              log.info "Refreshing metadata for key #{entry[0]}"
+              split = entry[0].split("::")
+              namespace_name = split[0]
+              pod_name = split[1]
+              metadata = fetch_pod_metadata(namespace_name, pod_name)
+
+              if !metadata.nil? && !metadata.empty?
+                @cache[entry[0]] = metadata
+              else
+                log.info "Deleting entry for key #{entry[0]}"
+                @cache.delete(entry[0])
+              end
+            rescue => e
+              log.error "Cannot refresh metadata for entry #{entry}"
+            end
+          }
+        }
       end
     end
   end

--- a/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
@@ -125,7 +125,7 @@ module Fluent
 
           entries.each { |entry|
             begin
-              log.info "Refreshing metadata for key #{entry[0]}"
+              log.debug "Refreshing metadata for key #{entry[0]}"
               split = entry[0].split("::")
               namespace_name = split[0]
               pod_name = split[1]
@@ -138,7 +138,7 @@ module Fluent
                 @cache.delete(entry[0])
               end
             rescue => e
-              log.error "Cannot refresh metadata for entry #{entry}"
+              log.error "Cannot refresh metadata for entry #{entry}: #{e}"
             end
           }
         }


### PR DESCRIPTION
###### Description

This PR uses the fluentd timer helper plugin to asynchronously refresh the cache entries at a configurable interval. 
(I tried to put the timer logic inside `cache_strategy.rb` together with all the existing caching logic but since it is a module that does not extend fluentd, I couldn't import the fluentd timer there.)

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
- [x] Confirm cache refresh works and reduces prometheus send latency
