### PR TITLE
Use versioned URLs for docs

### DIFF
--- a/deploy/docs/Helm3.md
+++ b/deploy/docs/Helm3.md
@@ -42,7 +42,7 @@ manifest_sorter.go:175: info: skipping unknown hook: "crd-install"
 NOTE: If you need to install the chart with a different release name or namespace you will need to override some configuration fields for both Prometheus and fluent-bit. We recommend using an override file due to the number of fields that need to be overridden. In the following command, replace the `<RELEASE-NAME>` and `<NAMESPACE>` variables with your values and then run it to download the override file with your replaced values:
 
 ```bash
-curl https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/master/deploy/helm/sumologic/values.yaml | \
+curl https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.13.0/deploy/helm/sumologic/values.yaml | \
 sed 's/\-sumologic.sumologic'"/-sumologic.<NAMESPACE>/g" | \
 sed 's/\- sumologic'"/- <NAMESPACE>/g" | \
 sed 's/\collection'"/<RELEASE-NAME>/g" > values.yaml
@@ -50,7 +50,7 @@ sed 's/\collection'"/<RELEASE-NAME>/g" > values.yaml
 
 For example, if your release name is `my-release` and namespace is `my-namespace`:
 ```bash
-curl https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/master/deploy/helm/sumologic/values.yaml | \
+curl https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.13.0/deploy/helm/sumologic/values.yaml | \
 sed 's/\-sumologic.sumologic'"/-sumologic.my-namespace/g" | \
 sed 's/\collection'"/my-release/g" > values.yaml
 ```

--- a/deploy/docs/Installation_with_Helm.md
+++ b/deploy/docs/Installation_with_Helm.md
@@ -57,13 +57,13 @@ helm install sumologic/sumologic --name collection --namespace sumologic --set s
 To customize your configuration, download the values.yaml file by running
 
 ```bash
-curl https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/master/deploy/helm/sumologic/values.yaml
+curl https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.13.0/deploy/helm/sumologic/values.yaml
 ```
 
 NOTE: If you need to install the chart with a different release name or namespace you will need to override some configuration fields for both Prometheus and fluent-bit. We recommend using an override file due to the number of fields that need to be overridden. In the following command, replace the `<RELEASE-NAME>` and `<NAMESPACE>` variables with your values and then run it to download the override file with your replaced values:
 
 ```bash
-curl https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/master/deploy/helm/sumologic/values.yaml | \
+curl https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.13.0/deploy/helm/sumologic/values.yaml | \
 sed 's/\-sumologic.sumologic'"/-sumologic.<NAMESPACE>/g" | \
 sed 's/\- sumologic'"/- <NAMESPACE>/g" | \
 sed 's/\collection'"/<RELEASE-NAME>/g" > values.yaml
@@ -71,7 +71,7 @@ sed 's/\collection'"/<RELEASE-NAME>/g" > values.yaml
 
 For example, if your release name is `my-release` and namespace is `my-namespace`:
 ```bash
-curl https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/master/deploy/helm/sumologic/values.yaml | \
+curl https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.13.0/deploy/helm/sumologic/values.yaml | \
 sed 's/\-sumologic.sumologic'"/-sumologic.my-namespace/g" | \
 sed 's/\collection'"/my-release/g" > values.yaml
 ```

--- a/deploy/docs/Non_Helm_Installation.md
+++ b/deploy/docs/Non_Helm_Installation.md
@@ -72,7 +72,7 @@ kubectl create namespace sumologic
 Run the following command to download and apply the YAML file containing all the Kubernetes resources. Replace the `<NAMESPACE>`, `<SUMOLOGIC_ACCESSID>`, `<SUMOLOGIC_ACCESSKEY>`, `<COLLECTOR_NAME>` and `<CLUSTER_NAME>` variables with your values.
 
 ```sh
-curl -s https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/master/deploy/kubernetes/setup-sumologic.yaml.tmpl | \
+curl -s https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.13.0/deploy/kubernetes/setup-sumologic.yaml.tmpl | \
 sed 's/\$NAMESPACE'"/<NAMESPACE>/g" | \
 sed 's/\$SUMOLOGIC_ACCESSID'"/<SUMOLOGIC_ACCESSID>/g" | \
 sed 's/\$SUMOLOGIC_ACCESSKEY'"/<SUMOLOGIC_ACCESSKEY>/g" | \
@@ -153,7 +153,7 @@ In this step you will deploy Fluentd using a Sumo-provided .yaml manifest.
 If you don't need to customize the configuration apply the `fluentd-sumologic.yaml` manifest with the following command:
 
 ```sh
-curl https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/master/deploy/kubernetes/fluentd-sumologic.yaml.tmpl | \
+curl https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.13.0/deploy/kubernetes/fluentd-sumologic.yaml.tmpl | \
 sed 's/\$NAMESPACE'"/sumologic/g" | \
 kubectl -n sumologic apply -f -
 ```
@@ -163,7 +163,7 @@ kubectl -n sumologic apply -f -
 If you need to customize the configuration there are two commands to run. First, get the `fluentd-sumologic.yaml` manifest with following command:
 
 ```sh
-curl https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/master/deploy/kubernetes/fluentd-sumologic.yaml.tmpl | \
+curl https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.13.0/deploy/kubernetes/fluentd-sumologic.yaml.tmpl | \
 sed 's/\$NAMESPACE'"/sumologic/g" >> fluentd-sumologic.yaml
 ```
 

--- a/deploy/docs/existingPrometheusDoc.md
+++ b/deploy/docs/existingPrometheusDoc.md
@@ -13,7 +13,7 @@
 Run the following to download the `values.yaml` file
 
 ```bash
-curl -LJO https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/master/deploy/helm/sumologic/values.yaml
+curl -LJO https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.13.0/deploy/helm/sumologic/values.yaml
 ```
 
 Edit the `values.yaml` file to `prometheus-operator.enabled = false`, and run


### PR DESCRIPTION
#### Note that we'll have to manually update all of these when we cut a new release. It's not too difficult to do a find+replace on v0.13.0, but we'll have to remember until we add it to our CI

###### Description

Since our changes to these files could be breaking changes, we want to ensure our docs point to the correct versioned urls. In addition, once we cut a major release, this will make it easy for customers who are on older versions to realize they can change the version in the url to the version they are running.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
