### PR TITLE
add K8S_NODE_NAME for metadata plugin

### DIFF
--- a/deploy/helm/sumologic/templates/deployment.yaml
+++ b/deploy/helm/sumologic/templates/deployment.yaml
@@ -107,6 +107,10 @@ spec:
         - name: pos-files
           mountPath: /mnt/pos/
         env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         - name: SUMO_ENDPOINT_METRICS
           valueFrom:
             secretKeyRef:

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -572,6 +572,10 @@ spec:
         - name: pos-files
           mountPath: /mnt/pos/
         env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         - name: SUMO_ENDPOINT_METRICS
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
###### Description

If the name of the Kubernetes node the Kubernetes metadata plugin is running on is set as an environment variable with the name K8S_NODE_NAME, it will reduce cache misses and needless calls to the Kubernetes API.

This PR adds that env variable. 

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
