### PR TITLE
Expose setting resource constraints for helm dependencies

### DIFF
--- a/deploy/helm/fluent-bit-overrides.yaml
+++ b/deploy/helm/fluent-bit-overrides.yaml
@@ -1,4 +1,13 @@
 # This file is auto-generated.
+## Resource limits for fluent-bit
+resources: {}
+# limits:
+#   cpu: 100m
+#   memory: 128Mi
+# requests:
+#   cpu: 10m
+#   memory: 8Mi
+
 service:
   flush: 5
 metrics:

--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -8,6 +8,8 @@ grafana:
   enabled: false
   defaultDashboardsEnabled: false
 prometheusOperator:
+  ## Resource limits for prometheus operator
+  resources: {}
   admissionWebhooks:
     enabled: false
   tlsProxy:
@@ -60,6 +62,10 @@ prometheus:
       matchLabels:
         app: collection-sumologic-otelcol
   prometheusSpec:
+    ## Define resources requests and limits for single Pods.
+    resources: {}
+    # requests:
+    #   memory: 400Mi
     thanos:
       version: v0.10.0
     containers:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -337,6 +337,15 @@ metrics-server:
 ## Configure fluent-bit 
 ## ref: https://github.com/helm/charts/blob/master/stable/fluent-bit/values.yaml
 fluent-bit:
+  ## Resource limits for fluent-bit
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 10m
+    #   memory: 8Mi
+
   enabled: true
   service:
     flush: 5
@@ -466,6 +475,8 @@ prometheus-operator:
     enabled: false
     defaultDashboardsEnabled: false
   prometheusOperator:
+    ## Resource limits for prometheus operator
+    resources: {}
     admissionWebhooks:
       enabled: false
     tlsProxy:
@@ -518,6 +529,10 @@ prometheus-operator:
           matchLabels:
             app: collection-sumologic-otelcol
     prometheusSpec:
+      ## Define resources requests and limits for single Pods.
+      resources: {}
+      # requests:
+      #   memory: 400Mi
       thanos:
         version: v0.10.0
       containers:


### PR DESCRIPTION


###### Description

This PR exposes setting resource constraints for fluentbit, prometheus, prometheus-operator. 

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
