### PR TITLE
Do not drop record in filter if it's 'broken'

### DIFF
--- a/fluent-plugin-kubernetes-sumologic/lib/fluent/plugin/filter_kubernetes_sumologic.rb
+++ b/fluent-plugin-kubernetes-sumologic/lib/fluent/plugin/filter_kubernetes_sumologic.rb
@@ -104,6 +104,15 @@ module Fluent::Plugin
     end
 
     def filter(tag, time, record)
+      begin
+        return proper_filter(tag, time, record)
+      rescue => exception
+        log.warn "Error during tagging record #{record}"
+        return record
+      end
+    end
+
+    def proper_filter(tag, time, record)
       log_fields = {}
 
       # Set the sumo metadata fields


### PR DESCRIPTION
###### Description

Do not drop record in filter if it's 'broken'

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
