### PR TITLE
Fix filtering metrics for old kubernetes versions

### DIFF
--- a/deploy/helm/sumologic/conf/metrics/metrics.conf
+++ b/deploy/helm/sumologic/conf/metrics/metrics.conf
@@ -10,7 +10,7 @@
   @label @DATAPOINT
 </match>
 <label @DATAPOINT>
-{{- if and (eq .Capabilities.KubeVersion.Major "1") (gt (int .Capabilities.KubeVersion.Minor) 13) (lt (int .Capabilities.KubeVersion.Minor) 17) }}
+{{- if and (eq .Capabilities.KubeVersion.Major "1") (gt (int (regexFind "^\\d+" .Capabilities.KubeVersion.Minor)) 13) (lt (int (regexFind "^\\d+" .Capabilities.KubeVersion.Minor)) 17) }}
   <filter prometheus.metrics**> # NOTE: Remove this filter if you are running Kubernetes 1.13 or below.
     @type grep
     <exclude>


### PR DESCRIPTION
###### Description

Cast version which have suffixes to the base one before comparison: e.g. `15+` -> `15`

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
