### PR TITLE
Upgrade script grep sed bash fixes

### DIFF
--- a/deploy/helm/sumologic/upgrade-1.0.0.sh
+++ b/deploy/helm/sumologic/upgrade-1.0.0.sh
@@ -10,7 +10,6 @@ readonly PREVIOUS_VERSION=0.17
 
 readonly TEMP_FILE=upgrade-1.0.0-temp-file
 
-readonly MIN_SED_VERSION=4
 readonly MIN_GREP_VERSION=2.5
 readonly MIN_BASH_VERSION=4.4
 
@@ -199,9 +198,9 @@ function check_yq_version() {
 }
 
 function check_grep_version() {
-  local sed_version
+  local grep_version
 
-  # do not fail on missing or incorrect sed
+  # do not fail on missing or incorrect grep
   set +e
   grep_version=$(grep -V 2>&1 | head -n 1 | grep -oE "\d.*$")
   set -e
@@ -209,19 +208,6 @@ function check_grep_version() {
   local stripped_grep_version=${grep_version%%-*}
 
   check_app_version "grep" "${MIN_GREP_VERSION}" "${stripped_grep_version}"
-}
-
-function check_sed_version() {
-  local sed_version
-
-  # do not fail on missing or incorrect sed
-  set +e
-  sed_version=$(sed --version 2>&1 | head -n 1 | grep -oE "\d.*$")
-  set -e
-
-  local stripped_sed_version=${sed_version%%-*}
-
-  check_app_version "sed" "${MIN_SED_VERSION}" "${stripped_sed_version}"
 }
 
 function check_bash_version() {
@@ -515,8 +501,6 @@ check_yq_version
 check_required_command grep
 check_grep_version
 check_required_command sed
-# do not check sed version as it works now on both GNU and BSD versions
-#check_sed_version
 
 create_temp_file
 

--- a/deploy/helm/sumologic/upgrade-1.0.0.sh
+++ b/deploy/helm/sumologic/upgrade-1.0.0.sh
@@ -11,6 +11,7 @@ readonly PREVIOUS_VERSION=0.17
 readonly TEMP_FILE=upgrade-1.0.0-temp-file
 
 readonly MIN_BASH_VERSION=4.4
+readonly MIN_YQ_VERSION=3.2.1
 
 readonly KEY_MAPPINGS="
 eventsDeployment.nodeSelector:fluentd.events.statefulset.nodeSelector
@@ -138,7 +139,7 @@ This script will automatically take the configurations of your existing values.y
 and return one that is compatible with v1.0.0.
 
 Requirements:
-  yq (3.2.1) https://github.com/mikefarah/yq/releases/tag/3.2.1
+  yq (>=3.2.1) https://github.com/mikefarah/yq/releases/tag/3.2.1
   grep
   sed
 
@@ -193,7 +194,10 @@ function check_app_version() {
 }
 
 function check_yq_version() {
-  yq --version | grep 3.2.1 >/dev/null 2>&1 || { error "yq version is invalid. It should be exactly 3.2.1"; fatal "Please install it from: https://github.com/mikefarah/yq/releases/tag/3.2.1"; }
+  local yq_version
+  yq_version=$(yq --version | grep -oE '[^[:space:]]+$')
+
+  check_app_version "grep" "${MIN_YQ_VERSION}" "${yq_version}"
 }
 
 function check_bash_version() {

--- a/deploy/helm/sumologic/upgrade-1.0.0.sh
+++ b/deploy/helm/sumologic/upgrade-1.0.0.sh
@@ -188,8 +188,8 @@ function check_app_version() {
   local app_version="${3}"
 
   if [[ -z ${app_version} ]] || [[ $(compare_versions "${no_lower_than}" "${app_version}") == "fail" ]]; then
-    error "${app_name} version is invalid - it should be no lower than ${no_lower_than}"
-    fatal "Please update your ${app_name} version and retry."
+    error "${app_name} version: '${app_version}' is invalid - it should be no lower than ${no_lower_than}"
+    fatal "Please update your ${app_name} and retry."
   fi
 }
 

--- a/deploy/helm/sumologic/upgrade-1.0.0.sh
+++ b/deploy/helm/sumologic/upgrade-1.0.0.sh
@@ -10,7 +10,6 @@ readonly PREVIOUS_VERSION=0.17
 
 readonly TEMP_FILE=upgrade-1.0.0-temp-file
 
-readonly MIN_GREP_VERSION=2.5
 readonly MIN_BASH_VERSION=4.4
 
 readonly KEY_MAPPINGS="
@@ -195,19 +194,6 @@ function check_app_version() {
 
 function check_yq_version() {
   yq --version | grep 3.2.1 >/dev/null 2>&1 || { error "yq version is invalid. It should be exactly 3.2.1"; fatal "Please install it from: https://github.com/mikefarah/yq/releases/tag/3.2.1"; }
-}
-
-function check_grep_version() {
-  local grep_version
-
-  # do not fail on missing or incorrect grep
-  set +e
-  grep_version=$(grep -V 2>&1 | head -n 1 | grep -oE "\d.*$")
-  set -e
-
-  local stripped_grep_version=${grep_version%%-*}
-
-  check_app_version "grep" "${MIN_GREP_VERSION}" "${stripped_grep_version}"
 }
 
 function check_bash_version() {
@@ -499,7 +485,6 @@ check_bash_version
 check_required_command yq
 check_yq_version
 check_required_command grep
-check_grep_version
 check_required_command sed
 
 create_temp_file

--- a/deploy/helm/sumologic/upgrade-1.0.0.sh
+++ b/deploy/helm/sumologic/upgrade-1.0.0.sh
@@ -139,9 +139,10 @@ This script will automatically take the configurations of your existing values.y
 and return one that is compatible with v1.0.0.
 
 Requirements:
-  yq (>=3.2.1) https://github.com/mikefarah/yq/releases/tag/3.2.1
+  yq (>= ${MIN_YQ_VERSION}) https://github.com/mikefarah/yq/releases/tag/3.2.1
   grep
   sed
+  bash (>= ${MIN_BASH_VERSION})
 
 Usage:
   # for default helm release name 'collection' and namespace 'sumologic'

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -42,8 +42,12 @@ sudo -H -u vagrant -i helm init --wait
 
 usermod -a -G microk8s vagrant
 
-# Install yq
-sudo curl https://github.com/mikefarah/yq/releases/download/3.2.1/yq_linux_amd64 -L -o /usr/local/bin/yq && sudo chmod +x /usr/local/bin/yq
+# install yq with access to file structure
+curl https://github.com/mikefarah/yq/releases/download/3.2.1/yq_linux_amd64 -L -o /usr/local/bin/yq-3.2.1
+chmod +x /usr/local/bin/yq-3.2.1
+curl https://github.com/mikefarah/yq/releases/download/3.3.0/yq_linux_amd64 -L -o /usr/local/bin/yq-3.3.0
+chmod +x /usr/local/bin/yq-3.3.0
+ln -s /usr/local/bin/yq-3.3.0 /usr/local/bin/yq
 
 set +x
 echo Dashboard local in-vagrant IP:


### PR DESCRIPTION
###### Description

Fixes #644

* fix for upgrade script doesn't work under GNU sed >= 4.4
* upgrade needs recent GNU Bash but doesn't check for that
* grep does not have to be modern
* allow for newer yq

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
