### PR TITLE
Prevent fluentd from handling records containing its own logs.

### DIFF
--- a/deploy/helm/sumologic/conf/common.conf
+++ b/deploy/helm/sumologic/conf/common.conf
@@ -1,3 +1,8 @@
+# Prevent fluentd from handling records containing its own logs.
+<match fluentd.**>
+  @type null
+</match>
+# expose the Fluentd metrics to Prometheus
 <source>
   @type prometheus
   metrics_path /metrics

--- a/deploy/helm/sumologic/conf/events/events.conf
+++ b/deploy/helm/sumologic/conf/events/events.conf
@@ -13,6 +13,11 @@
   deploy_namespace {{ .Release.Namespace }}
 </source>
 {{- end }}
+# Prevent fluentd from handling records containing its own logs.
+<match fluentd.**>
+  @type null
+</match>
+# expose the Fluentd metrics to Prometheus
 <source>
   @type prometheus
   metrics_path /metrics

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -31,6 +31,11 @@ data:
     overflow_action drop_oldest_chunk
     
   common.conf: |-
+    # Prevent fluentd from handling records containing its own logs.
+    <match fluentd.**>
+      @type null
+    </match>
+    # expose the Fluentd metrics to Prometheus
     <source>
       @type prometheus
       metrics_path /metrics
@@ -360,6 +365,11 @@ data:
       @type events
       deploy_namespace $NAMESPACE
     </source>
+    # Prevent fluentd from handling records containing its own logs.
+    <match fluentd.**>
+      @type null
+    </match>
+    # expose the Fluentd metrics to Prometheus
     <source>
       @type prometheus
       metrics_path /metrics


### PR DESCRIPTION
###### Description

We do not want to ingest the demo log which we use for fluentd liveness probe to be ingested in Sumo. This PR prevents fluentd from handling records containing its own logs.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
