### PR TITLE
Expose resource config for prometheus node-exporter and kube state metrics.

### DIFF
--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -13,10 +13,34 @@ grafana:
 prometheusOperator:
   ## Resource limits for prometheus operator
   resources: {}
+  # limits:
+  #   cpu: 200m
+  #   memory: 200Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 100Mi
   admissionWebhooks:
     enabled: false
   tlsProxy:
     enabled: false
+  ## Resource limits for kube-state-metrics
+  kube-state-metrics:
+    resources: {}
+    # limits:
+    #   cpu: 200m
+    #   memory: 200Mi
+    # requests:
+    #   cpu: 200m
+    #   memory: 200Mi
+  ## Resource limits for prometheus node exporter
+  prometheus-node-exporter:
+    resources: {}
+    # limits:
+    #   cpu: 200m
+    #   memory: 50Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 30Mi
 prometheus:
   additionalServiceMonitors:
   - name: collection-sumologic

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -514,10 +514,34 @@ prometheus-operator:
   prometheusOperator:
     ## Resource limits for prometheus operator
     resources: {}
+      # limits:
+      #   cpu: 200m
+      #   memory: 200Mi
+      # requests:
+      #   cpu: 100m
+      #   memory: 100Mi
     admissionWebhooks:
       enabled: false
     tlsProxy:
       enabled: false
+    ## Resource limits for kube-state-metrics
+    kube-state-metrics:
+      resources: {}
+        # limits:
+        #   cpu: 200m
+        #   memory: 200Mi
+        # requests:
+        #   cpu: 200m
+        #   memory: 200Mi
+    ## Resource limits for prometheus node exporter
+    prometheus-node-exporter:
+      resources: {}
+        # limits:
+        #   cpu: 200m
+        #   memory: 50Mi
+        # requests:
+        #   cpu: 100m
+        #   memory: 30Mi
   prometheus:
     additionalServiceMonitors:
       - name: collection-sumologic


### PR DESCRIPTION
Expose resource config for prometheus node-exporter and kube state metrics.

###### Description

Fill in your description here.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
