### PR TITLE
add plugin specific log level for metadata and output plugins

### DIFF
--- a/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
@@ -30,11 +30,13 @@
   # third-party kubernetes metadata  filter plugin
   <filter containers.**>
     @type kubernetes_metadata
+    @log_level {{ .Values.fluentd.metadata.pluginLogLevel }}
     @include logs.kubernetes.metadata.filter.conf
   </filter>
   # sumologic kubernetes metadata enrichment filter plugin
   <filter containers.**>
     @type enhance_k8s_metadata
+    @log_level {{ .Values.fluentd.metadata.pluginLogLevel }}
     @include logs.enhance.k8s.metadata.filter.conf
   </filter>
 {{- .Values.fluentd.logs.containers.extraFilterPluginConf | nindent 4 }}
@@ -46,6 +48,7 @@
   <match containers.**>
     @type sumologic
     @id sumologic.endpoint.logs
+    @log_level {{ .Values.fluentd.logs.output.pluginLogLevel }}
 {{- .Values.fluentd.logs.containers.outputConf | nindent 6 }}
     <buffer>
       {{- if or .Values.fluentd.persistence.enabled (eq .Values.fluentd.buffer.type "file") }}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -189,6 +189,8 @@ fluentd:
     cacheTtl: "3600"
     ## Option to control the interval at which metadata cache is asynchronously refreshed (in seconds).
     cacheRefresh: "1800"
+    ## Option to give plugin specific log level
+    pluginLogLevel: "error"
 
   logs:
     ## Configuration for sumologic output plugin
@@ -202,6 +204,8 @@ fluentd:
       addTimestamp: true
       ## Field name when add_timestamp is on.
       timestampKey: "timestamp"
+      ## Option to give plugin specific log level
+      pluginLogLevel: "error"
       ## Additional config parameters for sumologic output plugin
       extraConf: |-
 

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -260,11 +260,13 @@ data:
       # third-party kubernetes metadata  filter plugin
       <filter containers.**>
         @type kubernetes_metadata
+        @log_level error
         @include logs.kubernetes.metadata.filter.conf
       </filter>
       # sumologic kubernetes metadata enrichment filter plugin
       <filter containers.**>
         @type enhance_k8s_metadata
+        @log_level error
         @include logs.enhance.k8s.metadata.filter.conf
       </filter>
       
@@ -276,6 +278,7 @@ data:
       <match containers.**>
         @type sumologic
         @id sumologic.endpoint.logs
+        @log_level error
         @include logs.output.conf
         <buffer>
           @type memory


### PR DESCRIPTION
###### Description

We have seen that the plugins are sending the `info` level logs. This PR adds the plugin-specific log level to avoid unnecessary logs.
![image](https://user-images.githubusercontent.com/56007827/78396356-1a076500-75a4-11ea-90e5-e970b1b0350f.png)


###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
