### PR TITLE
[WIP] Hostname fix and otelcol update

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -656,7 +656,7 @@ otelcol:
     memBallastSizeMib: "683"
     image:
       name: "sumologic/opentelemetry-collector"
-      tag: "0.2.7.0"
+      tag: "0.2.7.1"
       pullPolicy: IfNotPresent
   config:
     receivers:
@@ -681,6 +681,8 @@ otelcol:
       k8s_tagger:
         # When true, only IP is assigned and passed (so it could be tagged on another collector)
         passthrough: false
+        # Enable calls for owners
+        owner_lookup_enabled: true
         # Extracted fields and assigned names
         extract:
           metadata:
@@ -690,10 +692,9 @@ otelcol:
             - cluster
             - daemonSetName
             - deployment
-            - host
+            - hostName
             - namespace
             - node
-            - owners
             - podId
             - podName
             - replicaSetName
@@ -706,7 +707,7 @@ otelcol:
             cluster: cluster
             daemonSetName: daemonset
             deployment: deployment
-            hostName: hostname
+            hostName: host
             namespace: namespace
             node: node
             podId: pod_id

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -699,7 +699,6 @@ otelcol:
             - podName
             - replicaSetName
             - serviceName
-            - startTime
             - statefulSetName
           tags:
             containerId: container_id
@@ -714,7 +713,6 @@ otelcol:
             podName: pod
             replicaSetName: replicaset
             serviceName: service_name
-            startTime: start_time
             statefulSetName: statefulset
           annotations:
             - tag_name: pod_annotation_%s

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -214,7 +214,7 @@ fluentd:
       ## Set the _sourceName metadata field in Sumo Logic.
       sourceName: "%{namespace}.%{pod}.%{container}"
       ## Set the _sourceHost metadata field in Sumo Logic.
-      sourceHost: "%{host}"
+      sourceHost: "%{source_host}"
       ## Set the _sourceCategory metadata field in Sumo Logic.
       sourceCategory: "%{namespace}/%{pod_name}"
       ## Set the prefix, for _sourceCategory metadata.

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -214,7 +214,7 @@ fluentd:
       ## Set the _sourceName metadata field in Sumo Logic.
       sourceName: "%{namespace}.%{pod}.%{container}"
       ## Set the _sourceHost metadata field in Sumo Logic.
-      sourceHost: "#{host}"
+      sourceHost: "%{host}"
       ## Set the _sourceCategory metadata field in Sumo Logic.
       sourceCategory: "%{namespace}/%{pod_name}"
       ## Set the prefix, for _sourceCategory metadata.

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -214,7 +214,7 @@ fluentd:
       ## Set the _sourceName metadata field in Sumo Logic.
       sourceName: "%{namespace}.%{pod}.%{container}"
       ## Set the _sourceHost metadata field in Sumo Logic.
-      sourceHost: ""
+      sourceHost: "#{host}"
       ## Set the _sourceCategory metadata field in Sumo Logic.
       sourceCategory: "%{namespace}/%{pod_name}"
       ## Set the prefix, for _sourceCategory metadata.
@@ -690,7 +690,7 @@ otelcol:
             - cluster
             - daemonSetName
             - deployment
-            - hostName
+            - host
             - namespace
             - node
             - owners

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -210,7 +210,7 @@ data:
     tag_to_kubernetes_name_regexp '.+?\.containers\.(?<pod_name>[^_]+)_(?<namespace>[^_]+)_(?<container_name>.+)-(?<docker_id>[a-z0-9]{64})\.log$'
   logs.kubernetes.sumologic.filter.conf: |-
     source_name "%{namespace}.%{pod}.%{container}"
-    source_host "#{host}"
+    source_host "%{host}"
     log_format "fields"
     source_category "%{namespace}/%{pod_name}"
     source_category_prefix "kubernetes/"

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -210,7 +210,7 @@ data:
     tag_to_kubernetes_name_regexp '.+?\.containers\.(?<pod_name>[^_]+)_(?<namespace>[^_]+)_(?<container_name>.+)-(?<docker_id>[a-z0-9]{64})\.log$'
   logs.kubernetes.sumologic.filter.conf: |-
     source_name "%{namespace}.%{pod}.%{container}"
-    source_host ""
+    source_host "#{host}"
     log_format "fields"
     source_category "%{namespace}/%{pod_name}"
     source_category_prefix "kubernetes/"

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -210,7 +210,7 @@ data:
     tag_to_kubernetes_name_regexp '.+?\.containers\.(?<pod_name>[^_]+)_(?<namespace>[^_]+)_(?<container_name>.+)-(?<docker_id>[a-z0-9]{64})\.log$'
   logs.kubernetes.sumologic.filter.conf: |-
     source_name "%{namespace}.%{pod}.%{container}"
-    source_host "%{host}"
+    source_host "%{source_host}"
     log_format "fields"
     source_category "%{namespace}/%{pod_name}"
     source_category_prefix "kubernetes/"


### PR DESCRIPTION
###### Description

This does several things:

- uses `host` rather than `hostName` for the tag
- bumps OpenTelemetry Collector to more recent version (with config format changed)
- add default value to `_sourceHost` (being the... `host`)
- removes `start_time` tag

This is `v1.0` equivalent of https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/530

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
