### PR TITLE
Generate labels and names using helm templates

### DIFF
--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -39,6 +39,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- template "sumologic.fullname" . }}-fluentd-logs
 {{- end -}}
 
+{{- define "sumologic.labels.app.logs.pod" -}}
+{{- template "sumologic.labels.app.logs" . }}
+{{- end -}}
+
 {{- define "sumologic.labels.app.logs.service" -}}
 {{- template "sumologic.labels.app.logs" . }}
 {{- end -}}
@@ -53,6 +57,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 
 {{- define "sumologic.labels.app.logs.statefulset" -}}
 {{- template "sumologic.labels.app.logs" . }}
+{{- end -}}
+
+{{- define "sumologic.labels.app.metrics" -}}
+{{- template "sumologic.fullname" . }}-fluentd-metrics
+{{- end -}}
+
+{{- define "sumologic.labels.app.metrics.pod" -}}
+{{- template "sumologic.labels.app.metrics" . }}
 {{- end -}}
 
 {{- define "sumologic.labels.app.metrics.service" -}}
@@ -75,6 +87,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- template "sumologic.fullname" . }}-fluentd-events
 {{- end -}}
 
+{{- define "sumologic.labels.app.events.pod" -}}
+{{- template "sumologic.labels.app.events" . }}
+{{- end -}}
+
 {{- define "sumologic.labels.app.events.service" -}}
 {{- template "sumologic.labels.app.events" . }}
 {{- end -}}
@@ -93,6 +109,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 
 {{- define "sumologic.labels.app.otelcol" -}}
 {{- template "sumologic.fullname" . }}-otelcol
+{{- end -}}
+
+{{- define "sumologic.labels.app.otelcol.pod" -}}
+{{- template "sumologic.labels.app.otelcol" . }}
 {{- end -}}
 
 {{- define "sumologic.labels.app.otelcol.service" -}}

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -39,6 +39,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- template "sumologic.fullname" . }}-fluentd-metrics-headless
 {{- end -}}
 
+{{- define "sumologic.labels.app.events" -}}
+{{- template "sumologic.fullname" . }}-fluentd-events
+{{- end -}}
+
+{{- define "sumologic.labels.app.events.headless" -}}
+{{- template "sumologic.fullname" . }}-fluentd-events-headless
+{{- end -}}
+
 {{- define "sumologic.metadata.name.logs" -}}
 {{ template "sumologic.fullname" . }}-fluentd-logs
 {{- end -}}

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -83,6 +83,30 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{ template "sumologic.fullname" . }}-setup
 {{- end -}}
 
+{{- define "sumologic.labels.logs" -}}
+app: {{ template "sumologic.labels.app.logs" . }}
+sumologic/app: fluentd-logs
+sumologic/component: logs
+{{- end -}}
+
+{{- define "sumologic.labels.metrics" -}}
+app: {{ template "sumologic.labels.app.metrics" . }}
+sumologic/app: fluentd-metrics
+sumologic/component: metrics
+{{- end -}}
+
+{{- define "sumologic.labels.events" -}}
+app: {{ template "sumologic.labels.app.events" . }}
+sumologic/app: fluentd-events
+sumologic/component: events
+{{- end -}}
+
+{{- define "sumologic.labels.traces" -}}
+app: {{ template "sumologic.labels.app.otelcol" . }}
+sumologic/app: otelcol
+sumologic/component: traces
+{{- end -}}
+
 {{/*
 Create common labels used throughout the chart.
 If dryRun=true, we do not create any chart labels.

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -63,6 +63,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{ template "sumologic.metadata.name.logs" . }}
 {{- end -}}
 
+{{- define "sumologic.metadata.name.logs.statefulset" -}}
+{{ template "sumologic.metadata.name.logs" . }}
+{{- end -}}
+
 {{- define "sumologic.metadata.name.metrics" -}}
 {{ template "sumologic.fullname" . }}-fluentd-metrics
 {{- end -}}
@@ -72,6 +76,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "sumologic.metadata.name.metrics.configmap" -}}
+{{ template "sumologic.metadata.name.metrics" . }}
+{{- end -}}
+
+{{- define "sumologic.metadata.name.metrics.statefulset" -}}
 {{ template "sumologic.metadata.name.metrics" . }}
 {{- end -}}
 
@@ -87,11 +95,19 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{ template "sumologic.metadata.name.events" . }}
 {{- end -}}
 
+{{- define "sumologic.metadata.name.events.statefulset" -}}
+{{ template "sumologic.metadata.name.events" . }}
+{{- end -}}
+
 {{- define "sumologic.metadata.name.otelcol" -}}
 {{ template "sumologic.fullname" . }}-otelcol
 {{- end -}}
 
 {{- define "sumologic.metadata.name.otelcol.configmap" -}}
+{{ template "sumologic.metadata.name.otelcol" . }}
+{{- end -}}
+
+{{- define "sumologic.metadata.name.otelcol.deployment" -}}
 {{ template "sumologic.metadata.name.otelcol" . }}
 {{- end -}}
 

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -35,6 +35,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- template "sumologic.labels.app.logs" . }}
 {{- end -}}
 
+{{- define "sumologic.labels.app.logs.statefulset" -}}
+{{- template "sumologic.labels.app.logs" . }}
+{{- end -}}
+
 {{- define "sumologic.labels.app.metrics" -}}
 {{- template "sumologic.fullname" . }}-fluentd-metrics
 {{- end -}}
@@ -44,6 +48,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "sumologic.labels.app.metrics.configmap" -}}
+{{- template "sumologic.labels.app.metrics" . }}
+{{- end -}}
+
+{{- define "sumologic.labels.app.metrics.statefulset" -}}
 {{- template "sumologic.labels.app.metrics" . }}
 {{- end -}}
 
@@ -59,12 +67,20 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- template "sumologic.labels.app.events" . }}
 {{- end -}}
 
+{{- define "sumologic.labels.app.events.statefulset" -}}
+{{- template "sumologic.labels.app.events" . }}
+{{- end -}}
+
 {{- define "sumologic.labels.app.otelcol" -}}
 {{- template "sumologic.fullname" . }}-otelcol
 {{- end -}}
 
 {{- define "sumologic.labels.app.otelcol.configmap" -}}
 {{- template "sumologic.labels.app.metrics" . }}
+{{- end -}}
+
+{{- define "sumologic.labels.app.otelcol.deployment" -}}
+{{- template "sumologic.labels.app.otelcol" . }}
 {{- end -}}
 
 {{- define "sumologic.labels.app.setup.configmap" -}}

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -59,12 +59,20 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{ template "sumologic.fullname" . }}-fluentd-logs-headless
 {{- end -}}
 
+{{- define "sumologic.metadata.name.logs.configmap" -}}
+{{ template "sumologic.metadata.name.logs" . }}
+{{- end -}}
+
 {{- define "sumologic.metadata.name.metrics" -}}
 {{ template "sumologic.fullname" . }}-fluentd-metrics
 {{- end -}}
 
 {{- define "sumologic.metadata.name.metrics.headless" -}}
 {{ template "sumologic.fullname" . }}-fluentd-metrics-headless
+{{- end -}}
+
+{{- define "sumologic.metadata.name.metrics.configmap" -}}
+{{ template "sumologic.metadata.name.metrics" . }}
 {{- end -}}
 
 {{- define "sumologic.metadata.name.events" -}}
@@ -75,12 +83,24 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{ template "sumologic.fullname" . }}-fluentd-events-headless
 {{- end -}}
 
+{{- define "sumologic.metadata.name.events.configmap" -}}
+{{ template "sumologic.metadata.name.events" . }}
+{{- end -}}
+
 {{- define "sumologic.metadata.name.otelcol" -}}
 {{ template "sumologic.fullname" . }}-otelcol
 {{- end -}}
 
+{{- define "sumologic.metadata.name.otelcol.configmap" -}}
+{{ template "sumologic.metadata.name.otelcol" . }}
+{{- end -}}
+
 {{- define "sumologic.metadata.name.setup" -}}
 {{ template "sumologic.fullname" . }}-setup
+{{- end -}}
+
+{{- define "sumologic.metadata.name.setup.configmap" -}}
+{{ template "sumologic.metadata.name.setup" . }}
 {{- end -}}
 
 {{- define "sumologic.labels.logs" -}}

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -27,8 +27,12 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- template "sumologic.fullname" . }}-fluentd-logs
 {{- end -}}
 
-{{- define "sumologic.labels.app.logs.headless" -}}
-{{- template "sumologic.fullname" . }}-fluentd-logs-headless
+{{- define "sumologic.labels.app.logs.service" -}}
+{{- template "sumologic.labels.app.logs" . }}
+{{- end -}}
+
+{{- define "sumologic.labels.app.logs.service-headless" -}}
+{{- template "sumologic.labels.app.logs.service" . }}-headless
 {{- end -}}
 
 {{- define "sumologic.labels.app.logs.configmap" -}}
@@ -39,12 +43,12 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- template "sumologic.labels.app.logs" . }}
 {{- end -}}
 
-{{- define "sumologic.labels.app.metrics" -}}
-{{- template "sumologic.fullname" . }}-fluentd-metrics
+{{- define "sumologic.labels.app.metrics.service" -}}
+{{- template "sumologic.labels.app.metrics" . }}
 {{- end -}}
 
-{{- define "sumologic.labels.app.metrics.headless" -}}
-{{- template "sumologic.fullname" . }}-fluentd-metrics-headless
+{{- define "sumologic.labels.app.metrics.service-headless" -}}
+{{- template "sumologic.labels.app.metrics.service" . }}-headless
 {{- end -}}
 
 {{- define "sumologic.labels.app.metrics.configmap" -}}
@@ -59,8 +63,12 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- template "sumologic.fullname" . }}-fluentd-events
 {{- end -}}
 
-{{- define "sumologic.labels.app.events.headless" -}}
-{{- template "sumologic.fullname" . }}-fluentd-events-headless
+{{- define "sumologic.labels.app.events.service" -}}
+{{- template "sumologic.labels.app.events" . }}
+{{- end -}}
+
+{{- define "sumologic.labels.app.events.service-headless" -}}
+{{- template "sumologic.labels.app.events.service" . }}-headless
 {{- end -}}
 
 {{- define "sumologic.labels.app.events.configmap" -}}
@@ -75,6 +83,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- template "sumologic.fullname" . }}-otelcol
 {{- end -}}
 
+{{- define "sumologic.labels.app.otelcol.service" -}}
+{{- template "sumologic.labels.app.otelcol" . }}
+{{- end -}}
+
 {{- define "sumologic.labels.app.otelcol.configmap" -}}
 {{- template "sumologic.labels.app.metrics" . }}
 {{- end -}}
@@ -83,16 +95,28 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- template "sumologic.labels.app.otelcol" . }}
 {{- end -}}
 
-{{- define "sumologic.labels.app.setup.configmap" -}}
+{{- define "sumologic.labels.app.setup" -}}
 {{- template "sumologic.labels.app" . }}
+{{- end -}}
+
+{{- define "sumologic.labels.app.setup.job" -}}
+{{- template "sumologic.labels.app.setup" . }}
+{{- end -}}
+
+{{- define "sumologic.labels.app.setup.configmap" -}}
+{{- template "sumologic.labels.app.setup" . }}
 {{- end -}}
 
 {{- define "sumologic.metadata.name.logs" -}}
 {{ template "sumologic.fullname" . }}-fluentd-logs
 {{- end -}}
 
-{{- define "sumologic.metadata.name.logs.headless" -}}
-{{ template "sumologic.fullname" . }}-fluentd-logs-headless
+{{- define "sumologic.metadata.name.logs.service" -}}
+{{ template "sumologic.metadata.name.logs" . }}
+{{- end -}}
+
+{{- define "sumologic.metadata.name.logs.service-headless" -}}
+{{ template "sumologic.metadata.name.logs.service" . }}-headless
 {{- end -}}
 
 {{- define "sumologic.metadata.name.logs.configmap" -}}
@@ -107,8 +131,12 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{ template "sumologic.fullname" . }}-fluentd-metrics
 {{- end -}}
 
-{{- define "sumologic.metadata.name.metrics.headless" -}}
-{{ template "sumologic.fullname" . }}-fluentd-metrics-headless
+{{- define "sumologic.metadata.name.metrics.service" -}}
+{{ template "sumologic.metadata.name.metrics" . }}
+{{- end -}}
+
+{{- define "sumologic.metadata.name.metrics.service-headless" -}}
+{{ template "sumologic.metadata.name.metrics.service" . }}-headless
 {{- end -}}
 
 {{- define "sumologic.metadata.name.metrics.configmap" -}}
@@ -123,8 +151,12 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{ template "sumologic.fullname" . }}-fluentd-events
 {{- end -}}
 
-{{- define "sumologic.metadata.name.events.headless" -}}
-{{ template "sumologic.fullname" . }}-fluentd-events-headless
+{{- define "sumologic.metadata.name.events.service" -}}
+{{ template "sumologic.metadata.name.events" . }}
+{{- end -}}
+
+{{- define "sumologic.metadata.name.events.service-headless" -}}
+{{ template "sumologic.metadata.name.events.service" . }}-headless
 {{- end -}}
 
 {{- define "sumologic.metadata.name.events.configmap" -}}
@@ -139,6 +171,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{ template "sumologic.fullname" . }}-otelcol
 {{- end -}}
 
+{{- define "sumologic.metadata.name.otelcol.service" -}}
+{{ template "sumologic.metadata.name.otelcol" . }}
+{{- end -}}
+
 {{- define "sumologic.metadata.name.otelcol.configmap" -}}
 {{ template "sumologic.metadata.name.otelcol" . }}
 {{- end -}}
@@ -149,6 +185,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 
 {{- define "sumologic.metadata.name.setup" -}}
 {{ template "sumologic.fullname" . }}-setup
+{{- end -}}
+
+{{- define "sumologic.metadata.name.setup.job" -}}
+{{ template "sumologic.metadata.name.setup" . }}
 {{- end -}}
 
 {{- define "sumologic.metadata.name.setup.configmap" -}}

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -79,6 +79,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{ template "sumologic.fullname" . }}-otelcol
 {{- end -}}
 
+{{- define "sumologic.metadata.name.setup" -}}
+{{ template "sumologic.fullname" . }}-setup
+{{- end -}}
+
 {{/*
 Create common labels used throughout the chart.
 If dryRun=true, we do not create any chart labels.

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -156,25 +156,21 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "sumologic.labels.logs" -}}
-app: {{ template "sumologic.labels.app.logs" . }}
 sumologic/app: fluentd-logs
 sumologic/component: logs
 {{- end -}}
 
 {{- define "sumologic.labels.metrics" -}}
-app: {{ template "sumologic.labels.app.metrics" . }}
 sumologic/app: fluentd-metrics
 sumologic/component: metrics
 {{- end -}}
 
 {{- define "sumologic.labels.events" -}}
-app: {{ template "sumologic.labels.app.events" . }}
 sumologic/app: fluentd-events
 sumologic/component: events
 {{- end -}}
 
 {{- define "sumologic.labels.traces" -}}
-app: {{ template "sumologic.labels.app.otelcol" . }}
 sumologic/app: otelcol
 sumologic/component: traces
 {{- end -}}

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -31,12 +31,20 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- template "sumologic.fullname" . }}-fluentd-logs-headless
 {{- end -}}
 
+{{- define "sumologic.labels.app.logs.configmap" -}}
+{{- template "sumologic.labels.app.logs" . }}
+{{- end -}}
+
 {{- define "sumologic.labels.app.metrics" -}}
 {{- template "sumologic.fullname" . }}-fluentd-metrics
 {{- end -}}
 
 {{- define "sumologic.labels.app.metrics.headless" -}}
 {{- template "sumologic.fullname" . }}-fluentd-metrics-headless
+{{- end -}}
+
+{{- define "sumologic.labels.app.metrics.configmap" -}}
+{{- template "sumologic.labels.app.metrics" . }}
 {{- end -}}
 
 {{- define "sumologic.labels.app.events" -}}
@@ -47,8 +55,20 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- template "sumologic.fullname" . }}-fluentd-events-headless
 {{- end -}}
 
+{{- define "sumologic.labels.app.events.configmap" -}}
+{{- template "sumologic.labels.app.events" . }}
+{{- end -}}
+
 {{- define "sumologic.labels.app.otelcol" -}}
 {{- template "sumologic.fullname" . }}-otelcol
+{{- end -}}
+
+{{- define "sumologic.labels.app.otelcol.configmap" -}}
+{{- template "sumologic.labels.app.metrics" . }}
+{{- end -}}
+
+{{- define "sumologic.labels.app.setup.configmap" -}}
+{{- template "sumologic.labels.app" . }}
 {{- end -}}
 
 {{- define "sumologic.metadata.name.logs" -}}

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -39,6 +39,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{ template "sumologic.fullname" . }}-fluentd-metrics-headless
 {{- end -}}
 
+{{- define "sumologic.metadata.name.events" -}}
+{{ template "sumologic.fullname" . }}-fluentd-events
+{{- end -}}
+
+{{- define "sumologic.metadata.name.events.headless" -}}
+{{ template "sumologic.fullname" . }}-fluentd-events-headless
+{{- end -}}
+
 {{/*
 Create common labels used throughout the chart.
 If dryRun=true, we do not create any chart labels.

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -59,6 +59,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- template "sumologic.labels.app.logs" . }}
 {{- end -}}
 
+{{- define "sumologic.labels.app.logs.hpa" -}}
+{{- template "sumologic.labels.app.logs" . }}
+{{- end -}}
+
 {{- define "sumologic.labels.app.metrics" -}}
 {{- template "sumologic.fullname" . }}-fluentd-metrics
 {{- end -}}
@@ -80,6 +84,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "sumologic.labels.app.metrics.statefulset" -}}
+{{- template "sumologic.labels.app.metrics" . }}
+{{- end -}}
+
+{{- define "sumologic.labels.app.metrics.hpa" -}}
 {{- template "sumologic.labels.app.metrics" . }}
 {{- end -}}
 

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -23,6 +23,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- template "sumologic.fullname" . }}
 {{- end -}}
 
+{{- define "sumologic.labels.app.logs" -}}
+{{- template "sumologic.fullname" . }}-fluentd-logs
+{{- end -}}
+
+{{- define "sumologic.labels.app.logs.headless" -}}
+{{- template "sumologic.fullname" . }}-fluentd-logs-headless
+{{- end -}}
+
 {{- define "sumologic.metadata.name.logs" -}}
 {{ template "sumologic.fullname" . }}-fluentd-logs
 {{- end -}}

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -23,6 +23,18 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- template "sumologic.fullname" . }}
 {{- end -}}
 
+{{- define "sumologic.labels.app.roles.clusterrole" -}}
+{{- template "sumologic.fullname" . }}
+{{- end -}}
+
+{{- define "sumologic.labels.app.roles.clusterrolebinding" -}}
+{{- template "sumologic.fullname" . }}
+{{- end -}}
+
+{{- define "sumologic.labels.app.roles.serviceaccount" -}}
+{{- template "sumologic.fullname" . }}
+{{- end -}}
+
 {{- define "sumologic.labels.app.logs" -}}
 {{- template "sumologic.fullname" . }}-fluentd-logs
 {{- end -}}
@@ -105,6 +117,30 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 
 {{- define "sumologic.labels.app.setup.configmap" -}}
 {{- template "sumologic.labels.app.setup" . }}
+{{- end -}}
+
+{{- define "sumologic.labels.app.setup.roles.clusterrole" -}}
+{{- template "sumologic.labels.app.setup" . }}
+{{- end -}}
+
+{{- define "sumologic.labels.app.setup.roles.clusterrolebinding" -}}
+{{- template "sumologic.labels.app.setup" . }}
+{{- end -}}
+
+{{- define "sumologic.labels.app.setup.rolesserviceaccount" -}}
+{{- template "sumologic.labels.app.setup" . }}
+{{- end -}}
+
+{{- define "sumologic.metadata.name.roles.clusterrole" -}}
+{{- template "sumologic.fullname" . }}
+{{- end -}}
+
+{{- define "sumologic.metadata.name.roles.clusterrolebinding" -}}
+{{- template "sumologic.fullname" . }}
+{{- end -}}
+
+{{- define "sumologic.metadata.name.roles.serviceaccount" -}}
+{{- template "sumologic.fullname" . }}
 {{- end -}}
 
 {{- define "sumologic.metadata.name.logs" -}}
@@ -192,6 +228,18 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "sumologic.metadata.name.setup.configmap" -}}
+{{ template "sumologic.metadata.name.setup" . }}
+{{- end -}}
+
+{{- define "sumologic.metadata.name.setup.roles.clusterrole" -}}
+{{ template "sumologic.metadata.name.setup" . }}
+{{- end -}}
+
+{{- define "sumologic.metadata.name.setup.roles.clusterrolebinding" -}}
+{{ template "sumologic.metadata.name.setup" . }}
+{{- end -}}
+
+{{- define "sumologic.metadata.name.setup.roles.clusterrolebinding" -}}
 {{ template "sumologic.metadata.name.setup" . }}
 {{- end -}}
 

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -31,6 +31,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- template "sumologic.fullname" . }}-fluentd-logs-headless
 {{- end -}}
 
+{{- define "sumologic.labels.app.metrics" -}}
+{{- template "sumologic.fullname" . }}-fluentd-metrics
+{{- end -}}
+
+{{- define "sumologic.labels.app.metrics.headless" -}}
+{{- template "sumologic.fullname" . }}-fluentd-metrics-headless
+{{- end -}}
+
 {{- define "sumologic.metadata.name.logs" -}}
 {{ template "sumologic.fullname" . }}-fluentd-logs
 {{- end -}}

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -47,6 +47,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- template "sumologic.fullname" . }}-fluentd-events-headless
 {{- end -}}
 
+{{- define "sumologic.labels.app.otelcol" -}}
+{{- template "sumologic.fullname" . }}-otelcol
+{{- end -}}
+
 {{- define "sumologic.metadata.name.logs" -}}
 {{ template "sumologic.fullname" . }}-fluentd-logs
 {{- end -}}
@@ -69,6 +73,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 
 {{- define "sumologic.metadata.name.events.headless" -}}
 {{ template "sumologic.fullname" . }}-fluentd-events-headless
+{{- end -}}
+
+{{- define "sumologic.metadata.name.otelcol" -}}
+{{ template "sumologic.fullname" . }}-otelcol
 {{- end -}}
 
 {{/*

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -155,7 +155,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- template "sumologic.labels.app.setup" . }}
 {{- end -}}
 
-{{- define "sumologic.labels.app.setup.rolesserviceaccount" -}}
+{{- define "sumologic.labels.app.setup.roles.serviceaccount" -}}
 {{- template "sumologic.labels.app.setup" . }}
 {{- end -}}
 

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -23,6 +23,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- template "sumologic.fullname" . }}
 {{- end -}}
 
+{{- define "sumologic.metadata.name.logs" -}}
+{{ template "sumologic.fullname" . }}-fluentd-logs
+{{- end -}}
+
+{{- define "sumologic.metadata.name.logs.headless" -}}
+{{ template "sumologic.fullname" . }}-fluentd-logs-headless
+{{- end -}}
+
 {{/*
 Create common labels used throughout the chart.
 If dryRun=true, we do not create any chart labels.

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -259,7 +259,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{ template "sumologic.metadata.name.setup" . }}
 {{- end -}}
 
-{{- define "sumologic.metadata.name.setup.roles.clusterrolebinding" -}}
+{{- define "sumologic.metadata.name.setup.roles.serviceaccount" -}}
 {{ template "sumologic.metadata.name.setup" . }}
 {{- end -}}
 

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -31,6 +31,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{ template "sumologic.fullname" . }}-fluentd-logs-headless
 {{- end -}}
 
+{{- define "sumologic.metadata.name.metrics" -}}
+{{ template "sumologic.fullname" . }}-fluentd-metrics
+{{- end -}}
+
+{{- define "sumologic.metadata.name.metrics.headless" -}}
+{{ template "sumologic.fullname" . }}-fluentd-metrics-headless
+{{- end -}}
+
 {{/*
 Create common labels used throughout the chart.
 If dryRun=true, we do not create any chart labels.

--- a/deploy/helm/sumologic/templates/chart-configmap.yaml
+++ b/deploy/helm/sumologic/templates/chart-configmap.yaml
@@ -4,5 +4,5 @@ metadata:
   name: sumologic-configmap
 data:
   fluentdLogs: {{ template "sumologic.metadata.name.logs" . }}
-  fluentdMetrics: {{ template "sumologic.fullname" . }}-fluentd-metrics
+  fluentdMetrics: {{ template "sumologic.metadata.name.metrics" . }}
   fluentdNamespace: {{ .Release.Namespace }}

--- a/deploy/helm/sumologic/templates/chart-configmap.yaml
+++ b/deploy/helm/sumologic/templates/chart-configmap.yaml
@@ -3,6 +3,6 @@ kind: ConfigMap
 metadata:
   name: sumologic-configmap
 data:
-  fluentdLogs: {{ template "sumologic.fullname" . }}-fluentd-logs
+  fluentdLogs: {{ template "sumologic.metadata.name.logs" . }}
   fluentdMetrics: {{ template "sumologic.fullname" . }}-fluentd-metrics
   fluentdNamespace: {{ .Release.Namespace }}

--- a/deploy/helm/sumologic/templates/clusterrole.yaml
+++ b/deploy/helm/sumologic/templates/clusterrole.yaml
@@ -1,9 +1,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ template "sumologic.fullname" . }}
+  name: {{ template "sumologic.metadata.name.roles.clusterrole" . }}
   labels:
-    app: {{ template "sumologic.labels.app" . }}
+    app: {{ template "sumologic.labels.app.roles.clusterrole" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 rules:
 - apiGroups: ["", "apps", "extensions", "events.k8s.io"]

--- a/deploy/helm/sumologic/templates/clusterrolebinding.yaml
+++ b/deploy/helm/sumologic/templates/clusterrolebinding.yaml
@@ -1,15 +1,15 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "sumologic.fullname" . }}
+  name: {{ template "sumologic.metadata.name.roles.clusterrolebinding" . }}
   labels:
-    app: {{ template "sumologic.labels.app" . }}
+    app: {{ template "sumologic.labels.app.roles.clusterrolebinding" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
   namespace: {{ .Release.Namespace }}
-  name: {{ template "sumologic.fullname" . }}
+  name: {{ template "sumologic.metadata.name.roles.serviceaccount" . }}
 roleRef:
   kind: ClusterRole
-  name: {{ template "sumologic.fullname" . }}
+  name: {{ template "sumologic.metadata.name.roles.clusterrole" . }}
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/helm/sumologic/templates/configmap.yaml
+++ b/deploy/helm/sumologic/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "sumologic.fullname" . }}-fluentd-logs
+  name: {{ template "sumologic.metadata.name.logs" . }}
   labels:
     app: {{ template "sumologic.labels.app" . }}-fluentd-logs
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/configmap.yaml
+++ b/deploy/helm/sumologic/templates/configmap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "sumologic.metadata.name.logs.configmap" . }}
   labels:
-    app: {{ template "sumologic.labels.app.logs" . }}
+    app: {{ template "sumologic.labels.app.logs.configmap" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 data:
   fluent.conf: |-

--- a/deploy/helm/sumologic/templates/configmap.yaml
+++ b/deploy/helm/sumologic/templates/configmap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "sumologic.metadata.name.logs" . }}
   labels:
-    app: {{ template "sumologic.labels.app" . }}-fluentd-logs
+    app: {{ template "sumologic.labels.app.logs" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 data:
   fluent.conf: |-

--- a/deploy/helm/sumologic/templates/configmap.yaml
+++ b/deploy/helm/sumologic/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "sumologic.metadata.name.logs" . }}
+  name: {{ template "sumologic.metadata.name.logs.configmap" . }}
   labels:
     app: {{ template "sumologic.labels.app.logs" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/events-configmap.yaml
+++ b/deploy/helm/sumologic/templates/events-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "sumologic.metadata.name.events" . }}
+  name: {{ template "sumologic.metadata.name.events.configmap" . }}
   labels:
     app: {{ template "sumologic.labels.app.events" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/events-configmap.yaml
+++ b/deploy/helm/sumologic/templates/events-configmap.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "sumologic.metadata.name.events" . }}
   labels:
-    app: {{ printf "%s-fluentd-events" (include "sumologic.labels.app" .) }}
+    app: {{ template "sumologic.labels.app.events" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 data:
   fluent.conf: |-

--- a/deploy/helm/sumologic/templates/events-configmap.yaml
+++ b/deploy/helm/sumologic/templates/events-configmap.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "sumologic.metadata.name.events.configmap" . }}
   labels:
-    app: {{ template "sumologic.labels.app.events" . }}
+    app: {{ template "sumologic.labels.app.events.configmap" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 data:
   fluent.conf: |-

--- a/deploy/helm/sumologic/templates/events-configmap.yaml
+++ b/deploy/helm/sumologic/templates/events-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ printf "%s-fluentd-events" (include "sumologic.fullname" .) }}
+  name: {{ template "sumologic.metadata.name.events" . }}
   labels:
     app: {{ printf "%s-fluentd-events" (include "sumologic.labels.app" .) }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/events-service-headless.yaml
+++ b/deploy/helm/sumologic/templates/events-service-headless.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-fluentd-events-headless" (include "sumologic.fullname" .) }}
+  name: {{ template "sumologic.metadata.name.events.headless" . }}
   labels:
     app: {{ printf "%s-fluentd-events-headless" (include "sumologic.labels.app" .) }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/events-service-headless.yaml
+++ b/deploy/helm/sumologic/templates/events-service-headless.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:
-    app: {{ template "sumologic.labels.app.events" . }}
+    app: {{ template "sumologic.labels.app.events.pod" . }}
   clusterIP: None
   ports:
   - name: metrics

--- a/deploy/helm/sumologic/templates/events-service-headless.yaml
+++ b/deploy/helm/sumologic/templates/events-service-headless.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "sumologic.metadata.name.events.headless" . }}
+  name: {{ template "sumologic.metadata.name.events.service-headless" . }}
   labels:
-    app: {{ template "sumologic.labels.app.events.headless" . }}
+    app: {{ template "sumologic.labels.app.events.service-headless" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:

--- a/deploy/helm/sumologic/templates/events-service-headless.yaml
+++ b/deploy/helm/sumologic/templates/events-service-headless.yaml
@@ -4,11 +4,11 @@ kind: Service
 metadata:
   name: {{ template "sumologic.metadata.name.events.headless" . }}
   labels:
-    app: {{ printf "%s-fluentd-events-headless" (include "sumologic.labels.app" .) }}
+    app: {{ template "sumologic.labels.app.events.headless" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:
-    app: {{ printf "%s-fluentd-events" (include "sumologic.labels.app" .) }}
+    app: {{ template "sumologic.labels.app.events.headless" . }}
   clusterIP: None
   ports:
   - name: metrics

--- a/deploy/helm/sumologic/templates/events-service-headless.yaml
+++ b/deploy/helm/sumologic/templates/events-service-headless.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ template "sumologic.metadata.name.events.service-headless" . }}
   labels:
     app: {{ template "sumologic.labels.app.events.service-headless" . }}
+    {{- include "sumologic.labels.events" . | nindent 4 }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:

--- a/deploy/helm/sumologic/templates/events-service-headless.yaml
+++ b/deploy/helm/sumologic/templates/events-service-headless.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:
-    app: {{ template "sumologic.labels.app.events.headless" . }}
+    app: {{ template "sumologic.labels.app.events" . }}
   clusterIP: None
   ports:
   - name: metrics

--- a/deploy/helm/sumologic/templates/events-service.yaml
+++ b/deploy/helm/sumologic/templates/events-service.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:
-    app: {{ template "sumologic.labels.app.events" . }}
+    app: {{ template "sumologic.labels.app.events.pod" . }}
   ports:
   - name: metrics
     port: 24231

--- a/deploy/helm/sumologic/templates/events-service.yaml
+++ b/deploy/helm/sumologic/templates/events-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-fluentd-events" (include "sumologic.fullname" .) }}
+  name: {{ template "sumologic.metadata.name.events" . }}
   labels:
     app: {{ printf "%s-fluentd-events" (include "sumologic.labels.app" .) }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/events-service.yaml
+++ b/deploy/helm/sumologic/templates/events-service.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "sumologic.metadata.name.events" . }}
+  name: {{ template "sumologic.metadata.name.events.service" . }}
   labels:
-    app: {{ template "sumologic.labels.app.events" . }}
+    app: {{ template "sumologic.labels.app.events.service" . }}
     {{- include "sumologic.labels.events" . | nindent 4 }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:

--- a/deploy/helm/sumologic/templates/events-service.yaml
+++ b/deploy/helm/sumologic/templates/events-service.yaml
@@ -4,11 +4,11 @@ kind: Service
 metadata:
   name: {{ template "sumologic.metadata.name.events" . }}
   labels:
-    app: {{ printf "%s-fluentd-events" (include "sumologic.labels.app" .) }}
+    app: {{ template "sumologic.labels.app.events" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:
-    app: {{ printf "%s-fluentd-events" (include "sumologic.labels.app" .) }}
+    app: {{ template "sumologic.labels.app.events" . }}
   ports:
   - name: metrics
     port: 24231

--- a/deploy/helm/sumologic/templates/events-service.yaml
+++ b/deploy/helm/sumologic/templates/events-service.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: {{ template "sumologic.metadata.name.events" . }}
   labels:
-    app: {{ template "sumologic.labels.app.events" . }}
+    {{- include "sumologic.labels.events" . | nindent 4 }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:

--- a/deploy/helm/sumologic/templates/events-service.yaml
+++ b/deploy/helm/sumologic/templates/events-service.yaml
@@ -4,6 +4,7 @@ kind: Service
 metadata:
   name: {{ template "sumologic.metadata.name.events" . }}
   labels:
+    app: {{ template "sumologic.labels.app.events" . }}
     {{- include "sumologic.labels.events" . | nindent 4 }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:

--- a/deploy/helm/sumologic/templates/events-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/events-statefulset.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ template "sumologic.metadata.name.events" . }}
+  name: {{ template "sumologic.metadata.name.events.statefulset" . }}
   labels:
     app: {{ template "sumologic.labels.app.events" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/events-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/events-statefulset.yaml
@@ -34,7 +34,7 @@ spec:
           type: ""
       - name: config-volume
         configMap:
-          name: {{ template "sumologic.metadata.name.events" . }}
+          name: {{ template "sumologic.metadata.name.events.configmap" . }}
       securityContext:
         fsGroup: {{ .Values.fluentd.securityContext.fsGroup }}
       containers:

--- a/deploy/helm/sumologic/templates/events-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/events-statefulset.yaml
@@ -10,7 +10,7 @@ spec:
   selector:
     matchLabels:
       app: {{ template "sumologic.labels.app.events" . }}
-  serviceName: {{ template "sumologic.metadata.name.events.headless" . }}
+  serviceName: {{ template "sumologic.metadata.name.events.service-headless" . }}
   podManagementPolicy: "Parallel"
   template:
     metadata:

--- a/deploy/helm/sumologic/templates/events-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/events-statefulset.yaml
@@ -4,7 +4,7 @@ kind: StatefulSet
 metadata:
   name: {{ template "sumologic.metadata.name.events.statefulset" . }}
   labels:
-    app: {{ template "sumologic.labels.app.events" . }}
+    app: {{ template "sumologic.labels.app.events.statefulset" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:

--- a/deploy/helm/sumologic/templates/events-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/events-statefulset.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "sumologic.labels.app.events" . }}
+        app: {{ template "sumologic.labels.app.events.pod" . }}
         {{- include "sumologic.labels.common" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "sumologic.metadata.name.roles.serviceaccount" . }}

--- a/deploy/helm/sumologic/templates/events-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/events-statefulset.yaml
@@ -18,7 +18,7 @@ spec:
         app: {{ template "sumologic.labels.app.events" . }}
         {{- include "sumologic.labels.common" . | nindent 8 }}
     spec:
-      serviceAccountName: {{ template "sumologic.fullname" . }}
+      serviceAccountName: {{ template "sumologic.metadata.name.roles.serviceaccount" . }}
 {{- if .Values.fluentd.events.statefulset.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.fluentd.events.statefulset.nodeSelector | indent 8 }}

--- a/deploy/helm/sumologic/templates/events-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/events-statefulset.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ template "sumologic.labels.app.events" . }}
+      app: {{ template "sumologic.labels.app.events.pod" . }}
   serviceName: {{ template "sumologic.metadata.name.events.service-headless" . }}
   podManagementPolicy: "Parallel"
   template:

--- a/deploy/helm/sumologic/templates/events-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/events-statefulset.yaml
@@ -4,18 +4,18 @@ kind: StatefulSet
 metadata:
   name: {{ template "sumologic.metadata.name.events" . }}
   labels:
-    app: {{ printf "%s-fluentd-events" (include "sumologic.labels.app" .) }}
+    app: {{ template "sumologic.labels.app.events" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      app: {{ printf "%s-fluentd-events" (include "sumologic.labels.app" .) }}
+      app: {{ template "sumologic.labels.app.events" . }}
   serviceName: {{ template "sumologic.metadata.name.events.headless" . }}
   podManagementPolicy: "Parallel"
   template:
     metadata:
       labels:
-        app: {{ printf "%s-fluentd-events" (include "sumologic.labels.app" .) }}
+        app: {{ template "sumologic.labels.app.events" . }}
         {{- include "sumologic.labels.common" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "sumologic.fullname" . }}

--- a/deploy/helm/sumologic/templates/events-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/events-statefulset.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ printf "%s-fluentd-events" (include "sumologic.fullname" .) }}
+  name: {{ template "sumologic.metadata.name.events" . }}
   labels:
     app: {{ printf "%s-fluentd-events" (include "sumologic.labels.app" .) }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
@@ -10,7 +10,7 @@ spec:
   selector:
     matchLabels:
       app: {{ printf "%s-fluentd-events" (include "sumologic.labels.app" .) }}
-  serviceName: {{ printf "%s-fluentd-events-headless" (include "sumologic.fullname" .) }}
+  serviceName: {{ template "sumologic.metadata.name.events.headless" . }}
   podManagementPolicy: "Parallel"
   template:
     metadata:
@@ -34,7 +34,7 @@ spec:
           type: ""
       - name: config-volume
         configMap:
-          name: {{ printf "%s-fluentd-events" (include "sumologic.fullname" .) }}
+          name: {{ template "sumologic.metadata.name.events" . }}
       securityContext:
         fsGroup: {{ .Values.fluentd.securityContext.fsGroup }}
       containers:

--- a/deploy/helm/sumologic/templates/hpa.yaml
+++ b/deploy/helm/sumologic/templates/hpa.yaml
@@ -2,9 +2,9 @@
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ template "sumologic.metadata.name.logs" . }}
+  name: {{ template "sumologic.metadata.name.logs.hpa" . }}
   labels:
-    app: {{ template "sumologic.labels.app.logs" . }}
+    app: {{ template "sumologic.labels.app.logs.hpa" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   scaleTargetRef:

--- a/deploy/helm/sumologic/templates/hpa.yaml
+++ b/deploy/helm/sumologic/templates/hpa.yaml
@@ -10,7 +10,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: StatefulSet
-    name: {{ template "sumologic.metadata.name.logs" . }}
+    name: {{ template "sumologic.metadata.name.logs.statefulset" . }}
   minReplicas: {{ .Values.fluentd.logs.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.fluentd.logs.autoscaling.maxReplicas }}
   targetCPUUtilizationPercentage: {{ .Values.fluentd.logs.autoscaling.targetCPUUtilizationPercentage }}

--- a/deploy/helm/sumologic/templates/hpa.yaml
+++ b/deploy/helm/sumologic/templates/hpa.yaml
@@ -4,7 +4,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "sumologic.metadata.name.logs" . }}
   labels:
-    app: {{ template "sumologic.labels.app" . }}-fluentd-logs
+    app: {{ template "sumologic.labels.app.logs" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   scaleTargetRef:

--- a/deploy/helm/sumologic/templates/hpa.yaml
+++ b/deploy/helm/sumologic/templates/hpa.yaml
@@ -2,7 +2,7 @@
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ template "sumologic.fullname" . }}-fluentd-logs
+  name: {{ template "sumologic.metadata.name.logs" . }}
   labels:
     app: {{ template "sumologic.labels.app" . }}-fluentd-logs
     {{- include "sumologic.labels.common" . | nindent 4 }}
@@ -10,7 +10,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: StatefulSet
-    name: {{ template "sumologic.fullname" . }}-fluentd-logs
+    name: {{ template "sumologic.metadata.name.logs" . }}
   minReplicas: {{ .Values.fluentd.logs.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.fluentd.logs.autoscaling.maxReplicas }}
   targetCPUUtilizationPercentage: {{ .Values.fluentd.logs.autoscaling.targetCPUUtilizationPercentage }}

--- a/deploy/helm/sumologic/templates/metrics-configmap.yaml
+++ b/deploy/helm/sumologic/templates/metrics-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "sumologic.fullname" . }}-fluentd-metrics
+  name: {{ template "sumologic.metadata.name.metrics" . }}
   labels:
     app: {{ template "sumologic.labels.app" . }}-fluentd-metrics
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/metrics-configmap.yaml
+++ b/deploy/helm/sumologic/templates/metrics-configmap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "sumologic.metadata.name.metrics.configmap" . }}
   labels:
-    app: {{ template "sumologic.labels.app.metrics" . }}
+    app: {{ template "sumologic.labels.app.metrics.configmap" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 data:
   fluent.conf: |-

--- a/deploy/helm/sumologic/templates/metrics-configmap.yaml
+++ b/deploy/helm/sumologic/templates/metrics-configmap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "sumologic.metadata.name.metrics" . }}
   labels:
-    app: {{ template "sumologic.labels.app" . }}-fluentd-metrics
+    app: {{ template "sumologic.labels.app.metrics" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 data:
   fluent.conf: |-

--- a/deploy/helm/sumologic/templates/metrics-configmap.yaml
+++ b/deploy/helm/sumologic/templates/metrics-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "sumologic.metadata.name.metrics" . }}
+  name: {{ template "sumologic.metadata.name.metrics.configmap" . }}
   labels:
     app: {{ template "sumologic.labels.app.metrics" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/metrics-hpa.yaml
+++ b/deploy/helm/sumologic/templates/metrics-hpa.yaml
@@ -10,7 +10,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: StatefulSet
-    name: {{ template "sumologic.metadata.name.metrics" . }}
+    name: {{ template "sumologic.metadata.name.metrics.statefulset" . }}
   minReplicas: {{ .Values.fluentd.metrics.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.fluentd.metrics.autoscaling.maxReplicas }}
   targetCPUUtilizationPercentage: {{ .Values.fluentd.metrics.autoscaling.targetCPUUtilizationPercentage }}

--- a/deploy/helm/sumologic/templates/metrics-hpa.yaml
+++ b/deploy/helm/sumologic/templates/metrics-hpa.yaml
@@ -4,13 +4,13 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "sumologic.metadata.name.metrics" . }}
   labels:
-    app: {{ template "sumologic.labels.app" . }}-fluentd-metrics
+    app: {{ template "sumologic.labels.app.metrics" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: StatefulSet
-    name: {{ template "sumologic.fullname" . }}-fluentd-metrics
+    name: {{ template "sumologic.metadata.name.metrics" . }}
   minReplicas: {{ .Values.fluentd.metrics.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.fluentd.metrics.autoscaling.maxReplicas }}
   targetCPUUtilizationPercentage: {{ .Values.fluentd.metrics.autoscaling.targetCPUUtilizationPercentage }}

--- a/deploy/helm/sumologic/templates/metrics-hpa.yaml
+++ b/deploy/helm/sumologic/templates/metrics-hpa.yaml
@@ -2,9 +2,9 @@
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ template "sumologic.metadata.name.metrics" . }}
+  name: {{ template "sumologic.metadata.name.metrics.hpa" . }}
   labels:
-    app: {{ template "sumologic.labels.app.metrics" . }}
+    app: {{ template "sumologic.labels.app.metrics.hpa" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   scaleTargetRef:

--- a/deploy/helm/sumologic/templates/metrics-hpa.yaml
+++ b/deploy/helm/sumologic/templates/metrics-hpa.yaml
@@ -2,7 +2,7 @@
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ template "sumologic.fullname" . }}-fluentd-metrics
+  name: {{ template "sumologic.metadata.name.metrics" . }}
   labels:
     app: {{ template "sumologic.labels.app" . }}-fluentd-metrics
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/metrics-service-headless.yaml
+++ b/deploy/helm/sumologic/templates/metrics-service-headless.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "sumologic.fullname" . }}-fluentd-metrics-headless
+  name: {{ template "sumologic.metadata.name.metrics.headless" . }}
   labels:
     app: {{ template "sumologic.labels.app" . }}-fluentd-metrics-headless
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/metrics-service-headless.yaml
+++ b/deploy/helm/sumologic/templates/metrics-service-headless.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:
-    app: {{ template "sumologic.labels.app.metrics" . }}
+    app: {{ template "sumologic.labels.app.metrics.pod" . }}
   clusterIP: None
   ports:
   - name: prom-write

--- a/deploy/helm/sumologic/templates/metrics-service-headless.yaml
+++ b/deploy/helm/sumologic/templates/metrics-service-headless.yaml
@@ -3,11 +3,11 @@ kind: Service
 metadata:
   name: {{ template "sumologic.metadata.name.metrics.headless" . }}
   labels:
-    app: {{ template "sumologic.labels.app" . }}-fluentd-metrics-headless
+    app: {{ template "sumologic.labels.app.metrics.headless" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:
-    app: {{ template "sumologic.labels.app" . }}-fluentd-metrics
+    app: {{ template "sumologic.labels.app.metrics" . }}
   clusterIP: None
   ports:
   - name: prom-write

--- a/deploy/helm/sumologic/templates/metrics-service-headless.yaml
+++ b/deploy/helm/sumologic/templates/metrics-service-headless.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "sumologic.metadata.name.metrics.headless" . }}
+  name: {{ template "sumologic.metadata.name.metrics.service-headless" . }}
   labels:
-    app: {{ template "sumologic.labels.app.metrics.headless" . }}
+    app: {{ template "sumologic.labels.app.metrics.service-headless" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:

--- a/deploy/helm/sumologic/templates/metrics-service-headless.yaml
+++ b/deploy/helm/sumologic/templates/metrics-service-headless.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ template "sumologic.metadata.name.metrics.service-headless" . }}
   labels:
     app: {{ template "sumologic.labels.app.metrics.service-headless" . }}
+    {{- include "sumologic.labels.events" . | nindent 4 }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:

--- a/deploy/helm/sumologic/templates/metrics-service.yaml
+++ b/deploy/helm/sumologic/templates/metrics-service.yaml
@@ -3,11 +3,11 @@ kind: Service
 metadata:
   name: {{ template "sumologic.metadata.name.metrics" . }}
   labels:
-    app: {{ template "sumologic.labels.app" . }}-fluentd-metrics
+    app: {{ template "sumologic.labels.app.metrics" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:
-    app: {{ template "sumologic.labels.app" . }}-fluentd-metrics
+    app: {{ template "sumologic.labels.app.metrics" . }}
   ports:
   - name: prom-write
     port: 9888

--- a/deploy/helm/sumologic/templates/metrics-service.yaml
+++ b/deploy/helm/sumologic/templates/metrics-service.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:
-    app: {{ template "sumologic.labels.app.metrics" . }}
+    app: {{ template "sumologic.labels.app.metrics.pod" . }}
   ports:
   - name: prom-write
     port: 9888

--- a/deploy/helm/sumologic/templates/metrics-service.yaml
+++ b/deploy/helm/sumologic/templates/metrics-service.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "sumologic.metadata.name.metrics" . }}
+  name: {{ template "sumologic.metadata.name.metrics.service" . }}
   labels:
-    app: {{ template "sumologic.labels.app.metrics" . }}
+    app: {{ template "sumologic.labels.app.metrics.service" . }}
     {{- include "sumologic.labels.metrics" . | nindent 4 }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:

--- a/deploy/helm/sumologic/templates/metrics-service.yaml
+++ b/deploy/helm/sumologic/templates/metrics-service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   name: {{ template "sumologic.metadata.name.metrics" . }}
   labels:
+    app: {{ template "sumologic.labels.app.metrics" . }}
     {{- include "sumologic.labels.metrics" . | nindent 4 }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:

--- a/deploy/helm/sumologic/templates/metrics-service.yaml
+++ b/deploy/helm/sumologic/templates/metrics-service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ template "sumologic.metadata.name.metrics" . }}
   labels:
-    app: {{ template "sumologic.labels.app.metrics" . }}
+    {{- include "sumologic.labels.metrics" . | nindent 4 }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:

--- a/deploy/helm/sumologic/templates/metrics-service.yaml
+++ b/deploy/helm/sumologic/templates/metrics-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "sumologic.fullname" . }}-fluentd-metrics
+  name: {{ template "sumologic.metadata.name.metrics" . }}
   labels:
     app: {{ template "sumologic.labels.app" . }}-fluentd-metrics
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/metrics-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics-statefulset.yaml
@@ -73,7 +73,7 @@ spec:
           type: ""
       - name: config-volume
         configMap:
-          name: {{ template "sumologic.metadata.name.metrics" . }}
+          name: {{ template "sumologic.metadata.name.metrics.configmap" . }}
       securityContext:
         fsGroup: {{ .Values.fluentd.securityContext.fsGroup }}
       containers:

--- a/deploy/helm/sumologic/templates/metrics-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics-statefulset.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       app: {{ template "sumologic.labels.app.metrics" . }}
-  serviceName: {{ template "sumologic.metadata.name.metrics.headless" . }}
+  serviceName: {{ template "sumologic.metadata.name.metrics.service-headless" . }}
   podManagementPolicy: "Parallel"
   replicas: {{ .Values.fluentd.metrics.statefulset.replicaCount }}
   template:

--- a/deploy/helm/sumologic/templates/metrics-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics-statefulset.yaml
@@ -40,7 +40,7 @@ spec:
               - key: app
                 operator: In
                 values:
-                - {{ template "sumologic.labels.app" . }}-fluentd-logs
+                - {{ template "sumologic.labels.app.logs" . }}
                 - {{ template "sumologic.labels.app" . }}-fluentd-metrics
               - key: app
                 operator: In
@@ -57,7 +57,7 @@ spec:
                 - key: app
                   operator: In
                   values:
-                  - {{ template "sumologic.labels.app" . }}-fluentd-logs
+                  - {{ template "sumologic.labels.app.logs" . }}
                   - {{ template "sumologic.labels.app" . }}-fluentd-metrics
                 - key: app
                   operator: In

--- a/deploy/helm/sumologic/templates/metrics-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics-statefulset.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "sumologic.labels.app.metrics" . }}
+        app: {{ template "sumologic.labels.app.metrics.pod" . }}
         {{- include "sumologic.labels.common" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "sumologic.metadata.name.roles.serviceaccount" . }}

--- a/deploy/helm/sumologic/templates/metrics-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics-statefulset.yaml
@@ -3,7 +3,7 @@ kind: StatefulSet
 metadata:
   name: {{ template "sumologic.metadata.name.metrics.statefulset" . }}
   labels:
-    app: {{ template "sumologic.labels.app.metrics" . }}
+    app: {{ template "sumologic.labels.app.metrics.statefulset" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:

--- a/deploy/helm/sumologic/templates/metrics-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics-statefulset.yaml
@@ -18,7 +18,7 @@ spec:
         app: {{ template "sumologic.labels.app.metrics" . }}
         {{- include "sumologic.labels.common" . | nindent 8 }}
     spec:
-      serviceAccountName: {{ template "sumologic.fullname" . }}
+      serviceAccountName: {{ template "sumologic.metadata.name.roles.serviceaccount" . }}
 {{- if .Values.fluentd.metrics.statefulset.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.fluentd.metrics.statefulset.nodeSelector | indent 8 }}

--- a/deploy/helm/sumologic/templates/metrics-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics-statefulset.yaml
@@ -3,19 +3,19 @@ kind: StatefulSet
 metadata:
   name: {{ template "sumologic.metadata.name.metrics" . }}
   labels:
-    app: {{ template "sumologic.labels.app" . }}-fluentd-metrics
+    app: {{ template "sumologic.labels.app.metrics" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      app: {{ template "sumologic.labels.app" . }}-fluentd-metrics
+      app: {{ template "sumologic.labels.app.metrics" . }}
   serviceName: {{ template "sumologic.metadata.name.metrics.headless" . }}
   podManagementPolicy: "Parallel"
   replicas: {{ .Values.fluentd.metrics.statefulset.replicaCount }}
   template:
     metadata:
       labels:
-        app: {{ template "sumologic.labels.app" . }}-fluentd-metrics
+        app: {{ template "sumologic.labels.app.metrics" . }}
         {{- include "sumologic.labels.common" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "sumologic.fullname" . }}
@@ -41,7 +41,7 @@ spec:
                 operator: In
                 values:
                 - {{ template "sumologic.labels.app.logs" . }}
-                - {{ template "sumologic.labels.app" . }}-fluentd-metrics
+                - {{ template "sumologic.labels.app.metrics" . }}
               - key: app
                 operator: In
                 values:
@@ -58,7 +58,7 @@ spec:
                   operator: In
                   values:
                   - {{ template "sumologic.labels.app.logs" . }}
-                  - {{ template "sumologic.labels.app" . }}-fluentd-metrics
+                  - {{ template "sumologic.labels.app.metrics" . }}
                 - key: app
                   operator: In
                   values:

--- a/deploy/helm/sumologic/templates/metrics-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics-statefulset.yaml
@@ -57,8 +57,8 @@ spec:
                 - key: app
                   operator: In
                   values:
-                  - {{ template "sumologic.labels.app.logs" . }}
-                  - {{ template "sumologic.labels.app.metrics" . }}
+                  - {{ template "sumologic.labels.app.logs.pod" . }}
+                  - {{ template "sumologic.labels.app.metrics.pod" . }}
                 - key: app
                   operator: In
                   values:

--- a/deploy/helm/sumologic/templates/metrics-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics-statefulset.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ template "sumologic.fullname" . }}-fluentd-metrics
+  name: {{ template "sumologic.metadata.name.metrics" . }}
   labels:
     app: {{ template "sumologic.labels.app" . }}-fluentd-metrics
     {{- include "sumologic.labels.common" . | nindent 4 }}
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       app: {{ template "sumologic.labels.app" . }}-fluentd-metrics
-  serviceName: {{ template "sumologic.fullname" . }}-fluentd-metrics-headless
+  serviceName: {{ template "sumologic.metadata.name.metrics.headless" . }}
   podManagementPolicy: "Parallel"
   replicas: {{ .Values.fluentd.metrics.statefulset.replicaCount }}
   template:
@@ -73,7 +73,7 @@ spec:
           type: ""
       - name: config-volume
         configMap:
-          name: {{ template "sumologic.fullname" . }}-fluentd-metrics
+          name: {{ template "sumologic.metadata.name.metrics" . }}
       securityContext:
         fsGroup: {{ .Values.fluentd.securityContext.fsGroup }}
       containers:

--- a/deploy/helm/sumologic/templates/metrics-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics-statefulset.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ template "sumologic.metadata.name.metrics" . }}
+  name: {{ template "sumologic.metadata.name.metrics.statefulset" . }}
   labels:
     app: {{ template "sumologic.labels.app.metrics" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/metrics-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics-statefulset.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ template "sumologic.labels.app.metrics" . }}
+      app: {{ template "sumologic.labels.app.metrics.pod" . }}
   serviceName: {{ template "sumologic.metadata.name.metrics.service-headless" . }}
   podManagementPolicy: "Parallel"
   replicas: {{ .Values.fluentd.metrics.statefulset.replicaCount }}

--- a/deploy/helm/sumologic/templates/otelcol-configmap.yaml
+++ b/deploy/helm/sumologic/templates/otelcol-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "sumologic.metadata.name.otelcol" . }}
+  name: {{ template "sumologic.metadata.name.otelcol.configmap" . }}
   labels:
     app: {{ template "sumologic.labels.app.otelcol" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/otelcol-configmap.yaml
+++ b/deploy/helm/sumologic/templates/otelcol-configmap.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ printf "%s-otelcol" (include "sumologic.fullname" .) }}
+  name: {{ template "sumologic.metadata.name.otelcol" . }}
   labels:
-    app: {{ printf "%s-otelcol" (include "sumologic.labels.app" .) }}
+    app: {{ template "sumologic.labels.app.otelcol" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 data:
   {{- (tpl (.Files.Glob "conf/traces/traces.otelcol.conf.yaml").AsConfig .) | nindent 2 }}

--- a/deploy/helm/sumologic/templates/otelcol-configmap.yaml
+++ b/deploy/helm/sumologic/templates/otelcol-configmap.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "sumologic.metadata.name.otelcol.configmap" . }}
   labels:
-    app: {{ template "sumologic.labels.app.otelcol" . }}
+    app: {{ template "sumologic.labels.app.otelcol.configmap" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 data:
   {{- (tpl (.Files.Glob "conf/traces/traces.otelcol.conf.yaml").AsConfig .) | nindent 2 }}

--- a/deploy/helm/sumologic/templates/otelcol-deployment.yaml
+++ b/deploy/helm/sumologic/templates/otelcol-deployment.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "sumologic.labels.app.otelcol" . }}
+        app: {{ template "sumologic.labels.app.otelcol.pod" . }}
         {{- include "sumologic.labels.common" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "sumologic.metadata.name.roles.serviceaccount" . }}

--- a/deploy/helm/sumologic/templates/otelcol-deployment.yaml
+++ b/deploy/helm/sumologic/templates/otelcol-deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "sumologic.metadata.name.otelcol" . }}
+  name: {{ template "sumologic.metadata.name.otelcol.deployment" . }}
   labels:
     app: {{ template "sumologic.labels.app.otelcol" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/otelcol-deployment.yaml
+++ b/deploy/helm/sumologic/templates/otelcol-deployment.yaml
@@ -67,6 +67,6 @@ spec:
             port: 13133 # Health Check extension default port.
       volumes:
         - configMap:
-            name: {{ template "sumologic.metadata.name.otelcol" . }}
+            name: {{ template "sumologic.metadata.name.otelcol.configmap" . }}
           name: otel-collector-config-vol
 {{- end }}

--- a/deploy/helm/sumologic/templates/otelcol-deployment.yaml
+++ b/deploy/helm/sumologic/templates/otelcol-deployment.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: {{ template "sumologic.metadata.name.otelcol.deployment" . }}
   labels:
-    app: {{ template "sumologic.labels.app.otelcol" . }}
+    app: {{ template "sumologic.labels.app.otelcol.deployment" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   minReadySeconds: 5

--- a/deploy/helm/sumologic/templates/otelcol-deployment.yaml
+++ b/deploy/helm/sumologic/templates/otelcol-deployment.yaml
@@ -2,9 +2,9 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ printf "%s-otelcol" (include "sumologic.fullname" .) }}
+  name: {{ template "sumologic.metadata.name.otelcol" . }}
   labels:
-    app: {{ printf "%s-otelcol" (include "sumologic.labels.app" .) }}
+    app: {{ template "sumologic.labels.app.otelcol" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   minReadySeconds: 5
@@ -12,11 +12,11 @@ spec:
   replicas: {{ .Values.otelcol.deployment.replicas }}
   selector:
     matchLabels:
-      app: {{ printf "%s-otelcol" (include "sumologic.labels.app" .) }}
+      app: {{ template "sumologic.labels.app.otelcol" . }}
   template:
     metadata:
       labels:
-        app: {{ printf "%s-otelcol" (include "sumologic.labels.app" .) }}
+        app: {{ template "sumologic.labels.app.otelcol" . }}
         {{- include "sumologic.labels.common" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "sumologic.fullname" . }}
@@ -67,6 +67,6 @@ spec:
             port: 13133 # Health Check extension default port.
       volumes:
         - configMap:
-            name: {{ printf "%s-otelcol" (include "sumologic.fullname" .) }}
+            name: {{ template "sumologic.metadata.name.otelcol" . }}
           name: otel-collector-config-vol
 {{- end }}

--- a/deploy/helm/sumologic/templates/otelcol-deployment.yaml
+++ b/deploy/helm/sumologic/templates/otelcol-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         app: {{ template "sumologic.labels.app.otelcol" . }}
         {{- include "sumologic.labels.common" . | nindent 8 }}
     spec:
-      serviceAccountName: {{ template "sumologic.fullname" . }}
+      serviceAccountName: {{ template "sumologic.metadata.name.roles.serviceaccount" . }}
       {{- if .Values.otelcol.deployment.nodeSelector }}
       nodeSelector:
         {{ toYaml .Values.otelcol.deployment.nodeSelector | indent 8 }}

--- a/deploy/helm/sumologic/templates/otelcol-deployment.yaml
+++ b/deploy/helm/sumologic/templates/otelcol-deployment.yaml
@@ -12,7 +12,7 @@ spec:
   replicas: {{ .Values.otelcol.deployment.replicas }}
   selector:
     matchLabels:
-      app: {{ template "sumologic.labels.app.otelcol" . }}
+      app: {{ template "sumologic.labels.app.otelcol.pod" . }}
   template:
     metadata:
       labels:

--- a/deploy/helm/sumologic/templates/otelcol-service.yaml
+++ b/deploy/helm/sumologic/templates/otelcol-service.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: {{ template "sumologic.metadata.name.otelcol" . }}
   labels:
-    app: {{ template "sumologic.labels.app.otelcol" . }}
+    {{- include "sumologic.labels.traces" . | nindent 4 }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:

--- a/deploy/helm/sumologic/templates/otelcol-service.yaml
+++ b/deploy/helm/sumologic/templates/otelcol-service.yaml
@@ -4,6 +4,7 @@ kind: Service
 metadata:
   name: {{ template "sumologic.metadata.name.otelcol" . }}
   labels:
+    app: {{ template "sumologic.labels.app.otelcol" . }}
     {{- include "sumologic.labels.traces" . | nindent 4 }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:

--- a/deploy/helm/sumologic/templates/otelcol-service.yaml
+++ b/deploy/helm/sumologic/templates/otelcol-service.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "sumologic.metadata.name.otelcol" . }}
+  name: {{ template "sumologic.metadata.name.otelcol.service" . }}
   labels:
-    app: {{ template "sumologic.labels.app.otelcol" . }}
+    app: {{ template "sumologic.labels.app.otelcol.service" . }}
     {{- include "sumologic.labels.traces" . | nindent 4 }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:

--- a/deploy/helm/sumologic/templates/otelcol-service.yaml
+++ b/deploy/helm/sumologic/templates/otelcol-service.yaml
@@ -2,13 +2,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-otelcol" (include "sumologic.fullname" .) }}
+  name: {{ template "sumologic.metadata.name.otelcol" . }}
   labels:
-    app: {{ printf "%s-otelcol" (include "sumologic.labels.app" .) }}
+    app: {{ template "sumologic.labels.app.otelcol" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:
-    app: {{ printf "%s-otelcol" (include "sumologic.labels.app" .) }}
+    app: {{ template "sumologic.labels.app.otelcol" . }}
   ports:
   - name: jaeger-sampling # Default endpoint for Jaeger Sampling (if enabled)
     port: 5778

--- a/deploy/helm/sumologic/templates/otelcol-service.yaml
+++ b/deploy/helm/sumologic/templates/otelcol-service.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:
-    app: {{ template "sumologic.labels.app.otelcol" . }}
+    app: {{ template "sumologic.labels.app.otelcol.pod" . }}
   ports:
   - name: jaeger-sampling # Default endpoint for Jaeger Sampling (if enabled)
     port: 5778

--- a/deploy/helm/sumologic/templates/service-headless.yaml
+++ b/deploy/helm/sumologic/templates/service-headless.yaml
@@ -3,11 +3,11 @@ kind: Service
 metadata:
   name: {{ template "sumologic.metadata.name.logs.headless" . }}
   labels:
-    app: {{ template "sumologic.labels.app" . }}-fluentd-logs-headless
+    app: {{ template "sumologic.labels.app.logs.headless" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:
-    app: {{ template "sumologic.labels.app" . }}-fluentd-logs
+    app: {{ template "sumologic.labels.app.logs" . }}
   clusterIP: None
   ports:
   {{- if .Values.sumologic.traces.enabled }}

--- a/deploy/helm/sumologic/templates/service-headless.yaml
+++ b/deploy/helm/sumologic/templates/service-headless.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:
-    app: {{ template "sumologic.labels.app.logs" . }}
+    app: {{ template "sumologic.labels.app.logs.pod" . }}
   clusterIP: None
   ports:
   {{- if .Values.sumologic.traces.enabled }}

--- a/deploy/helm/sumologic/templates/service-headless.yaml
+++ b/deploy/helm/sumologic/templates/service-headless.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "sumologic.fullname" . }}-fluentd-logs-headless
+  name: {{ template "sumologic.metadata.name.logs.headless" . }}
   labels:
     app: {{ template "sumologic.labels.app" . }}-fluentd-logs-headless
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/service-headless.yaml
+++ b/deploy/helm/sumologic/templates/service-headless.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "sumologic.metadata.name.logs.headless" . }}
+  name: {{ template "sumologic.metadata.name.logs.service-headless" . }}
   labels:
-    app: {{ template "sumologic.labels.app.logs.headless" . }}
+    app: {{ template "sumologic.labels.app.logs.service-headless" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:

--- a/deploy/helm/sumologic/templates/service.yaml
+++ b/deploy/helm/sumologic/templates/service.yaml
@@ -3,11 +3,11 @@ kind: Service
 metadata:
   name: {{ template "sumologic.metadata.name.logs" . }}
   labels:
-    app: {{ template "sumologic.labels.app" . }}-fluentd-logs
+    app: {{ template "sumologic.labels.app.logs" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:
-    app: {{ template "sumologic.labels.app" . }}-fluentd-logs
+    app: {{ template "sumologic.labels.app.logs" . }}
   ports:
   {{- if .Values.sumologic.traces.enabled }}
   - name: zipkin-write

--- a/deploy/helm/sumologic/templates/service.yaml
+++ b/deploy/helm/sumologic/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:
-    app: {{ template "sumologic.labels.app.logs" . }}
+    app: {{ template "sumologic.labels.app.logs.pod" . }}
   ports:
   {{- if .Values.sumologic.traces.enabled }}
   - name: zipkin-write

--- a/deploy/helm/sumologic/templates/service.yaml
+++ b/deploy/helm/sumologic/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ template "sumologic.metadata.name.logs" . }}
   labels:
-    app: {{ template "sumologic.labels.app.logs" . }}
+    {{- include "sumologic.labels.logs" . | nindent 4 }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:

--- a/deploy/helm/sumologic/templates/service.yaml
+++ b/deploy/helm/sumologic/templates/service.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "sumologic.metadata.name.logs" . }}
+  name: {{ template "sumologic.metadata.name.logs.service" . }}
   labels:
-    app: {{ template "sumologic.labels.app.logs" . }}
+    app: {{ template "sumologic.labels.app.logs.service" . }}
     {{- include "sumologic.labels.logs" . | nindent 4 }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:

--- a/deploy/helm/sumologic/templates/service.yaml
+++ b/deploy/helm/sumologic/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "sumologic.fullname" . }}-fluentd-logs
+  name: {{ template "sumologic.metadata.name.logs" . }}
   labels:
     app: {{ template "sumologic.labels.app" . }}-fluentd-logs
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/service.yaml
+++ b/deploy/helm/sumologic/templates/service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   name: {{ template "sumologic.metadata.name.logs" . }}
   labels:
+    app: {{ template "sumologic.labels.app.logs" . }}
     {{- include "sumologic.labels.logs" . | nindent 4 }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:

--- a/deploy/helm/sumologic/templates/serviceaccount.yaml
+++ b/deploy/helm/sumologic/templates/serviceaccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "sumologic.fullname" . }}
+  name: {{ template "sumologic.metadata.name.roles.serviceaccount" . }}
   labels:
-    app: {{ template "sumologic.labels.app" . }}
+    app: {{ template "sumologic.labels.app.roles.serviceaccount" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/setup/setup-clusterrole.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-clusterrole.yaml
@@ -2,11 +2,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name:  {{ template "sumologic.metadata.name.setup" . }}
+  name:  {{ template "sumologic.metadata.name.setup.roles.clusterrole" . }}
   annotations:
 {{ toYaml .Values.sumologic.setup.clusterRole.annotations | indent 4 }}
   labels:
-    app: {{ template "sumologic.labels.app" . }}
+    app: {{ template "sumologic.labels.app.roles.clusterrole" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 rules:
   - apiGroups:

--- a/deploy/helm/sumologic/templates/setup/setup-clusterrole.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name:  {{ template "sumologic.fullname" . }}-setup
+  name:  {{ template "sumologic.metadata.name.setup" . }}
   annotations:
 {{ toYaml .Values.sumologic.setup.clusterRole.annotations | indent 4 }}
   labels:

--- a/deploy/helm/sumologic/templates/setup/setup-clusterrole.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-clusterrole.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
 {{ toYaml .Values.sumologic.setup.clusterRole.annotations | indent 4 }}
   labels:
-    app: {{ template "sumologic.labels.app.roles.clusterrole" . }}
+    app: {{ template "sumologic.labels.app.setup.roles.clusterrole" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 rules:
   - apiGroups:

--- a/deploy/helm/sumologic/templates/setup/setup-clusterrolebinding.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-clusterrolebinding.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
 {{ toYaml .Values.sumologic.setup.clusterRoleBinding.annotations | indent 4 }}
   labels:
-    app: {{ template "sumologic.labels.app.roles.clusterrolebinding" . }}
+    app: {{ template "sumologic.labels.app.setup.roles.clusterrolebinding" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/helm/sumologic/templates/setup/setup-clusterrolebinding.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name:  {{ template "sumologic.fullname" . }}-setup
+  name:  {{ template "sumologic.metadata.name.setup" . }}
   annotations:
 {{ toYaml .Values.sumologic.setup.clusterRoleBinding.annotations | indent 4 }}
   labels:
@@ -11,10 +11,10 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "sumologic.fullname" . }}-setup
+  name: {{ template "sumologic.metadata.name.setup" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "sumologic.fullname" . }}-setup
+    name: {{ template "sumologic.metadata.name.setup" . }}
     namespace: {{ .Release.Namespace }}
 
 {{- end }}

--- a/deploy/helm/sumologic/templates/setup/setup-clusterrolebinding.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-clusterrolebinding.yaml
@@ -2,19 +2,19 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name:  {{ template "sumologic.metadata.name.setup" . }}
+  name:  {{ template "sumologic.metadata.name.setup.roles.clusterrolebinding" . }}
   annotations:
 {{ toYaml .Values.sumologic.setup.clusterRoleBinding.annotations | indent 4 }}
   labels:
-    app: {{ template "sumologic.labels.app" . }}
+    app: {{ template "sumologic.labels.app.roles.clusterrolebinding" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "sumologic.metadata.name.setup" . }}
+  name: {{ template "sumologic.metadata.name.setup.roles.clusterrole" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "sumologic.metadata.name.setup" . }}
+    name: {{ template "sumologic.metadata.name.setup.roles.serviceaccount" . }}
     namespace: {{ .Release.Namespace }}
 
 {{- end }}

--- a/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
 {{ toYaml .Values.sumologic.setup.configMap.annotations | indent 4 }}
   labels:
-    app: {{ template "sumologic.labels.app" . }}
+    app: {{ template "sumologic.labels.app.setup.configmap" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 data:
   {{- (tpl (.Files.Glob "conf/setup/*").AsConfig .) | nindent 2 }}

--- a/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name:  {{ template "sumologic.fullname" . }}-setup
+  name:  {{ template "sumologic.metadata.name.setup" . }}
   annotations:
 {{ toYaml .Values.sumologic.setup.configMap.annotations | indent 4 }}
   labels:

--- a/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name:  {{ template "sumologic.metadata.name.setup" . }}
+  name:  {{ template "sumologic.metadata.name.setup.configmap" . }}
   annotations:
 {{ toYaml .Values.sumologic.setup.configMap.annotations | indent 4 }}
   labels:

--- a/deploy/helm/sumologic/templates/setup/setup-job.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-job.yaml
@@ -13,7 +13,7 @@ spec:
   template:
     spec:
       restartPolicy: OnFailure
-      serviceAccountName: {{ template "sumologic.metadata.name.setup" . }}
+      serviceAccountName: {{ template "sumologic.metadata.name.setup.roles.serviceaccount" . }}
       volumes:
       - name: setup
         configMap:

--- a/deploy/helm/sumologic/templates/setup/setup-job.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-job.yaml
@@ -2,12 +2,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "sumologic.metadata.name.setup" . }}
+  name: {{ template "sumologic.metadata.name.setup.job" . }}
   namespace: {{ .Release.Namespace }}
   annotations:
 {{ toYaml .Values.sumologic.setup.job.annotations | indent 4 }}
   labels:
-    app: {{ template "sumologic.labels.app" . }}
+    app: {{ template "sumologic.labels.app.setup.job" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   template:

--- a/deploy/helm/sumologic/templates/setup/setup-job.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "sumologic.fullname" . }}-setup
+  name: {{ template "sumologic.metadata.name.setup" . }}
   namespace: {{ .Release.Namespace }}
   annotations:
 {{ toYaml .Values.sumologic.setup.job.annotations | indent 4 }}
@@ -13,11 +13,11 @@ spec:
   template:
     spec:
       restartPolicy: OnFailure
-      serviceAccountName: {{ template "sumologic.fullname" . }}-setup
+      serviceAccountName: {{ template "sumologic.metadata.name.setup" . }}
       volumes:
       - name: setup
         configMap:
-          name: {{ template "sumologic.fullname" . }}-setup
+          name: {{ template "sumologic.metadata.name.setup" . }}
           defaultMode: 0777
       containers:
       - name: setup

--- a/deploy/helm/sumologic/templates/setup/setup-job.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-job.yaml
@@ -17,7 +17,7 @@ spec:
       volumes:
       - name: setup
         configMap:
-          name: {{ template "sumologic.metadata.name.setup" . }}
+          name: {{ template "sumologic.metadata.name.setup.configmap" . }}
           defaultMode: 0777
       containers:
       - name: setup

--- a/deploy/helm/sumologic/templates/setup/setup-serviceaccount.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name:  {{ template "sumologic.fullname" . }}-setup
+  name:  {{ template "sumologic.metadata.name.setup" . }}
   annotations:
 {{ toYaml .Values.sumologic.setup.serviceAccount.annotations | indent 4 }}
   labels:

--- a/deploy/helm/sumologic/templates/setup/setup-serviceaccount.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-serviceaccount.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name:  {{ template "sumologic.metadata.name.setup" . }}
+  name:  {{ template "sumologic.metadata.name.setup.roles.serviceaccount" . }}
   annotations:
 {{ toYaml .Values.sumologic.setup.serviceAccount.annotations | indent 4 }}
   labels:
-    app: {{ template "sumologic.labels.app" . }}
+    app: {{ template "sumologic.labels.app.roles.serviceaccount" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 {{- end }}

--- a/deploy/helm/sumologic/templates/setup/setup-serviceaccount.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-serviceaccount.yaml
@@ -6,6 +6,6 @@ metadata:
   annotations:
 {{ toYaml .Values.sumologic.setup.serviceAccount.annotations | indent 4 }}
   labels:
-    app: {{ template "sumologic.labels.app.roles.serviceaccount" . }}
+    app: {{ template "sumologic.labels.app.setup.roles.serviceaccount" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 {{- end }}

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       app: {{ template "sumologic.labels.app.logs" . }}
-  serviceName: {{ template "sumologic.metadata.name.logs.headless" . }}
+  serviceName: {{ template "sumologic.metadata.name.logs.service-headless" . }}
   podManagementPolicy: "Parallel"
   replicas: {{ .Values.fluentd.logs.statefulset.replicaCount }}
   template:

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -3,19 +3,19 @@ kind: StatefulSet
 metadata:
   name: {{ template "sumologic.metadata.name.logs" . }}
   labels:
-    app: {{ template "sumologic.labels.app" . }}-fluentd-logs
+    app: {{ template "sumologic.labels.app.logs" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      app: {{ template "sumologic.labels.app" . }}-fluentd-logs
+      app: {{ template "sumologic.labels.app.logs" . }}
   serviceName: {{ template "sumologic.metadata.name.logs.headless" . }}
   podManagementPolicy: "Parallel"
   replicas: {{ .Values.fluentd.logs.statefulset.replicaCount }}
   template:
     metadata:
       labels:
-        app: {{ template "sumologic.labels.app" . }}-fluentd-logs
+        app: {{ template "sumologic.labels.app.logs" . }}
         {{- include "sumologic.labels.common" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "sumologic.fullname" . }}
@@ -40,7 +40,7 @@ spec:
               - key: app
                 operator: In
                 values:
-                - {{ template "sumologic.labels.app" . }}-fluentd-logs
+                - {{ template "sumologic.labels.app.logs" . }}
                 - {{ template "sumologic.labels.app" . }}-fluentd-metrics
               - key: app
                 operator: In
@@ -57,7 +57,7 @@ spec:
                 - key: app
                   operator: In
                   values:
-                  - {{ template "sumologic.labels.app" . }}-fluentd-logs
+                  - {{ template "sumologic.labels.app.logs" . }}
                   - {{ template "sumologic.labels.app" . }}-fluentd-metrics
                 - key: app
                   operator: In

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ template "sumologic.labels.app.logs" . }}
+      app: {{ template "sumologic.labels.app.logs.pod" . }}
   serviceName: {{ template "sumologic.metadata.name.logs.service-headless" . }}
   podManagementPolicy: "Parallel"
   replicas: {{ .Values.fluentd.logs.statefulset.replicaCount }}

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -41,7 +41,7 @@ spec:
                 operator: In
                 values:
                 - {{ template "sumologic.labels.app.logs" . }}
-                - {{ template "sumologic.labels.app" . }}-fluentd-metrics
+                - {{ template "sumologic.labels.app.metrics" . }}
               - key: app
                 operator: In
                 values:
@@ -58,7 +58,7 @@ spec:
                   operator: In
                   values:
                   - {{ template "sumologic.labels.app.logs" . }}
-                  - {{ template "sumologic.labels.app" . }}-fluentd-metrics
+                  - {{ template "sumologic.labels.app.metrics" . }}
                 - key: app
                   operator: In
                   values:

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -73,7 +73,7 @@ spec:
           type: ""
       - name: config-volume
         configMap:
-          name: {{ template "sumologic.metadata.name.logs" . }}
+          name: {{ template "sumologic.metadata.name.logs.configmap" . }}
       securityContext:
         fsGroup: {{ .Values.fluentd.securityContext.fsGroup }}
       containers:

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -18,7 +18,7 @@ spec:
         app: {{ template "sumologic.labels.app.logs" . }}
         {{- include "sumologic.labels.common" . | nindent 8 }}
     spec:
-      serviceAccountName: {{ template "sumologic.fullname" . }}
+      serviceAccountName: {{ template "sumologic.metadata.name.roles.serviceaccount" . }}
 {{- if .Values.fluentd.logs.statefulset.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.fluentd.logs.statefulset.nodeSelector | indent 8 }}

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ template "sumologic.fullname" . }}-fluentd-logs
+  name: {{ template "sumologic.metadata.name.logs" . }}
   labels:
     app: {{ template "sumologic.labels.app" . }}-fluentd-logs
     {{- include "sumologic.labels.common" . | nindent 4 }}
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       app: {{ template "sumologic.labels.app" . }}-fluentd-logs
-  serviceName: {{ template "sumologic.fullname" . }}-fluentd-logs-headless
+  serviceName: {{ template "sumologic.metadata.name.logs.headless" . }}
   podManagementPolicy: "Parallel"
   replicas: {{ .Values.fluentd.logs.statefulset.replicaCount }}
   template:
@@ -73,7 +73,7 @@ spec:
           type: ""
       - name: config-volume
         configMap:
-          name: {{ template "sumologic.fullname" . }}-fluentd-logs
+          name: {{ template "sumologic.metadata.name.logs" . }}
       securityContext:
         fsGroup: {{ .Values.fluentd.securityContext.fsGroup }}
       containers:

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -3,7 +3,7 @@ kind: StatefulSet
 metadata:
   name: {{ template "sumologic.metadata.name.logs.statefulset" . }}
   labels:
-    app: {{ template "sumologic.labels.app.logs" . }}
+    app: {{ template "sumologic.labels.app.logs.statefulset" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -57,8 +57,8 @@ spec:
                 - key: app
                   operator: In
                   values:
-                  - {{ template "sumologic.labels.app.logs" . }}
-                  - {{ template "sumologic.labels.app.metrics" . }}
+                  - {{ template "sumologic.labels.app.logs.pod" . }}
+                  - {{ template "sumologic.labels.app.metrics.pod" . }}
                 - key: app
                   operator: In
                   values:

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "sumologic.labels.app.logs" . }}
+        app: {{ template "sumologic.labels.app.logs.pod" . }}
         {{- include "sumologic.labels.common" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "sumologic.metadata.name.roles.serviceaccount" . }}

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ template "sumologic.metadata.name.logs" . }}
+  name: {{ template "sumologic.metadata.name.logs.statefulset" . }}
   labels:
     app: {{ template "sumologic.labels.app.logs" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -558,6 +558,8 @@ metadata:
   name: collection-sumologic-fluentd-events-headless
   labels:
     app: collection-sumologic-fluentd-events-headless
+    sumologic/app: fluentd-events
+    sumologic/component: events
     
 spec:
   selector:
@@ -577,6 +579,8 @@ metadata:
   name: collection-sumologic-fluentd-events
   labels:
     app: collection-sumologic-fluentd-events
+    sumologic/app: fluentd-events
+    sumologic/component: events
     
 spec:
   selector:
@@ -594,6 +598,8 @@ metadata:
   name: collection-sumologic-fluentd-metrics-headless
   labels:
     app: collection-sumologic-fluentd-metrics-headless
+    sumologic/app: fluentd-events
+    sumologic/component: events
     
 spec:
   selector:
@@ -617,6 +623,8 @@ metadata:
   name: collection-sumologic-fluentd-metrics
   labels:
     app: collection-sumologic-fluentd-metrics
+    sumologic/app: fluentd-metrics
+    sumologic/component: metrics
     
 spec:
   selector:
@@ -662,6 +670,8 @@ metadata:
   name: collection-sumologic-fluentd-logs
   labels:
     app: collection-sumologic-fluentd-logs
+    sumologic/app: fluentd-logs
+    sumologic/component: logs
     
 spec:
   selector:


### PR DESCRIPTION
###### Description

The purpose is to not lost track of relations between kubernetes objects

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
