### PR TITLE
disable falco by default

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -632,8 +632,8 @@ prometheus-operator:
 ## Configure falco
 ## ref: https://github.com/helm/charts/blob/master/stable/falco/values.yaml
 falco:
-  ## Set the enabled flag to false to disable falco.
-  enabled: true
+  ## Set the enabled flag to true to enable falco.
+  enabled: false
   #ebpf:
   #  enabled: true
   falco:


### PR DESCRIPTION
###### Description

We're seeing an issue our current policy of installing Falco, by default, as part of our Kubernetes collection solution. We've bundled Falco as part of K8s Collection in order to provide collection of security events. However, the installation of Falco triggers the following security alert if the customer has installed our solution in an EKS cluster that is already being monitored by GuardDuty.

“falco pod is connecting to Bitcoin mining server."

The reason Falco triggers this alert is that it is trying to detect nefarious bitcoin mining within the cluster. It does so by first connecting to well know bitcoin servers, and resolving those hostnames to IPs. It them other processes in the cluster that are connecting to those IP's. This is Falco doing its job, but Falco's activity appears to GuardDuty as a bad actor.

Disabling the installation of Falco by default to avoid this kind of problem.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
