### PR TITLE
Fix typo in container logs pipeline

### DIFF
--- a/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
@@ -31,7 +31,7 @@
   # sumologic kubernetes metadata enrichment filter plugin
   <filter containers.**>
     @type enhance_k8s_metadata
-    @include logs.kubernetes.enhance.k8s.metadata.filter.conf
+    @include logs.enhance.k8s.metadata.filter.conf
   </filter>
   # kubernetes sumologic filter plugin
   <filter containers.**>

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -201,7 +201,7 @@ data:
     add_timestamp "#{ENV['ADD_TIMESTAMP']}"
     timestamp_key "#{ENV['TIMESTAMP_KEY']}"
     proxy_uri "#{ENV['PROXY_URI']}"
-  logs.source.containers.conf: |-
+  logs.source.containers.conf: |
     <filter containers.**>
       @type record_transformer
       enable_ruby
@@ -235,7 +235,7 @@ data:
       # sumologic kubernetes metadata enrichment filter plugin
       <filter containers.**>
         @type enhance_k8s_metadata
-        @include logs.kubernetes.enhance.k8s.metadata.filter.conf
+        @include logs.enhance.k8s.metadata.filter.conf
       </filter>
       # kubernetes sumologic filter plugin
       <filter containers.**>


### PR DESCRIPTION
###### Description

Tried reproducing missing metadata locally, when I ran `kubectl describe configmap collection-sumologic` I noticed there was no config in the `enhance_k8s_metadata` plugin section

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
