### PR TITLE
Change cache refresh interval to 30 min

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -196,7 +196,7 @@ sumologic:
     cacheTtl: "3600"
 
     ## Option to control the interval at which metadata cache is asynchronously refreshed (in seconds).
-    cacheRefresh: "600"
+    cacheRefresh: "1800"
 
 ## Configure metrics-server
 ## ref: https://github.com/helm/charts/blob/master/stable/metrics-server/values.yaml

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -594,7 +594,7 @@ spec:
         - name: K8S_METADATA_FILTER_CACHE_TTL
           value: "3600"
         - name: K8S_METADATA_FILTER_CACHE_REFRESH
-          value: "600"
+          value: "1800"
         - name: VERIFY_SSL
           value: "true"
         - name: EXCLUDE_NAMESPACE_REGEX

--- a/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
@@ -38,7 +38,7 @@ module Fluent
 
       config_param :cache_size, :integer, default: 1000
       config_param :cache_ttl, :integer, default: 60 * 60
-      config_param :cache_refresh, :integer, default: 60 * 10
+      config_param :cache_refresh, :integer, default: 60 * 30
 
       def configure(conf)
         super


### PR DESCRIPTION
###### Description

Changing to 30 from 10min default cache refresh interval to reduce apiserver load.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
