### PR TITLE
add sed command to replace cluster name for non-helm users

### DIFF
--- a/deploy/docs/Non_Helm_Installation.md
+++ b/deploy/docs/Non_Helm_Installation.md
@@ -155,6 +155,7 @@ If you don't need to customize the configuration apply the `fluentd-sumologic.ya
 ```sh
 curl https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.17.0/deploy/kubernetes/fluentd-sumologic.yaml.tmpl | \
 sed 's/\$NAMESPACE'"/sumologic/g" | \
+sed 's/cluster kubernetes/cluster $CLUSTER_NAME/g' | \
 kubectl -n sumologic apply -f -
 ```
 


### PR DESCRIPTION
###### Description

Update non-helm documentation to add sed command to replace cluster name for non-helm users

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
