### PR TITLE
Add missing source_category_replace_dash to systemd conf.

### DIFF
--- a/deploy/helm/sumologic/conf/logs/logs.source.systemd.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.systemd.conf
@@ -8,6 +8,7 @@
     source_category kubelet
     source_name k8s_kubelet
     source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
+    source_category_replace_dash "#{ENV['SOURCE_CATEGORY_REPLACE_DASH']}"
     exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
     exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
     exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"
@@ -37,6 +38,7 @@
     @type kubernetes_sumologic
     source_category system
     source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
+    source_category_replace_dash "#{ENV['SOURCE_CATEGORY_REPLACE_DASH']}"
     exclude_facility_regex "#{ENV['EXCLUDE_FACILITY_REGEX']}"
     exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
     exclude_priority_regex "#{ENV['EXCLUDE_PRIORITY_REGEX']}"


### PR DESCRIPTION
###### Description

This PR adds source_category_replace_dash to systemd log filters.
[The default setting is "/"](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/master/fluent-plugin-kubernetes-sumologic/lib/fluent/plugin/filter_kubernetes_sumologic.rb#L11) and we noticed that container logs were honoring our override, but systemd logs were not.

###### Testing performed

- [ ] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
