### PR TITLE
add quotes when specifying events sourceCategory

### DIFF
--- a/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
@@ -94,7 +94,7 @@ data:
 
     resource "sumologic_http_source" "events_source" {
         name         = local.events-source-name
-        category     = {{ if .Values.fluentd.events.sourceCategory }}{{ .Values.fluentd.events.sourceCategory }}{{- else}}{{ "\"${var.cluster_name}/${local.events-source-name}\"" }}{{- end}}
+        category     = {{ if .Values.fluentd.events.sourceCategory }}{{ .Values.fluentd.events.sourceCategory | quote }}{{- else}}{{ "\"${var.cluster_name}/${local.events-source-name}\"" }}{{- end}}
         collector_id = "${sumologic_collector.collector.id}"
     }
 


### PR DESCRIPTION
###### Description

When a user specifies a custom `fluentd.events.sourceCategory`, the terraform template treats it as variable and results in an error, so we need to wrap it in quotes so that TF can treat it as a string.

We will need to backport this to `0.17` as well (except the config is `sumologic.events.sourceCategory` in `0.17`), since current customers are running into this bug.

###### Testing performed

- [x] reproduced the issue with provided `values.yaml`
- [x] re-packaged helm chart, reinstalled with helm
- [x] verified the collector was created correctly, with the correct source category for events
