### PR TITLE
ingest retry succeeded logs and expose param in values file 

### DIFF
--- a/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
@@ -19,14 +19,16 @@
 <label @NORMAL>
   #  only match fluentd logs based on fluentd container name. by default, this is
   #  <filter **collection-sumologic**>
+{{ if .Values.fluentd.logLevelFilter }}
   {{ printf "<filter **%s**>" (include "sumologic.fullname" .) }}
     # only ingest fluentd logs of levels: {error, fatal} and warning messages if buffer is full
     @type grep
     <regexp>
       key log
-      pattern /\[error\]|\[fatal\]|drop_oldest_chunk/
+      pattern /\[error\]|\[fatal\]|drop_oldest_chunk|retry succeeded/
     </regexp>
   </filter>
+{{- end}}
   # third-party kubernetes metadata  filter plugin
   <filter containers.**>
     @type kubernetes_metadata

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -78,6 +78,8 @@ fluentd:
   ## Sumo will only ingest the error log level and some specific warnings, the info logs can be seen in kubectl logs.
   ## ref: https://docs.fluentd.org/deployment/logging
   logLevel: "info"
+  ## to ingest all fluentd logs, turn the logLevelFilter to false 
+  logLevelFilter: true
 
   ## Verify SumoLogic HTTPS certificates
   verifySsl: true

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -124,12 +124,13 @@ data:
     <label @NORMAL>
       #  only match fluentd logs based on fluentd container name. by default, this is
       #  <filter **collection-sumologic**>
+    
       <filter **collection-sumologic**>
         # only ingest fluentd logs of levels: {error, fatal} and warning messages if buffer is full
         @type grep
         <regexp>
           key log
-          pattern /\[error\]|\[fatal\]|drop_oldest_chunk/
+          pattern /\[error\]|\[fatal\]|drop_oldest_chunk|retry succeeded/
         </regexp>
       </filter>
       # third-party kubernetes metadata  filter plugin


### PR DESCRIPTION
ingest retry succeeded logs and expose param in values file to turn off the filter

###### Description

Fixes #621

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
