### PR TITLE
change tag to release branch

### DIFF
--- a/deploy/docs/standAlonePrometheus.md
+++ b/deploy/docs/standAlonePrometheus.md
@@ -3,7 +3,7 @@
 1. Download the Prometheus Operator `prometheus-overrides.yaml` by running
 
 ```bash
-$ curl -LJO https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/v0.17.0/deploy/helm/prometheus-overrides.yaml
+$ curl -LJO https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/release-v0.17/deploy/helm/prometheus-overrides.yaml
 ```
 
 2. Make the following modifications to the `remoteWrite` section of the `prometheus-overrides.yaml` file:


### PR DESCRIPTION
###### Description

All other URL's seem to be already using the correct release branch.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
