### PR TITLE
Fix Travis build due to default shallow git clone

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -18,7 +18,7 @@ if [ -n "$GITHUB_TOKEN" ]; then
   git config --global user.email "travis@travis-ci.org"
   git config --global user.name "Travis CI"
   git remote add origin-repo https://${GITHUB_TOKEN}@github.com/SumoLogic/sumologic-kubernetes-collection.git > /dev/null 2>&1
-  git fetch origin-repo
+  git fetch --unshallow origin-repo
   git checkout $TRAVIS_PULL_REQUEST_BRANCH
 fi
 


### PR DESCRIPTION
###### Description

Fix Travis build due to default shallow git clone

https://docs.travis-ci.com/user/customizing-the-build#git-clone-depth

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
