### PR TITLE
Hostname and _sourceHost fix for v0.17

### DIFF
--- a/deploy/helm/sumologic/conf/traces/traces.conf
+++ b/deploy/helm/sumologic/conf/traces/traces.conf
@@ -19,6 +19,21 @@
     source_name_key_name '_sourceName'
     collector_key_name '_collector'
     collector_value "{{- if .Values.sumologic.collectorName }}{{ .Values.sumologic.collectorName }}{{- else}}{{ .Values.sumologic.clusterName }}{{- end}}"
+
+    source_name "#{ENV['SOURCE_NAME']}"
+    source_host "#{ENV['SOURCE_HOST']}"
+    log_format "#{ENV['LOG_FORMAT']}"
+    kubernetes_meta "#{ENV['KUBERNETES_META']}"
+    kubernetes_meta_reduce "#{ENV['KUBERNETES_META_REDUCE']}"
+    add_stream "#{ENV['ADD_STREAM']}"
+    add_time "#{ENV['ADD_TIME']}"
+    source_category "#{ENV['SOURCE_CATEGORY']}"
+    source_category_prefix "#{ENV['SOURCE_CATEGORY_PREFIX']}"
+    source_category_replace_dash "#{ENV['SOURCE_CATEGORY_REPLACE_DASH']}"
+    exclude_namespace_regex "#{ENV['EXCLUDE_NAMESPACE_REGEX']}"
+    exclude_pod_regex "#{ENV['EXCLUDE_POD_REGEX']}"
+    exclude_container_regex "#{ENV['EXCLUDE_CONTAINER_REGEX']}"
+    exclude_host_regex "#{ENV['EXCLUDE_HOST_REGEX']}"
   </filter>
 {{- if .Values.sumologic.traces.fluentd_stdout }}
   <filter tracing.**>

--- a/deploy/helm/sumologic/templates/deployment.yaml
+++ b/deploy/helm/sumologic/templates/deployment.yaml
@@ -171,6 +171,8 @@ spec:
           value: {{ .Values.sumologic.sourceCategoryReplaceDash | quote }}
         - name: SOURCE_NAME
           value: {{ .Values.sumologic.sourceName | quote }}
+        - name: SOURCE_HOST
+          value: {{ .Values.sumologic.sourceHost | quote }}
         - name: KUBERNETES_META
           value: {{ .Values.sumologic.kubernetesMeta | quote }}
         - name: KUBERNETES_META_REDUCE

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -125,6 +125,9 @@ sumologic:
   ## Set the _sourceName metadata field in SumoLogic.
   sourceName: "%{namespace}.%{pod}.%{container}"
 
+  ## Set the _sourceHost metadata field in SumoLogic.
+  sourcHost: "%{host}"
+
   ## Set the _sourceCategory metadata field in SumoLogic.
   sourceCategory: "%{namespace}/%{pod_name}"
 
@@ -538,7 +541,7 @@ otelcol:
     memBallastSizeMib: "683"
     image:
       name: "sumologic/opentelemetry-collector"
-      tag: "0.2.7.0"
+      tag: "0.2.7.1"
       pullPolicy: IfNotPresent
   config:
     receivers:
@@ -563,6 +566,8 @@ otelcol:
       k8s_tagger:
         # When true, only IP is assigned and passed (so it could be tagged on another collector)
         passthrough: false
+        # Enable calls for owners
+        owner_lookup_enabled: true
         # Extracted fields and assigned names
         extract:
           metadata:
@@ -575,7 +580,6 @@ otelcol:
             - hostName
             - namespace
             - node
-            - owners
             - podId
             - podName
             - replicaSetName
@@ -588,7 +592,7 @@ otelcol:
             cluster: cluster
             daemonSetName: daemonset
             deployment: deployment
-            hostName: hostname
+            hostName: host
             namespace: namespace
             node: node
             podId: pod_id

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -126,7 +126,7 @@ sumologic:
   sourceName: "%{namespace}.%{pod}.%{container}"
 
   ## Set the _sourceHost metadata field in SumoLogic.
-  sourceHost: "%{host}"
+  sourceHost: "%{source_host}"
 
   ## Set the _sourceCategory metadata field in SumoLogic.
   sourceCategory: "%{namespace}/%{pod_name}"

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -126,7 +126,7 @@ sumologic:
   sourceName: "%{namespace}.%{pod}.%{container}"
 
   ## Set the _sourceHost metadata field in SumoLogic.
-  sourcHost: "%{host}"
+  sourceHost: "%{host}"
 
   ## Set the _sourceCategory metadata field in SumoLogic.
   sourceCategory: "%{namespace}/%{pod_name}"

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -584,7 +584,6 @@ otelcol:
             - podName
             - replicaSetName
             - serviceName
-            - startTime
             - statefulSetName
           tags:
             containerId: container_id
@@ -599,7 +598,6 @@ otelcol:
             podName: pod
             replicaSetName: replicaset
             serviceName: service_name
-            startTime: start_time
             statefulSetName: statefulset
           annotations:
             - tag_name: pod_annotation_%s

--- a/fluent-plugin-kubernetes-sumologic/lib/fluent/plugin/filter_kubernetes_sumologic.rb
+++ b/fluent-plugin-kubernetes-sumologic/lib/fluent/plugin/filter_kubernetes_sumologic.rb
@@ -12,7 +12,7 @@ module Fluent::Plugin
     config_param :source_category_prefix, :string, :default => "kubernetes/"
     config_param :source_name, :string, :default => "%{namespace}.%{pod}.%{container}"
     config_param :log_format, :string, :default => "json"
-    config_param :source_host, :string, :default => ""
+    config_param :source_host, :string, :default => "%{host}"
     config_param :exclude_container_regex, :string, :default => ""
     config_param :exclude_facility_regex, :string, :default => ""
     config_param :exclude_host_regex, :string, :default => ""

--- a/fluent-plugin-kubernetes-sumologic/lib/fluent/plugin/filter_kubernetes_sumologic.rb
+++ b/fluent-plugin-kubernetes-sumologic/lib/fluent/plugin/filter_kubernetes_sumologic.rb
@@ -12,7 +12,7 @@ module Fluent::Plugin
     config_param :source_category_prefix, :string, :default => "kubernetes/"
     config_param :source_name, :string, :default => "%{namespace}.%{pod}.%{container}"
     config_param :log_format, :string, :default => "json"
-    config_param :source_host, :string, :default => "%{host}"
+    config_param :source_host, :string, :default => "%{source_host}"
     config_param :exclude_container_regex, :string, :default => ""
     config_param :exclude_facility_regex, :string, :default => ""
     config_param :exclude_host_regex, :string, :default => ""


### PR DESCRIPTION
###### Description

This does several things:

- uses `host` rather than `hostName` for the tag
- bumps OpenTelemetry Collector to more recent version (with config format changed)
- add default value to `_sourceHost` (being the... `host`)
- removes `start_time` tag

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
