### PR TITLE
Use Otelcol v0.3 and send spans directly

### DIFF
--- a/deploy/helm/sumologic/conf/traces/traces.otelcol.conf.yaml
+++ b/deploy/helm/sumologic/conf/traces/traces.otelcol.conf.yaml
@@ -1,4 +1,11 @@
 {{- $yamlFile := toYaml $.Values.otelcol.config }}
-{{- $fullname := include "sumologic.fullname" . }}
-{{- $url := list "http://" $fullname ":9411/api/v2/spans" | join "" }}
-{{- $yamlFile | replace "exporters.zipkin.url_replace" $url | nindent 2 }}
+{{- $tracesEndpoint := include "sumologic.traces.endpoint" . }}
+{{- $yamlFile | replace "exporters.zipkin.url_replace" $tracesEndpoint | nindent 2 }}
+{{- $sourceName := include "sumologic.sourceName" . }}
+{{- $sourceCategory := include "sumologic.sourceCategory" . }}
+{{- $sourceCategoryPrefix := include "sumologic.sourceCategoryPrefix" . }}
+{{- $sourceCategoryReplaceDash := include "sumologic.sourceCategoryReplaceDash" . }}
+{{- $yamlFile | replace "processors.source.name.replace" $sourceName | nindent 2 }}
+{{- $yamlFile | replace "processors.source.category.replace" $sourceCategory | nindent 2 }}
+{{- $yamlFile | replace "processors.source.category_prefix.replace" $sourceCategoryPrefix | nindent 2 }}
+{{- $yamlFile | replace "processors.source.category_replace_dash.replace" $sourceCategoryReplaceDash | nindent 2 }}

--- a/deploy/helm/sumologic/conf/traces/traces.otelcol.conf.yaml
+++ b/deploy/helm/sumologic/conf/traces/traces.otelcol.conf.yaml
@@ -1,7 +1,8 @@
 {{- $yamlFile := toYaml $.Values.otelcol.config }}
-{{- $tracesEndpoint := include "sumologic.traces.endpoint" . | quote }}
-{{- $sourceName := include "sumologic.sourceName" . | quote }}
-{{- $sourceCategory := include "sumologic.sourceCategory" . | quote }}
-{{- $sourceCategoryPrefix := include "sumologic.sourceCategoryPrefix" . | quote }}
-{{- $sourceCategoryReplaceDash := include "sumologic.sourceCategoryReplaceDash" . | quote }}
-{{- $yamlFile | replace "exporters.zipkin.url_replace" $tracesEndpoint | replace "processors.source.name.replace" $sourceName | replace "processors.source.category.replace" $sourceCategory | replace "processors.source.category_prefix.replace" $sourceCategoryPrefix | replace "processors.source.category_replace_dash.replace" $sourceCategoryReplaceDash | nindent 2 }}
+{{- $_collector := .Values.sumologic.collectorName | default .Values.sumologic.clusterName | quote }}
+{{- $endpoint := .Values.sumologic.traces.endpoint | quote }}
+{{- $sourceName := .Values.sumologic.sourceName | quote }}
+{{- $sourceCategory := .Values.sumologic.sourceCategory | quote }}
+{{- $sourceCategoryPrefix := .Values.sumologic.sourceCategoryPrefix | quote }}
+{{- $sourceCategoryReplaceDash := .Values.sumologic.sourceCategoryReplaceDash | quote }}
+{{- $yamlFile | replace "processors.source.collector.replace" $_collector | replace "exporters.zipkin.url_replace" $endpoint | replace "processors.source.name.replace" $sourceName | replace "processors.source.category.replace" $sourceCategory | replace "processors.source.category_prefix.replace" $sourceCategoryPrefix | replace "processors.source.category_replace_dash.replace" $sourceCategoryReplaceDash | nindent 2 }}

--- a/deploy/helm/sumologic/conf/traces/traces.otelcol.conf.yaml
+++ b/deploy/helm/sumologic/conf/traces/traces.otelcol.conf.yaml
@@ -1,11 +1,7 @@
 {{- $yamlFile := toYaml $.Values.otelcol.config }}
-{{- $tracesEndpoint := include "sumologic.traces.endpoint" . }}
-{{- $yamlFile | replace "exporters.zipkin.url_replace" $tracesEndpoint | nindent 2 }}
-{{- $sourceName := include "sumologic.sourceName" . }}
-{{- $sourceCategory := include "sumologic.sourceCategory" . }}
-{{- $sourceCategoryPrefix := include "sumologic.sourceCategoryPrefix" . }}
-{{- $sourceCategoryReplaceDash := include "sumologic.sourceCategoryReplaceDash" . }}
-{{- $yamlFile | replace "processors.source.name.replace" $sourceName | nindent 2 }}
-{{- $yamlFile | replace "processors.source.category.replace" $sourceCategory | nindent 2 }}
-{{- $yamlFile | replace "processors.source.category_prefix.replace" $sourceCategoryPrefix | nindent 2 }}
-{{- $yamlFile | replace "processors.source.category_replace_dash.replace" $sourceCategoryReplaceDash | nindent 2 }}
+{{- $tracesEndpoint := include "sumologic.traces.endpoint" . | quote }}
+{{- $sourceName := include "sumologic.sourceName" . | quote }}
+{{- $sourceCategory := include "sumologic.sourceCategory" . | quote }}
+{{- $sourceCategoryPrefix := include "sumologic.sourceCategoryPrefix" . | quote }}
+{{- $sourceCategoryReplaceDash := include "sumologic.sourceCategoryReplaceDash" . | quote }}
+{{- $yamlFile | replace "exporters.zipkin.url_replace" $tracesEndpoint | replace "processors.source.name.replace" $sourceName | replace "processors.source.category.replace" $sourceCategory | replace "processors.source.category_prefix.replace" $sourceCategoryPrefix | replace "processors.source.category_replace_dash.replace" $sourceCategoryReplaceDash | nindent 2 }}

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -16,13 +16,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
-Expand traces endpoint variable.
-*/}}
-{{- define "sumologic.traces.endpoint" -}}
-{{- default .Values.sumologic.traces.endpoint | trimSuffix "-" }}
-{{- end -}}
-
-{{/*
 Create default fully qualified labels.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -16,6 +16,32 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
+Expand traces endpoint variable.
+*/}}
+{{- define "sumologic.traces.endpoint" -}}
+{{- default .Values.sumologic.traces.endpoint | trimSuffix "-" }}
+{{- end -}}
+
+{{/*
+Expand tracing source config.
+*/}}
+{{- define "sumologic.sourceName" -}}
+{{- default .Values.sumologic.sourceName | trimSuffix "-" }}
+{{- end -}}
+
+{{- define "sumologic.sourceCategory" -}}
+{{- default .Values.sumologic.sourceCategory | trimSuffix "-" }}
+{{- end -}}
+
+{{- define "sumologic.sourceCategoryPrefix" -}}
+{{- default .Values.sumologic.sourceCategoryPrefix | trimSuffix "-" }}
+{{- end -}}
+
+{{- define "sumologic.sourceCategoryReplaceDash" -}}
+{{- default .Values.sumologic.sourceCategoryReplaceDash | trimSuffix "-" }}
+{{- end -}}
+
+{{/*
 Create default fully qualified labels.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -23,25 +23,6 @@ Expand traces endpoint variable.
 {{- end -}}
 
 {{/*
-Expand tracing source config.
-*/}}
-{{- define "sumologic.sourceName" -}}
-{{- default .Values.sumologic.sourceName | trimSuffix "-" }}
-{{- end -}}
-
-{{- define "sumologic.sourceCategory" -}}
-{{- default .Values.sumologic.sourceCategory | trimSuffix "-" }}
-{{- end -}}
-
-{{- define "sumologic.sourceCategoryPrefix" -}}
-{{- default .Values.sumologic.sourceCategoryPrefix | trimSuffix "-" }}
-{{- end -}}
-
-{{- define "sumologic.sourceCategoryReplaceDash" -}}
-{{- default .Values.sumologic.sourceCategoryReplaceDash | trimSuffix "-" }}
-{{- end -}}
-
-{{/*
 Create default fully qualified labels.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/deploy/helm/sumologic/templates/otelcol-deployment.yaml
+++ b/deploy/helm/sumologic/templates/otelcol-deployment.yaml
@@ -53,6 +53,7 @@ spec:
         - containerPort: 14267 # Default endpoint for Jaeger TChannel receiver.
         - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
         - containerPort: 55678 # Default endpoint for Opencensus receiver.
+        - containerPort: 55680 # Default endpoint for OTLP receiver.
         volumeMounts:
         - name: otel-collector-config-vol
           mountPath: /conf

--- a/deploy/helm/sumologic/templates/otelcol-service.yaml
+++ b/deploy/helm/sumologic/templates/otelcol-service.yaml
@@ -30,6 +30,6 @@ spec:
     port: 14268
   - name: opencensus # Default endpoint for Opencensus receiver.
     port: 55678
-    protocol: TCP
-    targetPort: 55678
+  - name: otlp # Default endpoint for OTLP receiver.
+    port: 55680
 {{- end }}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -561,10 +561,12 @@ otelcol:
       zipkin:
         endpoint: "0.0.0.0:9411"
     processors:
+      # Adds _sourceCategory and _sourceName
       source:
-        source_name: "%{namespace}.%{pod}.%{container}"
-        source_category: "%{namespace}/%{pod_name}"
-
+        source_name: {{ .Values.sumologic.sourceName | quote }}
+        source_category: {{ .Values.sumologic.sourceCategory | quote }}
+        source_category_prefix: {{ .Values.sumologic.sourceCategoryPrefix | quote }}
+        source_category_replace_dash: {{ .Values.sumologic.sourceCategoryReplaceDash | quote }}
       # Tags spans with K8S metadata, basing on the context IP
       k8s_tagger:
         # When true, only IP is assigned and passed (so it could be tagged on another collector)

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -538,8 +538,8 @@ otelcol:
     memBallastSizeMib: "683"
     image:
       name: "sumologic/opentelemetry-collector"
-      tag: "0.2.7.1"
-      pullPolicy: IfNotPresent
+      tag: "0.3.0.3"
+      pullPolicy: Always
   config:
     receivers:
       jaeger:
@@ -556,9 +556,15 @@ otelcol:
             endpoint: "0.0.0.0:14268"
       opencensus:
         endpoint: "0.0.0.0:55678"
+      otlp:
+        endpoint: "0.0.0.0:55680"
       zipkin:
         endpoint: "0.0.0.0:9411"
     processors:
+      source:
+        source_name: "%{namespace}.%{pod}.%{container}"
+        source_category: "%{namespace}/%{pod_name}"
+
       # Tags spans with K8S metadata, basing on the context IP
       k8s_tagger:
         # When true, only IP is assigned and passed (so it could be tagged on another collector)
@@ -597,10 +603,10 @@ otelcol:
             #serviceName: service
             statefulSetName: statefulset
           annotations:
-            - tag_name: pod_annotation_%s
+            - tag_name: "annotation:%s"
               key: "*"
           labels:
-            - tag_name: pod_label_%s
+            - tag_name: "label:%s"
               key: "*"
 
       # The memory_limiter processor is used to prevent out of memory situations on the collector.
@@ -630,15 +636,13 @@ otelcol:
       batch:
         # Number of spans after which a batch will be sent regardless of time
         send_batch_size: 256
-        # Number of tickers that loop over batch buckets
-        num_tickers: 10
         # Time duration after which a batch will be sent regardless of size
         timeout: 5s
     extensions:
       health_check: {}
     exporters:
       zipkin:
-        url: "exporters.zipkin.url_replace"
+        url: {{ .Values.sumologic.traces.endpoint || quote }}
       # Following generates verbose logs with span content, useful to verify what
       # metadata is being tagged. To enable, uncomment and add "logging" to exporters below.
       # There are two levels that could be used: `debug` and `info` with the former
@@ -650,5 +654,5 @@ otelcol:
       pipelines:
         traces:
           receivers: [jaeger, zipkin, opencensus]
-          processors: [memory_limiter, k8s_tagger, batch, queued_retry]
+          processors: [memory_limiter, k8s_tagger, source, batch, queued_retry]
           exporters: [zipkin]

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -539,7 +539,7 @@ otelcol:
     image:
       name: "sumologic/opentelemetry-collector"
       tag: "0.3.0.3"
-      pullPolicy: Always
+      pullPolicy: IfNotPresent
   config:
     receivers:
       jaeger:
@@ -563,10 +563,10 @@ otelcol:
     processors:
       # Adds _sourceCategory and _sourceName
       source:
-        source_name: {{ .Values.sumologic.sourceName | quote }}
-        source_category: {{ .Values.sumologic.sourceCategory | quote }}
-        source_category_prefix: {{ .Values.sumologic.sourceCategoryPrefix | quote }}
-        source_category_replace_dash: {{ .Values.sumologic.sourceCategoryReplaceDash | quote }}
+        source_name: "processors.source.name.replace"
+        source_category: "processors.source.category.replace"
+        source_category_prefix: "processors.source.category_prefix.replace"
+        source_category_replace_dash: "processors.source.category_replace_dash.replace"
       # Tags spans with K8S metadata, basing on the context IP
       k8s_tagger:
         # When true, only IP is assigned and passed (so it could be tagged on another collector)
@@ -644,7 +644,7 @@ otelcol:
       health_check: {}
     exporters:
       zipkin:
-        url: {{ .Values.sumologic.traces.endpoint || quote }}
+        url:  "exporters.zipkin.url_replace"
       # Following generates verbose logs with span content, useful to verify what
       # metadata is being tagged. To enable, uncomment and add "logging" to exporters below.
       # There are two levels that could be used: `debug` and `info` with the former

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -538,7 +538,7 @@ otelcol:
     memBallastSizeMib: "683"
     image:
       name: "sumologic/opentelemetry-collector"
-      tag: "0.3.0.4"
+      tag: "0.3.0.5"
       pullPolicy: IfNotPresent
   config:
     receivers:
@@ -563,6 +563,7 @@ otelcol:
     processors:
       # Adds _sourceCategory and _sourceName
       source:
+        collector: "processors.source.collector.replace"
         source_name: "processors.source.name.replace"
         source_category: "processors.source.category.replace"
         source_category_prefix: "processors.source.category_prefix.replace"
@@ -605,10 +606,10 @@ otelcol:
             #serviceName: service
             statefulSetName: statefulset
           annotations:
-            - tag_name: "annotation:%s"
+            - tag_name: "pod_annotation_%s"
               key: "*"
           labels:
-            - tag_name: "label:%s"
+            - tag_name: "pod_labels_%s"
               key: "*"
 
       # The memory_limiter processor is used to prevent out of memory situations on the collector.
@@ -644,7 +645,7 @@ otelcol:
       health_check: {}
     exporters:
       zipkin:
-        url:  "exporters.zipkin.url_replace"
+        url: "exporters.zipkin.url_replace"
       # Following generates verbose logs with span content, useful to verify what
       # metadata is being tagged. To enable, uncomment and add "logging" to exporters below.
       # There are two levels that could be used: `debug` and `info` with the former

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -538,7 +538,7 @@ otelcol:
     memBallastSizeMib: "683"
     image:
       name: "sumologic/opentelemetry-collector"
-      tag: "0.3.0.3"
+      tag: "0.3.0.4"
       pullPolicy: IfNotPresent
   config:
     receivers:


### PR DESCRIPTION
###### Description

Use OpenTelemetry Collector @ Sumo v0.3 series, which includes sources processor (tagging `_sourceCategory` and `_sourceName`) and sends traces directly

###### Testing performed

- [ ] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
