### PR TITLE
change the dynamic namespace env variable to be fluentd namespace

### DIFF
--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -78,8 +78,9 @@ prometheus:
             key: release
       - name: NAMESPACE
         valueFrom:
-          fieldRef:
-            fieldPath: metadata.namespace
+          configMapKeyRef:
+            name: sumologic-configmap
+            key: fluentdNamespace
     remoteWrite:
     - # kube state metrics
       url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.state

--- a/deploy/helm/sumologic/templates/chart-configmap.yaml
+++ b/deploy/helm/sumologic/templates/chart-configmap.yaml
@@ -4,3 +4,4 @@ metadata:
   name: sumologic-configmap
 data:
   release: {{ template "sumologic.fullname" . }}
+  fluentdNamespace: {{ .Release.Namespace }}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -545,8 +545,9 @@ prometheus-operator:
               key: release
         - name: NAMESPACE
           valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+            configMapKeyRef:
+              name: sumologic-configmap
+              key: fluentdNamespace
 
       remoteWrite:
         # kube state metrics

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -7,6 +7,7 @@ metadata:
   name: sumologic-configmap
 data:
   release: collection-sumologic
+  fluentdNamespace: $NAMESPACE
 ---
 # Source: sumologic/templates/configmap.yaml
 apiVersion: v1


### PR DESCRIPTION
###### Description

This PR changes the dynamic namespace env variable to be fluentd namespace for the prometheus remote write URL's.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
