### PR TITLE
Move spans per request to configuration for zipkin plugin

### DIFF
--- a/deploy/helm/sumologic/conf/traces/traces.conf
+++ b/deploy/helm/sumologic/conf/traces/traces.conf
@@ -31,5 +31,14 @@
     content_type application/json
     open_timeout 1
     spans_per_request {{ .Values.sumologic.traces.spans_per_request }}
+    <buffer>
+      {{- if eq .Values.sumologic.fluentd.buffer "file" }}
+      @type file
+      path /fluentd/buffer/events
+      {{- else }}
+      @type memory
+      {{- end }}
+      @include buffer.output.conf
+    </buffer>
   </match>
 </label>

--- a/deploy/helm/sumologic/conf/traces/traces.conf
+++ b/deploy/helm/sumologic/conf/traces/traces.conf
@@ -30,5 +30,6 @@
     endpoint "#{ENV['SUMO_ENDPOINT_TRACES']}"
     content_type application/json
     open_timeout 1
+    spans_per_request {{ .Values.sumologic.traces.spans_per_request }}
   </match>
 </label>

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -103,6 +103,8 @@ sumologic:
     fluentd_stdout: false
     # Sumologic endpoint for traces
     endpoint: ''
+    # How many spans per request should be send to receiver
+    spans_per_request: 100
 
   ## Format to post logs into Sumo. json, json_merge, or text
   logFormat: fields

--- a/fluent-plugin-zipkin/lib/fluent/plugin/out_zipkin.rb
+++ b/fluent-plugin-zipkin/lib/fluent/plugin/out_zipkin.rb
@@ -76,6 +76,9 @@ module Fluent::Plugin
     desc 'The list of retryable response code'
     config_param :retryable_response_codes, :array, value_type: :integer, default: [503]
 
+    desc 'Maximum number of spans per request'
+    config_param :spans_per_request, :int, default: 100
+
     config_section :auth, required: false, multi: false do
       desc 'The method for HTTP authentication'
       config_param :method, :enum, list: [:basic], default: :basic
@@ -112,7 +115,7 @@ module Fluent::Plugin
 
     def write(chunk)
       uri = parse_endpoint(chunk)
-      data = split_chunk(chunk, size: 100)
+      data = split_chunk(chunk, size: @spans_per_request)
 
       data.each do |spans|
         begin

--- a/fluent-plugin-zipkin/lib/fluent/plugin/out_zipkin.rb
+++ b/fluent-plugin-zipkin/lib/fluent/plugin/out_zipkin.rb
@@ -77,7 +77,7 @@ module Fluent::Plugin
     config_param :retryable_response_codes, :array, value_type: :integer, default: [503]
 
     desc 'Maximum number of spans per request'
-    config_param :spans_per_request, :int, default: 100
+    config_param :spans_per_request, :integer, default: 100
 
     config_section :auth, required: false, multi: false do
       desc 'The method for HTTP authentication'


### PR DESCRIPTION
###### Description

Move spans per request to configuration for zipkin 

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
