### PR TITLE
Use env for prometheus metrics namespace

### DIFF
--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -50,7 +50,7 @@ prometheus:
     - port: metrics
     namespaceSelector:
       matchNames:
-      - sumologic
+      - $(NAMESPACE)
     selector:
       matchLabels:
         app: collection-sumologic-fluentd-logs
@@ -61,7 +61,7 @@ prometheus:
     - port: metrics
     namespaceSelector:
       matchNames:
-      - sumologic
+      - $(NAMESPACE)
     selector:
       matchLabels:
         app: collection-sumologic-fluentd-metrics
@@ -72,7 +72,7 @@ prometheus:
     - port: metrics
     namespaceSelector:
       matchNames:
-      - sumologic
+      - $(NAMESPACE)
     selector:
       matchLabels:
         app: collection-sumologic-fluentd-events
@@ -84,7 +84,7 @@ prometheus:
       path: /api/v1/metrics/prometheus
     namespaceSelector:
       matchNames:
-      - sumologic
+      - $(NAMESPACE)
     selector:
       matchLabels:
         app: fluent-bit
@@ -95,7 +95,7 @@ prometheus:
     - port: metrics
     namespaceSelector:
       matchNames:
-      - sumologic
+      - $(NAMESPACE)
     selector:
       matchLabels:
         app: collection-sumologic-otelcol

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -16,11 +16,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
-Create default fully qualified labels.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+Create default labels
 */}}
 {{- define "sumologic.labels.app" -}}
-{{- template "sumologic.fullname" . }}
+{{- printf "collection-sumologic" }}
 {{- end -}}
 
 {{/*

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -584,7 +584,7 @@ prometheus-operator:
         - port: metrics
         namespaceSelector:
           matchNames:
-          - sumologic
+          - $(NAMESPACE)
         selector:
           matchLabels:
             app: collection-sumologic-fluentd-logs
@@ -595,7 +595,7 @@ prometheus-operator:
         - port: metrics
         namespaceSelector:
           matchNames:
-          - sumologic
+          - $(NAMESPACE)
         selector:
           matchLabels:
             app: collection-sumologic-fluentd-metrics
@@ -606,7 +606,7 @@ prometheus-operator:
           - port: metrics
         namespaceSelector:
           matchNames:
-            - sumologic
+            - $(NAMESPACE)
         selector:
           matchLabels:
             app: collection-sumologic-fluentd-events
@@ -618,7 +618,7 @@ prometheus-operator:
             path: /api/v1/metrics/prometheus
         namespaceSelector:
           matchNames:
-            - sumologic
+            - $(NAMESPACE)
         selector:
           matchLabels:
             app: fluent-bit
@@ -629,7 +629,7 @@ prometheus-operator:
           - port: metrics
         namespaceSelector:
           matchNames:
-            - sumologic
+            - $(NAMESPACE)
         selector:
           matchLabels:
             app: collection-sumologic-otelcol


### PR DESCRIPTION
###### Description

Get namespace dynamically

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
