### PR TITLE
Bump otelcol to newer version

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -538,7 +538,7 @@ otelcol:
     memBallastSizeMib: "683"
     image:
       name: "sumologic/opentelemetry-collector"
-      tag: "0.2.6.7"
+      tag: "0.2.7.0"
       pullPolicy: IfNotPresent
   config:
     receivers:


### PR DESCRIPTION
###### Description

Updates Open Telemetry collector to a new version. It is based on more recent codebase of the parent project and includes a fix for tagging hostname when it's not set (then, pod name is taken, per https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-hostname-and-subdomain-fields )

###### Testing performed

- [ ] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
