### PR TITLE
Revert "Bump version in the docs to v0.16.0"

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Detailed instructions are available in our Installation Guides below.
 
 Sumo Logic Helm Chart Version
 |:--------
-[0.16.0](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/v0.16.0/deploy/README.md)
 [0.15.0](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/v0.15.0/deploy/README.md) 
 [0.14.0](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/v0.14.0/deploy/README.md) 
 [0.13.0](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/v0.13.0/deploy/README.md) 

--- a/deploy/docs/Helm3.md
+++ b/deploy/docs/Helm3.md
@@ -43,7 +43,7 @@ manifest_sorter.go:175: info: skipping unknown hook: "crd-install"
 NOTE: If you need to install the chart with a different release name or namespace you will need to override some configuration fields for both Prometheus and fluent-bit. We recommend using an override file due to the number of fields that need to be overridden. In the following command, replace the `<RELEASE-NAME>` and `<NAMESPACE>` variables with your values and then run it to download the override file with your replaced values:
 
 ```bash
-curl https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.16.0/deploy/helm/sumologic/values.yaml | \
+curl https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.15.0/deploy/helm/sumologic/values.yaml | \
 sed 's/\-sumologic.sumologic'"/-sumologic.<NAMESPACE>/g" | \
 sed 's/\- sumologic'"/- <NAMESPACE>/g" | \
 sed 's/\collection'"/<RELEASE-NAME>/g" > values.yaml
@@ -51,7 +51,7 @@ sed 's/\collection'"/<RELEASE-NAME>/g" > values.yaml
 
 For example, if your release name is `my-release` and namespace is `my-namespace`:
 ```bash
-curl https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.16.0/deploy/helm/sumologic/values.yaml | \
+curl https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.15.0/deploy/helm/sumologic/values.yaml | \
 sed 's/\-sumologic.sumologic'"/-sumologic.my-namespace/g" | \
 sed 's/\collection'"/my-release/g" > values.yaml
 ```

--- a/deploy/docs/Installation_with_Helm.md
+++ b/deploy/docs/Installation_with_Helm.md
@@ -66,7 +66,7 @@ ebpf:
 To customize your configuration, download the values.yaml file by running
 
 ```bash
-curl https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.16.0/deploy/helm/sumologic/values.yaml
+curl https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.15.0/deploy/helm/sumologic/values.yaml
 ```
 
 #### To install the chart with a different release name or namespace:

--- a/deploy/docs/Non_Helm_Installation.md
+++ b/deploy/docs/Non_Helm_Installation.md
@@ -72,7 +72,7 @@ kubectl create namespace sumologic
 Run the following command to download and apply the YAML file containing all the Kubernetes resources. Replace the `<NAMESPACE>`, `<SUMOLOGIC_ACCESSID>`, `<SUMOLOGIC_ACCESSKEY>`, `<COLLECTOR_NAME>` and `<CLUSTER_NAME>` variables with your values.
 
 ```sh
-curl -s https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.16.0/deploy/kubernetes/setup-sumologic.yaml.tmpl | \
+curl -s https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.15.0/deploy/kubernetes/setup-sumologic.yaml.tmpl | \
 sed 's/\$NAMESPACE'"/<NAMESPACE>/g" | \
 sed 's/\$SUMOLOGIC_ACCESSID'"/<SUMOLOGIC_ACCESSID>/g" | \
 sed 's/\$SUMOLOGIC_ACCESSKEY'"/<SUMOLOGIC_ACCESSKEY>/g" | \
@@ -153,7 +153,7 @@ In this step you will deploy Fluentd using a Sumo-provided .yaml manifest.
 If you don't need to customize the configuration apply the `fluentd-sumologic.yaml` manifest with the following command:
 
 ```sh
-curl https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.16.0/deploy/kubernetes/fluentd-sumologic.yaml.tmpl | \
+curl https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.15.0/deploy/kubernetes/fluentd-sumologic.yaml.tmpl | \
 sed 's/\$NAMESPACE'"/sumologic/g" | \
 kubectl -n sumologic apply -f -
 ```
@@ -163,7 +163,7 @@ kubectl -n sumologic apply -f -
 If you need to customize the configuration there are two commands to run. First, get the `fluentd-sumologic.yaml` manifest with following command:
 
 ```sh
-curl https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.16.0/deploy/kubernetes/fluentd-sumologic.yaml.tmpl | \
+curl https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.15.0/deploy/kubernetes/fluentd-sumologic.yaml.tmpl | \
 sed 's/\$NAMESPACE'"/sumologic/g" >> fluentd-sumologic.yaml
 ```
 
@@ -191,7 +191,7 @@ In this step, you will configure the Prometheus server to write metrics to Fluen
 Download the Prometheus Operator `prometheus-overrides.yaml` by running
 
 ```bash
-$ curl -LJO https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.16.0/deploy/helm/prometheus-overrides.yaml
+$ curl -LJO https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.15.0/deploy/helm/prometheus-overrides.yaml
 ```
 
 Before installing `prometheus-operator`, edit `prometheus-overrides.yaml` to define a unique cluster identifier. The default value of the `cluster` field in the `externalLabels` section of `prometheus-overrides.yaml` is `kubernetes`. If you will be deploying the metric collection solution on multiple Kubernetes clusters, you will want to use a unique identifier for each. For example, you might use “Dev”, “Prod”, and so on.
@@ -247,7 +247,7 @@ In this step, you will deploy FluentBit to forward logs to Fluentd.
 Run the following commands to download the FluentBit `fluent-bit-overrides.yaml` file and install `fluent-bit`
 
 ```bash
-$ curl -LJO https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.16.0/deploy/helm/fluent-bit-overrides.yaml
+$ curl -LJO https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.15.0/deploy/helm/fluent-bit-overrides.yaml
 $ helm fetch stable/fluent-bit --version 2.8.1
 $ helm template fluent-bit-2.8.1.tgz --name fluent-bit --namespace=sumologic -f fluent-bit-overrides.yaml > fluent-bit.yaml
 $ kubectl apply -f fluent-bit.yaml
@@ -262,7 +262,7 @@ In this step, you will deploy [Falco](https://falco.org/) to detect anomalous ac
 Download the file `falco-overrides.yaml` from GitHub:
 
 ```bash
-$ curl -LJO https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.16.0/deploy/helm/falco-overrides.yaml
+$ curl -LJO https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.15.0/deploy/helm/falco-overrides.yaml
 $ helm fetch stable/falco --version 1.0.9
 $ helm template falco-1.0.9.tgz --name falco --namespace=sumologic -f falco-overrides.yaml > falco.yaml
 $ kubectl apply -f falco.yaml

--- a/deploy/docs/Upgrading_with_Helm.md
+++ b/deploy/docs/Upgrading_with_Helm.md
@@ -29,7 +29,7 @@ In the above command, since no arguments were specified, the `--reuse-values` fl
 **Always download the latest version of `values.yaml` from the following link and synchronize it based on your existing `values.yaml` file before running the upgrade.**
 
 ```bash
-curl https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.16.0/deploy/helm/sumologic/values.yaml
+curl https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.15.0/deploy/helm/sumologic/values.yaml
 ```
 
 ### Example to upgrade using the `--version` flag:

--- a/deploy/docs/existingPrometheusDoc.md
+++ b/deploy/docs/existingPrometheusDoc.md
@@ -13,7 +13,7 @@
 Run the following to download the `values.yaml` file
 
 ```bash
-curl -LJO https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.16.0/deploy/helm/sumologic/values.yaml
+curl -LJO https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.15.0/deploy/helm/sumologic/values.yaml
 ```
 
 Edit the `values.yaml` file to `prometheus-operator.enabled = false`, and run
@@ -37,7 +37,7 @@ Run the following to update the [remote write configuration](https://prometheus.
 In the below command, replace `<SUMOLOGIC_HELM_CHART_NAMESPACE>` with the actual namespace where the sumologic helm chart is installed. This is done to point the prometheus remote write URL to the Fluentd endpoints correctly.
 
 ```bash
-curl -LJO https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.16.0/deploy/helm/prometheus-overrides.yaml| \
+curl -LJO https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.15.0/deploy/helm/prometheus-overrides.yaml| \
 sed 's/\$(NAMESPACE)/<SUMOLOGIC_HELM_CHART_NAMESPACE>/g' prometheus-overrides.yaml > prometheus-overrides.yaml
 ```
 


### PR DESCRIPTION
###### Description

Let's take the docs for now and reintroduce them when the release is really ready.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
