### PR TITLE
Expose otelcol UDP enpoints too

### DIFF
--- a/deploy/helm/sumologic/templates/otelcol-deployment.yaml
+++ b/deploy/helm/sumologic/templates/otelcol-deployment.yaml
@@ -42,12 +42,17 @@ spec:
         resources:
           {{- toYaml .Values.otelcol.deployment.resources | nindent 10 }}
         ports:
-        - containerPort: 55678 # Default endpoint for Opencensus receiver.
+        - containerPort: 5778  # Default endpoint for Jaeger Sampling.
+        - containerPort: 6831  # Default endpoint for Jaeger Thrift Compact receiver.
+          protocol: UDP
+        - containerPort: 6832  # Default endpoint for Jaeger Thrift Binary receiver.
+          protocol: UDP
+        - containerPort: 8888  # Default endpoint for querying metrics.
+        - containerPort: 9411  # Default endpoint for Zipkin receiver.
+        - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
         - containerPort: 14267 # Default endpoint for Jaeger TChannel receiver.
         - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
-        - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
-        - containerPort: 9411 # Default endpoint for Zipkin receiver.
-        - containerPort: 8888  # Default endpoint for querying metrics.
+        - containerPort: 55678 # Default endpoint for Opencensus receiver.
         volumeMounts:
         - name: otel-collector-config-vol
           mountPath: /conf

--- a/deploy/helm/sumologic/templates/otelcol-service.yaml
+++ b/deploy/helm/sumologic/templates/otelcol-service.yaml
@@ -10,18 +10,26 @@ spec:
   selector:
     app: {{ printf "%s-otelcol" (include "sumologic.labels.app" .) }}
   ports:
-  - name: opencensus # Default endpoint for Opencensus receiver.
-    port: 55678
-    protocol: TCP
-    targetPort: 55678
+  - name: jaeger-sampling # Default endpoint for Jaeger Sampling (if enabled)
+    port: 5778
+  - name: jaeger-thrift-compact # Default endpoint for Jaeger Thrift Compact receiver.
+    port: 6831
+    protocol: UDP
+  - name: jaeger-thrift-binary # Default endpoint for Jaeger Thrift Binary receiver.
+    port: 6832
+    protocol: UDP
+  - name: metrics # Default endpoint for querying metrics.
+    port: 8888
+  - name: zipkin # Default endpoint for Zipkin receiver.
+    port: 9411
   - name: jaeger-grpc  # Default endpoint for Jaeger gRPC
     port: 14250
   - name: jaegert-channel  # Default endpoint for Jaeger TChannel receiver.
     port: 14267
   - name: jaeger-thrift-http # Default endpoint for Jaeger HTTP receiver.
     port: 14268
-  - name: zipkin # Default endpoint for Zipkin receiver.
-    port: 9411
-  - name: metrics # Default endpoint for querying metrics.
-    port: 8888
+  - name: opencensus # Default endpoint for Opencensus receiver.
+    port: 55678
+    protocol: TCP
+    targetPort: 55678
 {{- end }}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -537,18 +537,24 @@ otelcol:
     memBallastSizeMib: "683"
     image:
       name: "sumologic/opentelemetry-collector"
-      tag: "0.2.6.6"
+      tag: "0.2.6.7"
       pullPolicy: IfNotPresent
   config:
     receivers:
-      opencensus:
-        endpoint: "0.0.0.0:55678"
       jaeger:
         protocols:
+          thrift_compact:
+            endpoint: "0.0.0.0:6831"
+          thrift_binary:
+            endpoint: "0.0.0.0:6832"
           grpc:
             endpoint: "0.0.0.0:14250"
+          thrift_tchannel:
+            endpoint: "0.0.0.0:14267"
           thrift_http:
             endpoint: "0.0.0.0:14268"
+      opencensus:
+        endpoint: "0.0.0.0:55678"
       zipkin:
         endpoint: "0.0.0.0:9411"
     processors:


### PR DESCRIPTION
###### Description

Jaeger Client typically uses UDP `thrift-compact` protocol for sending spans. Lets expose it by default 

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
