### PR TITLE
Do not pass histogram metrics to the fluentd

### DIFF
--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -136,15 +136,26 @@ prometheus:
       - action: drop
         regex: .*_bucket
         sourceLabels: [__name__]
-    - # kubelet metrics
+    - # kubelet metrics:
+      # kubelet_docker_operations_errors
+      # kubelet_docker_operations_errors_total
+      # kubelet_docker_operations_duration_seconds_count
+      # kubelet_docker_operations_duration_seconds_sum
+      # kubelet_runtime_operations_duration_seconds_count
+      # kubelet_runtime_operations_duration_seconds_sum
+      # kubelet_running_container_count
+      # kubelet_running_pod_count
+      # kubelet_docker_operations_latency_microseconds
+      # kubelet_docker_operations_latency_microseconds_count
+      # kubelet_docker_operations_latency_microseconds_sum
+      # kubelet_runtime_operations_latency_microseconds
+      # kubelet_runtime_operations_latency_microseconds_count
+      # kubelet_runtime_operations_latency_microseconds_sum
       url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.kubelet
       writeRelabelConfigs:
       - action: keep
-        regex: kubelet;(?:kubelet_docker_operations_errors.*|kubelet_docker_operations_(?:latency_micro|duration_)seconds.*|kubelet_running_container_count|kubelet_running_pod_count|kubelet_runtime_operations_(?:latency_micro|duration_)seconds.*)
+        regex: kubelet;(?:kubelet_docker_operations_errors(?:|_total)|kubelet_(?:docker|runtime)_operations_duration_seconds_(?:count|sum)|kubelet_running_(?:container|pod)_count|kubelet_(:?docker|runtime)_operations_latency_microseconds(?:|_count|_sum))
         sourceLabels: [job, __name__]
-      - action: drop
-        regex: .*_bucket
-        sourceLabels: [__name__]
     - # cadvisor container metrics
       url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.container
       writeRelabelConfigs:

--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -128,14 +128,32 @@ prometheus:
         regex: kube-scheduler;scheduler_(?:e2e_scheduling|binding|scheduling_algorithm)_latency_microseconds.*
         sourceLabels: [job, __name__]
     - # api server metrics
+      # apiserver_request_count
+      # apiserver_request_total
+      # apiserver_request_duration_seconds_count
+      # apiserver_request_duration_seconds_sum
+      # apiserver_request_latencies_count
+      # apiserver_request_latencies_sum
+      # apiserver_request_latencies_summary
+      # apiserver_request_latencies_summary_count
+      # apiserver_request_latencies_summary_sum
+      # etcd_request_cache_get_duration_seconds_count
+      # etcd_request_cache_get_duration_seconds_sum
+      # etcd_request_cache_add_duration_seconds_count
+      # etcd_request_cache_add_duration_seconds_sum
+      # etcd_request_cache_add_latencies_summary_count
+      # etcd_request_cache_add_latencies_summary_sum
+      # etcd_request_cache_get_latencies_summary_count
+      # etcd_request_cache_get_latencies_summary_sum
+      # etcd_helper_cache_hit_count
+      # etcd_helper_cache_hit_total
+      # etcd_helper_cache_miss_count
+      # etcd_helper_cache_miss_total
       url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.apiserver
       writeRelabelConfigs:
       - action: keep
-        regex: apiserver;(?:apiserver_request_(?:count|total)|apiserver_request_(?:latencies|duration_seconds).*|etcd_request_cache_get_(?:latencies_summary|duration_seconds).*|etcd_request_cache_add_(?:latencies_summary|duration_seconds).*|etcd_helper_cache_hit_(?:count|total)|etcd_helper_cache_miss_(?:count|total))
+        regex: apiserver;(?:apiserver_request_(?:count|total)|apiserver_request_(?:duration_seconds|latencies)_(?:count_sum)|apiserver_request_latencies_summary(?:|_count|_sum)|etcd_request_cache_(?:add|get)_(?:duration_seconds|latencies_summary)_(?:count|sum)|etcd_helper_cache_(?:hit|miss)_(?:count|total))
         sourceLabels: [job, __name__]
-      - action: drop
-        regex: .*_bucket
-        sourceLabels: [__name__]
     - # kubelet metrics:
       # kubelet_docker_operations_errors
       # kubelet_docker_operations_errors_total

--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -115,30 +115,45 @@ prometheus:
       - action: keep
         regex: kube-state-metrics;(?:kube_statefulset_status_observed_generation|kube_statefulset_status_replicas|kube_statefulset_replicas|kube_statefulset_metadata_generation|kube_daemonset_status_current_number_scheduled|kube_daemonset_status_desired_number_scheduled|kube_daemonset_status_number_misscheduled|kube_daemonset_status_number_unavailable|kube_deployment_spec_replicas|kube_deployment_status_replicas_available|kube_deployment_status_replicas_unavailable|kube_node_info|kube_node_status_allocatable|kube_node_status_capacity|kube_node_status_condition|kube_pod_container_info|kube_pod_container_resource_requests|kube_pod_container_resource_limits|kube_pod_container_status_ready|kube_pod_container_status_terminated_reason|kube_pod_container_status_waiting_reason|kube_pod_container_status_restarts_total|kube_pod_status_phase)
         sourceLabels: [job, __name__]
+      - action: drop
+        regex: .*_bucket
+        sourceLabels: [__name__]
     - # controller manager metrics
       url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.controller-manager
       writeRelabelConfigs:
       - action: keep
         regex: kubelet;cloudprovider_.*_api_request_duration_seconds.*
         sourceLabels: [job, __name__]
+      - action: drop
+        regex: .*_bucket
+        sourceLabels: [__name__]
     - # scheduler metrics
       url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.scheduler
       writeRelabelConfigs:
       - action: keep
         regex: kube-scheduler;scheduler_(?:e2e_scheduling|binding|scheduling_algorithm)_latency_microseconds.*
         sourceLabels: [job, __name__]
+      - action: drop
+        regex: .*_bucket
+        sourceLabels: [__name__]
     - # api server metrics
       url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.apiserver
       writeRelabelConfigs:
       - action: keep
         regex: apiserver;(?:apiserver_request_(?:count|total)|apiserver_request_(?:latencies|duration_seconds).*|etcd_request_cache_get_(?:latencies_summary|duration_seconds).*|etcd_request_cache_add_(?:latencies_summary|duration_seconds).*|etcd_helper_cache_hit_(?:count|total)|etcd_helper_cache_miss_(?:count|total))
         sourceLabels: [job, __name__]
+      - action: drop
+        regex: .*_bucket
+        sourceLabels: [__name__]
     - # kubelet metrics
       url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.kubelet
       writeRelabelConfigs:
       - action: keep
         regex: kubelet;(?:kubelet_docker_operations_errors.*|kubelet_docker_operations_(?:latency_micro|duration_)seconds.*|kubelet_running_container_count|kubelet_running_pod_count|kubelet_runtime_operations_(?:latency_micro|duration_)seconds.*)
         sourceLabels: [job, __name__]
+      - action: drop
+        regex: .*_bucket
+        sourceLabels: [__name__]
     - # cadvisor container metrics
       url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.container
       writeRelabelConfigs:
@@ -151,27 +166,42 @@ prometheus:
       - action: keep
         regex: kubelet;.+;(?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes)
         sourceLabels: [job, container, __name__]
+      - action: drop
+        regex: .*_bucket
+        sourceLabels: [__name__]
     - # cadvisor aggregate container metrics
       url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.container
       writeRelabelConfigs:
       - action: keep
         regex: kubelet;(?:container_network_receive_bytes_total|container_network_transmit_bytes_total)
         sourceLabels: [job, __name__]
+      - action: drop
+        regex: .*_bucket
+        sourceLabels: [__name__]
     - # node exporter metrics
       url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.node
       writeRelabelConfigs:
       - action: keep
         regex: node-exporter;(?:node_load1|node_load5|node_load15|node_cpu_seconds_total)
         sourceLabels: [job, __name__]
+      - action: drop
+        regex: .*_bucket
+        sourceLabels: [__name__]
     - # prometheus operator rules
       url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.operator.rule
       writeRelabelConfigs:
       - action: keep
         regex: 'cluster_quantile:apiserver_request_latencies:histogram_quantile|instance:node_filesystem_usage:sum|instance:node_network_receive_bytes:rate:sum|cluster_quantile:scheduler_e2e_scheduling_latency:histogram_quantile|cluster_quantile:scheduler_scheduling_algorithm_latency:histogram_quantile|cluster_quantile:scheduler_binding_latency:histogram_quantile|node_namespace_pod:kube_pod_info:|:kube_pod_info_node_count:|node:node_num_cpu:sum|:node_cpu_utilisation:avg1m|node:node_cpu_utilisation:avg1m|node:cluster_cpu_utilisation:ratio|:node_cpu_saturation_load1:|node:node_cpu_saturation_load1:|:node_memory_utilisation:|node:node_memory_bytes_total:sum|node:node_memory_utilisation:ratio|node:cluster_memory_utilisation:ratio|:node_memory_swap_io_bytes:sum_rate|node:node_memory_utilisation:|node:node_memory_utilisation_2:|node:node_memory_swap_io_bytes:sum_rate|:node_disk_utilisation:avg_irate|node:node_disk_utilisation:avg_irate|:node_disk_saturation:avg_irate|node:node_disk_saturation:avg_irate|node:node_filesystem_usage:|node:node_filesystem_avail:|:node_net_utilisation:sum_irate|node:node_net_utilisation:sum_irate|:node_net_saturation:sum_irate|node:node_net_saturation:sum_irate|node:node_inodes_total:|node:node_inodes_free:'
         sourceLabels: [__name__]
+      - action: drop
+        regex: .*_bucket
+        sourceLabels: [__name__]
     - # health
       url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics
       writeRelabelConfigs:
       - action: keep
         regex: (?:up|prometheus_remote_storage_.*|fluentd_.*|fluentbit.*|otelcol.*)
+        sourceLabels: [__name__]
+      - action: drop
+        regex: .*_bucket
         sourceLabels: [__name__]

--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -152,7 +152,7 @@ prometheus:
       url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.apiserver
       writeRelabelConfigs:
       - action: keep
-        regex: apiserver;(?:apiserver_request_(?:count|total)|apiserver_request_(?:duration_seconds|latencies)_(?:_count|_sum)|apiserver_request_latencies_summary(?:|_count|_sum)|etcd_request_cache_(?:add|get)_(?:duration_seconds|latencies_summary)_(?:count|sum)|etcd_helper_cache_(?:hit|miss)_(?:count|total))
+        regex: apiserver;(?:apiserver_request_(?:count|total)|apiserver_request_(?:duration_seconds|latencies)_(?:count|sum)|apiserver_request_latencies_summary(?:|_count|_sum)|etcd_request_cache_(?:add|get)_(?:duration_seconds|latencies_summary)_(?:count|sum)|etcd_helper_cache_(?:hit|miss)_(?:count|total))
         sourceLabels: [job, __name__]
     - # kubelet metrics:
       # kubelet_docker_operations_errors

--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -152,7 +152,7 @@ prometheus:
       url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.apiserver
       writeRelabelConfigs:
       - action: keep
-        regex: apiserver;(?:apiserver_request_(?:count|total)|apiserver_request_(?:duration_seconds|latencies)_(?:count_sum)|apiserver_request_latencies_summary(?:|_count|_sum)|etcd_request_cache_(?:add|get)_(?:duration_seconds|latencies_summary)_(?:count|sum)|etcd_helper_cache_(?:hit|miss)_(?:count|total))
+        regex: apiserver;(?:apiserver_request_(?:count|total)|apiserver_request_(?:duration_seconds|latencies)_(?:_count|_sum)|apiserver_request_latencies_summary(?:|_count|_sum)|etcd_request_cache_(?:add|get)_(?:duration_seconds|latencies_summary)_(?:count|sum)|etcd_helper_cache_(?:hit|miss)_(?:count|total))
         sourceLabels: [job, __name__]
     - # kubelet metrics:
       # kubelet_docker_operations_errors

--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -115,27 +115,18 @@ prometheus:
       - action: keep
         regex: kube-state-metrics;(?:kube_statefulset_status_observed_generation|kube_statefulset_status_replicas|kube_statefulset_replicas|kube_statefulset_metadata_generation|kube_daemonset_status_current_number_scheduled|kube_daemonset_status_desired_number_scheduled|kube_daemonset_status_number_misscheduled|kube_daemonset_status_number_unavailable|kube_deployment_spec_replicas|kube_deployment_status_replicas_available|kube_deployment_status_replicas_unavailable|kube_node_info|kube_node_status_allocatable|kube_node_status_capacity|kube_node_status_condition|kube_pod_container_info|kube_pod_container_resource_requests|kube_pod_container_resource_limits|kube_pod_container_status_ready|kube_pod_container_status_terminated_reason|kube_pod_container_status_waiting_reason|kube_pod_container_status_restarts_total|kube_pod_status_phase)
         sourceLabels: [job, __name__]
-      - action: drop
-        regex: .*_bucket
-        sourceLabels: [__name__]
     - # controller manager metrics
       url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.controller-manager
       writeRelabelConfigs:
       - action: keep
         regex: kubelet;cloudprovider_.*_api_request_duration_seconds.*
         sourceLabels: [job, __name__]
-      - action: drop
-        regex: .*_bucket
-        sourceLabels: [__name__]
     - # scheduler metrics
       url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.scheduler
       writeRelabelConfigs:
       - action: keep
         regex: kube-scheduler;scheduler_(?:e2e_scheduling|binding|scheduling_algorithm)_latency_microseconds.*
         sourceLabels: [job, __name__]
-      - action: drop
-        regex: .*_bucket
-        sourceLabels: [__name__]
     - # api server metrics
       url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.apiserver
       writeRelabelConfigs:
@@ -166,42 +157,27 @@ prometheus:
       - action: keep
         regex: kubelet;.+;(?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes)
         sourceLabels: [job, container, __name__]
-      - action: drop
-        regex: .*_bucket
-        sourceLabels: [__name__]
     - # cadvisor aggregate container metrics
       url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.container
       writeRelabelConfigs:
       - action: keep
         regex: kubelet;(?:container_network_receive_bytes_total|container_network_transmit_bytes_total)
         sourceLabels: [job, __name__]
-      - action: drop
-        regex: .*_bucket
-        sourceLabels: [__name__]
     - # node exporter metrics
       url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.node
       writeRelabelConfigs:
       - action: keep
         regex: node-exporter;(?:node_load1|node_load5|node_load15|node_cpu_seconds_total)
         sourceLabels: [job, __name__]
-      - action: drop
-        regex: .*_bucket
-        sourceLabels: [__name__]
     - # prometheus operator rules
       url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.operator.rule
       writeRelabelConfigs:
       - action: keep
         regex: 'cluster_quantile:apiserver_request_latencies:histogram_quantile|instance:node_filesystem_usage:sum|instance:node_network_receive_bytes:rate:sum|cluster_quantile:scheduler_e2e_scheduling_latency:histogram_quantile|cluster_quantile:scheduler_scheduling_algorithm_latency:histogram_quantile|cluster_quantile:scheduler_binding_latency:histogram_quantile|node_namespace_pod:kube_pod_info:|:kube_pod_info_node_count:|node:node_num_cpu:sum|:node_cpu_utilisation:avg1m|node:node_cpu_utilisation:avg1m|node:cluster_cpu_utilisation:ratio|:node_cpu_saturation_load1:|node:node_cpu_saturation_load1:|:node_memory_utilisation:|node:node_memory_bytes_total:sum|node:node_memory_utilisation:ratio|node:cluster_memory_utilisation:ratio|:node_memory_swap_io_bytes:sum_rate|node:node_memory_utilisation:|node:node_memory_utilisation_2:|node:node_memory_swap_io_bytes:sum_rate|:node_disk_utilisation:avg_irate|node:node_disk_utilisation:avg_irate|:node_disk_saturation:avg_irate|node:node_disk_saturation:avg_irate|node:node_filesystem_usage:|node:node_filesystem_avail:|:node_net_utilisation:sum_irate|node:node_net_utilisation:sum_irate|:node_net_saturation:sum_irate|node:node_net_saturation:sum_irate|node:node_inodes_total:|node:node_inodes_free:'
         sourceLabels: [__name__]
-      - action: drop
-        regex: .*_bucket
-        sourceLabels: [__name__]
     - # health
       url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics
       writeRelabelConfigs:
       - action: keep
         regex: (?:up|prometheus_remote_storage_.*|fluentd_.*|fluentbit.*|otelcol.*)
-        sourceLabels: [__name__]
-      - action: drop
-        regex: .*_bucket
         sourceLabels: [__name__]

--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -127,7 +127,7 @@ prometheus:
       - action: keep
         regex: kube-scheduler;scheduler_(?:e2e_scheduling|binding|scheduling_algorithm)_latency_microseconds.*
         sourceLabels: [job, __name__]
-    - # api server metrics
+    - # api server metrics:
       # apiserver_request_count
       # apiserver_request_total
       # apiserver_request_duration_seconds_count

--- a/deploy/helm/sumologic/upgrade-1.0.0.sh
+++ b/deploy/helm/sumologic/upgrade-1.0.0.sh
@@ -206,10 +206,10 @@ expected_metrics="/prometheus.metrics.state\n
 /prometheus.metrics.controller-manager\n
 /prometheus.metrics.scheduler\n
 /prometheus.metrics.apiserver\n
--          regex: apiserver;(?:apiserver_request_(?:count|total)|apiserver_request_(?:latencies|duration_seconds).*|etcd_request_cache_get_(?:latencies_summary|duration_seconds).*|etcd_request_cache_add_(?:latencies_summary|duration_seconds).*|etcd_helper_cache_hit_(?:count|total)|etcd_helper_cache_miss_(?:count|total))\n
+-          regex: apiserver;(?:apiserver_request_(?:count|total)|apiserver_request_(?:duration_seconds|latencies)_(?:count|sum)|apiserver_request_latencies_summary(?:|_count|_sum)|etcd_request_cache_(?:add|get)_(?:duration_seconds|latencies_summary)_(?:count|sum)|etcd_helper_cache_(?:hit|miss)_(?:count|total))\n
 +          regex: apiserver;(?:apiserver_request_(?:count|total)|apiserver_request_latenc(?:ies|y_seconds).*|etcd_request_cache_get_latenc(?:ies_summary|y_seconds).*|etcd_request_cache_add_latenc(?:ies_summary|y_seconds).*|etcd_helper_cache_hit_(?:count|total)|etcd_helper_cache_miss_(?:count|total))\n
 /prometheus.metrics.kubelet\n
--          regex: kubelet;(?:kubelet_docker_operations_errors.*|kubelet_docker_operations_(?:latency_micro|duration_)seconds.*|kubelet_running_container_count|kubelet_running_pod_count|kubelet_runtime_operations_(?:latency_micro|duration_)seconds.*)\n
+-          regex: kubelet;(?:kubelet_docker_operations_errors(?:|_total)|kubelet_(?:docker|runtime)_operations_duration_seconds_(?:count|sum)|kubelet_running_(?:container|pod)_count|kubelet_(:?docker|runtime)_operations_latency_microseconds(?:|_count|_sum))\n
 +          regex: kubelet;(?:kubelet_docker_operations_errors|kubelet_docker_operations_latency_microseconds|kubelet_running_container_count|kubelet_running_pod_count|kubelet_runtime_operations_latency_microseconds.*)\n
 /prometheus.metrics.container\n
 -          regex: kubelet;.+;(?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes)\n

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -638,15 +638,26 @@ prometheus-operator:
             - action: drop
               regex: .*_bucket
               sourceLabels: [__name__]
-        # kubelet metrics
+        # kubelet metrics:
+        # kubelet_docker_operations_errors
+        # kubelet_docker_operations_errors_total
+        # kubelet_docker_operations_duration_seconds_count
+        # kubelet_docker_operations_duration_seconds_sum
+        # kubelet_runtime_operations_duration_seconds_count
+        # kubelet_runtime_operations_duration_seconds_sum
+        # kubelet_running_container_count
+        # kubelet_running_pod_count
+        # kubelet_docker_operations_latency_microseconds
+        # kubelet_docker_operations_latency_microseconds_count
+        # kubelet_docker_operations_latency_microseconds_sum
+        # kubelet_runtime_operations_latency_microseconds
+        # kubelet_runtime_operations_latency_microseconds_count
+        # kubelet_runtime_operations_latency_microseconds_sum
         - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.kubelet
           writeRelabelConfigs:
             - action: keep
-              regex: kubelet;(?:kubelet_docker_operations_errors.*|kubelet_docker_operations_(?:latency_micro|duration_)seconds.*|kubelet_running_container_count|kubelet_running_pod_count|kubelet_runtime_operations_(?:latency_micro|duration_)seconds.*)
+              regex: kubelet;(?:kubelet_docker_operations_errors(?:|_total)|kubelet_(?:docker|runtime)_operations_duration_seconds_(?:count|sum)|kubelet_running_(?:container|pod)_count|kubelet_(:?docker|runtime)_operations_latency_microseconds(?:|_count|_sum))
               sourceLabels: [job, __name__]
-            - action: drop
-              regex: .*_bucket
-              sourceLabels: [__name__]
         # cadvisor container metrics
         - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.container
           writeRelabelConfigs:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -654,7 +654,7 @@ prometheus-operator:
         - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.apiserver
           writeRelabelConfigs:
             - action: keep
-              regex: apiserver;(?:apiserver_request_(?:count|total)|apiserver_request_(?:duration_seconds|latencies)_(?:_count|_sum)|apiserver_request_latencies_summary(?:|_count|_sum)|etcd_request_cache_(?:add|get)_(?:duration_seconds|latencies_summary)_(?:count|sum)|etcd_helper_cache_(?:hit|miss)_(?:count|total))
+              regex: apiserver;(?:apiserver_request_(?:count|total)|apiserver_request_(?:duration_seconds|latencies)_(?:count|sum)|apiserver_request_latencies_summary(?:|_count|_sum)|etcd_request_cache_(?:add|get)_(?:duration_seconds|latencies_summary)_(?:count|sum)|etcd_helper_cache_(?:hit|miss)_(?:count|total))
               sourceLabels: [job, __name__]
         # kubelet metrics:
         # kubelet_docker_operations_errors

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -617,27 +617,18 @@ prometheus-operator:
             - action: keep
               regex: kube-state-metrics;(?:kube_statefulset_status_observed_generation|kube_statefulset_status_replicas|kube_statefulset_replicas|kube_statefulset_metadata_generation|kube_daemonset_status_current_number_scheduled|kube_daemonset_status_desired_number_scheduled|kube_daemonset_status_number_misscheduled|kube_daemonset_status_number_unavailable|kube_deployment_spec_replicas|kube_deployment_status_replicas_available|kube_deployment_status_replicas_unavailable|kube_node_info|kube_node_status_allocatable|kube_node_status_capacity|kube_node_status_condition|kube_pod_container_info|kube_pod_container_resource_requests|kube_pod_container_resource_limits|kube_pod_container_status_ready|kube_pod_container_status_terminated_reason|kube_pod_container_status_waiting_reason|kube_pod_container_status_restarts_total|kube_pod_status_phase)
               sourceLabels: [job, __name__]
-            - action: drop
-              regex: .*_bucket
-              sourceLabels: [__name__]
         # controller manager metrics
         - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.controller-manager
           writeRelabelConfigs:
             - action: keep
               regex: kubelet;cloudprovider_.*_api_request_duration_seconds.*
               sourceLabels: [job, __name__]
-            - action: drop
-              regex: .*_bucket
-              sourceLabels: [__name__]
         # scheduler metrics
         - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.scheduler
           writeRelabelConfigs:
             - action: keep
               regex: kube-scheduler;scheduler_(?:e2e_scheduling|binding|scheduling_algorithm)_latency_microseconds.*
               sourceLabels: [job, __name__]
-            - action: drop
-              regex: .*_bucket
-              sourceLabels: [__name__]
         # api server metrics
         - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.apiserver
           writeRelabelConfigs:
@@ -668,44 +659,29 @@ prometheus-operator:
             - action: keep
               regex: kubelet;.+;(?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes)
               sourceLabels: [job,container,__name__]
-            - action: drop
-              regex: .*_bucket
-              sourceLabels: [__name__]
         # cadvisor aggregate container metrics
         - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.container
           writeRelabelConfigs:
             - action: keep
               regex: kubelet;(?:container_network_receive_bytes_total|container_network_transmit_bytes_total)
               sourceLabels: [job,__name__]
-            - action: drop
-              regex: .*_bucket
-              sourceLabels: [__name__]
         # node exporter metrics
         - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.node
           writeRelabelConfigs:
             - action: keep
               regex: node-exporter;(?:node_load1|node_load5|node_load15|node_cpu_seconds_total)
               sourceLabels: [job, __name__]
-            - action: drop
-              regex: .*_bucket
-              sourceLabels: [__name__]
         # prometheus operator rules
         - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.operator.rule
           writeRelabelConfigs:
             - action: keep
               regex: 'cluster_quantile:apiserver_request_latencies:histogram_quantile|instance:node_filesystem_usage:sum|instance:node_network_receive_bytes:rate:sum|cluster_quantile:scheduler_e2e_scheduling_latency:histogram_quantile|cluster_quantile:scheduler_scheduling_algorithm_latency:histogram_quantile|cluster_quantile:scheduler_binding_latency:histogram_quantile|node_namespace_pod:kube_pod_info:|:kube_pod_info_node_count:|node:node_num_cpu:sum|:node_cpu_utilisation:avg1m|node:node_cpu_utilisation:avg1m|node:cluster_cpu_utilisation:ratio|:node_cpu_saturation_load1:|node:node_cpu_saturation_load1:|:node_memory_utilisation:|node:node_memory_bytes_total:sum|node:node_memory_utilisation:ratio|node:cluster_memory_utilisation:ratio|:node_memory_swap_io_bytes:sum_rate|node:node_memory_utilisation:|node:node_memory_utilisation_2:|node:node_memory_swap_io_bytes:sum_rate|:node_disk_utilisation:avg_irate|node:node_disk_utilisation:avg_irate|:node_disk_saturation:avg_irate|node:node_disk_saturation:avg_irate|node:node_filesystem_usage:|node:node_filesystem_avail:|:node_net_utilisation:sum_irate|node:node_net_utilisation:sum_irate|:node_net_saturation:sum_irate|node:node_net_saturation:sum_irate|node:node_inodes_total:|node:node_inodes_free:'
               sourceLabels: [__name__]
-            - action: drop
-              regex: .*_bucket
-              sourceLabels: [__name__]
         # health
         - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics
           writeRelabelConfigs:
             - action: keep
               regex: (?:up|prometheus_remote_storage_.*|fluentd_.*|fluentbit.*|otelcol.*)
-              sourceLabels: [__name__]
-            - action: drop
-              regex: .*_bucket
               sourceLabels: [__name__]
 
 ## Configure falco

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -617,18 +617,27 @@ prometheus-operator:
             - action: keep
               regex: kube-state-metrics;(?:kube_statefulset_status_observed_generation|kube_statefulset_status_replicas|kube_statefulset_replicas|kube_statefulset_metadata_generation|kube_daemonset_status_current_number_scheduled|kube_daemonset_status_desired_number_scheduled|kube_daemonset_status_number_misscheduled|kube_daemonset_status_number_unavailable|kube_deployment_spec_replicas|kube_deployment_status_replicas_available|kube_deployment_status_replicas_unavailable|kube_node_info|kube_node_status_allocatable|kube_node_status_capacity|kube_node_status_condition|kube_pod_container_info|kube_pod_container_resource_requests|kube_pod_container_resource_limits|kube_pod_container_status_ready|kube_pod_container_status_terminated_reason|kube_pod_container_status_waiting_reason|kube_pod_container_status_restarts_total|kube_pod_status_phase)
               sourceLabels: [job, __name__]
+            - action: drop
+              regex: .*_bucket
+              sourceLabels: [__name__]
         # controller manager metrics
         - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.controller-manager
           writeRelabelConfigs:
             - action: keep
               regex: kubelet;cloudprovider_.*_api_request_duration_seconds.*
               sourceLabels: [job, __name__]
+            - action: drop
+              regex: .*_bucket
+              sourceLabels: [__name__]
         # scheduler metrics
         - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.scheduler
           writeRelabelConfigs:
             - action: keep
               regex: kube-scheduler;scheduler_(?:e2e_scheduling|binding|scheduling_algorithm)_latency_microseconds.*
               sourceLabels: [job, __name__]
+            - action: drop
+              regex: .*_bucket
+              sourceLabels: [__name__]
         # api server metrics
         - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.apiserver
           writeRelabelConfigs:
@@ -659,29 +668,44 @@ prometheus-operator:
             - action: keep
               regex: kubelet;.+;(?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes)
               sourceLabels: [job,container,__name__]
+            - action: drop
+              regex: .*_bucket
+              sourceLabels: [__name__]
         # cadvisor aggregate container metrics
         - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.container
           writeRelabelConfigs:
             - action: keep
               regex: kubelet;(?:container_network_receive_bytes_total|container_network_transmit_bytes_total)
               sourceLabels: [job,__name__]
+            - action: drop
+              regex: .*_bucket
+              sourceLabels: [__name__]
         # node exporter metrics
         - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.node
           writeRelabelConfigs:
             - action: keep
               regex: node-exporter;(?:node_load1|node_load5|node_load15|node_cpu_seconds_total)
               sourceLabels: [job, __name__]
+            - action: drop
+              regex: .*_bucket
+              sourceLabels: [__name__]
         # prometheus operator rules
         - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.operator.rule
           writeRelabelConfigs:
             - action: keep
               regex: 'cluster_quantile:apiserver_request_latencies:histogram_quantile|instance:node_filesystem_usage:sum|instance:node_network_receive_bytes:rate:sum|cluster_quantile:scheduler_e2e_scheduling_latency:histogram_quantile|cluster_quantile:scheduler_scheduling_algorithm_latency:histogram_quantile|cluster_quantile:scheduler_binding_latency:histogram_quantile|node_namespace_pod:kube_pod_info:|:kube_pod_info_node_count:|node:node_num_cpu:sum|:node_cpu_utilisation:avg1m|node:node_cpu_utilisation:avg1m|node:cluster_cpu_utilisation:ratio|:node_cpu_saturation_load1:|node:node_cpu_saturation_load1:|:node_memory_utilisation:|node:node_memory_bytes_total:sum|node:node_memory_utilisation:ratio|node:cluster_memory_utilisation:ratio|:node_memory_swap_io_bytes:sum_rate|node:node_memory_utilisation:|node:node_memory_utilisation_2:|node:node_memory_swap_io_bytes:sum_rate|:node_disk_utilisation:avg_irate|node:node_disk_utilisation:avg_irate|:node_disk_saturation:avg_irate|node:node_disk_saturation:avg_irate|node:node_filesystem_usage:|node:node_filesystem_avail:|:node_net_utilisation:sum_irate|node:node_net_utilisation:sum_irate|:node_net_saturation:sum_irate|node:node_net_saturation:sum_irate|node:node_inodes_total:|node:node_inodes_free:'
               sourceLabels: [__name__]
+            - action: drop
+              regex: .*_bucket
+              sourceLabels: [__name__]
         # health
         - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics
           writeRelabelConfigs:
             - action: keep
               regex: (?:up|prometheus_remote_storage_.*|fluentd_.*|fluentbit.*|otelcol.*)
+              sourceLabels: [__name__]
+            - action: drop
+              regex: .*_bucket
               sourceLabels: [__name__]
 
 ## Configure falco

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -629,7 +629,7 @@ prometheus-operator:
             - action: keep
               regex: kube-scheduler;scheduler_(?:e2e_scheduling|binding|scheduling_algorithm)_latency_microseconds.*
               sourceLabels: [job, __name__]
-        # api server metrics
+        # api server metrics:
         # apiserver_request_count
         # apiserver_request_total
         # apiserver_request_duration_seconds_count

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -630,14 +630,32 @@ prometheus-operator:
               regex: kube-scheduler;scheduler_(?:e2e_scheduling|binding|scheduling_algorithm)_latency_microseconds.*
               sourceLabels: [job, __name__]
         # api server metrics
+        # apiserver_request_count
+        # apiserver_request_total
+        # apiserver_request_duration_seconds_count
+        # apiserver_request_duration_seconds_sum
+        # apiserver_request_latencies_count
+        # apiserver_request_latencies_sum
+        # apiserver_request_latencies_summary
+        # apiserver_request_latencies_summary_count
+        # apiserver_request_latencies_summary_sum
+        # etcd_request_cache_get_duration_seconds_count
+        # etcd_request_cache_get_duration_seconds_sum
+        # etcd_request_cache_add_duration_seconds_count
+        # etcd_request_cache_add_duration_seconds_sum
+        # etcd_request_cache_add_latencies_summary_count
+        # etcd_request_cache_add_latencies_summary_sum
+        # etcd_request_cache_get_latencies_summary_count
+        # etcd_request_cache_get_latencies_summary_sum
+        # etcd_helper_cache_hit_count
+        # etcd_helper_cache_hit_total
+        # etcd_helper_cache_miss_count
+        # etcd_helper_cache_miss_total
         - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.apiserver
           writeRelabelConfigs:
             - action: keep
-              regex: apiserver;(?:apiserver_request_(?:count|total)|apiserver_request_(?:latencies|duration_seconds).*|etcd_request_cache_get_(?:latencies_summary|duration_seconds).*|etcd_request_cache_add_(?:latencies_summary|duration_seconds).*|etcd_helper_cache_hit_(?:count|total)|etcd_helper_cache_miss_(?:count|total))
+              regex: apiserver;(?:apiserver_request_(?:count|total)|apiserver_request_(?:duration_seconds|latencies)_(?:count_sum)|apiserver_request_latencies_summary(?:|_count|_sum)|etcd_request_cache_(?:add|get)_(?:duration_seconds|latencies_summary)_(?:count|sum)|etcd_helper_cache_(?:hit|miss)_(?:count|total))
               sourceLabels: [job, __name__]
-            - action: drop
-              regex: .*_bucket
-              sourceLabels: [__name__]
         # kubelet metrics:
         # kubelet_docker_operations_errors
         # kubelet_docker_operations_errors_total

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -635,12 +635,18 @@ prometheus-operator:
             - action: keep
               regex: apiserver;(?:apiserver_request_(?:count|total)|apiserver_request_(?:latencies|duration_seconds).*|etcd_request_cache_get_(?:latencies_summary|duration_seconds).*|etcd_request_cache_add_(?:latencies_summary|duration_seconds).*|etcd_helper_cache_hit_(?:count|total)|etcd_helper_cache_miss_(?:count|total))
               sourceLabels: [job, __name__]
+            - action: drop
+              regex: .*_bucket
+              sourceLabels: [__name__]
         # kubelet metrics
         - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.kubelet
           writeRelabelConfigs:
             - action: keep
               regex: kubelet;(?:kubelet_docker_operations_errors.*|kubelet_docker_operations_(?:latency_micro|duration_)seconds.*|kubelet_running_container_count|kubelet_running_pod_count|kubelet_runtime_operations_(?:latency_micro|duration_)seconds.*)
               sourceLabels: [job, __name__]
+            - action: drop
+              regex: .*_bucket
+              sourceLabels: [__name__]
         # cadvisor container metrics
         - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.container
           writeRelabelConfigs:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -654,7 +654,7 @@ prometheus-operator:
         - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.apiserver
           writeRelabelConfigs:
             - action: keep
-              regex: apiserver;(?:apiserver_request_(?:count|total)|apiserver_request_(?:duration_seconds|latencies)_(?:count_sum)|apiserver_request_latencies_summary(?:|_count|_sum)|etcd_request_cache_(?:add|get)_(?:duration_seconds|latencies_summary)_(?:count|sum)|etcd_helper_cache_(?:hit|miss)_(?:count|total))
+              regex: apiserver;(?:apiserver_request_(?:count|total)|apiserver_request_(?:duration_seconds|latencies)_(?:_count|_sum)|apiserver_request_latencies_summary(?:|_count|_sum)|etcd_request_cache_(?:add|get)_(?:duration_seconds|latencies_summary)_(?:count|sum)|etcd_helper_cache_(?:hit|miss)_(?:count|total))
               sourceLabels: [job, __name__]
         # kubelet metrics:
         # kubelet_docker_operations_errors

--- a/deploy/kubernetes/kube-prometheus-sumo-logic-mixin.libsonnet
+++ b/deploy/kubernetes/kube-prometheus-sumo-logic-mixin.libsonnet
@@ -15,6 +15,13 @@
               "job",
               "__name__"
             ]
+          },
+          {
+            action: "drop",
+            regex: ".*_bucket",
+            sourceLabels: [
+              "__name__"
+            ]
           }
         ]
       },
@@ -26,6 +33,13 @@
             regex: "kubelet;cloudprovider_.*_api_request_duration_seconds.*",
             sourceLabels: [
               "job",
+              "__name__"
+            ]
+          },
+          {
+            action: "drop",
+            regex: ".*_bucket",
+            sourceLabels: [
               "__name__"
             ]
           }
@@ -41,6 +55,13 @@
               "job",
               "__name__"
             ]
+          },
+          {
+            action: "drop",
+            regex: ".*_bucket",
+            sourceLabels: [
+              "__name__"
+            ]
           }
         ]
       },
@@ -54,6 +75,13 @@
               "job",
               "__name__"
             ]
+          },
+          {
+            action: "drop",
+            regex: ".*_bucket",
+            sourceLabels: [
+              "__name__"
+            ]
           }
         ]
       },
@@ -65,6 +93,13 @@
             regex: "kubelet;(?:kubelet_docker_operations_errors.*|kubelet_docker_operations_(?:latency_micro|duration_)seconds.*|kubelet_running_container_count|kubelet_running_pod_count|kubelet_runtime_operations_(?:latency_micro|duration_)seconds.*)",
             sourceLabels: [
               "job",
+              "__name__"
+            ]
+          },
+          {
+            action: "drop",
+            regex: ".*_bucket",
+            sourceLabels: [
               "__name__"
             ]
           }
@@ -93,6 +128,13 @@
               "container",
               "__name__"
             ]
+          },
+          {
+            action: "drop",
+            regex: ".*_bucket",
+            sourceLabels: [
+              "__name__"
+            ]
           }
         ]
       },
@@ -104,6 +146,13 @@
             regex: "kubelet;(?:container_network_receive_bytes_total|container_network_transmit_bytes_total)",
             sourceLabels: [
               "job",
+              "__name__"
+            ]
+          },
+          {
+            action: "drop",
+            regex: ".*_bucket",
+            sourceLabels: [
               "__name__"
             ]
           }
@@ -119,6 +168,13 @@
               "job",
               "__name__"
             ]
+          },
+          {
+            action: "drop",
+            regex: ".*_bucket",
+            sourceLabels: [
+              "__name__"
+            ]
           }
         ]
       },
@@ -131,6 +187,13 @@
             sourceLabels: [
               "__name__"
             ]
+          },
+          {
+            action: "drop",
+            regex: ".*_bucket",
+            sourceLabels: [
+              "__name__"
+            ]
           }
         ]
       },
@@ -140,6 +203,13 @@
           {
             action: "keep",
             regex: "(?:up|prometheus_remote_storage_.*|fluentd_.*|fluentbit.*|otelcol.*)",
+            sourceLabels: [
+              "__name__"
+            ]
+          },
+          {
+            action: "drop",
+            regex: ".*_bucket",
             sourceLabels: [
               "__name__"
             ]

--- a/deploy/kubernetes/kube-prometheus-sumo-logic-mixin.libsonnet
+++ b/deploy/kubernetes/kube-prometheus-sumo-logic-mixin.libsonnet
@@ -69,16 +69,9 @@
         writeRelabelConfigs: [
           {
             action: "keep",
-            regex: "kubelet;(?:kubelet_docker_operations_errors.*|kubelet_docker_operations_(?:latency_micro|duration_)seconds.*|kubelet_running_container_count|kubelet_running_pod_count|kubelet_runtime_operations_(?:latency_micro|duration_)seconds.*)",
+            regex: "kubelet;(?:kubelet_docker_operations_errors(?:|_total)|kubelet_(?:docker|runtime)_operations_duration_seconds_(?:count|sum)|kubelet_running_(?:container|pod)_count|kubelet_(:?docker|runtime)_operations_latency_microseconds(?:|_count|_sum))",
             sourceLabels: [
               "job",
-              "__name__"
-            ]
-          },
-          {
-            action: "drop",
-            regex: ".*_bucket",
-            sourceLabels: [
               "__name__"
             ]
           }

--- a/deploy/kubernetes/kube-prometheus-sumo-logic-mixin.libsonnet
+++ b/deploy/kubernetes/kube-prometheus-sumo-logic-mixin.libsonnet
@@ -49,7 +49,7 @@
         writeRelabelConfigs: [
           {
             action: "keep",
-            regex: "apiserver;(?:apiserver_request_(?:count|total)|apiserver_request_(?:duration_seconds|latencies)_(?:count_sum)|apiserver_request_latencies_summary(?:|_count|_sum)|etcd_request_cache_(?:add|get)_(?:duration_seconds|latencies_summary)_(?:count|sum)|etcd_helper_cache_(?:hit|miss)_(?:count|total))",
+            regex: "apiserver;(?:apiserver_request_(?:count|total)|apiserver_request_(?:duration_seconds|latencies)_(?:_count|_sum)|apiserver_request_latencies_summary(?:|_count|_sum)|etcd_request_cache_(?:add|get)_(?:duration_seconds|latencies_summary)_(?:count|sum)|etcd_helper_cache_(?:hit|miss)_(?:count|total))",
             sourceLabels: [
               "job",
               "__name__"

--- a/deploy/kubernetes/kube-prometheus-sumo-logic-mixin.libsonnet
+++ b/deploy/kubernetes/kube-prometheus-sumo-logic-mixin.libsonnet
@@ -15,13 +15,6 @@
               "job",
               "__name__"
             ]
-          },
-          {
-            action: "drop",
-            regex: ".*_bucket",
-            sourceLabels: [
-              "__name__"
-            ]
           }
         ]
       },
@@ -35,13 +28,6 @@
               "job",
               "__name__"
             ]
-          },
-          {
-            action: "drop",
-            regex: ".*_bucket",
-            sourceLabels: [
-              "__name__"
-            ]
           }
         ]
       },
@@ -53,13 +39,6 @@
             regex: "kube-scheduler;scheduler_(?:e2e_scheduling|binding|scheduling_algorithm)_latency_microseconds.*",
             sourceLabels: [
               "job",
-              "__name__"
-            ]
-          },
-          {
-            action: "drop",
-            regex: ".*_bucket",
-            sourceLabels: [
               "__name__"
             ]
           }
@@ -128,13 +107,6 @@
               "container",
               "__name__"
             ]
-          },
-          {
-            action: "drop",
-            regex: ".*_bucket",
-            sourceLabels: [
-              "__name__"
-            ]
           }
         ]
       },
@@ -146,13 +118,6 @@
             regex: "kubelet;(?:container_network_receive_bytes_total|container_network_transmit_bytes_total)",
             sourceLabels: [
               "job",
-              "__name__"
-            ]
-          },
-          {
-            action: "drop",
-            regex: ".*_bucket",
-            sourceLabels: [
               "__name__"
             ]
           }
@@ -168,13 +133,6 @@
               "job",
               "__name__"
             ]
-          },
-          {
-            action: "drop",
-            regex: ".*_bucket",
-            sourceLabels: [
-              "__name__"
-            ]
           }
         ]
       },
@@ -187,13 +145,6 @@
             sourceLabels: [
               "__name__"
             ]
-          },
-          {
-            action: "drop",
-            regex: ".*_bucket",
-            sourceLabels: [
-              "__name__"
-            ]
           }
         ]
       },
@@ -203,13 +154,6 @@
           {
             action: "keep",
             regex: "(?:up|prometheus_remote_storage_.*|fluentd_.*|fluentbit.*|otelcol.*)",
-            sourceLabels: [
-              "__name__"
-            ]
-          },
-          {
-            action: "drop",
-            regex: ".*_bucket",
             sourceLabels: [
               "__name__"
             ]

--- a/deploy/kubernetes/kube-prometheus-sumo-logic-mixin.libsonnet
+++ b/deploy/kubernetes/kube-prometheus-sumo-logic-mixin.libsonnet
@@ -49,16 +49,9 @@
         writeRelabelConfigs: [
           {
             action: "keep",
-            regex: "apiserver;(?:apiserver_request_(?:count|total)|apiserver_request_(?:latencies|duration_seconds).*|etcd_request_cache_get_(?:latencies_summary|duration_seconds).*|etcd_request_cache_add_(?:latencies_summary|duration_seconds).*|etcd_helper_cache_hit_(?:count|total)|etcd_helper_cache_miss_(?:count|total))",
+            regex: "apiserver;(?:apiserver_request_(?:count|total)|apiserver_request_(?:duration_seconds|latencies)_(?:count_sum)|apiserver_request_latencies_summary(?:|_count|_sum)|etcd_request_cache_(?:add|get)_(?:duration_seconds|latencies_summary)_(?:count|sum)|etcd_helper_cache_(?:hit|miss)_(?:count|total))",
             sourceLabels: [
               "job",
-              "__name__"
-            ]
-          },
-          {
-            action: "drop",
-            regex: ".*_bucket",
-            sourceLabels: [
               "__name__"
             ]
           }

--- a/deploy/kubernetes/kube-prometheus-sumo-logic-mixin.libsonnet
+++ b/deploy/kubernetes/kube-prometheus-sumo-logic-mixin.libsonnet
@@ -49,7 +49,7 @@
         writeRelabelConfigs: [
           {
             action: "keep",
-            regex: "apiserver;(?:apiserver_request_(?:count|total)|apiserver_request_(?:duration_seconds|latencies)_(?:_count|_sum)|apiserver_request_latencies_summary(?:|_count|_sum)|etcd_request_cache_(?:add|get)_(?:duration_seconds|latencies_summary)_(?:count|sum)|etcd_helper_cache_(?:hit|miss)_(?:count|total))",
+            regex: "apiserver;(?:apiserver_request_(?:count|total)|apiserver_request_(?:duration_seconds|latencies)_(?:count|sum)|apiserver_request_latencies_summary(?:|_count|_sum)|etcd_request_cache_(?:add|get)_(?:duration_seconds|latencies_summary)_(?:count|sum)|etcd_helper_cache_(?:hit|miss)_(?:count|total))",
             sourceLabels: [
               "job",
               "__name__"


### PR DESCRIPTION
###### Description

Drop histogram metrics (with `_bucket` suffix)

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
