### PR TITLE
Include otelcol metrics

### DIFF
--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -149,5 +149,5 @@ prometheus:
       url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics
       writeRelabelConfigs:
       - action: keep
-        regex: (?:up|prometheus_remote_storage_.*|fluentd_.*|fluentbit.*)
+        regex: (?:up|prometheus_remote_storage_.*|fluentd_.*|fluentbit.*|otelcol.*)
         sourceLabels: [__name__]

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -508,7 +508,7 @@ prometheus-operator:
         - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics
           writeRelabelConfigs:
             - action: keep
-              regex: (?:up|prometheus_remote_storage_.*|fluentd_.*|fluentbit.*)
+              regex: (?:up|prometheus_remote_storage_.*|fluentd_.*|fluentbit.*|otelcol.*)
               sourceLabels: [__name__]
 
 ## Configure falco

--- a/deploy/kubernetes/kube-prometheus-sumo-logic-mixin.libsonnet
+++ b/deploy/kubernetes/kube-prometheus-sumo-logic-mixin.libsonnet
@@ -139,7 +139,7 @@
         writeRelabelConfigs: [
           {
             action: "keep",
-            regex: "(?:up|prometheus_remote_storage_.*|fluentd_.*|fluentbit.*)",
+            regex: "(?:up|prometheus_remote_storage_.*|fluentd_.*|fluentbit.*|otelcol.*)",
             sourceLabels: [
               "__name__"
             ]


### PR DESCRIPTION
###### Description

Include OpenTelemetry Collector metrics (if present) when pushing them through fluentd

###### Testing performed

- [ ] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
