### PR TITLE
change fluentd log level to warn

### DIFF
--- a/deploy/helm/sumologic/conf/common.conf
+++ b/deploy/helm/sumologic/conf/common.conf
@@ -14,5 +14,6 @@
 {{- if .Values.sumologic.fluentdLogLevel }}
 <system>
   log_level {{ .Values.sumologic.fluentdLogLevel }}
+  suppress_repeated_stacktrace {{ .Values.sumologic.fluentd.suppressRepeatedStackTrace }}
 </system>
 {{- end }}

--- a/deploy/helm/sumologic/conf/logs/logs.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.conf
@@ -5,3 +5,4 @@
 </source>
 @include logs.source.containers.conf
 @include logs.source.systemd.conf
+@include logs.source.generic.conf

--- a/deploy/helm/sumologic/conf/logs/logs.source.generic.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.generic.conf
@@ -1,0 +1,17 @@
+<match fluent**>
+  @type null
+</match>
+<match **>
+  @type sumologic
+  @id sumologic.endpoint.logs.generic
+  @include logs.output.conf
+  <buffer>
+    {{- if eq .Values.sumologic.fluentd.buffer "file" }}
+    @type file
+    path /fluentd/buffer/logs.generic
+    {{- else }}
+    @type memory
+    {{- end }}
+    @include buffer.output.conf
+  </buffer>
+</match>

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -159,7 +159,7 @@ sumologic:
 
   ## Sets the fluentd log level. The default log level, if not specified, is error.
   ## ref: https://docs.fluentd.org/deployment/logging
-  fluentdLogLevel: "error"
+  fluentdLogLevel: "warn"
 
   ## Override Kubernetes resource types you want to get events for from different Kubernetes
   ## API versions. The key represents the name of the resource type and the value represents

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -170,6 +170,9 @@ sumologic:
   
 
   fluentd:
+    ## Option to specify the Fluentd system config.
+    ## https://docs.fluentd.org/deployment/system-config#suppress_repeated_stacktrace
+    suppressRepeatedStackTrace: "true"
     ## Option to specify the Fluentd buffer as file/memory.
     buffer: "memory"
     ## Option to turn autoscaling on for fluentd and specify metrics for HPA.

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -37,6 +37,7 @@ data:
     </source>
     <system>
       log_level warn
+      suppress_repeated_stacktrace true
     </system>
   
   metrics.conf: |-
@@ -157,6 +158,7 @@ data:
     </source>
     @include logs.source.containers.conf
     @include logs.source.systemd.conf
+    @include logs.source.generic.conf
   logs.output.conf: |-
     data_type logs
     log_key log
@@ -233,6 +235,19 @@ data:
         </buffer>
       </match>
     </label>
+  logs.source.generic.conf: |-
+    <match fluent**>
+      @type null
+    </match>
+    <match **>
+      @type sumologic
+      @id sumologic.endpoint.logs.generic
+      @include logs.output.conf
+      <buffer>
+        @type memory
+        @include buffer.output.conf
+      </buffer>
+    </match>
   logs.source.systemd.conf: |-
     <match host.kubelet.**>
       @type relabel


### PR DESCRIPTION
###### Description

Since we have changed the default fluentd buffer `overflow_action` to `drop_oldest_chunk`, we can't leave the log level at `error` log and silently drop data. Therefore, changing the log level to  `warn` for now until we integrate the use of fluentd-throttle-plugin.

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
