### PR TITLE
Increase the default number of output threads to  8

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -97,7 +97,7 @@ sumologic:
   flushInterval: "5s"
 
   ## Increase number of http threads to Sumo. May be required in heavy logging clusters
-  numThreads: 4
+  numThreads: 8
 
   chunkLimitSize: "1m"
 

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -558,7 +558,7 @@ spec:
         - name: FLUSH_INTERVAL
           value: "5s"
         - name: NUM_THREADS
-          value: "4"
+          value: "8"
         - name: CHUNK_LIMIT_SIZE
           value: "1m"
         - name: QUEUE_CHUNK_LIMIT_SIZE
@@ -675,7 +675,7 @@ spec:
         - name: FLUSH_INTERVAL
           value: "5s"
         - name: NUM_THREADS
-          value: "4"
+          value: "8"
         - name: CHUNK_LIMIT_SIZE
           value: "1m"
         - name: QUEUE_CHUNK_LIMIT_SIZE


### PR DESCRIPTION
###### Description

Increase the default number of output threads to  8

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
