### PR TITLE
Rename statefulset configs to avoid breaking change

### DIFF
--- a/deploy/helm/sumologic/templates/events-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/events-statefulset.yaml
@@ -17,13 +17,13 @@ spec:
         {{- include "sumologic.labels.common" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "sumologic.fullname" . }}
-{{- if .Values.eventsStatefulset.nodeSelector }}
+{{- if .Values.eventsDeployment.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.eventsStatefulset.nodeSelector | indent 8 }}
+{{ toYaml .Values.eventsDeployment.nodeSelector | indent 8 }}
 {{- end }}
-{{- if .Values.eventsStatefulset.tolerations }}
+{{- if .Values.eventsDeployment.tolerations }}
       tolerations:
-{{ toYaml .Values.eventsStatefulset.tolerations | indent 8 }}
+{{ toYaml .Values.eventsDeployment.tolerations | indent 8 }}
 {{- end }}
       volumes:
       - name: pos-files
@@ -40,7 +40,7 @@ spec:
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         resources:
-          {{- toYaml .Values.eventsStatefulset.resources | nindent 10 }}
+          {{- toYaml .Values.eventsDeployment.resources | nindent 10 }}
         volumeMounts:
         - name: config-volume
           mountPath: /fluentd/etc/

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       app: {{ template "sumologic.labels.app" . }}
-  replicas: {{ .Values.statefulset.replicaCount }}
+  replicas: {{ .Values.deployment.replicaCount }}
   template:
     metadata:
       labels:
@@ -17,13 +17,13 @@ spec:
         {{- include "sumologic.labels.common" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "sumologic.fullname" . }}
-{{- if .Values.statefulset.nodeSelector }}
+{{- if .Values.deployment.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.statefulset.nodeSelector | indent 8 }}
+{{ toYaml .Values.deployment.nodeSelector | indent 8 }}
 {{- end }}
-{{- if .Values.statefulset.tolerations }}
+{{- if .Values.deployment.tolerations }}
       tolerations:
-{{ toYaml .Values.statefulset.tolerations | indent 8 }}
+{{ toYaml .Values.deployment.tolerations | indent 8 }}
 {{- end }}
       volumes:
       - name: pos-files
@@ -40,7 +40,7 @@ spec:
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         resources:
-          {{- toYaml .Values.statefulset.resources | nindent 10 }}
+          {{- toYaml .Values.deployment.resources | nindent 10 }}
         ports:
         - name: prom-write
           containerPort: 9888

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -5,7 +5,7 @@ image:
 
 nameOverride: ""
 
-statefulset:
+deployment:
   nodeSelector: {}
   tolerations: {}
   replicaCount: 3
@@ -17,7 +17,7 @@ statefulset:
       memory: 768Mi
       cpu: 0.5
 
-eventsStatefulset:
+eventsDeployment:
   nodeSelector: {}
   tolerations: {}
   resources:


### PR DESCRIPTION
###### Description

Rename `statefulset` and `eventsStatefulset` back to `deployment` and `eventsDeployment` to avoid breaking change in the minor release. Will revert this PR for major release.

###### Testing performed

- [ ] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
