### PR TITLE
Allow to install plugins in docker image

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -84,4 +84,7 @@ COPY --from=builder /usr/local/bundle /usr/local/bundle
 COPY ./fluent.conf /fluentd/etc/
 COPY ./entrypoint.sh /bin/
 
+# Allow installing gems by fluent user
+RUN chown fluent /usr/local/bundle/*
+
 USER fluent

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -25,4 +25,11 @@ if [ "$1" = "fluentd" ]; then
     fi
 fi
 
+# Install custom plugins if specified by user
+if [ -n "${ADDITIONAL_PLUGINS}" ]; then
+    for plugin in ${ADDITIONAL_PLUGINS}; do
+        gem install ${plugin}
+    done
+fi
+
 exec "$@"

--- a/deploy/docs/Additional_Fluentd_Plugins.md
+++ b/deploy/docs/Additional_Fluentd_Plugins.md
@@ -1,12 +1,30 @@
 # Adding Additional Fluentd Plugins
-To add additional Fluentd plugins, you can simply create a new Docker image from our provided Docker image.
+
+To add additional Fluentd plugins, you can modify `values.yaml` or create a new Docker image from our provided Docker image.
+
+## Configuration
+
+__Note__: If your plugin require additional system libraries, it cannot be installed this way.
+
+```yaml
+# ...
+fluentd:
+  # ...
+  additionalPlugins:
+    - fluent-plugin-route
+    - fluent-plugin-aws-elasticsearch-service
+```
+
+## Docker
  
 __Note__: You will want to update `<RELEASE>` to the [docker tag](https://hub.docker.com/r/sumologic/kubernetes-fluentd/tags) you wish to use.
 
-```
+```dockerfile
 FROM sumologic/kubernetes-fluentd:<RELEASE>
 
 USER root
+# Here goes your changes
+RUN gem install fluent-plugin-route
 RUN gem install fluent-plugin-aws-elasticsearch-service
 
 USER fluent

--- a/deploy/docs/Additional_Fluentd_Plugins.md
+++ b/deploy/docs/Additional_Fluentd_Plugins.md
@@ -4,7 +4,7 @@ To add additional Fluentd plugins, you can modify `values.yaml` or create a new 
 
 ## Configuration
 
-__Note__: If your plugin require additional system libraries, it cannot be installed this way.
+__Note__: If your plugin requires additional system libraries, it cannot be installed this way.
 
 ```yaml
 # ...

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -159,6 +159,8 @@ spec:
         - name: SUMO_ENDPOINT_TRACES
           value: {{ .Values.sumologic.traces.endpoint }}
         {{- end }}
+        - name: ADDITIONAL_PLUGINS
+          value: {{ join " " .Values.fluentd.additionalPlugins | quote }}
 {{- if .Values.fluentd.persistence.enabled }}
   volumeClaimTemplates:
   - metadata:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -105,6 +105,8 @@ fluentd:
     @include metrics.conf
     @include logs.conf
 
+  additionalPlugins: []
+
   ## Sets the fluentd log level. The default log level, if not specified, is info.
   ## Sumo will only ingest the error log level and some specific warnings, the info logs can be seen in kubectl logs.
   ## ref: https://docs.fluentd.org/deployment/logging

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -753,6 +753,8 @@ spec:
             secretKeyRef:
               name: sumologic
               key: endpoint-logs
+        - name: ADDITIONAL_PLUGINS
+          value: ""
 ---
 # Source: sumologic/templates/hpa.yaml
 


### PR DESCRIPTION
###### Description

Allow to install plugins basing on values.yaml

Solves #139 for simple plugins (which do not require additional libraries)

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
