### PR TITLE
pin falco image tag

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -605,6 +605,8 @@ prometheus-operator:
 ## ref: https://github.com/helm/charts/blob/master/stable/falco/values.yaml
 falco:
   enabled: true
+  image:
+    tag: 0.18.0
   #ebpf:
   #  enabled: true
   falco:


### PR DESCRIPTION
###### Description

This PR pins the falco image tag to use `0.18.0` for resoving the precomiped kernel modules error.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
