### PR TITLE
Use endpoint for tracing from values.yaml

### DIFF
--- a/deploy/helm/sumologic/conf/traces/traces.conf
+++ b/deploy/helm/sumologic/conf/traces/traces.conf
@@ -13,7 +13,6 @@
     @type zipkin
     endpoint "#{ENV['SUMO_ENDPOINT_TRACES']}"
     content_type application/json
-    override_content_type application/vnd.sumologic.zipkin
     open_timeout 1
   </match>
 </label>

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -155,6 +155,10 @@ spec:
             secretKeyRef:
               name: sumologic
               key: endpoint-logs
+        {{- if .Values.sumologic.traces.enabled }}
+        - name: SUMO_ENDPOINT_TRACES
+          value: {{ .Values.sumologic.traces.endpoint }}
+        {{- end }}
 {{- if .Values.fluentd.persistence.enabled }}
   volumeClaimTemplates:
   - metadata:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -112,6 +112,8 @@ sumologic:
     # Use filter stdout plugin for tracing data
     # Warning: It will produce additional fluentd logs (one per trace)
     fluentd_stdout: false
+    # Sumologic endpoint for traces
+    endpoint: ''
 
 fluentd:
   rawConfig: |-


### PR DESCRIPTION
###### Description

This is mid-PR for integration with terraform (#445). It ensures that it's possible to send traces to proper endpoint before terraform release

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
