### PR TITLE
Revert "Remove some non-tracing changes from v0.16 - merge them later…

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -60,7 +60,8 @@ The following matrix displays the tested package versions for our Helm chart.
 
 Sumo Logic Helm Chart | Prometheus Operator | Fluent Bit | Falco  | Metrics Server
 |:-------- |:-------- |:-------- |:-------- |:--------
-0.14.0 - Latest | 8.2.0 | 2.8.1 | 1.1.1 | 2.7.0
+0.17.0 - Latest | 8.2.0 | 2.8.1 | 1.1.0 | 2.7.0
+0.14.0 | 8.2.0 | 2.8.1 | 1.1.1 | 2.7.0
 0.13.0 | 8.2.0 | 2.8.1 | 1.0.11 | 2.7.0
 0.12.0 | 8.2.0 | 2.8.1 | 1.0.9  |  -
 0.9.0 - 0.11.0 | 6.2.1 | 2.4.4 | 1.0.8   |  -

--- a/deploy/docs/existingPrometheusDoc.md
+++ b/deploy/docs/existingPrometheusDoc.md
@@ -21,13 +21,14 @@ Edit the `values.yaml` file to `prometheus-operator.enabled = false`, and run
 ```bash
 helm install sumologic/sumologic --name collection --namespace sumologic -f values.yaml --set sumologic.accessId=<SUMO_ACCESS_ID> --set sumologic.accessKey=<SUMO_ACCESS_KEY> --set sumologic.clusterName=<MY_CLUSTER_NAME> 
 ```
+
 **NOTE**:
-In case the prometheus-operator is installed in a different namespace as compared to where the sumologic solution is deployed, you would need to do the following two steps:  
+In case the prometheus-operator is installed in a different namespace as compared to where the Sumo Logic Solution is deployed, you would need to do the following two steps:
 
 ##### 1. Copy one of the configmaps that exposes the release name,  which is used in the remote write urls.
 
-For example: 
-If the sumologic solution is deployed in `<source-namespace>` and existing prometheus-operator is in `<destination-namespace>`, run the below command: 
+For example:\
+If the Sumo Logic Solution is deployed in `<source-namespace>` and the existing prometheus-operator is in `<destination-namespace>`, run the below command:
 ```bash
 kubectl get configmap sumologic-configmap --namespace=<source-namespace> —-export -o yaml | kubectl apply --namespace=<destination-namespace> -f -
 ```

--- a/deploy/docs/standAlonePrometheus.md
+++ b/deploy/docs/standAlonePrometheus.md
@@ -4,15 +4,15 @@ Update your Prometheus configuration file’s `remote_write` section, as per the
 
 * `writeRelabelConfigs:` change to `write_relabel_configs:`
 * `sourceLabels:` change to `source_labels:`
-*  Modify remote urls in the `remoteWrite` section of the `prometheus-overrides.yaml` file
+*  Modify remote URLs in the `remoteWrite` section of the `prometheus-overrides.yaml` file
 
-The urls in `remoteWrite` section of the `prometheus-overrides.yaml` file uses `env` variables which need to be changed to point it to the correct location.
+The URLs in `remoteWrite` section of the `prometheus-overrides.yaml` file uses `env` variables which need to be changed to point to the correct location.
 
-- Replace `$(CHART)` with the `release name-namespace` that you have used while installing the sumologic helm chart.
-- Replace `$(NAMESPACE)` with the namespace where prometheus is running.
+- Replace `$(CHART)` with the `release name-namespace` that you have used while installing the Sumo Logic helm chart.
+- Replace `$(NAMESPACE)` with the namespace where Prometheus is running.
 
-For eg:
-If you have installed the sumlogic helm chart with release name `collection` in `sumologic` namespace and the prometheus is running in `prometheus` namespace:
+For example:\
+If you have installed the Sumo Logic helm chart with release name `collection` in the `sumologic` namespace and Prometheus is running in the `prometheus` namespace:
 ```
 `$(CHART).$(NAMESPACE)` will be replaced by `collection-sumologic.prometheus`
 ```

--- a/deploy/helm/fluent-bit-overrides.yaml
+++ b/deploy/helm/fluent-bit-overrides.yaml
@@ -1,4 +1,13 @@
 # This file is auto-generated.
+## Resource limits for fluent-bit
+resources: {}
+# limits:
+#   cpu: 100m
+#   memory: 128Mi
+# requests:
+#   cpu: 10m
+#   memory: 8Mi
+
 service:
   flush: 5
 metrics:

--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -11,6 +11,8 @@ grafana:
   enabled: false
   defaultDashboardsEnabled: false
 prometheusOperator:
+  ## Resource limits for prometheus operator
+  resources: {}
   admissionWebhooks:
     enabled: false
   tlsProxy:
@@ -63,6 +65,10 @@ prometheus:
       matchLabels:
         app: collection-sumologic-otelcol
   prometheusSpec:
+    ## Define resources requests and limits for single Pods.
+    resources: {}
+    # requests:
+    #   memory: 400Mi
     thanos:
       version: v0.10.0
     containers:

--- a/deploy/helm/sumologic/conf/common.conf
+++ b/deploy/helm/sumologic/conf/common.conf
@@ -1,3 +1,8 @@
+# Prevent fluentd from handling records containing its own logs.
+<match fluentd.**>
+  @type null
+</match>
+# expose the Fluentd metrics to Prometheus
 <source>
   @type prometheus
   metrics_path /metrics

--- a/deploy/helm/sumologic/conf/events/events.conf
+++ b/deploy/helm/sumologic/conf/events/events.conf
@@ -13,6 +13,11 @@
   deploy_namespace {{ .Release.Namespace }}
 </source>
 {{- end }}
+# Prevent fluentd from handling records containing its own logs.
+<match fluentd.**>
+  @type null
+</match>
+# expose the Fluentd metrics to Prometheus
 <source>
   @type prometheus
   metrics_path /metrics

--- a/deploy/helm/sumologic/requirements.yaml
+++ b/deploy/helm/sumologic/requirements.yaml
@@ -8,7 +8,7 @@ dependencies:
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: prometheus-operator.enabled
   - name: falco
-    version: 1.1.1
+    version: 1.1.0
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: falco.enabled
   - name: metrics-server

--- a/deploy/helm/sumologic/templates/configmap.yaml
+++ b/deploy/helm/sumologic/templates/configmap.yaml
@@ -13,9 +13,9 @@ data:
 {{- if .Values.sumologic.traces.enabled }}
     @include traces.conf
 {{- end }}
-  {{- (tpl (.Files.Glob "conf/*.conf").AsConfig .) | nindent 2 }}
-  {{- (tpl (.Files.Glob "conf/metrics/*.conf").AsConfig .) | nindent 2 }}
-  {{- (tpl (.Files.Glob "conf/logs/*.conf").AsConfig .) | nindent 2 }}
-  {{- if .Values.sumologic.traces.enabled }}
-  {{- (tpl (.Files.Glob "conf/traces/*.conf").AsConfig .) | nindent 2 }}
-  {{- end }}
+{{- (tpl (.Files.Glob "conf/*.conf").AsConfig .) | nindent 2 }}
+{{- (tpl (.Files.Glob "conf/metrics/*.conf").AsConfig .) | nindent 2 }}
+{{- (tpl (.Files.Glob "conf/logs/*.conf").AsConfig .) | nindent 2 }}
+{{- if .Values.sumologic.traces.enabled }}
+{{- (tpl (.Files.Glob "conf/traces/*.conf").AsConfig .) | nindent 2 }}
+{{- end }}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -184,12 +184,12 @@ sumologic:
   # watchResourceEventsOverrides:
   #   pods: "v1"
   #   events: "events.k8s.io/v1beta1"
-  
 
   fluentd:
     ## Option to specify the Fluentd buffer as file/memory.
     buffer: "memory"
-    ## Option to turn autoscaling on for fluentd and specify metrics for HPA.
+    ## Option to turn autoscaling on for fluentd and specify params for HPA.
+    ## Autoscaling needs metrics-server to access cpu metrics.
     autoscaling:
       enabled: false
       minReplicas: 3
@@ -218,14 +218,25 @@ sumologic:
 ## Configure metrics-server
 ## ref: https://github.com/helm/charts/blob/master/stable/metrics-server/values.yaml
 metrics-server:
+  ## Set the enabled flag to true for enabling metrics-server.
+  ## This is required before enabling fluentd autoscaling unless you have an existing metrics-server in the cluster.
   enabled: false
   args:
     - --kubelet-insecure-tls
     - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
 
-## Configure fluent-bit 
+## Configure fluent-bit
 ## ref: https://github.com/helm/charts/blob/master/stable/fluent-bit/values.yaml
 fluent-bit:
+  ## Resource limits for fluent-bit
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 10m
+    #   memory: 8Mi
+
   enabled: true
   service:
     flush: 5
@@ -358,6 +369,8 @@ prometheus-operator:
     enabled: false
     defaultDashboardsEnabled: false
   prometheusOperator:
+    ## Resource limits for prometheus operator
+    resources: {}
     admissionWebhooks:
       enabled: false
     tlsProxy:
@@ -410,6 +423,10 @@ prometheus-operator:
           matchLabels:
             app: collection-sumologic-otelcol
     prometheusSpec:
+      ## Define resources requests and limits for single Pods.
+      resources: {}
+      # requests:
+      #   memory: 400Mi
       thanos:
         version: v0.10.0
       containers:

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -30,6 +30,11 @@ data:
     queued_chunks_limit_size "#{ENV['QUEUE_CHUNK_LIMIT_SIZE']}"
     overflow_action drop_oldest_chunk
   common.conf: |-
+    # Prevent fluentd from handling records containing its own logs.
+    <match fluentd.**>
+      @type null
+    </match>
+    # expose the Fluentd metrics to Prometheus
     <source>
       @type prometheus
       metrics_path /metrics
@@ -333,7 +338,6 @@ data:
       </match>
     </label>
   
-
 ---
 # Source: sumologic/templates/events-configmap.yaml
 
@@ -352,6 +356,11 @@ data:
       @type events
       deploy_namespace $NAMESPACE
     </source>
+    # Prevent fluentd from handling records containing its own logs.
+    <match fluentd.**>
+      @type null
+    </match>
+    # expose the Fluentd metrics to Prometheus
     <source>
       @type prometheus
       metrics_path /metrics


### PR DESCRIPTION
… on as v0.17"

This reverts commit 4433281c889f13797d4205c9cf817029194ec64c.

###### Description

1. Falco helm chart change
2. Removing fluentd health check logs
3. Resource config for helm chart dependencies

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
