### PR TITLE
Add fluentd to service name to fix urls

### DIFF
--- a/deploy/helm/sumologic/templates/events-service-headless.yaml
+++ b/deploy/helm/sumologic/templates/events-service-headless.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-events-headless" (include "sumologic.fullname" .) }}
+  name: {{ printf "%s-events-fluentd-headless" (include "sumologic.fullname" .) }}
   labels:
     app: {{ printf "%s-events" (include "sumologic.labels.app" .) }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/events-service.yaml
+++ b/deploy/helm/sumologic/templates/events-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-events" (include "sumologic.fullname" .) }}
+  name: {{ printf "%s-events" (include "sumologic.fullname" .) }}-fluentd
   labels:
     app: {{ printf "%s-events" (include "sumologic.labels.app" .) }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/events-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/events-statefulset.yaml
@@ -10,7 +10,7 @@ spec:
   selector:
     matchLabels:
       app: {{ printf "%s-events" (include "sumologic.labels.app" .) }}
-  serviceName: {{ printf "%s-events-headless" (include "sumologic.fullname" .) }}
+  serviceName: {{ printf "%s-events-fluentd-headless" (include "sumologic.fullname" .) }}
   podManagementPolicy: "Parallel"
   template:
     metadata:

--- a/deploy/helm/sumologic/templates/service-headless.yaml
+++ b/deploy/helm/sumologic/templates/service-headless.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "sumologic.fullname" . }}-headless
+  name: {{ template "sumologic.fullname" . }}-fluentd-headless
   labels:
     app: {{ template "sumologic.labels.app" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/service.yaml
+++ b/deploy/helm/sumologic/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "sumologic.fullname" . }}
+  name: {{ template "sumologic.fullname" . }}-fluentd
   labels:
     app: {{ template "sumologic.labels.app" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       app: {{ template "sumologic.labels.app" . }}
-  serviceName: {{ template "sumologic.fullname" . }}-headless
+  serviceName: {{ template "sumologic.fullname" . }}-fluentd-headless
   podManagementPolicy: "Parallel"
   replicas: {{ .Values.fluentd.statefulset.replicaCount }}
   template:

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -492,7 +492,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: collection-sumologic-events
+  name: collection-sumologic-events-fluentd
   labels:
     app: collection-sumologic-events
     
@@ -536,7 +536,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: collection-sumologic
+  name: collection-sumologic-fluentd
   labels:
     app: collection-sumologic
     

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -473,7 +473,7 @@ roleRef:
 apiVersion: v1
 kind: Service
 metadata:
-  name: collection-sumologic-events-headless
+  name: collection-sumologic-events-fluentd-headless
   labels:
     app: collection-sumologic-events
     
@@ -509,7 +509,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: collection-sumologic-headless
+  name: collection-sumologic-fluentd-headless
   labels:
     app: collection-sumologic
     
@@ -571,7 +571,7 @@ spec:
   selector:
     matchLabels:
       app: collection-sumologic-events
-  serviceName: collection-sumologic-events-headless
+  serviceName: collection-sumologic-events-fluentd-headless
   podManagementPolicy: "Parallel"
   template:
     metadata:
@@ -639,7 +639,7 @@ spec:
   selector:
     matchLabels:
       app: collection-sumologic
-  serviceName: collection-sumologic-headless
+  serviceName: collection-sumologic-fluentd-headless
   podManagementPolicy: "Parallel"
   replicas: 3
   template:


### PR DESCRIPTION
###### Description

Found that our e2e tests were failing due to logs and metrics not being sent, while events were still working. I updated the service name to include `fluentd`, tested locally and it seems to be working again

###### Testing performed

- [ ] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
