### PR TITLE
Strip empty fields from sending

### DIFF
--- a/fluent-plugin-zipkin/lib/fluent/plugin/out_zipkin.rb
+++ b/fluent-plugin-zipkin/lib/fluent/plugin/out_zipkin.rb
@@ -291,6 +291,14 @@ module Fluent::Plugin
       return return_value
     end
 
+    def get_str_or_nil(value)
+      if !value || value == ''
+        return nil
+      end
+
+      return value
+    end
+
     def get_spans_for_json(chunk, size: 100)
       return_value = []
       spans = []
@@ -318,10 +326,10 @@ module Fluent::Plugin
 
     def get_span_for_json(record)
 
-      if value = record.delete('trace_id')
+      if value = get_str_or_nil(record.delete('trace_id'))
         record['traceId'] = string_to_hexstring(value)
       end
-      if value = record.delete('parent_id')
+      if value = get_str_or_nil(record.delete('parent_id'))
         record['parentId'] = string_to_hexstring(value)
       end
       record['id'] = string_to_hexstring(record['id'])  # This line is failing during benchmark test (non-deterministic)
@@ -335,22 +343,22 @@ module Fluent::Plugin
       end
 
       if record['localEndpoint'] then
-        if record['localEndpoint']['ipv4']
-          record['localEndpoint']['ipv4'] = string_to_ipv4(record['localEndpoint']['ipv4'], 4)
+        if value = get_str_or_nil(record['localEndpoint'].delete('ipv4'))
+          record['localEndpoint']['ipv4'] = string_to_ipv4(value, 4)
         end
 
-        if record['localEndpoint']['ipv6']
-          record['localEndpoint']['ipv6'] = string_to_ipv4(record['localEndpoint']['ipv6'], 16)
+        if value = get_str_or_nil(record['localEndpoint'].delete('ipv6'))
+          record['localEndpoint']['ipv6'] = string_to_ipv4(value, 16)
         end
         record['localEndpoint']['serviceName'] = record['localEndpoint'].delete('service_name')
       end
 
       if record['remoteEndpoint'] then
-        if record['remoteEndpoint']['ipv4']
-          record['remoteEndpoint']['ipv4'] = string_to_ipv4(record['remoteEndpoint']['ipv4'], 4)
+        if value = get_str_or_nil(record['remoteEndpoint'].delete('ipv4'))
+          record['remoteEndpoint']['ipv4'] = string_to_ipv4(value, 4)
         end
-        if record['remoteEndpoint']['ipv6']
-          record['remoteEndpoint']['ipv6'] = string_to_ipv4(record['remoteEndpoint']['ipv6'], 16)
+        if value = get_str_or_nil(record['remoteEndpoint'].delete('ipv6'))
+          record['remoteEndpoint']['ipv6'] = string_to_ipv4(value, 16)
         end
         record['remoteEndpoint']['serviceName'] = record['remoteEndpoint'].delete('service_name')
       end

--- a/fluent-plugin-zipkin/test/plugin/test_out_zipkin.rb
+++ b/fluent-plugin-zipkin/test/plugin/test_out_zipkin.rb
@@ -131,4 +131,49 @@ class ZipkinOutputTest < ::Test::Unit::TestCase
 
     assert_equal(Oj.load(spans[0], mode: :compat), Oj.load(EXPECTED_JSON, mode: :compat))
   end
+
+  def test_json_empty_parent_id
+    expected_json = '[{"traceId":"746573745f6964","id":"746573745f6963","kind":"CLIENT","name":"test name","timestamp":1580308467000000,"duration":13,"localEndpoint":{"serviceName":"test_local","port":313},"remoteEndpoint":{"serviceName":"test_remote","port":777},"annotations":[{"timestamp":1580308467000006,"value":"test_value"}],"tags":{"tag1":"test_first_tag","tag2":"test_second_tag"}}]'
+    @plugin.configure(%[
+        content_type application/json
+        endpoint /dev/null
+    ])
+
+    chunk = [[0,
+      {
+        'trace_id' => 'test_id',
+        'parent_id' => '',
+        'id' => 'test_ic',
+        'kind' => 'CLIENT',
+        'name' => 'test name',
+        'timestamp' => 1580308467000000,
+        'duration' => 13,
+        'local_endpoint' => {
+            'service_name' => 'test_local',
+            'ipv4' => "".force_encoding("ASCII-8BIT"),
+            'ipv6' => "".force_encoding("ASCII-8BIT"),
+            'port' => 313,
+        },
+        'remote_endpoint' => {
+            'service_name' => 'test_remote',
+            'ipv4' => "".force_encoding("ASCII-8BIT"),
+            'ipv6' => "".force_encoding("ASCII-8BIT"),
+            'port' => 777,
+        },
+        'annotations' => [
+            {
+                'timestamp' => 1580308467000006,
+                'value' => 'test_value'
+            }
+        ],
+        'tags' => {
+            'tag1' => 'test_first_tag',
+            'tag2' => 'test_second_tag'
+        }
+    }]]
+
+    spans = @plugin.instance.send(:get_spans_for_json, chunk)
+
+    assert_equal(Oj.load(spans[0], mode: :compat), Oj.load(expected_json, mode: :compat))
+  end
 end


### PR DESCRIPTION
###### Description

Strip empty fields from sending via fluentd plugin:

* trace_id
* parent_id
* ipv4
* ipv6

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
