### PR TITLE
Update OtelCol and clean up tags

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -667,7 +667,7 @@ otelcol:
     memBallastSizeMib: "683"
     image:
       name: "sumologic/opentelemetry-collector"
-      tag: "0.2.7.0"
+      tag: "0.2.7.1"
       pullPolicy: IfNotPresent
   config:
     receivers:
@@ -692,39 +692,38 @@ otelcol:
       k8s_tagger:
         # When true, only IP is assigned and passed (so it could be tagged on another collector)
         passthrough: false
+        # When true, additional fields, such as serviceName are being also extracted
+        owner_lookup_enabled: true
         # Extracted fields and assigned names
         extract:
           metadata:
             # extract the following well-known metadata fields
             - containerId
             - containerName
-            - cluster
+            - clusterName
             - daemonSetName
-            - deployment
+            - deploymentName
             - hostName
             - namespace
-            - node
-            - owners
+            - nodeName
             - podId
             - podName
             - replicaSetName
             - serviceName
-            - startTime
             - statefulSetName
           tags:
             containerId: container_id
             containerName: container
-            cluster: cluster
+            clusterName: cluster
             daemonSetName: daemonset
-            deployment: deployment
-            hostName: hostname
+            deploymentName: deployment
+            hostName: host
             namespace: namespace
-            node: node
+            nodeName: node
             podId: pod_id
             podName: pod
             replicaSetName: replicaset
             serviceName: service_name
-            startTime: start_time
             statefulSetName: statefulset
           annotations:
             - tag_name: pod_annotation_%s

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -709,7 +709,7 @@ otelcol:
             - podId
             - podName
             - replicaSetName
-            - serviceName
+            # - serviceName
             - statefulSetName
           tags:
             containerId: container_id
@@ -723,7 +723,7 @@ otelcol:
             podId: pod_id
             podName: pod
             replicaSetName: replicaset
-            serviceName: service_name
+            # serviceName: service
             statefulSetName: statefulset
           annotations:
             - tag_name: pod_annotation_%s


### PR DESCRIPTION
###### Description

This is a replacement for https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/521/files

- uses host rather than hostName for the tag
- bumps OpenTelemetry Collector to more recent version (with config format changed)
- removes start_time tag

This is v1.0 equivalent of #530

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
