### PR TITLE
Fix control plane metrics url to be sync with fluentd

### DIFF
--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -153,13 +153,13 @@ prometheus:
         sourceLabels: [__name__]
     - # control plane metrics
       # coredns
-      url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.application.control-plane
+      url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.control-plane
       writeRelabelConfigs:
       - action: keep
         regex: coredns
         sourceLabels: [job]
     - # etcd server
-      url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.application.control-plane
+      url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.control-plane
       writeRelabelConfigs:
       - action: keep
         regex: kube-etcd

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -641,13 +641,13 @@ prometheus-operator:
               sourceLabels: [__name__]
         # control plane metrics
         # coredns
-        - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.application.control-plane
+        - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.control-plane
           writeRelabelConfigs:
             - action: keep
               regex: coredns
               sourceLabels: [job]
         # etcd server
-        - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.application.control-plane
+        - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.control-plane
           writeRelabelConfigs:
             - action: keep
               regex: kube-etcd

--- a/deploy/kubernetes/kube-prometheus-sumo-logic-mixin.libsonnet
+++ b/deploy/kubernetes/kube-prometheus-sumo-logic-mixin.libsonnet
@@ -147,7 +147,7 @@
         ]
       },
       {
-        url: $._config.sumologicCollectorSvc + "prometheus.metrics.application.control-plane",
+        url: $._config.sumologicCollectorSvc + "prometheus.metrics.control-plane",
         writeRelabelConfigs: [
           {
             action: "keep",
@@ -159,7 +159,7 @@
         ]
       },
       {
-        url: $._config.sumologicCollectorSvc + "prometheus.metrics.application.control-plane",
+        url: $._config.sumologicCollectorSvc + "prometheus.metrics.control-plane",
         writeRelabelConfigs: [
           {
             action: "keep",


### PR DESCRIPTION
###### Description

Fix url name for control plane metrics in prometheus config

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
