### PR TITLE
add generic fluentd pipeline to catch all logs

### DIFF
--- a/deploy/helm/sumologic/conf/logs/logs.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.conf
@@ -5,3 +5,4 @@
 </source>
 @include logs.source.containers.conf
 @include logs.source.systemd.conf
+@include logs.source.generic.conf

--- a/deploy/helm/sumologic/conf/logs/logs.source.generic.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.generic.conf
@@ -1,0 +1,14 @@
+<match **>
+  @type sumologic
+  @id sumologic.endpoint.logs.generic
+  @include logs.output.conf
+  <buffer>
+    {{- if eq .Values.sumologic.fluentd.buffer "file" }}
+    @type file
+    path /fluentd/buffer/logs.generic
+    {{- else }}
+    @type memory
+    {{- end }}
+    @include buffer.output.conf
+  </buffer>
+</match>

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -157,6 +157,7 @@ data:
     </source>
     @include logs.source.containers.conf
     @include logs.source.systemd.conf
+    @include logs.source.generic.conf
   logs.output.conf: |-
     data_type logs
     log_key log


### PR DESCRIPTION
###### Description

Currently we only collect the container logs in the fluentd pipeline. This PR adds a generic fluentd pipeline to catch all logs. User would need to configure a new Input in the Fluent-bit config to send it to fluentd.

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
