### PR TITLE
Use Otelcol v0.3 and send spans directly

### DIFF
--- a/deploy/helm/sumologic/conf/traces/traces.otelcol.conf.yaml
+++ b/deploy/helm/sumologic/conf/traces/traces.otelcol.conf.yaml
@@ -1,4 +1,8 @@
 {{- $yamlFile := toYaml $.Values.otelcol.config }}
-{{- $fullname := include "sumologic.fullname" . }}
-{{- $url := list "http://" $fullname "-fluentd-logs:9411/api/v2/spans" | join "" }}
-{{- $yamlFile | replace "exporters.zipkin.url_replace" $url | nindent 2 }}
+{{- $_collector := .Values.sumologic.collectorName | default .Values.sumologic.clusterName | quote }}
+{{- $endpoint := .Values.sumologic.traces.endpoint | quote }}
+{{- $sourceName := .Values.sumologic.sourceName | quote }}
+{{- $sourceCategory := .Values.sumologic.sourceCategory | quote }}
+{{- $sourceCategoryPrefix := .Values.sumologic.sourceCategoryPrefix | quote }}
+{{- $sourceCategoryReplaceDash := .Values.sumologic.sourceCategoryReplaceDash | quote }}
+{{- $yamlFile | replace "processors.source.collector.replace" $_collector | replace "exporters.zipkin.url_replace" $endpoint | replace "processors.source.name.replace" $sourceName | replace "processors.source.category.replace" $sourceCategory | replace "processors.source.category_prefix.replace" $sourceCategoryPrefix | replace "processors.source.category_replace_dash.replace" $sourceCategoryReplaceDash | nindent 2 }}

--- a/deploy/helm/sumologic/templates/otelcol-deployment.yaml
+++ b/deploy/helm/sumologic/templates/otelcol-deployment.yaml
@@ -53,6 +53,7 @@ spec:
         - containerPort: 14267 # Default endpoint for Jaeger TChannel receiver.
         - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
         - containerPort: 55678 # Default endpoint for Opencensus receiver.
+        - containerPort: 55680 # Default endpoint for OTLP receiver.
         volumeMounts:
         - name: otel-collector-config-vol
           mountPath: /conf

--- a/deploy/helm/sumologic/templates/otelcol-service.yaml
+++ b/deploy/helm/sumologic/templates/otelcol-service.yaml
@@ -30,6 +30,6 @@ spec:
     port: 14268
   - name: opencensus # Default endpoint for Opencensus receiver.
     port: 55678
-    protocol: TCP
-    targetPort: 55678
+  - name: otlp # Default endpoint for OTLP receiver.
+    port: 55680
 {{- end }}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -780,7 +780,7 @@ otelcol:
     memBallastSizeMib: "683"
     image:
       name: "sumologic/opentelemetry-collector"
-      tag: "0.2.7.1"
+      tag: "0.3.0.5"
       pullPolicy: IfNotPresent
   config:
     receivers:
@@ -798,9 +798,18 @@ otelcol:
             endpoint: "0.0.0.0:14268"
       opencensus:
         endpoint: "0.0.0.0:55678"
+      otlp:
+        endpoint: "0.0.0.0:55680"
       zipkin:
         endpoint: "0.0.0.0:9411"
     processors:
+      # Adds _sourceCategory and _sourceName
+      source:
+        collector: "processors.source.collector.replace"
+        source_name: "processors.source.name.replace"
+        source_category: "processors.source.category.replace"
+        source_category_prefix: "processors.source.category_prefix.replace"
+        source_category_replace_dash: "processors.source.category_replace_dash.replace"
       # Tags spans with K8S metadata, basing on the context IP
       k8s_tagger:
         # When true, only IP is assigned and passed (so it could be tagged on another collector)
@@ -839,10 +848,10 @@ otelcol:
             # serviceName: service
             statefulSetName: statefulset
           annotations:
-            - tag_name: pod_annotation_%s
+            - tag_name: "pod_annotation_%s"
               key: "*"
           labels:
-            - tag_name: pod_label_%s
+            - tag_name: "pod_labels_%s"
               key: "*"
 
       # The memory_limiter processor is used to prevent out of memory situations on the collector.
@@ -872,8 +881,6 @@ otelcol:
       batch:
         # Number of spans after which a batch will be sent regardless of time
         send_batch_size: 256
-        # Number of tickers that loop over batch buckets
-        num_tickers: 10
         # Time duration after which a batch will be sent regardless of size
         timeout: 5s
     extensions:
@@ -891,6 +898,6 @@ otelcol:
       extensions: [health_check]
       pipelines:
         traces:
-          receivers: [jaeger, zipkin, opencensus]
-          processors: [memory_limiter, k8s_tagger, batch, queued_retry]
+          receivers: [jaeger, zipkin, opencensus, otlp]
+          processors: [memory_limiter, k8s_tagger, source, batch, queued_retry]
           exporters: [zipkin]


### PR DESCRIPTION
###### Description

Uses Otelcol v0.3 series, which includes _source processor and allows to send spans directly (skipping fluentd)

This is a v1.0 version of https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/600

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
