### PR TITLE
Expose http sources for metrics in values.yaml

### DIFF
--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -401,13 +401,13 @@ prometheus:
         sourceLabels: [__name__]
     - # control plane metrics
       # coredns
-      url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.control-plane
+      url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.control-plane.coredns
       writeRelabelConfigs:
       - action: keep
         regex: coredns
         sourceLabels: [job]
     - # etcd server
-      url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.control-plane
+      url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.control-plane.kube-etcd
       writeRelabelConfigs:
       - action: keep
         regex: kube-etcd

--- a/deploy/helm/sumologic/conf/events/events.conf
+++ b/deploy/helm/sumologic/conf/events/events.conf
@@ -35,7 +35,7 @@
   @type sumologic
   @id sumologic.endpoint.events
   sumo_client {{ include "sumologic.sumo_client" . | quote }}
-  endpoint "#{ENV['SUMO_ENDPOINT_EVENTS']}"
+  endpoint "#{ENV['SUMO_ENDPOINT_EVENTS_SOURCE']}"
   data_type logs
   disable_cookies true
   verify_ssl {{ .Values.fluentd.verifySsl | quote }}

--- a/deploy/helm/sumologic/conf/logs/logs.output.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.output.conf
@@ -1,6 +1,6 @@
 data_type logs
 log_key log
-endpoint "#{ENV['SUMO_ENDPOINT_LOGS']}"
+endpoint "#{ENV['SUMO_ENDPOINT_LOGS_SOURCE']}"
 verify_ssl {{ .Values.fluentd.verifySsl | quote }}
 log_format {{ .Values.fluentd.logs.output.logFormat | quote }}
 add_timestamp {{ .Values.fluentd.logs.output.addTimestamp | quote }}

--- a/deploy/helm/sumologic/conf/metrics/metrics.conf
+++ b/deploy/helm/sumologic/conf/metrics/metrics.conf
@@ -60,6 +60,6 @@
 {{- if $source.source -}}
 {{- $endpoint = $source.source -}}
 {{- end -}}
-{{ include "utils.metrics.match" (dict "Context" $ctx "Match" $source.match "Id" $source.id "Endpoint" (printf "%s_%s" "METRICS" $endpoint) "Storage" (index $ctx.Values.fluentd.buffer.filePaths.metrics $name) ) | nindent 4 }}
+{{ include "utils.metrics.match" (dict "Context" $ctx "Match" $source.match "Id" $source.id "Endpoint" (include "terraform.sources.name_metrics" $endpoint) "Storage" (index $ctx.Values.fluentd.buffer.filePaths.metrics $name) ) | nindent 4 }}
 {{- end }}
 </label>

--- a/deploy/helm/sumologic/conf/metrics/metrics.conf
+++ b/deploy/helm/sumologic/conf/metrics/metrics.conf
@@ -60,6 +60,6 @@
 {{- if $source.source -}}
 {{- $endpoint = $source.source -}}
 {{- end -}}
-{{ include "utils.metrics.match" (dict "Context" $ctx "Drop" $source.drop "Match" $source.match "Id" $source.id "Endpoint" (include "terraform.sources.name_metrics" $endpoint) "Storage" (index $ctx.Values.fluentd.buffer.filePaths.metrics $name) ) | nindent 4 }}
+{{ include "utils.metrics.match" (dict "Context" $ctx "Drop" $source.drop "Tag" $source.tag "Id" $source.id "Endpoint" (include "terraform.sources.name_metrics" $endpoint) "Storage" (index $ctx.Values.fluentd.buffer.filePaths.metrics $name) ) | nindent 4 }}
 {{- end }}
 </label>

--- a/deploy/helm/sumologic/conf/metrics/metrics.conf
+++ b/deploy/helm/sumologic/conf/metrics/metrics.conf
@@ -60,6 +60,6 @@
 {{- if $source.source -}}
 {{- $endpoint = $source.source -}}
 {{- end -}}
-{{ include "utils.metrics.match" (dict "Context" $ctx "Match" $source.match "Id" $source.id "Endpoint" $endpoint "Storage" (index $ctx.Values.fluentd.buffer.filePaths.metrics $name) ) | nindent 4 }}
+{{ include "utils.metrics.match" (dict "Context" $ctx "Match" $source.match "Id" $source.id "Endpoint" (printf "%s_%s" "METRICS" $endpoint) "Storage" (index $ctx.Values.fluentd.buffer.filePaths.metrics $name) ) | nindent 4 }}
 {{- end }}
 </label>

--- a/deploy/helm/sumologic/conf/metrics/metrics.conf
+++ b/deploy/helm/sumologic/conf/metrics/metrics.conf
@@ -50,7 +50,7 @@
 {{- $ctx := . }}
 {{- $out_keys := list "" -}}
 {{- range $key, $value := .Values.fluentd.metrics.output -}}
-{{- $out_keys = append $out_keys (printf "%d_%d_%s" (len ( $value.weight | toString )) ($value.weight | int) $key) -}}
+{{- $out_keys = append $out_keys (printf "%d_%d_%s" (len ( $value.weight | int | toString )) ($value.weight | int) $key) -}}
 {{- end -}}
 {{- $out_keys := slice $out_keys 1 }}
 {{- range $_, $key := $out_keys | sortAlpha }}
@@ -60,6 +60,6 @@
 {{- if $source.source -}}
 {{- $endpoint = $source.source -}}
 {{- end -}}
-{{ include "utils.metrics.match" (dict "Context" $ctx "Match" $source.match "Id" $source.id "Endpoint" (include "terraform.sources.name_metrics" $endpoint) "Storage" (index $ctx.Values.fluentd.buffer.filePaths.metrics $name) ) | nindent 4 }}
+{{ include "utils.metrics.match" (dict "Context" $ctx "Drop" $source.drop "Match" $source.match "Id" $source.id "Endpoint" (include "terraform.sources.name_metrics" $endpoint) "Storage" (index $ctx.Values.fluentd.buffer.filePaths.metrics $name) ) | nindent 4 }}
 {{- end }}
 </label>

--- a/deploy/helm/sumologic/conf/metrics/metrics.conf
+++ b/deploy/helm/sumologic/conf/metrics/metrics.conf
@@ -55,7 +55,7 @@
 {{- $out_keys := slice $out_keys 1 }}
 {{- range $_, $key := $out_keys | sortAlpha }}
 {{- $name := join "_" (slice (splitList "_" $key) 2)  }}
-{{- $source := get $ctx.Values.fluentd.metrics.output $name }}
+{{- $source := index $ctx.Values.fluentd.metrics.output $name }}
 {{ include "utils.metrics.match" (dict "Context" $ctx "Match" $source.match "Id" $source.id "Endpoint" $source.endpoint "Storage" (get $ctx.Values.fluentd.buffer.filePaths.metrics $name) ) | nindent 4 }}
 {{- end }}
 </label>

--- a/deploy/helm/sumologic/conf/metrics/metrics.conf
+++ b/deploy/helm/sumologic/conf/metrics/metrics.conf
@@ -56,6 +56,10 @@
 {{- range $_, $key := $out_keys | sortAlpha }}
 {{- $name := join "_" (slice (splitList "_" $key) 2)  }}
 {{- $source := index $ctx.Values.fluentd.metrics.output $name }}
-{{ include "utils.metrics.match" (dict "Context" $ctx "Match" $source.match "Id" $source.id "Endpoint" $source.endpoint "Storage" (index $ctx.Values.fluentd.buffer.filePaths.metrics $name) ) | nindent 4 }}
+{{- $endpoint := $name }}
+{{- if $source.source -}}
+{{- $endpoint = $source.source -}}
+{{- end -}}
+{{ include "utils.metrics.match" (dict "Context" $ctx "Match" $source.match "Id" $source.id "Endpoint" $endpoint "Storage" (index $ctx.Values.fluentd.buffer.filePaths.metrics $name) ) | nindent 4 }}
 {{- end }}
 </label>

--- a/deploy/helm/sumologic/conf/metrics/metrics.conf
+++ b/deploy/helm/sumologic/conf/metrics/metrics.conf
@@ -47,14 +47,15 @@
   </filter>
 {{- .Values.fluentd.metrics.extraOutputPluginConf | nindent 4 }}
 
-{{ include "utils.metrics.match" (dict "Values" .Values "Match" "prometheus.metrics.apiserver**"          "Id" "sumologic.endpoint.metrics.apiserver"               "Endpoint" "SUMO_ENDPOINT_METRICS_APISERVER"                "Storage" .Values.fluentd.buffer.filePaths.metrics.apiserver)       | nindent 4 }}
-{{ include "utils.metrics.match" (dict "Values" .Values "Match" "prometheus.metrics.kubelet**"            "Id" "sumologic.endpoint.metrics.kubelet"                 "Endpoint" "SUMO_ENDPOINT_METRICS_KUBELET"                  "Storage" .Values.fluentd.buffer.filePaths.metrics.kubelet)         | nindent 4 }}
-{{ include "utils.metrics.match" (dict "Values" .Values "Match" "prometheus.metrics.container**"          "Id" "sumologic.endpoint.metrics.container"               "Endpoint" "SUMO_ENDPOINT_METRICS_KUBELET"                  "Storage" .Values.fluentd.buffer.filePaths.metrics.container)       | nindent 4 }}
-{{ include "utils.metrics.match" (dict "Values" .Values "Match" "prometheus.metrics.controller-manager**" "Id" "sumologic.endpoint.metrics.kube.controller.manager" "Endpoint" "SUMO_ENDPOINT_METRICS_KUBE_CONTROLLER_MANAGER"  "Storage" .Values.fluentd.buffer.filePaths.metrics.controller)      | nindent 4 }}
-{{ include "utils.metrics.match" (dict "Values" .Values "Match" "prometheus.metrics.scheduler**"          "Id" "sumologic.endpoint.metrics.kube.scheduler"          "Endpoint" "SUMO_ENDPOINT_METRICS_KUBE_SCHEDULER"           "Storage" .Values.fluentd.buffer.filePaths.metrics.scheduler)       | nindent 4 }}
-{{ include "utils.metrics.match" (dict "Values" .Values "Match" "prometheus.metrics.state**"              "Id" "sumologic.endpoint.metrics.kube.state"              "Endpoint" "SUMO_ENDPOINT_METRICS_KUBE_STATE"               "Storage" .Values.fluentd.buffer.filePaths.metrics.state)           | nindent 4 }}
-{{ include "utils.metrics.match" (dict "Values" .Values "Match" "prometheus.metrics.node**"               "Id" "sumologic.endpoint.metrics.node.exporter"           "Endpoint" "SUMO_ENDPOINT_METRICS_NODE_EXPORTER"            "Storage" .Values.fluentd.buffer.filePaths.metrics.node)            | nindent 4 }}
-{{ include "utils.metrics.match" (dict "Values" .Values "Match" "prometheus.metrics.control-plane**"      "Id" "sumologic.endpoint.metrics.control.plane"           "Endpoint" "SUMO_ENDPOINT_METRICS_CONTROL_PLANE"            "Storage" .Values.fluentd.buffer.filePaths.metrics.control_plane)   | nindent 4 }}
-{{ include "utils.metrics.match" (dict "Values" .Values "Match" "prometheus.metrics**"                    "Id" "sumologic.endpoint.metrics"                         "Endpoint" "SUMO_ENDPOINT_METRICS"                          "Storage" .Values.fluentd.buffer.filePaths.metrics.default)         | nindent 4 }}
-
+{{- $ctx := . }}
+{{- $out_keys := list "" -}}
+{{- range $key, $value := .Values.fluentd.metrics.output -}}
+{{- $out_keys = append $out_keys (printf "%d_%d_%s" (len ( $value.weight | toString )) ($value.weight | int) $key) -}}
+{{- end -}}
+{{- $out_keys := slice $out_keys 1 }}
+{{- range $_, $key := $out_keys | sortAlpha }}
+{{- $name := join "_" (slice (splitList "_" $key) 2)  }}
+{{- $source := get $ctx.Values.fluentd.metrics.output $name }}
+{{ include "utils.metrics.match" (dict "Context" $ctx "Match" $source.match "Id" $source.id "Endpoint" $source.endpoint "Storage" (get $ctx.Values.fluentd.buffer.filePaths.metrics $name) ) | nindent 4 }}
+{{- end }}
 </label>

--- a/deploy/helm/sumologic/conf/metrics/metrics.conf
+++ b/deploy/helm/sumologic/conf/metrics/metrics.conf
@@ -56,6 +56,6 @@
 {{- range $_, $key := $out_keys | sortAlpha }}
 {{- $name := join "_" (slice (splitList "_" $key) 2)  }}
 {{- $source := index $ctx.Values.fluentd.metrics.output $name }}
-{{ include "utils.metrics.match" (dict "Context" $ctx "Match" $source.match "Id" $source.id "Endpoint" $source.endpoint "Storage" (get $ctx.Values.fluentd.buffer.filePaths.metrics $name) ) | nindent 4 }}
+{{ include "utils.metrics.match" (dict "Context" $ctx "Match" $source.match "Id" $source.id "Endpoint" $source.endpoint "Storage" (index $ctx.Values.fluentd.buffer.filePaths.metrics $name) ) | nindent 4 }}
 {{- end }}
 </label>

--- a/deploy/helm/sumologic/conf/setup/setup.sh
+++ b/deploy/helm/sumologic/conf/setup/setup.sh
@@ -17,7 +17,7 @@ terraform init
 
 # Sumo Collector and HTTP sources
 terraform import sumologic_collector.collector "$COLLECTOR_NAME"
-{{ range $source := .Values.sumologic.sources }}
+{{ range $key, $source := .Values.sumologic.sources }}
 terraform import sumologic_http_source.{{ template "terraform.sources.name" $source }} "$COLLECTOR_NAME/{{ $source.value }}"
 {{- end }}
 terraform import sumologic_http_source.{{ template "terraform.sources.name" $logs }} "$COLLECTOR_NAME/{{ $logs.value }}"

--- a/deploy/helm/sumologic/conf/setup/setup.sh
+++ b/deploy/helm/sumologic/conf/setup/setup.sh
@@ -15,15 +15,9 @@ terraform init
 
 # Sumo Collector and HTTP sources
 terraform import sumologic_collector.collector "$COLLECTOR_NAME"
-terraform import sumologic_http_source.default_metrics_source "$COLLECTOR_NAME/(default-metrics)"
-terraform import sumologic_http_source.apiserver_metrics_source "$COLLECTOR_NAME/apiserver-metrics"
-terraform import sumologic_http_source.events_source "$COLLECTOR_NAME/events"
-terraform import sumologic_http_source.kube_controller_manager_metrics_source "$COLLECTOR_NAME/kube-controller-manager-metrics"
-terraform import sumologic_http_source.kube_scheduler_metrics_source "$COLLECTOR_NAME/kube-scheduler-metrics"
-terraform import sumologic_http_source.kube_state_metrics_source "$COLLECTOR_NAME/kube-state-metrics"
-terraform import sumologic_http_source.kubelet_metrics_source "$COLLECTOR_NAME/kubelet-metrics"
-terraform import sumologic_http_source.logs_source "$COLLECTOR_NAME/logs"
-terraform import sumologic_http_source.node_exporter_metrics_source "$COLLECTOR_NAME/node-exporter-metrics"
+{{ range $source := .Values.sumologic.sources }}
+terraform import sumologic_http_source.{{ template "sources.terraform_name" $source }} "$COLLECTOR_NAME/{{ $source.value }}"
+{{- end }}
 
 # Kubernetes Namespace and Secret
 terraform import kubernetes_namespace.sumologic_collection_namespace {{ .Release.Namespace }}

--- a/deploy/helm/sumologic/conf/setup/setup.sh
+++ b/deploy/helm/sumologic/conf/setup/setup.sh
@@ -16,7 +16,7 @@ terraform init
 # Sumo Collector and HTTP sources
 terraform import sumologic_collector.collector "$COLLECTOR_NAME"
 {{ range $source := .Values.sumologic.sources }}
-terraform import sumologic_http_source.{{ template "sources.terraform_name" $source }} "$COLLECTOR_NAME/{{ $source.value }}"
+terraform import sumologic_http_source.{{ template "terraform.sources.name" $source }} "$COLLECTOR_NAME/{{ $source.value }}"
 {{- end }}
 
 # Kubernetes Namespace and Secret

--- a/deploy/helm/sumologic/conf/setup/setup.sh
+++ b/deploy/helm/sumologic/conf/setup/setup.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+{{- $logs := (dict "name" "logs" "value" "logs" "endpoint" "logs" )}}
+{{- $events := (dict "name" "events" "value" "events" "endpoint" "events" "category" true )}}
 cp /etc/terraform/sumo-k8s.tf /terraform
 cd /terraform
 
@@ -18,6 +20,9 @@ terraform import sumologic_collector.collector "$COLLECTOR_NAME"
 {{ range $source := .Values.sumologic.sources }}
 terraform import sumologic_http_source.{{ template "terraform.sources.name" $source }} "$COLLECTOR_NAME/{{ $source.value }}"
 {{- end }}
+terraform import sumologic_http_source.{{ template "terraform.sources.name" $logs }} "$COLLECTOR_NAME/{{ $logs.value }}"
+terraform import sumologic_http_source.{{ template "terraform.sources.name" $events }} "$COLLECTOR_NAME/{{ $events.value }}"
+
 
 # Kubernetes Namespace and Secret
 terraform import kubernetes_namespace.sumologic_collection_namespace {{ .Release.Namespace }}

--- a/deploy/helm/sumologic/conf/setup/setup.sh
+++ b/deploy/helm/sumologic/conf/setup/setup.sh
@@ -1,6 +1,4 @@
 #!/bin/sh
-{{- $logs := (dict "name" "logs" "value" "logs" "endpoint" "logs" )}}
-{{- $events := (dict "name" "events" "value" "events" "endpoint" "events" "category" true )}}
 cp /etc/terraform/sumo-k8s.tf /terraform
 cd /terraform
 
@@ -18,10 +16,10 @@ terraform init
 # Sumo Collector and HTTP sources
 terraform import sumologic_collector.collector "$COLLECTOR_NAME"
 {{ range $key, $source := .Values.sumologic.sources }}
-terraform import sumologic_http_source.{{ template "terraform.sources.name" $source }} "$COLLECTOR_NAME/{{ $source.value }}"
+terraform import sumologic_http_source.{{ template "terraform.sources.name_metrics" $key }} "$COLLECTOR_NAME/{{ $source.value }}"
 {{- end }}
-terraform import sumologic_http_source.{{ template "terraform.sources.name" $logs }} "$COLLECTOR_NAME/{{ $logs.value }}"
-terraform import sumologic_http_source.{{ template "terraform.sources.name" $events }} "$COLLECTOR_NAME/{{ $events.value }}"
+terraform import sumologic_http_source.{{ template "terraform.sources.name" "logs" }} "$COLLECTOR_NAME/logs"
+terraform import sumologic_http_source.{{ template "terraform.sources.name" "events" }} "$COLLECTOR_NAME/events"
 
 
 # Kubernetes Namespace and Secret

--- a/deploy/helm/sumologic/conf/setup/sumo-k8s.tf
+++ b/deploy/helm/sumologic/conf/setup/sumo-k8s.tf
@@ -84,15 +84,9 @@ resource "kubernetes_secret" "sumologic_collection_secret" {
   }
 
   data = {
-    endpoint-events                           = "${sumologic_http_source.events_source.url}"
-    endpoint-logs                             = "${sumologic_http_source.logs_source.url}"
-    endpoint-metrics                          = "${sumologic_http_source.default_metrics_source.url}"
-    endpoint-metrics-apiserver                = "${sumologic_http_source.apiserver_metrics_source.url}"
-    endpoint-metrics-kube-controller-manager  = "${sumologic_http_source.kube_controller_manager_metrics_source.url}"
-    endpoint-metrics-kube-scheduler           = "${sumologic_http_source.kube_scheduler_metrics_source.url}"
-    endpoint-metrics-kube-state               = "${sumologic_http_source.kube_state_metrics_source.url}"
-    endpoint-metrics-kubelet                  = "${sumologic_http_source.kubelet_metrics_source.url}"
-    endpoint-metrics-node-exporter            = "${sumologic_http_source.node_exporter_metrics_source.url}"
+    {{ range $source := .Values.sumologic.sources -}}
+    {{ include "sources.terraform_data" $source }}
+    {{ end -}}
   }
 
   type = "Opaque"

--- a/deploy/helm/sumologic/conf/setup/sumo-k8s.tf
+++ b/deploy/helm/sumologic/conf/setup/sumo-k8s.tf
@@ -41,51 +41,16 @@ resource "sumologic_collector" "collector" {
     }
 }
 
-resource "sumologic_http_source" "default_metrics_source" {
-    name         = local.default-metrics-source-name
+{{- $ctx := .Values }}
+{{ range $source := .Values.sumologic.sources }}
+resource "sumologic_http_source" "{{ template "sources.terraform_name" $source }}" {
+    name         = local.{{ template "sources.terraform_source_name" $source }}
     collector_id = "${sumologic_collector.collector.id}"
+    {{- if $source.category }}
+    category     = {{ if $ctx.fluentd.events.sourceCategory }}{{ $ctx.fluentd.events.sourceCategory | quote }}{{- else}}{{ "\"${var.cluster_name}/${local.events-source-name}\"" }}{{- end}}
+    {{- end }}
 }
-
-resource "sumologic_http_source" "apiserver_metrics_source" {
-    name         = local.apiserver-metrics-source-name
-    collector_id = "${sumologic_collector.collector.id}"
-}
-
-resource "sumologic_http_source" "events_source" {
-    name         = local.events-source-name
-    category     = {{ if .Values.fluentd.events.sourceCategory }}{{ .Values.fluentd.events.sourceCategory | quote }}{{- else}}{{ "\"${var.cluster_name}/${local.events-source-name}\"" }}{{- end}}
-    collector_id = "${sumologic_collector.collector.id}"
-}
-
-resource "sumologic_http_source" "kube_controller_manager_metrics_source" {
-    name         = local.kube-controller-manager-metrics-source-name
-    collector_id = "${sumologic_collector.collector.id}"
-}
-
-resource "sumologic_http_source" "kube_scheduler_metrics_source" {
-    name         = local.kube-scheduler-metrics-source-name
-    collector_id = "${sumologic_collector.collector.id}"
-}
-
-resource "sumologic_http_source" "kube_state_metrics_source" {
-    name         = local.kube-state-metrics-source-name
-    collector_id = "${sumologic_collector.collector.id}"
-}
-
-resource "sumologic_http_source" "kubelet_metrics_source" {
-    name         = local.kubelet-metrics-source-name
-    collector_id = "${sumologic_collector.collector.id}"
-}
-
-resource "sumologic_http_source" "logs_source" {
-    name         = local.logs-source-name
-    collector_id = "${sumologic_collector.collector.id}"
-}
-
-resource "sumologic_http_source" "node_exporter_metrics_source" {
-    name         = local.node-exporter-metrics-source-name
-    collector_id = "${sumologic_collector.collector.id}"
-}
+{{ end }}
 
 provider "kubernetes" {
 {{- $ctx := .Values -}}

--- a/deploy/helm/sumologic/conf/setup/sumo-k8s.tf
+++ b/deploy/helm/sumologic/conf/setup/sumo-k8s.tf
@@ -26,8 +26,8 @@ locals {
 {{- range $source := .Values.sumologic.sources }}
   {{ template "terraform.sources.local" $source }}
 {{- end }}
-{{ template "terraform.sources.local" $logs }}
-{{ template "terraform.sources.local" $events }}
+  {{ template "terraform.sources.local" $logs }}
+  {{ template "terraform.sources.local" $events }}
 }
 
 provider "sumologic" {}
@@ -39,10 +39,10 @@ resource "sumologic_collector" "collector" {
     }
 }
 
-{{- $ctx := .Values }}
-{{ range $source := .Values.sumologic.sources }}
+{{- $ctx := .Values -}}
+{{- range $source := .Values.sumologic.sources }}
 {{ include "terraform.sources.resource" (dict "Source" $source "Context" $ctx) | nindent 2 }}
-{{ end }}
+{{- end }}
 {{ include "terraform.sources.resource" (dict "Source" $logs "Context" $ctx) | nindent 2 }}
 {{ include "terraform.sources.resource" (dict "Source" $events "Context" $ctx) | nindent 2 }}
 

--- a/deploy/helm/sumologic/conf/setup/sumo-k8s.tf
+++ b/deploy/helm/sumologic/conf/setup/sumo-k8s.tf
@@ -21,15 +21,9 @@ variable "namespace_name" {
 }
 
 locals {
-  default-metrics-source-name                 = "(default-metrics)"
-  apiserver-metrics-source-name               = "apiserver-metrics"
-  events-source-name                          = "events"
-  kube-controller-manager-metrics-source-name = "kube-controller-manager-metrics"
-  kube-scheduler-metrics-source-name          = "kube-scheduler-metrics"
-  kube-state-metrics-source-name              = "kube-state-metrics"
-  kubelet-metrics-source-name                 = "kubelet-metrics"
-  logs-source-name                            = "logs"
-  node-exporter-metrics-source-name           = "node-exporter-metrics"
+  {{- range $source := .Values.sumologic.sources }}
+  {{ template "sources.terraform_local" $source }}
+  {{- end }}
 }
 
 provider "sumologic" {}

--- a/deploy/helm/sumologic/conf/setup/sumo-k8s.tf
+++ b/deploy/helm/sumologic/conf/setup/sumo-k8s.tf
@@ -22,7 +22,7 @@ variable "namespace_name" {
 
 locals {
   {{- range $source := .Values.sumologic.sources }}
-  {{ template "sources.terraform_local" $source }}
+  {{ template "terraform.sources.local" $source }}
   {{- end }}
 }
 
@@ -37,8 +37,8 @@ resource "sumologic_collector" "collector" {
 
 {{- $ctx := .Values }}
 {{ range $source := .Values.sumologic.sources }}
-resource "sumologic_http_source" "{{ template "sources.terraform_name" $source }}" {
-    name         = local.{{ template "sources.terraform_source_name" $source }}
+resource "sumologic_http_source" "{{ template "terraform.sources.name" $source }}" {
+    name         = local.{{ template "terraform.sources.source_name" $source }}
     collector_id = "${sumologic_collector.collector.id}"
     {{- if $source.category }}
     category     = {{ if $ctx.fluentd.events.sourceCategory }}{{ $ctx.fluentd.events.sourceCategory | quote }}{{- else}}{{ "\"${var.cluster_name}/${local.events-source-name}\"" }}{{- end}}
@@ -85,7 +85,7 @@ resource "kubernetes_secret" "sumologic_collection_secret" {
 
   data = {
     {{ range $source := .Values.sumologic.sources -}}
-    {{ include "sources.terraform_data" $source }}
+    {{ include "terraform.sources.data" $source }}
     {{ end -}}
   }
 

--- a/deploy/helm/sumologic/conf/setup/sumo-k8s.tf
+++ b/deploy/helm/sumologic/conf/setup/sumo-k8s.tf
@@ -43,6 +43,11 @@ resource "sumologic_http_source" "{{ template "terraform.sources.name" $source }
     {{- if $source.category }}
     category     = {{ if $ctx.fluentd.events.sourceCategory }}{{ $ctx.fluentd.events.sourceCategory | quote }}{{- else}}{{ "\"${var.cluster_name}/${local.events-source-name}\"" }}{{- end}}
     {{- end }}
+    {{- if $source.fields }}
+    {{- range $fkey, $fvalue := $source.fields }}
+    {{ $fkey }}  = "{{ $fvalue }}"
+    {{- end -}}
+    {{ end }}
 }
 {{ end }}
 

--- a/deploy/helm/sumologic/conf/setup/sumo-k8s.tf
+++ b/deploy/helm/sumologic/conf/setup/sumo-k8s.tf
@@ -85,10 +85,10 @@ resource "kubernetes_secret" "sumologic_collection_secret" {
 
   data = {
     {{ range $key, $source := .Values.sumologic.sources -}}
-    {{ include "terraform.sources.data" (include "terraform.sources.name_metrics" $key) }}
+    {{ include "terraform.sources.data" (dict "Endpoint" (include "terraform.sources.config-map-variable" (dict "Context" $ctx "Name" $key)) "Name" (include "terraform.sources.name_metrics" $key)) }}
     {{ end -}}
-    {{ include "terraform.sources.data" (include "terraform.sources.name" "logs") }}
-    {{ include "terraform.sources.data" (include "terraform.sources.name" "events") }}
+    {{ include "terraform.sources.data" (dict "Endpoint" (include "terraform.sources.config-map-variable" (dict "Context" $ctx "Name" "logs" "Endpoint" "endpoint-logs")) "Name" (include "terraform.sources.name" "logs")) }}
+    {{ include "terraform.sources.data" (dict "Endpoint" (include "terraform.sources.config-map-variable" (dict "Context" $ctx "Name" "events" "Endpoint" "endpoint-events")) "Name" (include "terraform.sources.name" "events")) }}
   }
 
   type = "Opaque"

--- a/deploy/helm/sumologic/conf/setup/sumo-k8s.tf
+++ b/deploy/helm/sumologic/conf/setup/sumo-k8s.tf
@@ -23,7 +23,7 @@ variable "namespace_name" {
 }
 
 locals {
-{{- range $source := .Values.sumologic.sources }}
+{{- range $key, $source := .Values.sumologic.sources }}
   {{ template "terraform.sources.local" $source }}
 {{- end }}
   {{ template "terraform.sources.local" $logs }}
@@ -40,7 +40,7 @@ resource "sumologic_collector" "collector" {
 }
 
 {{- $ctx := .Values -}}
-{{- range $source := .Values.sumologic.sources }}
+{{- range $key, $source := .Values.sumologic.sources }}
 {{ include "terraform.sources.resource" (dict "Source" $source "Context" $ctx) | nindent 2 }}
 {{- end }}
 {{ include "terraform.sources.resource" (dict "Source" $logs "Context" $ctx) | nindent 2 }}
@@ -84,7 +84,7 @@ resource "kubernetes_secret" "sumologic_collection_secret" {
   }
 
   data = {
-    {{ range $source := .Values.sumologic.sources -}}
+    {{ range $key, $source := .Values.sumologic.sources -}}
     {{ include "terraform.sources.data" $source }}
     {{ end -}}
     {{ include "terraform.sources.data" $logs }}

--- a/deploy/helm/sumologic/conf/setup/sumo-k8s.tf
+++ b/deploy/helm/sumologic/conf/setup/sumo-k8s.tf
@@ -24,7 +24,7 @@ variable "namespace_name" {
 
 locals {
 {{- range $key, $source := .Values.sumologic.sources }}
-  {{ template "terraform.sources.local" (dict "Name" (include "terraform.sources.name_metrics" $key) "Value" $source.value) }}
+  {{ template "terraform.sources.local" (dict "Name" (include "terraform.sources.name_metrics" $key) "Value" $source.name) }}
 {{- end }}
   {{ template "terraform.sources.local" (dict "Name" (include "terraform.sources.name" "logs") "Value" "logs") }}
   {{ template "terraform.sources.local" (dict "Name" (include "terraform.sources.name" "events") "Value" "events") }}

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -453,11 +453,11 @@ Generate line for data terraform section
 
 Example usage:
 
-{{ include "terraform.sources.data" $source }}
+{{ include "terraform.sources.data" (dict "Endpoint" "enpoint-default-metrics" "Name" "default") }}
 
 */}}
 {{- define "terraform.sources.data" -}}
-{{ printf "%-41s = \"${sumologic_http_source.%s.url}\"" (include "terraform.sources.endpoint_name" .) . }}
+{{ printf "%-41s = \"${sumologic_http_source.%s.url}\"" .Endpoint .Name }}
 {{- end -}}
 
 {{/*
@@ -483,4 +483,27 @@ resource "sumologic_http_source" "{{ .Name }}" {
     {{- end -}}
     {{ end }}
 }
+{{- end -}}
+
+{{/*
+get configuration variable name for sources confg map
+
+Example usage:
+
+{{ include "terraform.sources.config-map-variable" (dict "Context" .Values "Name" $name "Endpoint" $endpoint) }}
+
+*/}}
+{{- define "terraform.sources.config-map-variable" -}}
+{{- $name := .Name -}}
+{{- $ctx := .Context -}}
+{{- $endpoint := .Endpoint -}}
+{{- if not $endpoint -}}
+{{- $source := (index $ctx.sumologic.sources "default") -}}
+{{- if (index $ctx.sumologic.sources .Name "config-name") -}}
+{{- $endpoint = index $ctx.sumologic.sources .Name "config-name" -}}
+{{- else -}}
+{{- $endpoint = printf "endpoint-%s" (include "terraform.sources.name_metrics" $name) -}}
+{{- end -}}
+{{- end -}}
+{{ $endpoint }}
 {{- end -}}

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -377,3 +377,17 @@ Example usage (as one line):
   </buffer>
 </match>
 {{- end -}}
+
+{{/*
+Convert source name to terraform name:
+ * converts all `-` to `_`
+ * adds `_source` suffix
+
+Example usage:
+
+{{ include "sources.terraform_name" $source }}
+
+*/}}
+{{- define "sources.terraform_name" -}}
+{{ replace "-" "_" .name }}_source
+{{- end -}}

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -354,14 +354,14 @@ Example usage (as one line):
 
 {{ include "utils.metrics.match" (dict 
   "Values" . 
-  "Match" "prometheus.metrics.kubelet" 
+  "Tag" "prometheus.metrics.kubelet" 
   "Endpoint" "SUMO_ENDPOINT_METRICS" 
   "Storage" .Values.fluentd.buffer.filePaths.metrics.default
   "Id" sumologic.endpoint.metrics
 )}}
 */}}
 {{- define "utils.metrics.match" -}}
-<match {{ .Match }}>
+<match {{ .Tag }}>
 {{- if .Drop }}
   @type null
 {{- else }}

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -353,7 +353,7 @@ Generate metrics match configuration
 Example usage (as one line):
 
 {{ include "utils.metrics.match" (dict 
-  "Values" .Values 
+  "Values" . 
   "Match" "prometheus.metrics.kubelet" 
   "Endpoint" "SUMO_ENDPOINT_METRICS" 
   "Storage" .Values.fluentd.buffer.filePaths.metrics.default
@@ -364,10 +364,11 @@ Example usage (as one line):
 <match {{ .Match }}>
   @type sumologic
   @id {{ .Id }}
-  endpoint "#{ENV['{{ .Endpoint }}']}"
-{{- .Values.fluentd.metrics.outputConf | nindent 2 }}
+  sumo_client {{ include "sumologic.sumo_client" .Context | quote }}
+  endpoint "#{ENV['SUMO_ENDPOINT_{{ replace "-" "_" .Endpoint | upper }}']}"
+{{- .Context.Values.fluentd.metrics.outputConf | nindent 2 }}
   <buffer>
-    {{- if or .Values.fluentd.persistence.enabled (eq .Values.fluentd.buffer.type "file") }}
+    {{- if or .Context.Values.fluentd.persistence.enabled (eq .Context.Values.fluentd.buffer.type "file") }}
     @type file
     path {{ .Storage }}
     {{- else }}

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -385,10 +385,10 @@ Convert source name to terraform name:
 
 Example usage:
 
-{{ include "sources.terraform_name" $source }}
+{{ include "terraform.sources.name" $source }}
 
 */}}
-{{- define "sources.terraform_name" -}}
+{{- define "terraform.sources.name" -}}
 {{ replace "-" "_" .name }}_source
 {{- end -}}
 
@@ -398,24 +398,24 @@ Generate terraform name basing on name
 
 Example usage:
 
-{{ include "sources.terraform_source_name" $source }}
+{{ include "terraform.sources.source_name" $source }}
 
 */}}
-{{- define "sources.terraform_source_name" -}}
+{{- define "terraform.sources.source_name" -}}
 {{ printf "%s-source-name" .name }}
 {{- end -}}
 
 {{/*
 Generate line for local terraform section
- * `sources.terraform_source_name = value`
+ * `terraform.sources.source_name = value`
 
 Example usage:
 
-{{ include "sources.terraform_source_name" $source }}
+{{ include "terraform.sources.source_name" $source }}
 
 */}}
-{{- define "sources.terraform_local" -}}
-{{ printf "%-43s = \"%s\"" (include "sources.terraform_source_name" .) .value }}
+{{- define "terraform.sources.local" -}}
+{{ printf "%-43s = \"%s\"" (include "terraform.sources.source_name" .) .value }}
 {{- end -}}
 
 {{/*
@@ -423,9 +423,9 @@ Generate line for data terraform section
 
 Example usage:
 
-{{ include "sources.terraform_data" $source }}
+{{ include "terraform.sources.data" $source }}
 
 */}}
-{{- define "sources.terraform_data" -}}
-{{ printf "endpoint-%-32s = \"${sumologic_http_source.%s.url}\"" .endpoint (include "sources.terraform_name" .) }}
+{{- define "terraform.sources.data" -}}
+{{ printf "endpoint-%-32s = \"${sumologic_http_source.%s.url}\"" .endpoint (include "terraform.sources.name" .) }}
 {{- end -}}

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -404,3 +404,16 @@ Example usage:
 {{- define "sources.terraform_source_name" -}}
 {{ printf "%s-source-name" .name }}
 {{- end -}}
+
+{{/*
+Generate line for local terraform section
+ * `sources.terraform_source_name = value`
+
+Example usage:
+
+{{ include "sources.terraform_source_name" $source }}
+
+*/}}
+{{- define "sources.terraform_local" -}}
+{{ printf "%-43s = \"%s\"" (include "sources.terraform_source_name" .) .value }}
+{{- end -}}

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -428,7 +428,7 @@ Example usage:
 
 */}}
 {{- define "terraform.sources.data" -}}
-{{ printf "endpoint-%-32s = \"${sumologic_http_source.%s.url}\"" .endpoint (include "terraform.sources.name" .) }}
+{{ printf "endpoint-%-32s = \"${sumologic_http_source.%s.url}\"" .name (include "terraform.sources.name" .) }}
 {{- end -}}
 
 

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -391,3 +391,16 @@ Example usage:
 {{- define "sources.terraform_name" -}}
 {{ replace "-" "_" .name }}_source
 {{- end -}}
+
+{{/*
+Generate terraform name basing on name
+ * adds `-source-name` suffix
+
+Example usage:
+
+{{ include "sources.terraform_source_name" $source }}
+
+*/}}
+{{- define "sources.terraform_source_name" -}}
+{{ printf "%s-source-name" .name }}
+{{- end -}}

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -362,6 +362,9 @@ Example usage (as one line):
 */}}
 {{- define "utils.metrics.match" -}}
 <match {{ .Match }}>
+{{- if .Drop }}
+  @type null
+{{- else }}
   @type sumologic
   @id {{ .Id }}
   sumo_client {{ include "sumologic.sumo_client" .Context | quote }}
@@ -376,8 +379,9 @@ Example usage (as one line):
     {{- end }}
     @include buffer.output.conf
   </buffer>
+{{- end }}
 </match>
-{{- end -}}
+{{ end -}}
 
 {{/*
 Convert source name to terraform name:

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -430,3 +430,29 @@ Example usage:
 {{- define "terraform.sources.data" -}}
 {{ printf "endpoint-%-32s = \"${sumologic_http_source.%s.url}\"" .endpoint (include "terraform.sources.name" .) }}
 {{- end -}}
+
+
+{{/*
+Generate resource sections
+
+Example usage:
+
+{{ include "terraform.sources.resource" (dict "Source" $source "Context" $ctx) }}
+
+*/}}
+{{- define "terraform.sources.resource" -}}
+{{- $source := .Source -}}
+{{- $ctx := .Context -}}
+resource "sumologic_http_source" "{{ template "terraform.sources.name" $source }}" {
+    name         = local.{{ template "terraform.sources.source_name" $source }}
+    collector_id = "${sumologic_collector.collector.id}"
+    {{- if $source.category }}
+    category     = {{ if $ctx.fluentd.events.sourceCategory }}{{ $ctx.fluentd.events.sourceCategory | quote }}{{- else}}{{ "\"${var.cluster_name}/${local.events-source-name}\"" }}{{- end}}
+    {{- end }}
+    {{- if $source.fields }}
+    {{- range $fkey, $fvalue := $source.fields }}
+    {{ $fkey }}  = "{{ $fvalue }}"
+    {{- end -}}
+    {{ end }}
+}
+{{- end -}}

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -417,3 +417,15 @@ Example usage:
 {{- define "sources.terraform_local" -}}
 {{ printf "%-43s = \"%s\"" (include "sources.terraform_source_name" .) .value }}
 {{- end -}}
+
+{{/*
+Generate line for data terraform section
+
+Example usage:
+
+{{ include "sources.terraform_data" $source }}
+
+*/}}
+{{- define "sources.terraform_data" -}}
+{{ printf "endpoint-%-32s = \"${sumologic_http_source.%s.url}\"" .endpoint (include "sources.terraform_name" .) }}
+{{- end -}}

--- a/deploy/helm/sumologic/templates/events-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/events-statefulset.yaml
@@ -70,7 +70,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: sumologic
-              key: {{ template "terraform.sources.endpoint_name" (include "terraform.sources.name" "events") }}
+              key: {{ template "terraform.sources.config-map-variable" (dict "Context" .Values "Endpoint" "endpoint-events") }}
 {{- if .Values.fluentd.events.extraEnvVars }}
 {{ toYaml .Values.fluentd.events.extraEnvVars | nindent 10 }}
 {{- end }}

--- a/deploy/helm/sumologic/templates/events-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/events-statefulset.yaml
@@ -66,11 +66,11 @@ spec:
           initialDelaySeconds: 30
           periodSeconds: 5
         env:
-        - name: SUMO_ENDPOINT_EVENTS
+        - name: {{ template "terraform.sources.endpoint" (include "terraform.sources.name" "events") }}
           valueFrom:
             secretKeyRef:
               name: sumologic
-              key: endpoint-events
+              key: {{ template "terraform.sources.endpoint_name" (include "terraform.sources.name" "events") }}
 {{- if .Values.fluentd.events.extraEnvVars }}
 {{ toYaml .Values.fluentd.events.extraEnvVars | nindent 10 }}
 {{- end }}

--- a/deploy/helm/sumologic/templates/metrics-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics-statefulset.yaml
@@ -115,12 +115,13 @@ spec:
 {{ toYaml .Values.fluentd.metrics.extraVolumeMounts | indent 8 }}
 {{- end }}
         env:
+{{- $ctx := .Values -}}
 {{- range $key, $source := .Values.sumologic.sources }}
         - name: {{ template "terraform.sources.endpoint" (include "terraform.sources.name_metrics" $key) }}
           valueFrom:
             secretKeyRef:
               name: sumologic
-              key: {{ template "terraform.sources.endpoint_name" (include "terraform.sources.name_metrics" $key) }}
+              key: {{ template "terraform.sources.config-map-variable" (dict "Context" $ctx "Name" $key) }}
 {{- end }}
         {{- if .Values.sumologic.traces.enabled }}
         - name: SUMO_ENDPOINT_TRACES

--- a/deploy/helm/sumologic/templates/metrics-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics-statefulset.yaml
@@ -115,41 +115,13 @@ spec:
 {{ toYaml .Values.fluentd.metrics.extraVolumeMounts | indent 8 }}
 {{- end }}
         env:
-        - name: SUMO_ENDPOINT_METRICS
+{{- range $key, $source := .Values.sumologic.sources }}
+        - name: {{ template "terraform.sources.endpoint" (include "terraform.sources.name_metrics" $key) }}
           valueFrom:
             secretKeyRef:
               name: sumologic
-              key: endpoint-metrics
-        - name: SUMO_ENDPOINT_METRICS_APISERVER
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics-apiserver
-        - name: SUMO_ENDPOINT_METRICS_KUBELET
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics-kubelet
-        - name: SUMO_ENDPOINT_METRICS_KUBE_CONTROLLER_MANAGER
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics-kube-controller-manager
-        - name: SUMO_ENDPOINT_METRICS_KUBE_SCHEDULER
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics-kube-scheduler
-        - name: SUMO_ENDPOINT_METRICS_KUBE_STATE
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics-kube-state
-        - name: SUMO_ENDPOINT_METRICS_NODE_EXPORTER
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics-node-exporter
+              key: {{ template "terraform.sources.endpoint_name" (include "terraform.sources.name_metrics" $key) }}
+{{- end }}
         {{- if .Values.sumologic.traces.enabled }}
         - name: SUMO_ENDPOINT_TRACES
           value: {{ .Values.sumologic.traces.endpoint }}

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -120,51 +120,11 @@ spec:
 {{ toYaml .Values.fluentd.logs.extraVolumeMounts | indent 8 }}
 {{- end }}
         env:
-        - name: SUMO_ENDPOINT_METRICS
+        - name: {{ template "terraform.sources.endpoint" (include "terraform.sources.name" "logs") }}
           valueFrom:
             secretKeyRef:
               name: sumologic
-              key: endpoint-metrics
-        - name: SUMO_ENDPOINT_METRICS_APISERVER
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics-apiserver
-        - name: SUMO_ENDPOINT_METRICS_KUBELET
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics-kubelet
-        - name: SUMO_ENDPOINT_METRICS_KUBE_CONTROLLER_MANAGER
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics-kube-controller-manager
-        - name: SUMO_ENDPOINT_METRICS_KUBE_SCHEDULER
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics-kube-scheduler
-        - name: SUMO_ENDPOINT_METRICS_KUBE_STATE
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics-kube-state
-        - name: SUMO_ENDPOINT_METRICS_NODE_EXPORTER
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics-node-exporter
-        - name: SUMO_ENDPOINT_METRICS_CONTROL_PLANE
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics-control-plane
-        - name: SUMO_ENDPOINT_LOGS
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-logs
+              key: {{ template "terraform.sources.endpoint_name" (include "terraform.sources.name" "logs") }}
         {{- if .Values.sumologic.traces.enabled }}
         - name: SUMO_ENDPOINT_TRACES
           value: {{ .Values.sumologic.traces.endpoint }}

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -124,7 +124,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: sumologic
-              key: {{ template "terraform.sources.endpoint_name" (include "terraform.sources.name" "logs") }}
+              key: {{ template "terraform.sources.config-map-variable" (dict "Context" .Values "Endpoint" "endpoint-logs") }}
         {{- if .Values.sumologic.traces.enabled }}
         - name: SUMO_ENDPOINT_TRACES
           value: {{ .Values.sumologic.traces.endpoint }}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -94,28 +94,36 @@ sumologic:
   ## value: source values - it's visible in sumologic platform
   ## endpoint: binds source with fluentd configuration: (fluentd.metrics.output[])
   sources:
-    - name: default-metrics
+    default:
+      name: default-metrics
       value: (default-metrics)
       endpoint: metrics
-    - name: apiserver-metrics
+    apiserver:
+      name: apiserver-metrics
       value: apiserver-metrics
       endpoint: metrics-apiserver
-    - name: kube-controller-manager-metrics
+    controller:
+      name: kube-controller-manager-metrics
       value: kube-controller-manager-metrics
       endpoint: metrics-kube-controller-manager
-    - name: kube-scheduler-metrics
+    scheduler:
+      name: kube-scheduler-metrics
       value: kube-scheduler-metrics
       endpoint: metrics-kube-scheduler
-    - name: kube-state-metrics
+    state:
+      name: kube-state-metrics
       value: kube-state-metrics
       endpoint: metrics-kube-state
-    - name: kubelet-metrics
+    kubelet:
+      name: kubelet-metrics
       value: kubelet-metrics
       endpoint: metrics-kubelet
-    - name: node-exporter-metrics
+    node:
+      name: node-exporter-metrics
       value: node-exporter-metrics
       endpoint: metrics-node-exporter
-    - name: control-plane-metrics
+    control-plane:
+      name: control-plane-metrics
       value: control-plane-metrics
       endpoint: control-plane
 

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -100,10 +100,6 @@ sumologic:
     - name: apiserver-metrics
       value: apiserver-metrics
       endpoint: metrics-apiserver
-    - name: events
-      value: events
-      endpoint: events
-      category: true
     - name: kube-controller-manager-metrics
       value: kube-controller-manager-metrics
       endpoint: metrics-kube-controller-manager
@@ -116,9 +112,6 @@ sumologic:
     - name: kubelet-metrics
       value: kubelet-metrics
       endpoint: metrics-kubelet
-    - name: logs
-      value: logs
-      endpoint: logs
     - name: node-exporter-metrics
       value: node-exporter-metrics
       endpoint: metrics-node-exporter

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -89,6 +89,10 @@ sumologic:
         helm.sh/hook-weight: "0"
         helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 
+  ## Configuration of http sources
+  ## name: source name
+  ## value: source values - it's visible in sumologic platform
+  ## endpoint: binds source with fluentd configuration: (fluentd.metrics.output[])
   sources:
     - name: default-metrics
       value: (default-metrics)
@@ -467,6 +471,10 @@ fluentd:
     #     readOnly: true
   
     ## Output configuration
+    ## match: fluentd match
+    ## id: sumologic output @id
+    ## endpoint: It should match the sumologic.sources[].endpoint
+    ## Order of output plugins has meaning in case of fliuentd matches
     output:
       apiserver:
         match: prometheus.metrics.apiserver**

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -92,22 +92,29 @@ sumologic:
   ## Configuration of http sources
   ## name: source name
   ## value: source values - it's visible in sumologic platform
-  ## endpoint: binds source with fluentd configuration: (fluentd.metrics.output[])
+  ## config-name: This is mostly for backward compatibility
   sources:
     default:
       value: (default-metrics)
+      config-name: endpoint-metrics
     apiserver:
       value: apiserver-metrics
+      config-name: endpoint-metrics-apiserver
     controller:
       value: kube-controller-manager-metrics
+      config-name: endpoint-metrics-kube-controller-manager
     scheduler:
       value: kube-scheduler-metrics
+      config-name: endpoint-metrics-kube-scheduler
     state:
       value: kube-state-metrics
+      config-name: endpoint-metrics-kube-state
     kubelet:
       value: kubelet-metrics
+      config-name: endpoint-metrics-kubelet
     node:
       value: node-exporter-metrics
+      config-name: endpoint-metrics-node-exporter
     control-plane:
       value: control-plane-metrics
 

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -95,28 +95,20 @@ sumologic:
   ## endpoint: binds source with fluentd configuration: (fluentd.metrics.output[])
   sources:
     default:
-      name: default-metrics
       value: (default-metrics)
     apiserver:
-      name: apiserver-metrics
       value: apiserver-metrics
     controller:
-      name: kube-controller-manager-metrics
       value: kube-controller-manager-metrics
     scheduler:
-      name: kube-scheduler-metrics
       value: kube-scheduler-metrics
     state:
-      name: kube-state-metrics
       value: kube-state-metrics
     kubelet:
-      name: kubelet-metrics
       value: kubelet-metrics
     node:
-      name: node-exporter-metrics
       value: node-exporter-metrics
     control-plane:
-      name: control-plane-metrics
       value: control-plane-metrics
 
   # Traces configuration
@@ -467,6 +459,8 @@ fluentd:
     ## match: fluentd match
     ## id: sumologic output @id
     ## endpoint: It should match the sumologic.sources[].endpoint
+    ## drop: true
+    ## weight: default 10
     ## Order of output plugins has meaning in case of fliuentd matches
     output:
       apiserver:
@@ -1085,13 +1079,13 @@ prometheus-operator:
               sourceLabels: [__name__]
         # control plane metrics
         # coredns
-        - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.control-plane
+        - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.control-plane.coredns
           writeRelabelConfigs:
             - action: keep
               regex: coredns
               sourceLabels: [job]
         # etcd server
-        - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.control-plane
+        - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.control-plane.kube-etcd
           writeRelabelConfigs:
             - action: keep
               regex: kube-etcd

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -456,48 +456,48 @@ fluentd:
     #     readOnly: true
   
     ## Output configuration
-    ## match: fluentd match
+    ## tag: tag for fluentd match
     ## id: sumologic output @id
-    ## endpoint: It should match the sumologic.sources[].endpoint
-    ## drop: true
-    ## weight: default 10
-    ## Order of output plugins has meaning in case of fliuentd matches
+    ## endpoint: [optional] [output key by default] It should match the sumologic.sources[].endpoint
+    ## drop: [optional] [false by default] Change it to true to drop traffic for specific output
+    ## weight: [optional [0 by default] Order of fluentd output (lower means higher priority)
+    ## The weight has meaning in case of fluentd matches
     output:
       apiserver:
-        match: prometheus.metrics.apiserver**
+        tag: prometheus.metrics.apiserver**
         id: sumologic.endpoint.metrics.apiserver
         weight: 90
       kubelet:
-        match: prometheus.metrics.kubelet**
+        tag: prometheus.metrics.kubelet**
         id: sumologic.endpoint.metrics.kubelet
         weight: 90
       container:
-        match: prometheus.metrics.container**
+        tag: prometheus.metrics.container**
         id: sumologic.endpoint.metrics.container
         source: kubelet
         weight: 90
       controller:
-        match: prometheus.metrics.controller-manager**
+        tag: prometheus.metrics.controller-manager**
         id: sumologic.endpoint.metrics.kube.controller.manager
         weight: 90
       scheduler:
-        match: prometheus.metrics.scheduler**
+        tag: prometheus.metrics.scheduler**
         id: sumologic.endpoint.metrics.kube.scheduler
         weight: 90
       state:
-        match: prometheus.metrics.state**
+        tag: prometheus.metrics.state**
         id: sumologic.endpoint.metrics.kube.state
         weight: 90
       node:
-        match: prometheus.metrics.node**
+        tag: prometheus.metrics.node**
         id: sumologic.endpoint.metrics.node.exporter
         weight: 90
       control-plane:
-        match: prometheus.metrics.control-plane**
+        tag: prometheus.metrics.control-plane**
         id: sumologic.endpoint.metrics.control.plane
         weight: 90
       default:
-        match: prometheus.metrics**
+        tag: prometheus.metrics**
         id: sumologic.endpoint.metrics
         weight: 100
 

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -97,35 +97,27 @@ sumologic:
     default:
       name: default-metrics
       value: (default-metrics)
-      endpoint: metrics
     apiserver:
       name: apiserver-metrics
       value: apiserver-metrics
-      endpoint: metrics-apiserver
     controller:
       name: kube-controller-manager-metrics
       value: kube-controller-manager-metrics
-      endpoint: metrics-kube-controller-manager
     scheduler:
       name: kube-scheduler-metrics
       value: kube-scheduler-metrics
-      endpoint: metrics-kube-scheduler
     state:
       name: kube-state-metrics
       value: kube-state-metrics
-      endpoint: metrics-kube-state
     kubelet:
       name: kubelet-metrics
       value: kubelet-metrics
-      endpoint: metrics-kubelet
     node:
       name: node-exporter-metrics
       value: node-exporter-metrics
-      endpoint: metrics-node-exporter
     control-plane:
       name: control-plane-metrics
       value: control-plane-metrics
-      endpoint: control-plane
 
   # Traces configuration
   # This is experimental feature and may be unavailable for your account
@@ -480,47 +472,39 @@ fluentd:
       apiserver:
         match: prometheus.metrics.apiserver**
         id: sumologic.endpoint.metrics.apiserver
-        endpoint: metrics-apiserver
         weight: 90
       kubelet:
         match: prometheus.metrics.kubelet**
         id: sumologic.endpoint.metrics.kubelet
-        endpoint: metrics-kubelet
         weight: 90
       container:
         match: prometheus.metrics.container**
         id: sumologic.endpoint.metrics.container
-        endpoint: metrics-kubelet
+        source: kubelet
         weight: 90
       controller:
         match: prometheus.metrics.controller-manager**
         id: sumologic.endpoint.metrics.kube.controller.manager
-        endpoint: metrics-kube-controller-manager
         weight: 90
       scheduler:
         match: prometheus.metrics.scheduler**
         id: sumologic.endpoint.metrics.kube.scheduler
-        endpoint: metrics-kube-scheduler
         weight: 90
       state:
         match: prometheus.metrics.state**
         id: sumologic.endpoint.metrics.kube.state
-        endpoint: metrics-kube-state
         weight: 90
       node:
         match: prometheus.metrics.node**
         id: sumologic.endpoint.metrics.node.exporter
-        endpoint: metrics-node-exporter
         weight: 90
       control-plane:
         match: prometheus.metrics.control-plane**
         id: sumologic.endpoint.metrics.control.plane
-        endpoint: metrics-control-plane
         weight: 90
       default:
         match: prometheus.metrics**
         id: sumologic.endpoint.metrics
-        endpoint: metrics
         weight: 100
 
   events:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -89,6 +89,36 @@ sumologic:
         helm.sh/hook-weight: "0"
         helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 
+  sources:
+    - name: default-metrics
+      value: (default-metrics)
+      endpoint: metrics
+    - name: apiserver-metrics
+      value: apiserver-metrics
+      endpoint: metrics-apiserver
+    - name: events
+      value: events
+      endpoint: events
+      category: true
+    - name: kube-controller-manager-metrics
+      value: kube-controller-manager-metrics
+      endpoint: metrics-kube-controller-manager
+    - name: kube-scheduler-metrics
+      value: kube-scheduler-metrics
+      endpoint: metrics-kube-scheduler
+    - name: kube-state-metrics
+      value: kube-state-metrics
+      endpoint: metrics-kube-state
+    - name: kubelet-metrics
+      value: kubelet-metrics
+      endpoint: metrics-kubelet
+    - name: logs
+      value: logs
+      endpoint: logs
+    - name: node-exporter-metrics
+      value: node-exporter-metrics
+      endpoint: metrics-node-exporter
+
   # Traces configuration
   # This is experimental feature and may be unavailable for your account
   traces:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -118,6 +118,9 @@ sumologic:
     - name: node-exporter-metrics
       value: node-exporter-metrics
       endpoint: metrics-node-exporter
+    - name: control-plane-metrics
+      value: control-plane-metrics
+      endpoint: control-plane
 
   # Traces configuration
   # This is experimental feature and may be unavailable for your account

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -90,33 +90,32 @@ sumologic:
         helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 
   ## Configuration of http sources
-  ## name: source name
-  ## value: source values - it's visible in sumologic platform
+  ## name: source name visible in sumologic platform
   ## config-name: This is mostly for backward compatibility
   sources:
     default:
-      value: (default-metrics)
+      name: (default-metrics)
       config-name: endpoint-metrics
     apiserver:
-      value: apiserver-metrics
+      name: apiserver-metrics
       config-name: endpoint-metrics-apiserver
     controller:
-      value: kube-controller-manager-metrics
+      name: kube-controller-manager-metrics
       config-name: endpoint-metrics-kube-controller-manager
     scheduler:
-      value: kube-scheduler-metrics
+      name: kube-scheduler-metrics
       config-name: endpoint-metrics-kube-scheduler
     state:
-      value: kube-state-metrics
+      name: kube-state-metrics
       config-name: endpoint-metrics-kube-state
     kubelet:
-      value: kubelet-metrics
+      name: kubelet-metrics
       config-name: endpoint-metrics-kubelet
     node:
-      value: node-exporter-metrics
+      name: node-exporter-metrics
       config-name: endpoint-metrics-node-exporter
     control-plane:
-      value: control-plane-metrics
+      name: control-plane-metrics
 
   # Traces configuration
   # This is experimental feature and may be unavailable for your account

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -199,7 +199,7 @@ fluentd:
         scheduler: /fluentd/buffer/metrics.scheduler
         state: /fluentd/buffer/metrics.state
         node: /fluentd/buffer/metrics.node
-        control_plane: /fluentd/buffer/metrics.control_plane
+        control-plane: /fluentd/buffer/metrics.control_plane
         default: /fluentd/buffer/metrics.default
       events: /fluentd/buffer/events
       traces: /fluentd/buffer/traces
@@ -466,6 +466,54 @@ fluentd:
     #     mountPath: /certs
     #     readOnly: true
   
+    ## Output configuration
+    output:
+      apiserver:
+        match: prometheus.metrics.apiserver**
+        id: sumologic.endpoint.metrics.apiserver
+        endpoint: metrics-apiserver
+        weight: 90
+      kubelet:
+        match: prometheus.metrics.kubelet**
+        id: sumologic.endpoint.metrics.kubelet
+        endpoint: metrics-kubelet
+        weight: 90
+      container:
+        match: prometheus.metrics.container**
+        id: sumologic.endpoint.metrics.container
+        endpoint: metrics-kubelet
+        weight: 90
+      controller:
+        match: prometheus.metrics.controller-manager**
+        id: sumologic.endpoint.metrics.kube.controller.manager
+        endpoint: metrics-kube-controller-manager
+        weight: 90
+      scheduler:
+        match: prometheus.metrics.scheduler**
+        id: sumologic.endpoint.metrics.kube.scheduler
+        endpoint: metrics-kube-scheduler
+        weight: 90
+      state:
+        match: prometheus.metrics.state**
+        id: sumologic.endpoint.metrics.kube.state
+        endpoint: metrics-kube-state
+        weight: 90
+      node:
+        match: prometheus.metrics.node**
+        id: sumologic.endpoint.metrics.node.exporter
+        endpoint: metrics-node-exporter
+        weight: 90
+      control-plane:
+        match: prometheus.metrics.control-plane**
+        id: sumologic.endpoint.metrics.control.plane
+        endpoint: metrics-control-plane
+        weight: 90
+      default:
+        match: prometheus.metrics**
+        id: sumologic.endpoint.metrics
+        endpoint: metrics
+        weight: 100
+
   events:
     # If enabled, collect K8s events
     enabled: true

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -96,7 +96,7 @@ data:
   logs.output.conf: |-
     data_type logs
     log_key log
-    endpoint "#{ENV['SUMO_ENDPOINT_LOGS']}"
+    endpoint "#{ENV['SUMO_ENDPOINT_LOGS_SOURCE']}"
     verify_ssl "true"
     log_format "fields"
     add_timestamp "true"
@@ -282,7 +282,7 @@ data:
       @type sumologic
       @id sumologic.endpoint.events
       sumo_client "k8s_1.0.0"
-      endpoint "#{ENV['SUMO_ENDPOINT_EVENTS']}"
+      endpoint "#{ENV['SUMO_ENDPOINT_EVENTS_SOURCE']}"
       data_type logs
       disable_cookies true
       verify_ssl "true"
@@ -351,7 +351,7 @@ data:
       log_level info
     </system>
   
-  metrics.conf: |
+  metrics.conf: |-
     <source>
       @type http
       port 9888
@@ -389,107 +389,114 @@ data:
         relabel container_name:container,pod_name:pod
       </filter>
       
-  
-    
       <match prometheus.metrics.apiserver**>
         @type sumologic
         @id sumologic.endpoint.metrics.apiserver
-        endpoint "#{ENV['SUMO_ENDPOINT_METRICS_APISERVER']}"
+        sumo_client "k8s_1.0.0"
+        endpoint "#{ENV['SUMO_ENDPOINT_APISERVER_METRICS_SOURCE']}"
         @include metrics.output.conf
         <buffer>
           @type memory
           @include buffer.output.conf
         </buffer>
       </match>
-    
-      <match prometheus.metrics.kubelet**>
-        @type sumologic
-        @id sumologic.endpoint.metrics.kubelet
-        endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBELET']}"
-        @include metrics.output.conf
-        <buffer>
-          @type memory
-          @include buffer.output.conf
-        </buffer>
-      </match>
-    
+      
       <match prometheus.metrics.container**>
         @type sumologic
         @id sumologic.endpoint.metrics.container
-        endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBELET']}"
+        sumo_client "k8s_1.0.0"
+        endpoint "#{ENV['SUMO_ENDPOINT_KUBELET_METRICS_SOURCE']}"
         @include metrics.output.conf
         <buffer>
           @type memory
           @include buffer.output.conf
         </buffer>
       </match>
-    
-      <match prometheus.metrics.controller-manager**>
-        @type sumologic
-        @id sumologic.endpoint.metrics.kube.controller.manager
-        endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBE_CONTROLLER_MANAGER']}"
-        @include metrics.output.conf
-        <buffer>
-          @type memory
-          @include buffer.output.conf
-        </buffer>
-      </match>
-    
-      <match prometheus.metrics.scheduler**>
-        @type sumologic
-        @id sumologic.endpoint.metrics.kube.scheduler
-        endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBE_SCHEDULER']}"
-        @include metrics.output.conf
-        <buffer>
-          @type memory
-          @include buffer.output.conf
-        </buffer>
-      </match>
-    
-      <match prometheus.metrics.state**>
-        @type sumologic
-        @id sumologic.endpoint.metrics.kube.state
-        endpoint "#{ENV['SUMO_ENDPOINT_METRICS_KUBE_STATE']}"
-        @include metrics.output.conf
-        <buffer>
-          @type memory
-          @include buffer.output.conf
-        </buffer>
-      </match>
-    
-      <match prometheus.metrics.node**>
-        @type sumologic
-        @id sumologic.endpoint.metrics.node.exporter
-        endpoint "#{ENV['SUMO_ENDPOINT_METRICS_NODE_EXPORTER']}"
-        @include metrics.output.conf
-        <buffer>
-          @type memory
-          @include buffer.output.conf
-        </buffer>
-      </match>
-    
+      
       <match prometheus.metrics.control-plane**>
         @type sumologic
         @id sumologic.endpoint.metrics.control.plane
-        endpoint "#{ENV['SUMO_ENDPOINT_METRICS_CONTROL_PLANE']}"
+        sumo_client "k8s_1.0.0"
+        endpoint "#{ENV['SUMO_ENDPOINT_CONTROL_PLANE_METRICS_SOURCE']}"
         @include metrics.output.conf
         <buffer>
           @type memory
           @include buffer.output.conf
         </buffer>
       </match>
-    
+      
+      <match prometheus.metrics.controller-manager**>
+        @type sumologic
+        @id sumologic.endpoint.metrics.kube.controller.manager
+        sumo_client "k8s_1.0.0"
+        endpoint "#{ENV['SUMO_ENDPOINT_CONTROLLER_METRICS_SOURCE']}"
+        @include metrics.output.conf
+        <buffer>
+          @type memory
+          @include buffer.output.conf
+        </buffer>
+      </match>
+      
+      <match prometheus.metrics.kubelet**>
+        @type sumologic
+        @id sumologic.endpoint.metrics.kubelet
+        sumo_client "k8s_1.0.0"
+        endpoint "#{ENV['SUMO_ENDPOINT_KUBELET_METRICS_SOURCE']}"
+        @include metrics.output.conf
+        <buffer>
+          @type memory
+          @include buffer.output.conf
+        </buffer>
+      </match>
+      
+      <match prometheus.metrics.node**>
+        @type sumologic
+        @id sumologic.endpoint.metrics.node.exporter
+        sumo_client "k8s_1.0.0"
+        endpoint "#{ENV['SUMO_ENDPOINT_NODE_METRICS_SOURCE']}"
+        @include metrics.output.conf
+        <buffer>
+          @type memory
+          @include buffer.output.conf
+        </buffer>
+      </match>
+      
+      <match prometheus.metrics.scheduler**>
+        @type sumologic
+        @id sumologic.endpoint.metrics.kube.scheduler
+        sumo_client "k8s_1.0.0"
+        endpoint "#{ENV['SUMO_ENDPOINT_SCHEDULER_METRICS_SOURCE']}"
+        @include metrics.output.conf
+        <buffer>
+          @type memory
+          @include buffer.output.conf
+        </buffer>
+      </match>
+      
+      <match prometheus.metrics.state**>
+        @type sumologic
+        @id sumologic.endpoint.metrics.kube.state
+        sumo_client "k8s_1.0.0"
+        endpoint "#{ENV['SUMO_ENDPOINT_STATE_METRICS_SOURCE']}"
+        @include metrics.output.conf
+        <buffer>
+          @type memory
+          @include buffer.output.conf
+        </buffer>
+      </match>
+      
       <match prometheus.metrics**>
         @type sumologic
         @id sumologic.endpoint.metrics
-        endpoint "#{ENV['SUMO_ENDPOINT_METRICS']}"
+        sumo_client "k8s_1.0.0"
+        endpoint "#{ENV['SUMO_ENDPOINT_DEFAULT_METRICS_SOURCE']}"
         @include metrics.output.conf
         <buffer>
           @type memory
           @include buffer.output.conf
         </buffer>
       </match>
-  
+      
     </label>
   metrics.output.conf: |-
     data_type metrics
@@ -754,7 +761,7 @@ spec:
           initialDelaySeconds: 30
           periodSeconds: 5
         env:
-        - name: SUMO_ENDPOINT_EVENTS
+        - name: SUMO_ENDPOINT_EVENTS_SOURCE
           valueFrom:
             secretKeyRef:
               name: sumologic
@@ -844,41 +851,46 @@ spec:
         - name: pos-files
           mountPath: /mnt/pos/
         env:
-        - name: SUMO_ENDPOINT_METRICS
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics
-        - name: SUMO_ENDPOINT_METRICS_APISERVER
+        - name: SUMO_ENDPOINT_APISERVER_METRICS_SOURCE
           valueFrom:
             secretKeyRef:
               name: sumologic
               key: endpoint-metrics-apiserver
-        - name: SUMO_ENDPOINT_METRICS_KUBELET
+        - name: SUMO_ENDPOINT_CONTROL_PLANE_METRICS_SOURCE
           valueFrom:
             secretKeyRef:
               name: sumologic
-              key: endpoint-metrics-kubelet
-        - name: SUMO_ENDPOINT_METRICS_KUBE_CONTROLLER_MANAGER
+              key: endpoint-control_plane_metrics_source
+        - name: SUMO_ENDPOINT_CONTROLLER_METRICS_SOURCE
           valueFrom:
             secretKeyRef:
               name: sumologic
               key: endpoint-metrics-kube-controller-manager
-        - name: SUMO_ENDPOINT_METRICS_KUBE_SCHEDULER
+        - name: SUMO_ENDPOINT_DEFAULT_METRICS_SOURCE
           valueFrom:
             secretKeyRef:
               name: sumologic
-              key: endpoint-metrics-kube-scheduler
-        - name: SUMO_ENDPOINT_METRICS_KUBE_STATE
+              key: endpoint-metrics
+        - name: SUMO_ENDPOINT_KUBELET_METRICS_SOURCE
           valueFrom:
             secretKeyRef:
               name: sumologic
-              key: endpoint-metrics-kube-state
-        - name: SUMO_ENDPOINT_METRICS_NODE_EXPORTER
+              key: endpoint-metrics-kubelet
+        - name: SUMO_ENDPOINT_NODE_METRICS_SOURCE
           valueFrom:
             secretKeyRef:
               name: sumologic
               key: endpoint-metrics-node-exporter
+        - name: SUMO_ENDPOINT_SCHEDULER_METRICS_SOURCE
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-metrics-kube-scheduler
+        - name: SUMO_ENDPOINT_STATE_METRICS_SOURCE
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-metrics-kube-state
         - name: ADDITIONAL_PLUGINS
           value: ""
 ---
@@ -966,47 +978,7 @@ spec:
         - name: pos-files
           mountPath: /mnt/pos/
         env:
-        - name: SUMO_ENDPOINT_METRICS
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics
-        - name: SUMO_ENDPOINT_METRICS_APISERVER
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics-apiserver
-        - name: SUMO_ENDPOINT_METRICS_KUBELET
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics-kubelet
-        - name: SUMO_ENDPOINT_METRICS_KUBE_CONTROLLER_MANAGER
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics-kube-controller-manager
-        - name: SUMO_ENDPOINT_METRICS_KUBE_SCHEDULER
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics-kube-scheduler
-        - name: SUMO_ENDPOINT_METRICS_KUBE_STATE
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics-kube-state
-        - name: SUMO_ENDPOINT_METRICS_NODE_EXPORTER
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics-node-exporter
-        - name: SUMO_ENDPOINT_METRICS_CONTROL_PLANE
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics-control-plane
-        - name: SUMO_ENDPOINT_LOGS
+        - name: SUMO_ENDPOINT_LOGS_SOURCE
           valueFrom:
             secretKeyRef:
               name: sumologic

--- a/deploy/kubernetes/kube-prometheus-sumo-logic-mixin.libsonnet
+++ b/deploy/kubernetes/kube-prometheus-sumo-logic-mixin.libsonnet
@@ -147,7 +147,7 @@
         ]
       },
       {
-        url: $._config.sumologicCollectorSvc + "prometheus.metrics.control-plane",
+        url: $._config.sumologicCollectorSvc + "prometheus.metrics.control-plane.coredns",
         writeRelabelConfigs: [
           {
             action: "keep",
@@ -159,7 +159,7 @@
         ]
       },
       {
-        url: $._config.sumologicCollectorSvc + "prometheus.metrics.control-plane",
+        url: $._config.sumologicCollectorSvc + "prometheus.metrics.control-plane.kube-etcd",
         writeRelabelConfigs: [
           {
             action: "keep",

--- a/deploy/kubernetes/setup-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/setup-sumologic.yaml.tmpl
@@ -33,15 +33,18 @@ data:
   
     # Sumo Collector and HTTP sources
     terraform import sumologic_collector.collector "$COLLECTOR_NAME"
-    terraform import sumologic_http_source.default_metrics_source "$COLLECTOR_NAME/(default-metrics)"
-    terraform import sumologic_http_source.apiserver_metrics_source "$COLLECTOR_NAME/apiserver-metrics"
-    terraform import sumologic_http_source.events_source "$COLLECTOR_NAME/events"
-    terraform import sumologic_http_source.kube_controller_manager_metrics_source "$COLLECTOR_NAME/kube-controller-manager-metrics"
-    terraform import sumologic_http_source.kube_scheduler_metrics_source "$COLLECTOR_NAME/kube-scheduler-metrics"
-    terraform import sumologic_http_source.kube_state_metrics_source "$COLLECTOR_NAME/kube-state-metrics"
-    terraform import sumologic_http_source.kubelet_metrics_source "$COLLECTOR_NAME/kubelet-metrics"
+    
+    terraform import sumologic_http_source.apiserver_metrics_source "$COLLECTOR_NAME/"
+    terraform import sumologic_http_source.control_plane_metrics_source "$COLLECTOR_NAME/"
+    terraform import sumologic_http_source.controller_metrics_source "$COLLECTOR_NAME/"
+    terraform import sumologic_http_source.default_metrics_source "$COLLECTOR_NAME/"
+    terraform import sumologic_http_source.kubelet_metrics_source "$COLLECTOR_NAME/"
+    terraform import sumologic_http_source.node_metrics_source "$COLLECTOR_NAME/"
+    terraform import sumologic_http_source.scheduler_metrics_source "$COLLECTOR_NAME/"
+    terraform import sumologic_http_source.state_metrics_source "$COLLECTOR_NAME/"
     terraform import sumologic_http_source.logs_source "$COLLECTOR_NAME/logs"
-    terraform import sumologic_http_source.node_exporter_metrics_source "$COLLECTOR_NAME/node-exporter-metrics"
+    terraform import sumologic_http_source.events_source "$COLLECTOR_NAME/events"
+  
   
     # Kubernetes Namespace and Secret
     terraform import kubernetes_namespace.sumologic_collection_namespace $NAMESPACE
@@ -64,15 +67,16 @@ data:
     }
   
     locals {
-      default-metrics-source-name                 = "(default-metrics)"
-      apiserver-metrics-source-name               = "apiserver-metrics"
-      events-source-name                          = "events"
-      kube-controller-manager-metrics-source-name = "kube-controller-manager-metrics"
-      kube-scheduler-metrics-source-name          = "kube-scheduler-metrics"
-      kube-state-metrics-source-name              = "kube-state-metrics"
-      kubelet-metrics-source-name                 = "kubelet-metrics"
-      logs-source-name                            = "logs"
-      node-exporter-metrics-source-name           = "node-exporter-metrics"
+      apiserver_metrics_source                    = "apiserver-metrics"
+      control_plane_metrics_source                = "control-plane-metrics"
+      controller_metrics_source                   = "kube-controller-manager-metrics"
+      default_metrics_source                      = "(default-metrics)"
+      kubelet_metrics_source                      = "kubelet-metrics"
+      node_metrics_source                         = "node-exporter-metrics"
+      scheduler_metrics_source                    = "kube-scheduler-metrics"
+      state_metrics_source                        = "kube-state-metrics"
+      logs_source                                 = "logs"
+      events_source                               = "events"
     }
   
     provider "sumologic" {}
@@ -83,51 +87,56 @@ data:
           cluster = var.cluster_name
         }
     }
-  
-    resource "sumologic_http_source" "default_metrics_source" {
-        name         = local.default-metrics-source-name
-        collector_id = "${sumologic_collector.collector.id}"
-    }
-  
+    
     resource "sumologic_http_source" "apiserver_metrics_source" {
-        name         = local.apiserver-metrics-source-name
+        name         = local.apiserver_metrics_source
         collector_id = "${sumologic_collector.collector.id}"
     }
-  
-    resource "sumologic_http_source" "events_source" {
-        name         = local.events-source-name
-        category     = "${var.cluster_name}/${local.events-source-name}"
+    
+    resource "sumologic_http_source" "control_plane_metrics_source" {
+        name         = local.control_plane_metrics_source
         collector_id = "${sumologic_collector.collector.id}"
     }
-  
-    resource "sumologic_http_source" "kube_controller_manager_metrics_source" {
-        name         = local.kube-controller-manager-metrics-source-name
+    
+    resource "sumologic_http_source" "controller_metrics_source" {
+        name         = local.controller_metrics_source
         collector_id = "${sumologic_collector.collector.id}"
     }
-  
-    resource "sumologic_http_source" "kube_scheduler_metrics_source" {
-        name         = local.kube-scheduler-metrics-source-name
+    
+    resource "sumologic_http_source" "default_metrics_source" {
+        name         = local.default_metrics_source
         collector_id = "${sumologic_collector.collector.id}"
     }
-  
-    resource "sumologic_http_source" "kube_state_metrics_source" {
-        name         = local.kube-state-metrics-source-name
-        collector_id = "${sumologic_collector.collector.id}"
-    }
-  
+    
     resource "sumologic_http_source" "kubelet_metrics_source" {
-        name         = local.kubelet-metrics-source-name
+        name         = local.kubelet_metrics_source
         collector_id = "${sumologic_collector.collector.id}"
     }
-  
+    
+    resource "sumologic_http_source" "node_metrics_source" {
+        name         = local.node_metrics_source
+        collector_id = "${sumologic_collector.collector.id}"
+    }
+    
+    resource "sumologic_http_source" "scheduler_metrics_source" {
+        name         = local.scheduler_metrics_source
+        collector_id = "${sumologic_collector.collector.id}"
+    }
+    
+    resource "sumologic_http_source" "state_metrics_source" {
+        name         = local.state_metrics_source
+        collector_id = "${sumologic_collector.collector.id}"
+    }
+    
     resource "sumologic_http_source" "logs_source" {
-        name         = local.logs-source-name
+        name         = local.logs_source
         collector_id = "${sumologic_collector.collector.id}"
     }
-  
-    resource "sumologic_http_source" "node_exporter_metrics_source" {
-        name         = local.node-exporter-metrics-source-name
+    
+    resource "sumologic_http_source" "events_source" {
+        name         = local.events_source
         collector_id = "${sumologic_collector.collector.id}"
+        category     = "${var.cluster_name}/${local.events_source}"
     }
   
     provider "kubernetes" {
@@ -150,15 +159,16 @@ data:
       }
   
       data = {
-        endpoint-events                           = "${sumologic_http_source.events_source.url}"
-        endpoint-logs                             = "${sumologic_http_source.logs_source.url}"
-        endpoint-metrics                          = "${sumologic_http_source.default_metrics_source.url}"
         endpoint-metrics-apiserver                = "${sumologic_http_source.apiserver_metrics_source.url}"
-        endpoint-metrics-kube-controller-manager  = "${sumologic_http_source.kube_controller_manager_metrics_source.url}"
-        endpoint-metrics-kube-scheduler           = "${sumologic_http_source.kube_scheduler_metrics_source.url}"
-        endpoint-metrics-kube-state               = "${sumologic_http_source.kube_state_metrics_source.url}"
+        endpoint-control_plane_metrics_source     = "${sumologic_http_source.control_plane_metrics_source.url}"
+        endpoint-metrics-kube-controller-manager  = "${sumologic_http_source.controller_metrics_source.url}"
+        endpoint-metrics                          = "${sumologic_http_source.default_metrics_source.url}"
         endpoint-metrics-kubelet                  = "${sumologic_http_source.kubelet_metrics_source.url}"
-        endpoint-metrics-node-exporter            = "${sumologic_http_source.node_exporter_metrics_source.url}"
+        endpoint-metrics-node-exporter            = "${sumologic_http_source.node_metrics_source.url}"
+        endpoint-metrics-kube-scheduler           = "${sumologic_http_source.scheduler_metrics_source.url}"
+        endpoint-metrics-kube-state               = "${sumologic_http_source.state_metrics_source.url}"
+        endpoint-logs                             = "${sumologic_http_source.logs_source.url}"
+        endpoint-events                           = "${sumologic_http_source.events_source.url}"
       }
   
       type = "Opaque"


### PR DESCRIPTION
###### Description

Expose http sources in values.yaml

###### ToDO

 - [x] Move out configuration from configmap to separate files (like fluentd conf)
 - [x] Discuss if logs/events/default metrics should be exposed
        I decided to not expose logs and events so far
 - [x] Add enable/disable flag
 - [x] Dynamic generation of fluentd configuration(?)

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
