### PR TITLE
Use env for prometheus metrics namespace

### DIFF
--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -78,37 +78,37 @@ prometheus:
   additionalServiceMonitors:
   - name: collection-sumologic-fluentd-logs
     additionalLabels:
-      app: collection-sumologic-fluentd-logs
+      sumologic/app: fluentd-logs
     endpoints:
     - port: metrics
     namespaceSelector:
       matchNames:
-      - sumologic
+      - $(NAMESPACE)
     selector:
       matchLabels:
-        app: collection-sumologic-fluentd-logs
+        sumologic/app: fluentd-logs
   - name: collection-sumologic-fluentd-metrics
     additionalLabels:
-      app: collection-sumologic-fluentd-metrics
+      sumologic/app: fluentd-metrics
     endpoints:
     - port: metrics
     namespaceSelector:
       matchNames:
-      - sumologic
+      - $(NAMESPACE)
     selector:
       matchLabels:
-        app: collection-sumologic-fluentd-metrics
+        sumologic/app: fluentd-metrics
   - name: collection-sumologic-fluentd-events
     additionalLabels:
-      app: collection-sumologic-fluentd-events
+      sumologic/app: fluentd-events
     endpoints:
     - port: metrics
     namespaceSelector:
       matchNames:
-      - sumologic
+      - $(NAMESPACE)
     selector:
       matchLabels:
-        app: collection-sumologic-fluentd-events
+        sumologic/app: fluentd-events
   - name: collection-fluent-bit
     additionalLabels:
       app: collection-fluent-bit
@@ -117,21 +117,21 @@ prometheus:
       path: /api/v1/metrics/prometheus
     namespaceSelector:
       matchNames:
-      - sumologic
+      - $(NAMESPACE)
     selector:
       matchLabels:
         app: fluent-bit
   - name: collection-sumologic-otelcol
     additionalLabels:
-      app: collection-sumologic-otelcol
+      sumologic/app: otelcol
     endpoints:
     - port: metrics
     namespaceSelector:
       matchNames:
-      - sumologic
+      - $(NAMESPACE)
     selector:
       matchLabels:
-        app: collection-sumologic-otelcol
+        sumologic/app: otelcol
   prometheusSpec:
     ## Prometheus default scrape interval, default from upstream Prometheus Operator Helm chart
     ## NOTE changing the scrape interval to be >1m can result in metrics from recording rules to be missing and empty panels in Sumo Logic Kubernetes apps.

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -680,7 +680,7 @@ prometheus-operator:
         - port: metrics
         namespaceSelector:
           matchNames:
-          - sumologic
+          - $(NAMESPACE)
         selector:
           matchLabels:
             app: collection-sumologic-fluentd-logs
@@ -691,7 +691,7 @@ prometheus-operator:
         - port: metrics
         namespaceSelector:
           matchNames:
-          - sumologic
+          - $(NAMESPACE)
         selector:
           matchLabels:
             app: collection-sumologic-fluentd-metrics
@@ -702,7 +702,7 @@ prometheus-operator:
           - port: metrics
         namespaceSelector:
           matchNames:
-            - sumologic
+            - $(NAMESPACE)
         selector:
           matchLabels:
             app: collection-sumologic-fluentd-events
@@ -714,7 +714,7 @@ prometheus-operator:
             path: /api/v1/metrics/prometheus
         namespaceSelector:
           matchNames:
-            - sumologic
+            - $(NAMESPACE)
         selector:
           matchLabels:
             app: fluent-bit
@@ -725,7 +725,7 @@ prometheus-operator:
           - port: metrics
         namespaceSelector:
           matchNames:
-            - sumologic
+            - $(NAMESPACE)
         selector:
           matchLabels:
             app: collection-sumologic-otelcol

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -675,7 +675,7 @@ prometheus-operator:
     additionalServiceMonitors:
       - name: collection-sumologic-fluentd-logs
         additionalLabels:
-          app: collection-sumologic-fluentd-logs
+          sumologic/app: fluentd-logs
         endpoints:
         - port: metrics
         namespaceSelector:
@@ -683,10 +683,10 @@ prometheus-operator:
           - $(NAMESPACE)
         selector:
           matchLabels:
-            app: collection-sumologic-fluentd-logs
+            sumologic/app: fluentd-logs
       - name: collection-sumologic-fluentd-metrics
         additionalLabels:
-          app: collection-sumologic-fluentd-metrics
+          sumologic/app: fluentd-metrics
         endpoints:
         - port: metrics
         namespaceSelector:
@@ -694,10 +694,10 @@ prometheus-operator:
           - $(NAMESPACE)
         selector:
           matchLabels:
-            app: collection-sumologic-fluentd-metrics
+            sumologic/app: fluentd-metrics
       - name: collection-sumologic-fluentd-events
         additionalLabels:
-          app: collection-sumologic-fluentd-events
+          sumologic/app: fluentd-events
         endpoints:
           - port: metrics
         namespaceSelector:
@@ -705,7 +705,7 @@ prometheus-operator:
             - $(NAMESPACE)
         selector:
           matchLabels:
-            app: collection-sumologic-fluentd-events
+            sumologic/app: fluentd-events
       - name: collection-fluent-bit
         additionalLabels:
           app: collection-fluent-bit
@@ -720,7 +720,7 @@ prometheus-operator:
             app: fluent-bit
       - name: collection-sumologic-otelcol
         additionalLabels:
-          app: collection-sumologic-otelcol
+          sumologic/app: otelcol
         endpoints:
           - port: metrics
         namespaceSelector:
@@ -728,7 +728,7 @@ prometheus-operator:
             - $(NAMESPACE)
         selector:
           matchLabels:
-            app: collection-sumologic-otelcol
+            sumologic/app: otelcol
     prometheusSpec:
       ## Prometheus default scrape interval, default from upstream Prometheus Operator Helm chart
       ## NOTE changing the scrape interval to be >1m can result in metrics from recording rules to be missing and empty panels in Sumo Logic Kubernetes apps.


### PR DESCRIPTION
###### Description

Rebased #676  (Use env for prometheus metrics namespace)

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
