### PR TITLE
Update docs for prometheus dynamic remote write urls

### DIFF
--- a/deploy/docs/Installation_with_Helm.md
+++ b/deploy/docs/Installation_with_Helm.md
@@ -69,26 +69,10 @@ To customize your configuration, download the values.yaml file by running
 curl https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.15.0/deploy/helm/sumologic/values.yaml
 ```
 
-NOTE: If you need to install the chart with a different release name or namespace you will need to override some configuration fields for both Prometheus and fluent-bit. We recommend using an override file due to the number of fields that need to be overridden. In the following command, replace the `<RELEASE-NAME>` and `<NAMESPACE>` variables with your values and then run it to download the override file with your replaced values:
+####To install the chart with a different release name or namespace:
 
 ```bash
-curl https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.15.0/deploy/helm/sumologic/values.yaml | \
-sed 's/\-sumologic.sumologic'"/-sumologic.<NAMESPACE>/g" | \
-sed 's/\- sumologic'"/- <NAMESPACE>/g" | \
-sed 's/\collection'"/<RELEASE-NAME>/g" > values.yaml
-```
-
-For example, if your release name is `my-release` and namespace is `my-namespace`:
-```bash
-curl https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.15.0/deploy/helm/sumologic/values.yaml | \
-sed 's/\-sumologic.sumologic'"/-sumologic.my-namespace/g" | \
-sed 's/\collection'"/my-release/g" > values.yaml
-```
-
-Make any changes to the `values.yaml` file as needed, and run the following to install the chart with the override file.
-
-```bash
-helm install sumologic/sumologic --name my-release --namespace my-namespace -f values.yaml --set sumologic.accessId=<SUMO_ACCESS_ID> --set sumologic.accessKey=<SUMO_ACCESS_KEY> 
+helm install sumologic/sumologic --name my-release --namespace my-namespace -f values.yaml --set sumologic.accessId=<SUMO_ACCESS_ID> --set sumologic.accessKey=<SUMO_ACCESS_KEY> --set sumologic.clusterName=<MY_CLUSTER_NAME>
 ```
 
 __NOTE__ To filter or add custom metrics to Prometheus, [please refer to this document](additional_prometheus_configuration.md)

--- a/deploy/docs/Installation_with_Helm.md
+++ b/deploy/docs/Installation_with_Helm.md
@@ -69,7 +69,7 @@ To customize your configuration, download the values.yaml file by running
 curl https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.15.0/deploy/helm/sumologic/values.yaml
 ```
 
-####To install the chart with a different release name or namespace:
+#### To install the chart with a different release name or namespace:
 
 ```bash
 helm install sumologic/sumologic --name my-release --namespace my-namespace -f values.yaml --set sumologic.accessId=<SUMO_ACCESS_ID> --set sumologic.accessKey=<SUMO_ACCESS_KEY> --set sumologic.clusterName=<MY_CLUSTER_NAME>

--- a/deploy/docs/existingPrometheusDoc.md
+++ b/deploy/docs/existingPrometheusDoc.md
@@ -19,7 +19,15 @@ curl -LJO https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-colle
 Edit the `values.yaml` file to `prometheus-operator.enabled = false`, and run
 
 ```bash
-helm install sumologic/sumologic --name collection --namespace sumologic -f values.yaml --set sumologic.accessId=<SUMO_ACCESS_ID> --set sumologic.accessKey=<SUMO_ACCESS_KEY> 
+helm install sumologic/sumologic --name collection --namespace sumologic -f values.yaml --set sumologic.accessId=<SUMO_ACCESS_ID> --set sumologic.accessKey=<SUMO_ACCESS_KEY> --set sumologic.clusterName=<MY_CLUSTER_NAME> 
+```
+
+In case the prometheus-operator is installed in a different namespace as compared to where the sumologic solution is deployed, you would need to copy one of the configmaps that exposes the release name,  which is used in the remote write urls.
+
+For example: 
+If the sumologic solution is deployed in <source-namespace> and existing prometheus-operator is in <destination-namespace>, run the below command: 
+```bash
+kubectl get configmap sumologic-configmap — namespace=<source-namespace> — export -o yaml |\ kubectl apply — namespace=<destination-namespace> -f -
 ```
 
 ## Overwrite Prometheus Remote Write Configuration

--- a/deploy/docs/standAlonePrometheus.md
+++ b/deploy/docs/standAlonePrometheus.md
@@ -12,7 +12,7 @@ The urls in `remoteWrite` section of the `prometheus-overrides.yaml` file uses `
 - Replace `$(NAMESPACE)` with the namespace where prometheus is running.
 
 For eg:
-If you have installed the sumlogic helm chart with release name `collection` in `sumologic namespace and the prometheus is running in `prometheus` namespace:
+If you have installed the sumlogic helm chart with release name `collection` in `sumologic` namespace and the prometheus is running in `prometheus` namespace:
 ```
 `$(CHART).$(NAMESPACE)` will be replaced by `collection-sumologic.prometheus`
 ```

--- a/deploy/docs/standAlonePrometheus.md
+++ b/deploy/docs/standAlonePrometheus.md
@@ -4,5 +4,17 @@ Update your Prometheus configuration file’s `remote_write` section, as per the
 
 * `writeRelabelConfigs:` change to `write_relabel_configs:`
 * `sourceLabels:` change to `source_labels:`
+*  Modify remote urls in the `remoteWrite` section of the `prometheus-overrides.yaml` file
+
+The urls in `remoteWrite` section of the `prometheus-overrides.yaml` file uses `env` variables which need to be changed to point it to the correct location.
+
+- Replace `$(CHART)` with the `release name-namespace` that you have used while installing the sumologic helm chart.
+- Replace `$(NAMESPACE)` with the namespace where prometheus is running.
+
+For eg:
+If you have installed the sumlogic helm chart with release name `collection` in `sumologic namespace and the prometheus is running in `prometheus` namespace:
+```
+`$(CHART).$(NAMESPACE)` will be replaced by `collection-sumologic.prometheus`
+```
 
 __NOTE__ To filter or add custom metrics to Prometheus, [please refer to this document](additional_prometheus_configuration.md)


### PR DESCRIPTION
###### Description

With the new feature of installing the helm chart with a custom release name and a namespace, the prometheus remote write urls are dynamic. One of the variables used in these urls is sourced from a configmap and exposed via thanos in prometheus-operator.

If the user has existing prometheus/prometheus-operator, they will need to modify the urls. 

**Case 1 : Customer has existing prometheus operator in a different namespace.** 
 - Post installation of the sumologic helm chart, copy the `sumologic-configmap` to the namespace where prometheus-operator is installed.

**Case 2: Standalone Prometheus**
 - In this case the user will have to manually modify the remote write urls to point to the right location.

**Case 3: Side-by-side prometheus along with exisiting prometheus server in different namespace**
 - In this case we still deploy prometheus-operator and recommend using a different port eg. 9200. So, the original configmap should be accessible and the namespace will automatically be populated where the new prometheus server is started.

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
