### PR TITLE
Support tracing in filter plugin

### DIFF
--- a/deploy/helm/sumologic/conf/traces/traces.conf
+++ b/deploy/helm/sumologic/conf/traces/traces.conf
@@ -7,11 +7,11 @@
   <filter tracing.**>
     @type kubernetes_sumologic
     tracing_format true
-    tracing_namespace 'namespace'
-    tracing_pod 'pod'
-    tracing_pod_id 'pod_id'
-    tracing_container_name 'container_name'
-    tracing_host 'hostname'
+    tracing_namespace {{ include "utils.get_default" (dict "Values" .Values "Keys" (list "otelcol" "config" "processors" "k8s_tagger" "extract" "tags" "namespace") "Default" "namespace") }}
+    tracing_pod {{ include "utils.get_default" (dict "Values" .Values "Keys" (list "otelcol" "config" "processors" "k8s_tagger" "extract" "tags" "podName") "Default" "pod") }}
+    tracing_pod_id {{ include "utils.get_default" (dict "Values" .Values "Keys" (list "otelcol" "config" "processors" "k8s_tagger" "extract" "tags" "podId") "Default" "pod_id") }}
+    tracing_container_name {{ include "utils.get_default" (dict "Values" .Values "Keys" (list "otelcol" "config" "processors" "k8s_tagger" "extract" "tags" "containerName") "Default" "container_name") }}
+    tracing_host {{ include "utils.get_default" (dict "Values" .Values "Keys" (list "otelcol" "config" "processors" "k8s_tagger" "extract" "tags" "hostName") "Default" "hostname") }}
     tracing_label_prefix 'pod_label_'
     tracing_annotation_prefix 'pod_annotation_'
     source_host_key_name '_sourceHost'

--- a/deploy/helm/sumologic/conf/traces/traces.conf
+++ b/deploy/helm/sumologic/conf/traces/traces.conf
@@ -4,6 +4,22 @@
   port 9411
 </source>
 <label @TRACING>
+  <filter tracing.**>
+    @type kubernetes_sumologic
+    tracing_format true
+    tracing_namespace 'namespace'
+    tracing_pod 'pod'
+    tracing_pod_id 'pod_id'
+    tracing_container_name 'container_name'
+    tracing_host 'hostname'
+    tracing_label_prefix 'pod_label_'
+    tracing_annotation_prefix 'pod_annotation_'
+    source_host_key_name '_sourceHost'
+    source_category_key_name '_sourceCategory'
+    source_name_key_name '_sourceName'
+    collector_key_name '_collector'
+    collector_value "{{- if .Values.sumologic.collectorName }}{{ .Values.sumologic.collectorName }}{{- else}}{{ .Values.sumologic.clusterName }}{{- end}}"
+  </filter>
 {{- if .Values.sumologic.traces.fluentd_stdout }}
   <filter tracing.**>
     @type stdout

--- a/deploy/helm/sumologic/conf/traces/traces.conf
+++ b/deploy/helm/sumologic/conf/traces/traces.conf
@@ -7,11 +7,11 @@
   <filter tracing.**>
     @type kubernetes_sumologic
     tracing_format true
-    tracing_namespace {{ include "utils.get_default" (dict "Values" .Values "Keys" (list "otelcol" "config" "processors" "k8s_tagger" "extract" "tags" "namespace") "Default" "namespace") }}
-    tracing_pod {{ include "utils.get_default" (dict "Values" .Values "Keys" (list "otelcol" "config" "processors" "k8s_tagger" "extract" "tags" "podName") "Default" "pod") }}
-    tracing_pod_id {{ include "utils.get_default" (dict "Values" .Values "Keys" (list "otelcol" "config" "processors" "k8s_tagger" "extract" "tags" "podId") "Default" "pod_id") }}
-    tracing_container_name {{ include "utils.get_default" (dict "Values" .Values "Keys" (list "otelcol" "config" "processors" "k8s_tagger" "extract" "tags" "containerName") "Default" "container_name") }}
-    tracing_host {{ include "utils.get_default" (dict "Values" .Values "Keys" (list "otelcol" "config" "processors" "k8s_tagger" "extract" "tags" "hostName") "Default" "hostname") }}
+    tracing_namespace {{ include "utils.get_default" (dict "Values" .Values "Keys" (list "otelcol" "config" "processors" "k8s_tagger" "extract" "tags" "namespace") "Default" "namespace") | quote }}
+    tracing_pod {{ include "utils.get_default" (dict "Values" .Values "Keys" (list "otelcol" "config" "processors" "k8s_tagger" "extract" "tags" "podName") "Default" "pod") | quote }}
+    tracing_pod_id {{ include "utils.get_default" (dict "Values" .Values "Keys" (list "otelcol" "config" "processors" "k8s_tagger" "extract" "tags" "podId") "Default" "pod_id") | quote }}
+    tracing_container_name {{ include "utils.get_default" (dict "Values" .Values "Keys" (list "otelcol" "config" "processors" "k8s_tagger" "extract" "tags" "containerName") "Default" "container_name") | quote }}
+    tracing_host {{ include "utils.get_default" (dict "Values" .Values "Keys" (list "otelcol" "config" "processors" "k8s_tagger" "extract" "tags" "hostName") "Default" "hostname") | quote }}
     tracing_label_prefix 'pod_label_'
     tracing_annotation_prefix 'pod_annotation_'
     source_host_key_name '_sourceHost'

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -36,3 +36,15 @@ heritage: "{{ .Release.Service }}"
 {{- end -}}
 {{- end -}}
 
+{{/*
+Get configuration value, otherwise returns default
+*/}}
+{{- define "utils.get_default" -}}
+{{- $dict := .Values -}}
+{{- $keys := .Keys -}}
+{{- $default := .Default -}}
+{{- range $keys -}}
+  {{ $dict := get $dict . }}
+{{- end -}}
+{{ $default }}
+{{- end -}}

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -44,7 +44,7 @@ Get configuration value, otherwise returns default
 {{- $keys := .Keys -}}
 {{- $default := .Default -}}
 {{- range $keys -}}
-  {{ $dict := get $dict . }}
+  {{ $dict := index $dict . }}
 {{- end -}}
 {{ $default }}
 {{- end -}}

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -38,6 +38,13 @@ heritage: "{{ .Release.Service }}"
 
 {{/*
 Get configuration value, otherwise returns default
+
+Example usage:
+
+{{ include "utils.get_default" (dict "Values" .Values "Keys" (list "key1" "key2") "Default" "default_value") | quote }}
+
+It returns `.Value.key1.key2` if it exists otherwise `default_value`
+
 */}}
 {{- define "utils.get_default" -}}
 {{- $dict := .Values -}}

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -36,34 +36,3 @@ heritage: "{{ .Release.Service }}"
 {{- end -}}
 {{- end -}}
 
-{{/*
-Generate list of extensions/receivers/etc from dictionary:
-
-Example input:
-```
-extensions:
-  extension_a:
-    enabled: true
-  extension_b:
-    enabled: false
-```
-
-Usage: include "otelcol.generate_list" extensions"
-
-Expected output:
-```
-- extension_a
-```
-*/}}
-{{- define "otelcol.generate_list" -}}
-{{- $empty_list := true }}
-{{- range $key, $val := . }}
-  {{- if $val.enabled }}
-    {{- if $empty_list }}
-      {{- $empty_list = false }}
-    {{- end }}
-- {{ $key | quote }}
-  {{- end }}
-{{- end }}
-{{- if $empty_list }} [] {{ end }}
-{{- end -}}

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -43,8 +43,17 @@ Get configuration value, otherwise returns default
 {{- $dict := .Values -}}
 {{- $keys := .Keys -}}
 {{- $default := .Default -}}
+{{- $success := true }}
 {{- range $keys -}}
-  {{ $dict := index $dict . }}
-{{- end -}}
-{{ $default }}
+  {{- if (and $success (hasKey $dict .)) }}
+    {{- $dict = index $dict . }}
+  {{- else }}
+    {{- $success = false }}
+  {{- end }}
+{{- end }}
+{{- if $success }}
+  {{- $dict }}
+{{- else }}
+  {{- $default }}
+{{- end }}
 {{- end -}}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -698,5 +698,5 @@ otelcol:
       pipelines:
         traces:
           receivers: [jaeger, zipkin, opencensus]
-          processors: [batch, queued_retry, k8s_tagger]
+          processors: [k8s_tagger, batch, queued_retry]
           exporters: [zipkin]

--- a/fluent-plugin-kubernetes-sumologic/lib/fluent/plugin/filter_kubernetes_sumologic.rb
+++ b/fluent-plugin-kubernetes-sumologic/lib/fluent/plugin/filter_kubernetes_sumologic.rb
@@ -28,7 +28,9 @@ module Fluent::Plugin
     config_param :tracing_annotation_prefix, :string, :default => 'pod_annotation_'
     config_param :source_host_key_name, :string, :default => '_sourceHost'
     config_param :source_category_key_name, :string, :default => '_sourceCategory'
-    config_param :source_key_name, :string, :default => '_source'
+    config_param :source_name_key_name, :string, :default => '_sourceName'
+    config_param :collector_key_name, :string, :default => '_collector'
+    config_param :collector_value, :string, :default => 'undefined'
 
     def configure(conf)
       super
@@ -200,9 +202,10 @@ module Fluent::Plugin
         if @tracing_format
           # Move data to record in tracing format
           record['tags'][@source_host_key_name] = sumo_metadata[:host]
-          record['tags'][@source_key_name] = sumo_metadata[:source]
+          record['tags'][@source_name_key_name] = sumo_metadata[:source]
           record['tags'][@source_category_key_name] = sumo_metadata[:category]
-          
+          record['tags']['_source'] = 'traces'
+          record['tags'][@collector_key_name] = @collector_value
           return record
         end
 

--- a/fluent-plugin-kubernetes-sumologic/test/plugin/test_filter_kubernetes_sumologic.rb
+++ b/fluent-plugin-kubernetes-sumologic/test/plugin/test_filter_kubernetes_sumologic.rb
@@ -1370,6 +1370,7 @@ class SumoContainerOutputTest < Test::Unit::TestCase
   test "test_tracing_format" do
     conf = %{
       tracing_format true
+      source_host "%{container}-%{label:pod-template-hash}"
     }
     d = create_driver(conf)
     time = @time
@@ -1381,6 +1382,7 @@ class SumoContainerOutputTest < Test::Unit::TestCase
         "pod_id" => "170af806-c801-11e8-9009-025000000001",
         "pod_label_pod-template-hash" => "54575ccdb9",
         "pod_label_run" => "log-format-labs",
+        "pod_annotation_cluster" => "random-cluster",
         "host" => "docker-for-desktop",
         "master_url" => "https://10.96.0.1:443/api",
         "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
@@ -1392,7 +1394,7 @@ class SumoContainerOutputTest < Test::Unit::TestCase
     expected = {
         "tags" => {
           "_sourceCategory" => "kubernetes/default/log/format/labs/53575ccdb9",
-          "_sourceHost" => "",
+          "_sourceHost" => "log-format-labs-54575ccdb9",
           "_source" => "default.log-format-labs-53575ccdb9-9d677.log-format-labs",
           "container_name" => "log-format-labs",
           "namespace" => "default",
@@ -1400,6 +1402,7 @@ class SumoContainerOutputTest < Test::Unit::TestCase
           "pod_id" => "170af806-c801-11e8-9009-025000000001",
           "pod_label_pod-template-hash" => "54575ccdb9",
           "pod_label_run" => "log-format-labs",
+          "pod_annotation_cluster" => "random-cluster",
           "host" => "docker-for-desktop",
           "master_url" => "https://10.96.0.1:443/api",
           "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",

--- a/fluent-plugin-kubernetes-sumologic/test/plugin/test_filter_kubernetes_sumologic.rb
+++ b/fluent-plugin-kubernetes-sumologic/test/plugin/test_filter_kubernetes_sumologic.rb
@@ -1366,4 +1366,46 @@ class SumoContainerOutputTest < Test::Unit::TestCase
     assert_equal(1, d.filtered_records.size)
     assert_equal(expected, d.filtered_records[0])
   end
+
+  test "test_tracing_format" do
+    conf = %{
+      tracing_format true
+    }
+    d = create_driver(conf)
+    time = @time
+    input = {
+      "tags" => {
+        "container_name" => "log-format-labs",
+        "namespace" => "default",
+        "pod" => "log-format-labs-53575ccdb9-9d677",
+        "pod_id" => "170af806-c801-11e8-9009-025000000001",
+        "pod_label_pod-template-hash" => "54575ccdb9",
+        "pod_label_run" => "log-format-labs",
+        "host" => "docker-for-desktop",
+        "master_url" => "https://10.96.0.1:443/api",
+        "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
+      },
+    }
+    d.run do
+      d.feed("filter.test", time, input)
+    end
+    expected = {
+        "tags" => {
+          "_sourceCategory" => "kubernetes/default/log/format/labs/53575ccdb9",
+          "_sourceHost" => "",
+          "_source" => "default.log-format-labs-53575ccdb9-9d677.log-format-labs",
+          "container_name" => "log-format-labs",
+          "namespace" => "default",
+          "pod" => "log-format-labs-53575ccdb9-9d677",
+          "pod_id" => "170af806-c801-11e8-9009-025000000001",
+          "pod_label_pod-template-hash" => "54575ccdb9",
+          "pod_label_run" => "log-format-labs",
+          "host" => "docker-for-desktop",
+          "master_url" => "https://10.96.0.1:443/api",
+          "namespace_id" => "e8572415-9596-11e8-b28b-025000000001",
+        },
+    }
+    assert_equal(1, d.filtered_records.size)
+    assert_equal(expected, d.filtered_records[0])
+  end
 end

--- a/fluent-plugin-kubernetes-sumologic/test/plugin/test_filter_kubernetes_sumologic.rb
+++ b/fluent-plugin-kubernetes-sumologic/test/plugin/test_filter_kubernetes_sumologic.rb
@@ -1371,6 +1371,7 @@ class SumoContainerOutputTest < Test::Unit::TestCase
     conf = %{
       tracing_format true
       source_host "%{container}-%{label:pod-template-hash}"
+      collector_value "My collector"
     }
     d = create_driver(conf)
     time = @time
@@ -1395,7 +1396,9 @@ class SumoContainerOutputTest < Test::Unit::TestCase
         "tags" => {
           "_sourceCategory" => "kubernetes/default/log/format/labs/53575ccdb9",
           "_sourceHost" => "log-format-labs-54575ccdb9",
-          "_source" => "default.log-format-labs-53575ccdb9-9d677.log-format-labs",
+          "_source" => "traces",
+          "_collector" => "My collector",
+          "_sourceName" => "default.log-format-labs-53575ccdb9-9d677.log-format-labs",
           "container_name" => "log-format-labs",
           "namespace" => "default",
           "pod" => "log-format-labs-53575ccdb9-9d677",


### PR DESCRIPTION
###### Description

I have a PR under discussion. We have requirement for traces to tag `sourceHost` and `sourceCategory`. There is few possible way to solve this. This PR represents moreless set of changes/differences between traces and logs/metrics.
I see few possible solutions for this issue:

1. Separate filter plugin
2. Extract common part to another plugin (and logs related to another one
3. Filter which behaves little bit different depending on source (like in this PR)

@rvmiller89 @samjsong @vsinghal13 @perk-sumo @pmaciolek 
I would like to know your thoughs

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
