### PR TITLE
Allow to override base url for non-helm installation

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -97,7 +97,15 @@ if [ -n "$GITHUB_TOKEN" ] && [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]; then
   echo "# This file is auto-generated." > deploy/kubernetes/setup-sumologic.yaml.tmpl
 
   with_files=$(ls deploy/helm/sumologic/templates/setup/*.yaml | sed 's#deploy/helm/sumologic/templates#-x templates#g' | sed 's/yaml/yaml \\/g')
-  eval 'sudo helm template deploy/helm/sumologic $with_files --namespace "\$NAMESPACE" --name collection --set dryRun=true >> deploy/kubernetes/setup-sumologic.yaml.tmpl --set sumologic.accessId="\$SUMOLOGIC_ACCESSID" --set sumologic.accessKey="\$SUMOLOGIC_ACCESSKEY" --set sumologic.collectorName="\$COLLECTOR_NAME" --set sumologic.clusterName="\$CLUSTER_NAME"'
+  eval 'sudo helm template deploy/helm/sumologic $with_files \
+        --namespace "\$NAMESPACE" \
+        --name collection \
+        --set dryRun=true >> deploy/kubernetes/setup-sumologic.yaml.tmpl \
+        --set sumologic.accessId="\$SUMOLOGIC_ACCESSID" \
+        --set sumologic.accessKey="\$SUMOLOGIC_ACCESSKEY" \
+        --set sumologic.collectorName="\$COLLECTOR_NAME" \
+        --set sumologic.clusterName="\$CLUSTER_NAME" \
+        --set sumologic.endpoint="\$SUMOLOGIC_BASE_URL"'
   if [[ $(git diff deploy/kubernetes/setup-sumologic.yaml.tmpl) ]]; then
       echo "Detected changes in 'setup-sumologic.yaml.tmpl', committing the updated version to $TRAVIS_PULL_REQUEST_BRANCH..."
       git add deploy/kubernetes/setup-sumologic.yaml.tmpl

--- a/deploy/kubernetes/setup-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/setup-sumologic.yaml.tmpl
@@ -262,6 +262,6 @@ spec:
         - name: SUMOLOGIC_ACCESSKEY
           value: $SUMOLOGIC_ACCESSKEY
         - name: SUMOLOGIC_BASE_URL
-          value: 
+          value: $SUMOLOGIC_BASE_URL
         
 


### PR DESCRIPTION
###### Description

Allo to override base url for non-helm installation

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
