### PR TITLE
Set new release 0.16.0

### DIFF
--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sumologic
-version: 0.15.0
-appVersion: 0.15.0
+version: 0.16.0
+appVersion: 0.16.0
 description: A Helm chart for collecting Kubernetes logs, metrics and events into Sumo Logic.
 keywords:
   - monitoring

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: sumologic/kubernetes-fluentd
-  tag: 0.15.0
+  tag: 0.16.0
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -536,7 +536,7 @@ spec:
           name: collection-sumologic
       containers:
       - name: fluentd
-        image: sumologic/kubernetes-fluentd:0.15.0
+        image: sumologic/kubernetes-fluentd:0.16.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -695,7 +695,7 @@ spec:
           name: collection-sumologic-events
       containers:
       - name: fluentd-events
-        image: sumologic/kubernetes-fluentd:0.15.0
+        image: sumologic/kubernetes-fluentd:0.16.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/deploy/kubernetes/setup-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/setup-sumologic.yaml.tmpl
@@ -250,7 +250,7 @@ spec:
           defaultMode: 0777
       containers:
       - name: setup
-        image: sumologic/kubernetes-fluentd:0.15.0
+        image: sumologic/kubernetes-fluentd:0.16.0
         imagePullPolicy: IfNotPresent
         command: ["/etc/terraform/setup.sh"]
         volumeMounts:


### PR DESCRIPTION
###### Description

This is a minor release for the opentelemetry collector related changes (disabled by default).

###### Testing performed

- [x] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
