### PR TITLE
Set `Ignore_Older` to `24h` by default to prevent older logs from being ingested on install.

### DIFF
--- a/deploy/helm/fluent-bit-overrides.yaml
+++ b/deploy/helm/fluent-bit-overrides.yaml
@@ -60,6 +60,7 @@ rawConfig: |-
     Skip_Long_Lines  On
     DB               /tail-db/tail-containers-state-sumo.db
     DB.Sync          Normal
+    Ignore_Older     24h
   [INPUT]
     Name            systemd
     Tag             host.*

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -469,6 +469,7 @@ fluent-bit:
       Skip_Long_Lines  On
       DB               /tail-db/tail-containers-state-sumo.db
       DB.Sync          Normal
+      Ignore_Older     24h
     [INPUT]
       Name            systemd
       Tag             host.*


### PR DESCRIPTION
###### Description

Fixes #596.

Set `Ignore_Older` to `24h` by default to prevent older logs from being ingested when collection is first installed.  Relative times are supported.  Tested using shorter time range (1m) and validated that the older logs are not ingested.

https://github.com/fluent/fluent-bit/issues/221
https://docs.fluentbit.io/manual/pipeline/inputs/tail#config

Note, this is not supported on `systemd` plugin so only updating `tail` plugin.


Fill in your description here.

###### Testing performed

- [ ] ci/build.sh
- [X] Redeploy fluentd and fluentd-events pods
- [X] Confirm events, logs, and metrics are coming in