### PR TITLE
Ensure clusterName has no spaces to prevent issue with Explore rendering.

### DIFF
--- a/deploy/helm/sumologic/conf/metrics/metrics.conf
+++ b/deploy/helm/sumologic/conf/metrics/metrics.conf
@@ -22,7 +22,7 @@
   <filter prometheus.metrics**>
     @type record_modifier
     <record>
-      cluster {{ .Values.sumologic.clusterName }}
+      cluster {{ template "sumologic.clusterNameReplaceSpaceWithDash" . }}
     </record>
   </filter>
   <filter prometheus.metrics**>

--- a/deploy/helm/sumologic/conf/setup/sumo-k8s.tf
+++ b/deploy/helm/sumologic/conf/setup/sumo-k8s.tf
@@ -1,6 +1,6 @@
 variable "cluster_name" {
   type  = string
-  default = "{{ .Values.sumologic.clusterName }}"
+  default = "{{ template "sumologic.clusterNameReplaceSpaceWithDash" . }}"
 }
 
 {{- if .Values.sumologic.collectorName }}
@@ -11,7 +11,7 @@ variable "collector_name" {
 {{- else }}
 variable "collector_name" {
   type  = string
-  default = "{{ .Values.sumologic.clusterName }}"
+  default = "{{ template "sumologic.clusterNameReplaceSpaceWithDash" . }}"
 }
 {{- end }}
 

--- a/deploy/helm/sumologic/templates/NOTES.txt
+++ b/deploy/helm/sumologic/templates/NOTES.txt
@@ -1,6 +1,10 @@
 Thank you for installing {{ .Chart.Name }}. 
 
-A Collector with the name {{ .Values.sumologic.collectorName | default .Values.sumologic.clusterName | quote }} has been created in your Sumo Logic account.
+{{- if contains " " .Values.sumologic.clusterName }}
+WARNING: You defined sumologic.clusterName with spaces, which is not supported.  Spaces have been replaced with dashes.
+{{- end }}
+
+A Collector with the name {{ .Values.sumologic.collectorName | default (include "sumologic.clusterNameReplaceSpaceWithDash" . ) | quote }} has been created in your Sumo Logic account.
 
 Check the release status by running:
   kubectl --namespace {{ .Release.Namespace }} get pods -l "release={{ .Release.Name }}"

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -44,6 +44,13 @@ k8s_{{ .Chart.Version }}
 {{- end -}}
 
 {{/*
+Returns clusterName with spaces replaced with dashes
+*/}}
+{{- define "sumologic.clusterNameReplaceSpaceWithDash" -}}
+{{ .Values.sumologic.clusterName | replace " " "-"}}
+{{- end -}}
+
+{{/*
 Get configuration value, otherwise returns default
 
 Example usage:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -29,7 +29,7 @@ sumologic:
   # Collector name
   #collectorName: ""
 
-  # Cluster name
+  # Cluster name: Note spaces are not allowed and will be replaced with dashes.
   clusterName: "kubernetes"
 
   # Configuration of kubernetes for terraform client


### PR DESCRIPTION
Description

Fixes #608. When spaces are found in `sumologicClusterName`, replace them with dashes and warn via NOTES.txt.

Testing performed

 ci/build.sh
[ X ] Redeploy fluentd and fluentd-events pods
[ X ] Confirm events, logs, and metrics are coming in