### PR TITLE
add error handling on JSON parsing for the multiline fix

### DIFF
--- a/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
@@ -3,9 +3,9 @@
   enable_ruby
   renew_record true
   <record>
-    log    ${record["log"].split(/[\n\t]+/).map! {|item| JSON.parse(item)["log"]}.join("")}
-    stream ${[record["log"].split(/[\n\t]+/)[0]].map! {|item| JSON.parse(item)["stream"]}.join("")}
-    time   ${[record["log"].split(/[\n\t]+/)[0]].map! {|item| JSON.parse(item)["time"]}.join("")}
+    log    ${record["log"].split(/[\n\t]+/).map! {|item| JSON.parse(item)["log"]}.join("") rescue record["log"]}
+    stream ${[record["log"].split(/[\n\t]+/)[0]].map! {|item| JSON.parse(item)["stream"]}.join("") rescue record["stream"]}
+    time   ${[record["log"].split(/[\n\t]+/)[0]].map! {|item| JSON.parse(item)["time"]}.join("") rescue record["time"]}
   </record>
 </filter>
 # match all  container logs and label them @NORMAL

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -214,9 +214,9 @@ data:
       enable_ruby
       renew_record true
       <record>
-        log    ${record["log"].split(/[\n\t]+/).map! {|item| JSON.parse(item)["log"]}.join("")}
-        stream ${[record["log"].split(/[\n\t]+/)[0]].map! {|item| JSON.parse(item)["stream"]}.join("")}
-        time   ${[record["log"].split(/[\n\t]+/)[0]].map! {|item| JSON.parse(item)["time"]}.join("")}
+        log    ${record["log"].split(/[\n\t]+/).map! {|item| JSON.parse(item)["log"]}.join("") rescue record["log"]}
+        stream ${[record["log"].split(/[\n\t]+/)[0]].map! {|item| JSON.parse(item)["stream"]}.join("") rescue record["stream"]}
+        time   ${[record["log"].split(/[\n\t]+/)[0]].map! {|item| JSON.parse(item)["time"]}.join("") rescue record["time"]}
       </record>
     </filter>
     # match all  container logs and label them @NORMAL


### PR DESCRIPTION
###### Description

For the multiline to work, we added the first step of the fluentd pipeline to be a record transformer to process the stiched multiline logs in the correct format. 

This transformation relies on the fact that the `log` value is a JSON object based on the default multiline parser regex.

If the user changes the parser to say, `docker` parser, then the `log` is no longer a JSON and it fails. 

This PR adds error handling for the same. In case the `log` value is not JSON, we will pass the content as is.
###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
