### PR TITLE
Set the default Prometheus scrape interval to 30s explicitly

### DIFF
--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -65,10 +65,14 @@ prometheus:
       matchLabels:
         app: collection-sumologic-otelcol
   prometheusSpec:
+    ## Interval between consecutive scrapes.
+    ##
+    scrapeInterval: "30s"
     ## Define resources requests and limits for single Pods.
     resources: {}
     # requests:
     #   memory: 400Mi
+
     thanos:
       version: v0.10.0
     containers:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -551,10 +551,15 @@ prometheus-operator:
           matchLabels:
             app: collection-sumologic-otelcol
     prometheusSpec:
+      ## Interval between consecutive scrapes.
+      ##
+      scrapeInterval: "30s"
+
       ## Define resources requests and limits for single Pods.
       resources: {}
       # requests:
       #   memory: 400Mi
+
       thanos:
         version: v0.10.0
       containers:


### PR DESCRIPTION
###### Description

Fill in your description here.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
