### PR TITLE
Fix Travis build due to default shallow git clone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,5 @@ branches:
   - /^release-v\d+\.\d+$/
   - /^v\d+\.\d+\.\d+$/
   - /^v\d+\.\d+\.\d+-(alpha|beta|rc)\.\d+$/
+git:
+  depth: false


### PR DESCRIPTION
[fix] Travis build failed to create proper build tags due to default shallow git clone

`git describe` won't work correctly if there is more than 50 (Travis default) commits from the last description (tag)
https://docs.travis-ci.com/user/customizing-the-build#git-clone-depth
###### Description

Fill in your description here.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
