### PR TITLE
remove cluster label from prometheus config in values.yaml

### DIFF
--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -49,9 +49,6 @@ prometheus:
       matchLabels:
         app: fluent-bit
   prometheusSpec:
-    externalLabels:
-      # Set this to a value to distinguish between different k8s clusters
-      cluster: kubernetes
     remoteWrite:
     - # kube state metrics
       url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.state

--- a/deploy/helm/sumologic/conf/metrics/metrics.conf
+++ b/deploy/helm/sumologic/conf/metrics/metrics.conf
@@ -11,6 +11,12 @@
 </match>
 <label @DATAPOINT>
   <filter prometheus.metrics**>
+    @type record_modifier
+    <record>
+      cluster {{ .Values.sumologic.clusterName }}
+    </record>
+  </filter>
+  <filter prometheus.metrics**>
     @type enhance_k8s_metadata
     cache_size  "#{ENV['K8S_METADATA_FILTER_CACHE_SIZE']}"
     cache_ttl  "#{ENV['K8S_METADATA_FILTER_CACHE_TTL']}"

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -369,9 +369,6 @@ prometheus-operator:
           matchLabels:
             app: fluent-bit
     prometheusSpec:
-      externalLabels:
-        # Set this to a value to distinguish between different k8s clusters
-        cluster: kubernetes
       remoteWrite:
         # kube state metrics
         - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.state

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -53,6 +53,12 @@ data:
     </match>
     <label @DATAPOINT>
       <filter prometheus.metrics**>
+        @type record_modifier
+        <record>
+          cluster kubernetes
+        </record>
+      </filter>
+      <filter prometheus.metrics**>
         @type enhance_k8s_metadata
         cache_size  "#{ENV['K8S_METADATA_FILTER_CACHE_SIZE']}"
         cache_ttl  "#{ENV['K8S_METADATA_FILTER_CACHE_TTL']}"


### PR DESCRIPTION

###### Description

This PR removes cluster label from prometheus config in `values.yaml` and adds it in the fluentd metrics pipeline.

This will avoid the hassle of specifying the cluster name in the `helm install` command twice.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
