### PR TITLE
Change podManagementPolicy to Parallel for statefulsets

### DIFF
--- a/deploy/helm/sumologic/templates/events-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/events-statefulset.yaml
@@ -16,6 +16,7 @@ spec:
         app: {{ printf "%s-events" (include "sumologic.labels.app" .) }}
         {{- include "sumologic.labels.common" . | nindent 8 }}
     spec:
+      podManagementPolicy: "Parallel"
       serviceAccountName: {{ template "sumologic.fullname" . }}
 {{- if .Values.eventsStatefulset.nodeSelector }}
       nodeSelector:

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -16,6 +16,7 @@ spec:
         app: {{ template "sumologic.labels.app" . }}
         {{- include "sumologic.labels.common" . | nindent 8 }}
     spec:
+      podManagementPolicy: "Parallel"
       serviceAccountName: {{ template "sumologic.fullname" . }}
 {{- if .Values.statefulset.nodeSelector }}
       nodeSelector:

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -472,6 +472,7 @@ spec:
         app: collection-sumologic-events
         
     spec:
+      podManagementPolicy: "Parallel"
       serviceAccountName: collection-sumologic
       volumes:
       - name: pos-files
@@ -550,6 +551,7 @@ spec:
         app: collection-sumologic
         
     spec:
+      podManagementPolicy: "Parallel"
       serviceAccountName: collection-sumologic
       volumes:
       - name: pos-files


### PR DESCRIPTION
###### Description

Frank pointed out we are using ordered podManagementPolicy (default) and it results in very slow replica creation. Changing to parallel should speed up replica creation.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
