### PR TITLE
Removed references to out of date helm chart versions which are no lo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,11 @@ This repo contains all required resources to collect data from Kubernetes cluste
 Detailed instructions are available in our Installation Guides below.
 
 Sumo Logic Helm Chart Version
-|:--------
-[0.17.0](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/v0.17.0/deploy/README.md)
-[0.16.0](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/v0.16.0/deploy/README.md)
-[0.15.0](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/v0.15.0/deploy/README.md)
-[0.14.0](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/v0.14.0/deploy/README.md)
-[0.13.0](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/v0.13.0/deploy/README.md)
-[0.12.0](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/v0.12.0/deploy/README.md)
-[0.11.0](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/v0.11.0/deploy/README.md)
-[0.10.0](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/v0.10.0/deploy/README.md)
-[0.9.0](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/v0.9.0/deploy/README.md)
+| version | status |  
+|--|--|
+|[0.17.0](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/v0.17.0/deploy/README.md)| current / supported  |
+|[0.16.0](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/v0.16.0/deploy/README.md) | deprecated |
+|[0.15.0](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/v0.15.0/deploy/README.md) | deprecated |
 
 # License
 

--- a/deploy/docs/existingPrometheusDoc.md
+++ b/deploy/docs/existingPrometheusDoc.md
@@ -10,13 +10,13 @@
 
 ## Install Fluentd, Fluent-bit, and Falco
 
-Run the following to download the `values.yaml` file
+Installation of collection in a cluster where a prometheus operator already exists requires that you modify Sumo Logic's [values.yaml](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/master/deploy/helm/sumologic/values.yaml) file. Run the following to download the `values.yaml` file
 
 ```bash
 curl -LJO https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.17.0/deploy/helm/sumologic/values.yaml
 ```
 
-Edit the `values.yaml` file to `prometheus-operator.enabled = false`, and run
+Edit the `values.yaml` file, setting `prometheus-operator.enabled = false`. This modification will instruct Helm to install all the needed collection components (FluentD, FluentBit, and Falco), but it will not install the Prometheus Operator. Run the following command to install collection on your cluster.
 
 ```bash
 helm install sumologic/sumologic --name collection --namespace sumologic -f values.yaml --set sumologic.accessId=<SUMO_ACCESS_ID> --set sumologic.accessKey=<SUMO_ACCESS_KEY> --set sumologic.clusterName=<MY_CLUSTER_NAME> 
@@ -33,15 +33,15 @@ If the Sumo Logic Solution is deployed in `<source-namespace>` and the existing 
 kubectl get configmap sumologic-configmap --namespace=<source-namespace> --export -o yaml | kubectl apply --namespace=<destination-namespace> -f -
 ```
 ##### 2. Update Prometheus remote write URL's
-Run the following to update the [remote write configuration](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write) of the prometheus operator by installing with the prometheus overrides file we provide below.
+Run the following commands to update the [remote write configuration](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write) of the prometheus operator with the prometheus overrides we provide in our [prometheus-overrides.yaml](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/master/deploy/helm/prometheus-overrides.yaml).
 
-In the below command, replace `<SUMOLOGIC_HELM_CHART_NAMESPACE>` with the actual namespace where the sumologic helm chart is installed. This is done to point the prometheus remote write URL to the Fluentd endpoints correctly.
+Run the following command to download our prometheus-overrides.yaml file
 
 ```bash
 curl -LJO https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.17.0/deploy/helm/prometheus-overrides.yaml > prometheus-overrides.yaml
 ```
 
-Then run
+Next run
 
 ```bash
 helm upgrade prometheus-operator stable/prometheus-operator -f prometheus-overrides.yaml --set prometheus-operator.prometheus-node-exporter.service.port=9200 --set prometheus-operator.prometheus-node-exporter.service.targetPort=9200


### PR DESCRIPTION
Updated helm chart version list

###### Description
removed references to old, unsupported helm chart versions

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
