### PR TITLE
add check for multiline in the multiline record transformer

### DIFF
--- a/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
@@ -3,9 +3,9 @@
   enable_ruby
   renew_record true
   <record>
-    log    ${record["log"].split(/[\n\t]+/).map! {|item| JSON.parse(item)["log"]}.join("") rescue record["log"]}
-    stream ${[record["log"].split(/[\n\t]+/)[0]].map! {|item| JSON.parse(item)["stream"]}.join("") rescue record["stream"]}
-    time   ${[record["log"].split(/[\n\t]+/)[0]].map! {|item| JSON.parse(item)["time"]}.join("") rescue record["time"]}
+    log    ${record["log"].split(/[\n\t]+/).map! {|item| JSON.parse(item)["log"]}.any? ? record["log"].split(/[\n\t]+/).map! {|item| JSON.parse(item)["log"]}.join("") : record["log"] rescue record["log"]}
+    stream ${[record["log"].split(/[\n\t]+/)[0]].map! {|item| JSON.parse(item)["stream"]}.any? ? [record["log"].split(/[\n\t]+/)[0]].map! {|item| JSON.parse(item)["stream"]}.join("") : record["stream"] rescue record["stream"]}
+    time   ${[record["log"].split(/[\n\t]+/)[0]].map! {|item| JSON.parse(item)["time"]}.any? ? [record["log"].split(/[\n\t]+/)[0]].map! {|item| JSON.parse(item)["time"]}.join("") : record["time"] rescue record["time"]}
   </record>
 </filter>
 # match all  container logs and label them @NORMAL

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -220,9 +220,9 @@ data:
       enable_ruby
       renew_record true
       <record>
-        log    ${record["log"].split(/[\n\t]+/).map! {|item| JSON.parse(item)["log"]}.join("") rescue record["log"]}
-        stream ${[record["log"].split(/[\n\t]+/)[0]].map! {|item| JSON.parse(item)["stream"]}.join("") rescue record["stream"]}
-        time   ${[record["log"].split(/[\n\t]+/)[0]].map! {|item| JSON.parse(item)["time"]}.join("") rescue record["time"]}
+        log    ${record["log"].split(/[\n\t]+/).map! {|item| JSON.parse(item)["log"]}.any? ? record["log"].split(/[\n\t]+/).map! {|item| JSON.parse(item)["log"]}.join("") : record["log"] rescue record["log"]}
+        stream ${[record["log"].split(/[\n\t]+/)[0]].map! {|item| JSON.parse(item)["stream"]}.any? ? [record["log"].split(/[\n\t]+/)[0]].map! {|item| JSON.parse(item)["stream"]}.join("") : record["stream"] rescue record["stream"]}
+        time   ${[record["log"].split(/[\n\t]+/)[0]].map! {|item| JSON.parse(item)["time"]}.any? ? [record["log"].split(/[\n\t]+/)[0]].map! {|item| JSON.parse(item)["time"]}.join("") : record["time"] rescue record["time"]}
       </record>
     </filter>
     # match all  container logs and label them @NORMAL


### PR DESCRIPTION
###### Description

We noticed that the default record transformer filter might drop data if the input is JSON and it does not contain nested `log` key-value pair. 

For eg: 
```{"log":"{\"source_host\":\"sagepay-gateway-1-6bd89fbc6f-fv9pt\",\"method\":\"completeAuthorisation\",\"level\":\"INFO\",\"message\":\"avs response :DATA NOT CHECKED\",\"ndc\":\"EC4D3DE1-E41B-548C-0D5D-65BFBD8B2619\",\"mdc\":{\"Request-Tracker\":\"229D7DAC-D5C6-461A-A74F-A359614FD9E6\"},\"@timestamp\":\"2020-02-12T10:10:15.518Z\",\"file\":\"StandardAuthorisationStrategy.java\",\"line_number\":\"92\",\"thread_name\":\"http-apr-8080-exec-9\",\"@version\":1,\"logger_name\":\"com.protx.vsp.services.authorisationStrategy.StandardAuthorisationStrategy\",\"class\":\"com.protx.vsp.services.authorisationStrategy.StandardAuthorisationStrategy\"}\n","stream":"stdout","time":"2020-02-12T10:10:15.518359309Z"}```

This PR adds a check to see if the nested `log` key is present to detect multiline, then only the record transformer would modify the log,  else it passes the record as it is. 

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
