### PR TITLE
Backport 'add quotes when specifying events sourceCategory' (#549)

### DIFF
--- a/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
@@ -94,7 +94,7 @@ data:
 
     resource "sumologic_http_source" "events_source" {
         name         = local.events-source-name
-        category     = {{ if .Values.sumologic.events.sourceCategory }}{{ .Values.sumologic.events.sourceCategory }}{{- else}}{{ "\"${var.cluster_name}/${local.events-source-name}\"" }}{{- end}}
+        category     = {{ if .Values.sumologic.events.sourceCategory }}{{ .Values.sumologic.events.sourceCategory | quote }}{{- else}}{{ "\"${var.cluster_name}/${local.events-source-name}\"" }}{{- end}}
         collector_id = "${sumologic_collector.collector.id}"
     }
 


### PR DESCRIPTION
###### Description

Backport #549 as requested in #550

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
