### PR TITLE
remove -o flag

### DIFF
--- a/deploy/docs/v1_migration_doc.md
+++ b/deploy/docs/v1_migration_doc.md
@@ -119,7 +119,7 @@ For users who use a `values.yaml` file, we provide a script that users can run t
 
 - Get the existing values for the helm chart and store it as `current_values.yaml` with the below command:
 ```bash
-helm get values <RELEASE-NAME> -o yaml > current_values.yaml
+helm get values <RELEASE-NAME> > current_values.yaml
 ```
 - Run `curl` the upgrade script as follows:
 ```bash


### PR DESCRIPTION
###### Description

It seems like `-o` flag only works with Helm3 and not with Helm2.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
