### PR TITLE
Revert "Do not set tracing URL if it is not available"

### DIFF
--- a/deploy/helm/sumologic/conf/traces/traces.otelcol.conf.yaml
+++ b/deploy/helm/sumologic/conf/traces/traces.otelcol.conf.yaml
@@ -1,6 +1,6 @@
 {{- $yamlFile := toYaml $.Values.otelcol.config }}
 {{- $_collector := .Values.sumologic.collectorName | default .Values.sumologic.clusterName | quote }}
-{{- $endpoint := .Values.sumologic.traces.endpoint | default "exporters.zipkin.url_replace" | quote }}
+{{- $endpoint := .Values.sumologic.traces.endpoint | quote }}
 {{- $sourceName := .Values.sumologic.sourceName | quote }}
 {{- $sourceCategory := .Values.sumologic.sourceCategory | quote }}
 {{- $sourceCategoryPrefix := .Values.sumologic.sourceCategoryPrefix | quote }}


### PR DESCRIPTION
This reverts commit 24094ac267667d370414343b53d80a1f4189cfc6.

It's actually better for the container to fail early in case of the empty URL.

###### Description

Fill in your description here.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
