### PR TITLE
[1.0.0] expose override raw conf for container log pipeline

### DIFF
--- a/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
@@ -1,3 +1,6 @@
+{{ if .Values.fluentd.logs.containers.overrideRawConfig }}
+{{ .Values.fluentd.logs.containers.overrideRawConfig }}
+{{- else}}
 <filter containers.**>
   @type record_transformer
   enable_ruby
@@ -14,7 +17,8 @@
   @label @NORMAL
 </match>
 <label @NORMAL>
-  #  only match fluentd logs based on fluentd container name
+  #  only match fluentd logs based on fluentd container name. by default, this is
+  #  <filter **collection-sumologic**>
   {{ printf "<filter **%s**>" (include "sumologic.fullname" .) }}
     # only ingest fluentd logs of levels: {error, fatal} and warning messages if buffer is full
     @type grep
@@ -54,3 +58,4 @@
     </buffer>
   </match>
 </label>
+{{- end}}

--- a/deploy/helm/sumologic/conf/logs/logs.source.systemd.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.systemd.conf
@@ -1,3 +1,4 @@
+{{ if .Values.fluentd.logs.kubelet.enabled }}
 <match host.kubelet.**>
   @type relabel
   @label @KUBELET
@@ -29,6 +30,8 @@
     </buffer>
   </match>
 </label>
+{{- end}}
+{{ if .Values.fluentd.logs.systemd.enabled }}
 <match host.**>
   @type relabel
   @label @SYSTEMD
@@ -65,3 +68,4 @@
     </buffer>
   </match>
 </label>
+{{- end}}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -211,6 +211,9 @@ fluentd:
 
     ## Container log configuration
     containers:
+      ## To override the contents of logs.source.containers.conf file. Leave empty for the default pipeline
+      overrideRawConfig: |-
+
       outputConf: |-
         @include logs.output.conf
       ## Set the _sourceName metadata field in Sumo Logic.
@@ -257,6 +260,7 @@ fluentd:
 
     ## Kubelet log configuration
     kubelet:
+      enabled: true
       outputConf: |-
         @include logs.output.conf
       ## Set the _sourceName metadata field in Sumo Logic.
@@ -283,6 +287,7 @@ fluentd:
 
     ## Systemd log configuration
     systemd:
+      enabled: true
       outputConf: |-
         @include logs.output.conf
       ## Set the _sourceCategory metadata field in Sumo Logic.

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -230,6 +230,7 @@ data:
     proxy_uri ""
     
   logs.source.containers.conf: |
+    
     <filter containers.**>
       @type record_transformer
       enable_ruby
@@ -246,7 +247,8 @@ data:
       @label @NORMAL
     </match>
     <label @NORMAL>
-      #  only match fluentd logs based on fluentd container name
+      #  only match fluentd logs based on fluentd container name. by default, this is
+      #  <filter **collection-sumologic**>
       <filter **collection-sumologic**>
         # only ingest fluentd logs of levels: {error, fatal} and warning messages if buffer is full
         @type grep
@@ -292,6 +294,7 @@ data:
       </buffer>
     </match>
   logs.source.systemd.conf: |-
+    
     <match host.kubelet.**>
       @type relabel
       @label @KUBELET
@@ -318,6 +321,7 @@ data:
         </buffer>
       </match>
     </label>
+    
     <match host.**>
       @type relabel
       @label @SYSTEMD


### PR DESCRIPTION
###### Description

This is similar to the way that Fluent-bit exposes their config. They have the option to set configs, but also to override entire sections if needed.

Here are two of the use-cases we want to solve with this new `fluentd.logs.containers.overrideRawConfig`:
1. If the user wants to change config that requires some form of indentation. examples include adding a new label to split the pipeline based on metadata (metadata based ingest budgets?), or forking to S3 (need to use the `copy` plugin in the output)
2. If the user wants to add a new tag to enrich custom logs with metadata. In that case, they could update the tags in this pipeline from `<filter containers.**>` to `<filter containers.** custom.**>`, which will allow for the custom logs with the custom tag to also go through this pipeline. In the case that their log files are named in a different format than the default docker logs files, they can also update the relevant regexes to accommodate that.

The idea here is to enable users to customize the part of the fluentd pipeline that is most conducive to customizations, with the clear indication that by doing so, they are **overriding** the default pipeline and that therefore not every custom change can be tested and supported. We'll document examples on how to achieve certain behavior (like the above), but anything else will be at the user's discretion.


(also I added the `enabled` flag for systemd and kubelet logs as a feature request from a previous github issue)

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
