### PR TITLE
[1.0.0] change default DB path for fluentbit

### DIFF
--- a/deploy/helm/fluent-bit-overrides.yaml
+++ b/deploy/helm/fluent-bit-overrides.yaml
@@ -49,7 +49,7 @@ rawConfig: |-
     Rotate_Wait      60
     Mem_Buf_Limit    5MB
     Skip_Long_Lines  On
-    DB               /tail-db/tail-containers-state.db
+    DB               /tail-db/tail-containers-state-sumo.db
     DB.Sync          Normal
   [INPUT]
     Name            systemd

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -410,7 +410,7 @@ fluent-bit:
       Rotate_Wait      60
       Mem_Buf_Limit    5MB
       Skip_Long_Lines  On
-      DB               /tail-db/tail-containers-state.db
+      DB               /tail-db/tail-containers-state-sumo.db
       DB.Sync          Normal
     [INPUT]
       Name            systemd


### PR DESCRIPTION
###### Description

Fluent bit uses a DB to keep track of monitored files and offsets. This PR modifies the default DB path which is specified in the fluent-bit helm chart to avoid having `database error` in case a user already has fluent-bit installed in the cluster with the default DB path. 

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
