### PR TITLE
Fix upgrade script for vagrant env

### DIFF
--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -42,8 +42,8 @@ sudo -H -u vagrant -i helm init --wait
 
 usermod -a -G microk8s vagrant
 
-# Install yq
-sudo curl https://github.com/mikefarah/yq/releases/download/3.2.1/yq_linux_amd64 -L -o /usr/local/bin/yq && sudo chmod +x /usr/local/bin/yq
+# install yq with access to file structure
+sudo curl https://github.com/mikefarah/yq/releases/download/3.3.0/yq_linux_amd64 -L -o /usr/local/bin/yq && sudo chmod +x /usr/local/bin/yq
 
 set +x
 echo Dashboard local in-vagrant IP:


### PR DESCRIPTION
###### Description

* Unify sed flags for unix (mac) and linux (ubuntu)
* yq can be in version higher than 3.2.1, the reason of previous condition was that yq installed via snap doesn't have access to filesystem, so all read/write operations were failing:
   - https://mikefarah.gitbook.io/yq/#snap-notes
   - https://snapcraft.io/docs/snap-confinement

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
