### PR TITLE
change buffer params

### DIFF
--- a/deploy/helm/sumologic/conf/buffer.output.conf
+++ b/deploy/helm/sumologic/conf/buffer.output.conf
@@ -2,4 +2,5 @@ compress gzip
 flush_interval "#{ENV['FLUSH_INTERVAL']}"
 flush_thread_count "#{ENV['NUM_THREADS']}"
 chunk_limit_size "#{ENV['CHUNK_LIMIT_SIZE']}"
+queued_chunks_limit_size "#{ENV['QUEUE_CHUNK_LIMIT_SIZE']}"
 overflow_action drop_oldest_chunk

--- a/deploy/helm/sumologic/templates/events-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/events-statefulset.yaml
@@ -78,6 +78,8 @@ spec:
           value: {{ .Values.sumologic.numThreads | quote }}
         - name: CHUNK_LIMIT_SIZE
           value: {{ .Values.sumologic.chunkLimitSize | quote }}
+        - name: QUEUE_CHUNK_LIMIT_SIZE
+          value: {{ .Values.sumologic.queueChunkLimitSize | quote }}
         - name: TOTAL_LIMIT_SIZE
           value: {{ .Values.sumologic.totalLimitSize | quote }}
 {{- if .Values.sumologic.fluentd.persistence.enabled }}

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -120,6 +120,8 @@ spec:
           value: {{ .Values.sumologic.numThreads | quote }}
         - name: CHUNK_LIMIT_SIZE
           value: {{ .Values.sumologic.chunkLimitSize | quote }}
+        - name: QUEUE_CHUNK_LIMIT_SIZE
+          value: {{ .Values.sumologic.queueChunkLimitSize | quote }}
         - name: TOTAL_LIMIT_SIZE
           value: {{ .Values.sumologic.totalLimitSize | quote }}
         - name: SOURCE_CATEGORY

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -99,7 +99,7 @@ sumologic:
   ## Increase number of http threads to Sumo. May be required in heavy logging clusters
   numThreads: 4
 
-  chunkLimitSize: "100k"
+  chunkLimitSize: "1m"
 
   queueChunkLimitSize: 128
 

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -101,6 +101,8 @@ sumologic:
 
   chunkLimitSize: "100k"
 
+  queueChunkLimitSize: 128
+
   totalLimitSize: "128m"
 
   ## Set the _sourceName metadata field in SumoLogic.

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -18,6 +18,7 @@ data:
     flush_interval "#{ENV['FLUSH_INTERVAL']}"
     flush_thread_count "#{ENV['NUM_THREADS']}"
     chunk_limit_size "#{ENV['CHUNK_LIMIT_SIZE']}"
+    queued_chunks_limit_size "#{ENV['QUEUE_CHUNK_LIMIT_SIZE']}"
     overflow_action drop_oldest_chunk
   common.conf: |-
     <source>
@@ -354,6 +355,7 @@ data:
     flush_interval "#{ENV['FLUSH_INTERVAL']}"
     flush_thread_count "#{ENV['NUM_THREADS']}"
     chunk_limit_size "#{ENV['CHUNK_LIMIT_SIZE']}"
+    queued_chunks_limit_size "#{ENV['QUEUE_CHUNK_LIMIT_SIZE']}"
     overflow_action drop_oldest_chunk
   
 ---
@@ -529,7 +531,9 @@ spec:
         - name: NUM_THREADS
           value: "4"
         - name: CHUNK_LIMIT_SIZE
-          value: "100k"
+          value: "1m"
+        - name: QUEUE_CHUNK_LIMIT_SIZE
+          value: "128"
         - name: TOTAL_LIMIT_SIZE
           value: "128m"
 
@@ -650,7 +654,9 @@ spec:
         - name: NUM_THREADS
           value: "4"
         - name: CHUNK_LIMIT_SIZE
-          value: "100k"
+          value: "1m"
+        - name: QUEUE_CHUNK_LIMIT_SIZE
+          value: "128"
         - name: TOTAL_LIMIT_SIZE
           value: "128m"
         - name: SOURCE_CATEGORY


### PR DESCRIPTION
###### Description

This PR adds the new buffer parameter: `queued_chunks_limit_size` which limits the number of queued chunks. Its default value is the number of threads which is `flush_thread_count` . This value is set to be 128 so that at max we would have 128 chunks of 1 MB each,  in the queue whose size  `total_limit_size` is 128MB.

Also, changing the default chunk size `chunk_limit_size` to 1MB from 100k. 


###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
