### PR TITLE
Make Otelcol listen on 0.0.0.0 rather than localhost

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -518,14 +518,18 @@ otelcol:
     memBallastSizeMib: "683"
     image:
       name: "sumologic/opentelemetry-collector"
-      tag: "0.2.6.4"
+      tag: "0.2.6.5"
       pullPolicy: IfNotPresent
   config:
     receivers:
-      opencensus: {}
+      opencensus:
+        endpoint: "0.0.0.0:55678"
       jaeger:
         protocols:
           grpc:
+            endpoint: "0.0.0.0:14250"
+          thrift_http:
+            endpoint: "0.0.0.0:14268"
       zipkin:
         endpoint: "0.0.0.0:9411"
     processors:
@@ -582,6 +586,8 @@ otelcol:
     exporters:
       zipkin:
         url: "exporters.zipkin.url_replace"
+      # Following generates verbose logs with span content, useful to verify what
+      # metadata is being tagged. To enable, uncomment and add "logging" to exporters below
       # logging:
       #   loglevel: debug
     service:


### PR DESCRIPTION
###### Description

Not all endpoints list on `0.0.0.0` by default. Some of them do on `localhost`. This enables them to listen on `0.0.0.0` and also bumps OpenTelemetry Collector version used

###### Testing performed

Manual tests with settings applied