### PR TITLE
Bump sumologic fluentd output plugin and override sumo_client with helm version

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN gem install fluent-plugin-s3
 RUN gem install fluent-plugin-systemd -v 1.0.2 \
        && gem install fluent-plugin-record-modifier -v 2.0.1 \
        && gem install fluent-plugin-kubernetes_metadata_filter -v 2.4.1 \
-       && gem install fluent-plugin-sumologic_output -v 1.7.0 \
+       && gem install fluent-plugin-sumologic_output -v 1.7.1 \
        && gem install fluent-plugin-concat -v 2.4.0 \
        && gem install fluent-plugin-rewrite-tag-filter -v 2.2.0 \
        && gem install fluent-plugin-prometheus -v 1.6.1

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN gem install fluent-plugin-s3
 RUN gem install fluent-plugin-systemd -v 1.0.2 \
        && gem install fluent-plugin-record-modifier -v 2.0.1 \
        && gem install fluent-plugin-kubernetes_metadata_filter -v 2.4.1 \
-       && gem install fluent-plugin-sumologic_output -v 1.6.1 \
+       && gem install fluent-plugin-sumologic_output -v 1.7.0 \
        && gem install fluent-plugin-concat -v 2.4.0 \
        && gem install fluent-plugin-rewrite-tag-filter -v 2.2.0 \
        && gem install fluent-plugin-prometheus -v 1.6.1

--- a/deploy/helm/sumologic/conf/events/events.conf
+++ b/deploy/helm/sumologic/conf/events/events.conf
@@ -34,6 +34,7 @@
 <match kubernetes.**>
   @type sumologic
   @id sumologic.endpoint.events
+  sumo_client {{ include "sumologic.sumo_client" . | quote }}
   endpoint "#{ENV['SUMO_ENDPOINT_EVENTS']}"
   data_type logs
   disable_cookies true

--- a/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
@@ -51,6 +51,7 @@
   <match containers.**>
     @type sumologic
     @id sumologic.endpoint.logs
+    sumo_client {{ include "sumologic.sumo_client" . | quote }}
     @log_level {{ .Values.fluentd.logs.output.pluginLogLevel }}
 {{- .Values.fluentd.logs.containers.outputConf | nindent 6 }}
     <buffer>

--- a/deploy/helm/sumologic/conf/logs/logs.source.default.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.default.conf
@@ -4,6 +4,7 @@
 <match **>
   @type sumologic
   @id sumologic.endpoint.logs.default
+  sumo_client {{ include "sumologic.sumo_client" . | quote }}
 {{- .Values.fluentd.logs.default.outputConf | nindent 4 }}
   <buffer>
     {{- if or .Values.fluentd.persistence.enabled (eq .Values.fluentd.buffer.type "file") }}

--- a/deploy/helm/sumologic/conf/logs/logs.source.systemd.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.systemd.conf
@@ -21,6 +21,7 @@
   <match **>
     @type sumologic
     @id sumologic.endpoint.logs.kubelet
+    sumo_client {{ include "sumologic.sumo_client" . | quote }}
 {{- .Values.fluentd.logs.kubelet.outputConf | nindent 6 }}
     <buffer>
       {{- if or .Values.fluentd.persistence.enabled (eq .Values.fluentd.buffer.type "file") }}
@@ -63,6 +64,7 @@
   <match **>
     @type sumologic
     @id sumologic.endpoint.logs.systemd
+    sumo_client {{ include "sumologic.sumo_client" . | quote }}
 {{- .Values.fluentd.logs.systemd.outputConf | nindent 6 }}
     <buffer>
       {{- if or .Values.fluentd.persistence.enabled (eq .Values.fluentd.buffer.type "file") }}

--- a/deploy/helm/sumologic/conf/metrics/metrics.conf
+++ b/deploy/helm/sumologic/conf/metrics/metrics.conf
@@ -40,6 +40,7 @@
   <match prometheus.metrics.apiserver**>
     @type sumologic
     @id sumologic.endpoint.metrics.apiserver
+    sumo_client {{ include "sumologic.sumo_client" . | quote }}
     endpoint "#{ENV['SUMO_ENDPOINT_METRICS_APISERVER']}"
 {{- .Values.fluentd.metrics.outputConf | nindent 6 }}
     <buffer>
@@ -56,6 +57,7 @@
   <match prometheus.metrics.kubelet**>
     @type sumologic
     @id sumologic.endpoint.metrics.kubelet
+    sumo_client {{ include "sumologic.sumo_client" . | quote }}
     endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBELET']}"
 {{- .Values.fluentd.metrics.outputConf | nindent 6 }}
     <buffer>
@@ -71,6 +73,7 @@
   <match prometheus.metrics.container**>
     @type sumologic
     @id sumologic.endpoint.metrics.container
+    sumo_client {{ include "sumologic.sumo_client" . | quote }}
     endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBELET']}"
 {{- .Values.fluentd.metrics.outputConf | nindent 6 }}
     <buffer>
@@ -86,6 +89,7 @@
   <match prometheus.metrics.controller-manager**>
     @type sumologic
     @id sumologic.endpoint.metrics.kube.controller.manager
+    sumo_client {{ include "sumologic.sumo_client" . | quote }}
     endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBE_CONTROLLER_MANAGER']}"
 {{- .Values.fluentd.metrics.outputConf | nindent 6 }}
     <buffer>
@@ -101,6 +105,7 @@
   <match prometheus.metrics.scheduler**>
     @type sumologic
     @id sumologic.endpoint.metrics.kube.scheduler
+    sumo_client {{ include "sumologic.sumo_client" . | quote }}
     endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBE_SCHEDULER']}"
 {{- .Values.fluentd.metrics.outputConf | nindent 6 }}
     <buffer>
@@ -116,6 +121,7 @@
   <match prometheus.metrics.state**>
     @type sumologic
     @id sumologic.endpoint.metrics.kube.state
+    sumo_client {{ include "sumologic.sumo_client" . | quote }}
     endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBE_STATE']}"
 {{- .Values.fluentd.metrics.outputConf | nindent 6 }}
     <buffer>
@@ -131,6 +137,7 @@
   <match prometheus.metrics.node**>
     @type sumologic
     @id sumologic.endpoint.metrics.node.exporter
+    sumo_client {{ include "sumologic.sumo_client" . | quote }}
     endpoint "#{ENV['SUMO_ENDPOINT_METRICS_NODE_EXPORTER']}"
 {{- .Values.fluentd.metrics.outputConf | nindent 6 }}
     <buffer>
@@ -146,6 +153,7 @@
   <match prometheus.metrics**>
     @type sumologic
     @id sumologic.endpoint.metrics
+    sumo_client {{ include "sumologic.sumo_client" . | quote }}
     endpoint "#{ENV['SUMO_ENDPOINT_METRICS']}"
 {{- .Values.fluentd.metrics.outputConf | nindent 6 }}
     <buffer>

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -37,6 +37,13 @@ heritage: "{{ .Release.Service }}"
 {{- end -}}
 
 {{/*
+Returns sumologic version string
+*/}}
+{{- define "sumologic.sumo_client" -}}
+"k8s-{{ .Chart.Version }}"
+{{- end -}}
+
+{{/*
 Get configuration value, otherwise returns default
 
 Example usage:

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -40,7 +40,7 @@ heritage: "{{ .Release.Service }}"
 Returns sumologic version string
 */}}
 {{- define "sumologic.sumo_client" -}}
-"k8s-{{ .Chart.Version }}"
+k8s_{{ .Chart.Version }}
 {{- end -}}
 
 {{/*

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -95,6 +95,7 @@ data:
       <match prometheus.metrics.apiserver**>
         @type sumologic
         @id sumologic.endpoint.metrics.apiserver
+        sumo_client "k8s_1.0.0-beta.2"
         endpoint "#{ENV['SUMO_ENDPOINT_METRICS_APISERVER']}"
         @include metrics.output.conf
         <buffer>
@@ -106,6 +107,7 @@ data:
       <match prometheus.metrics.kubelet**>
         @type sumologic
         @id sumologic.endpoint.metrics.kubelet
+        sumo_client "k8s_1.0.0-beta.2"
         endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBELET']}"
         @include metrics.output.conf
         <buffer>
@@ -116,6 +118,7 @@ data:
       <match prometheus.metrics.container**>
         @type sumologic
         @id sumologic.endpoint.metrics.container
+        sumo_client "k8s_1.0.0-beta.2"
         endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBELET']}"
         @include metrics.output.conf
         <buffer>
@@ -126,6 +129,7 @@ data:
       <match prometheus.metrics.controller-manager**>
         @type sumologic
         @id sumologic.endpoint.metrics.kube.controller.manager
+        sumo_client "k8s_1.0.0-beta.2"
         endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBE_CONTROLLER_MANAGER']}"
         @include metrics.output.conf
         <buffer>
@@ -136,6 +140,7 @@ data:
       <match prometheus.metrics.scheduler**>
         @type sumologic
         @id sumologic.endpoint.metrics.kube.scheduler
+        sumo_client "k8s_1.0.0-beta.2"
         endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBE_SCHEDULER']}"
         @include metrics.output.conf
         <buffer>
@@ -146,6 +151,7 @@ data:
       <match prometheus.metrics.state**>
         @type sumologic
         @id sumologic.endpoint.metrics.kube.state
+        sumo_client "k8s_1.0.0-beta.2"
         endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBE_STATE']}"
         @include metrics.output.conf
         <buffer>
@@ -156,6 +162,7 @@ data:
       <match prometheus.metrics.node**>
         @type sumologic
         @id sumologic.endpoint.metrics.node.exporter
+        sumo_client "k8s_1.0.0-beta.2"
         endpoint "#{ENV['SUMO_ENDPOINT_METRICS_NODE_EXPORTER']}"
         @include metrics.output.conf
         <buffer>
@@ -166,6 +173,7 @@ data:
       <match prometheus.metrics**>
         @type sumologic
         @id sumologic.endpoint.metrics
+        sumo_client "k8s_1.0.0-beta.2"
         endpoint "#{ENV['SUMO_ENDPOINT_METRICS']}"
         @include metrics.output.conf
         <buffer>
@@ -279,6 +287,7 @@ data:
       <match containers.**>
         @type sumologic
         @id sumologic.endpoint.logs
+        sumo_client "k8s_1.0.0-beta.2"
         @log_level error
         @include logs.output.conf
         <buffer>
@@ -292,6 +301,7 @@ data:
     <match **>
       @type sumologic
       @id sumologic.endpoint.logs.default
+      sumo_client "k8s_1.0.0-beta.2"
       @include logs.output.conf
       <buffer>
         @type memory
@@ -320,6 +330,7 @@ data:
       <match **>
         @type sumologic
         @id sumologic.endpoint.logs.kubelet
+        sumo_client "k8s_1.0.0-beta.2"
         @include logs.output.conf
         <buffer>
           @type memory
@@ -353,6 +364,7 @@ data:
       <match **>
         @type sumologic
         @id sumologic.endpoint.logs.systemd
+        sumo_client "k8s_1.0.0-beta.2"
         @include logs.output.conf
         <buffer>
           @type memory
@@ -400,6 +412,7 @@ data:
     <match kubernetes.**>
       @type sumologic
       @id sumologic.endpoint.events
+      sumo_client "k8s_1.0.0-beta.2"
       endpoint "#{ENV['SUMO_ENDPOINT_EVENTS']}"
       data_type logs
       disable_cookies true


### PR DESCRIPTION
###### Description

Bump sumologic fluentd output plugin and override sumo_client with helm version

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
