### PR TITLE
Add generator for logs, events and traces sources

### DIFF
--- a/deploy/helm/sumologic/conf/events/events.conf
+++ b/deploy/helm/sumologic/conf/events/events.conf
@@ -35,7 +35,7 @@
   @type sumologic
   @id sumologic.endpoint.events
   sumo_client {{ include "sumologic.sumo_client" . | quote }}
-  endpoint "#{ENV['SUMO_ENDPOINT_EVENTS_SOURCE']}"
+  endpoint "#{ENV['SUMO_ENDPOINT_DEFAULT_EVENTS_SOURCE']}"
   data_type logs
   disable_cookies true
   verify_ssl {{ .Values.fluentd.verifySsl | quote }}

--- a/deploy/helm/sumologic/conf/logs/logs.output.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.output.conf
@@ -1,6 +1,6 @@
 data_type logs
 log_key log
-endpoint "#{ENV['SUMO_ENDPOINT_LOGS_SOURCE']}"
+endpoint "#{ENV['SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE']}"
 verify_ssl {{ .Values.fluentd.verifySsl | quote }}
 log_format {{ .Values.fluentd.logs.output.logFormat | quote }}
 add_timestamp {{ .Values.fluentd.logs.output.addTimestamp | quote }}

--- a/deploy/helm/sumologic/conf/metrics/metrics.conf
+++ b/deploy/helm/sumologic/conf/metrics/metrics.conf
@@ -62,6 +62,6 @@
 {{- if $source.source -}}
 {{- $endpoint = $source.source -}}
 {{- end -}}
-{{ include "utils.metrics.match" (dict "Context" $ctx "Drop" $source.drop "Tag" $source.tag "Id" $source.id "Endpoint" (include "terraform.sources.name_metrics" $endpoint) "Storage" (index $ctx.Values.fluentd.buffer.filePaths.metrics $name) ) | nindent 4 }}
+{{ include "utils.metrics.match" (dict "Context" $ctx "Drop" $source.drop "Tag" $source.tag "Id" $source.id "Endpoint" (include "terraform.sources.name" (dict "Name" $endpoint "Type" "metrics")) "Storage" (index $ctx.Values.fluentd.buffer.filePaths.metrics $name) ) | nindent 4 }}
 {{- end }}
 </label>

--- a/deploy/helm/sumologic/conf/setup/setup.sh
+++ b/deploy/helm/sumologic/conf/setup/setup.sh
@@ -15,11 +15,11 @@ terraform init
 
 # Sumo Collector and HTTP sources
 terraform import sumologic_collector.collector "$COLLECTOR_NAME"
-{{ range $key, $source := .Values.sumologic.sources }}
-terraform import sumologic_http_source.{{ template "terraform.sources.name_metrics" $key }} "$COLLECTOR_NAME/{{ $source.name }}"
+{{- range $type, $sources := .Values.sumologic.sources }}
+{{- range $key, $source := $sources }}
+terraform import sumologic_http_source.{{ template "terraform.sources.name" (dict "Name" $key "Type" $type) }} "$COLLECTOR_NAME/{{ $source.name }}"
 {{- end }}
-terraform import sumologic_http_source.{{ template "terraform.sources.name" "logs" }} "$COLLECTOR_NAME/logs"
-terraform import sumologic_http_source.{{ template "terraform.sources.name" "events" }} "$COLLECTOR_NAME/events"
+{{- end }}
 
 
 # Kubernetes Namespace and Secret

--- a/deploy/helm/sumologic/conf/setup/setup.sh
+++ b/deploy/helm/sumologic/conf/setup/setup.sh
@@ -15,9 +15,12 @@ terraform init
 
 # Sumo Collector and HTTP sources
 terraform import sumologic_collector.collector "$COLLECTOR_NAME"
+{{- $ctx := .Values -}}
 {{- range $type, $sources := .Values.sumologic.sources }}
 {{- range $key, $source := $sources }}
+{{- if eq (include "terraform.sources.component_enabled" (dict "Context" $ctx "Type" $type)) "true" }}
 terraform import sumologic_http_source.{{ template "terraform.sources.name" (dict "Name" $key "Type" $type) }} "$COLLECTOR_NAME/{{ $source.name }}"
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/deploy/helm/sumologic/conf/setup/sumo-k8s.tf
+++ b/deploy/helm/sumologic/conf/setup/sumo-k8s.tf
@@ -32,8 +32,10 @@ variable "namespace_name" {
 
 locals {
 {{- range $type, $sources := .Values.sumologic.sources }}
+{{- if eq (include "terraform.sources.component_enabled" (dict "Context" $ctx "Type" $type)) "true" }}
 {{- range $key, $source := $sources }}
   {{ template "terraform.sources.local" (dict "Name" (include "terraform.sources.name" (dict "Name" $key "Type" $type)) "Value" $source.name) }}
+{{- end }}
 {{- end }}
 {{- end }}
 }
@@ -52,8 +54,10 @@ resource "sumologic_collector" "collector" {
 }
 
 {{- range $type, $sources := .Values.sumologic.sources }}
+{{- if eq (include "terraform.sources.component_enabled" (dict "Context" $ctx "Type" $type)) "true" }}
 {{- range $key, $source := $sources }}
 {{ include "terraform.sources.resource" (dict "Name" (include "terraform.sources.name" (dict "Name" $key "Type" $type)) "Source" $source "Context" $ctx) | nindent 2 }}
+{{- end }}
 {{- end }}
 {{- end }}
 
@@ -96,8 +100,10 @@ resource "kubernetes_secret" "sumologic_collection_secret" {
 
   data = {
     {{- range $type, $sources := .Values.sumologic.sources }}
+    {{- if eq (include "terraform.sources.component_enabled" (dict "Context" $ctx "Type" $type)) "true" }}
     {{- range $key, $source := $sources }}
     {{ include "terraform.sources.data" (dict "Endpoint" (include "terraform.sources.config-map-variable" (dict "Type" $type "Context" $ctx "Name" $key)) "Name" (include "terraform.sources.name" (dict "Name" $key "Type" $type))) }}
+    {{- end }}
     {{- end }}
     {{- end }}
   }

--- a/deploy/helm/sumologic/conf/traces/traces.conf
+++ b/deploy/helm/sumologic/conf/traces/traces.conf
@@ -27,7 +27,7 @@
 {{- end }}
   <match tracing.**>
     @type zipkin
-    endpoint "#{ENV['SUMO_ENDPOINT_TRACES']}"
+    endpoint "#{ENV['SUMO_ENDPOINT_DEFAULT_TRACES_SOURCE']}"
     content_type application/json
     open_timeout 1
     spans_per_request {{ .Values.sumologic.traces.spans_per_request }}

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -582,7 +582,6 @@ Example usage:
 {{ $endpoint }}
 {{- end -}}
 
-
 {{/*
 Add or skip quotation denending on the value
 
@@ -603,5 +602,25 @@ Example Usage:
 {{- end -}}
 {{- else -}}
 {{ printf "\"%s\"" (toString .) }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Check if component (source/events/logs/traces etc.) is enabled or not
+
+Example Usage:
+{{- if eq (include "terraform.sources.component_enabled" (dict "Context" .Values "Type" "metrics")) "true" }}
+
+*/}}
+{{- define "terraform.sources.component_enabled" -}}
+{{- $type := .Type -}}
+{{- $ctx := .Context -}}
+{{- $value := true -}}
+{{- if hasKey $ctx.sumologic $type -}}
+{{- if not (index $ctx.sumologic $type "enabled") -}}
+{{- $value = false -}}
+{{- end -}}
+{{- end -}}
+{{ $value }}
 {{- end -}}
 {{- end -}}

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -623,4 +623,22 @@ Example Usage:
 {{- end -}}
 {{ $value }}
 {{- end -}}
+
+{{/*
+Generate fluentd envs for given source type:
+
+Example:
+
+{{ include "kubernetes.sources.envs" (dict "Context" .Values "Type" "metrics")}}
+*/}}
+{{- define "kubernetes.sources.envs" -}}
+{{- $ctx := .Context -}}
+{{- $type := .Type -}}
+{{- range $key, $source := (index .Context.sumologic.sources $type) }}
+        - name: {{ template "terraform.sources.endpoint" (include "terraform.sources.name" (dict "Name" $key "Type" $type)) }}
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: {{ template "terraform.sources.config-map-variable" (dict "Type" $type "Context" $ctx "Name" $key) }}
+{{- end }}
 {{- end -}}

--- a/deploy/helm/sumologic/templates/events-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/events-statefulset.yaml
@@ -67,13 +67,7 @@ spec:
           periodSeconds: 5
         env:
 {{- $ctx := .Values -}}
-{{- range $key, $source := .Values.sumologic.sources.events }}
-        - name: {{ template "terraform.sources.endpoint" (include "terraform.sources.name" (dict "Name" $key "Type" "events")) }}
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: {{ template "terraform.sources.config-map-variable" (dict "Type" "events" "Context" $ctx "Name" $key) }}
-{{- end }}
+{{ include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "events")}}
 {{- if .Values.fluentd.events.extraEnvVars }}
 {{ toYaml .Values.fluentd.events.extraEnvVars | nindent 10 }}
 {{- end }}

--- a/deploy/helm/sumologic/templates/events-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/events-statefulset.yaml
@@ -66,11 +66,14 @@ spec:
           initialDelaySeconds: 30
           periodSeconds: 5
         env:
-        - name: {{ template "terraform.sources.endpoint" (include "terraform.sources.name" "events") }}
+{{- $ctx := .Values -}}
+{{- range $key, $source := .Values.sumologic.sources.events }}
+        - name: {{ template "terraform.sources.endpoint" (include "terraform.sources.name" (dict "Name" $key "Type" "events")) }}
           valueFrom:
             secretKeyRef:
               name: sumologic
-              key: {{ template "terraform.sources.config-map-variable" (dict "Context" .Values "Endpoint" "endpoint-events") }}
+              key: {{ template "terraform.sources.config-map-variable" (dict "Type" "events" "Context" $ctx "Name" $key) }}
+{{- end }}
 {{- if .Values.fluentd.events.extraEnvVars }}
 {{ toYaml .Values.fluentd.events.extraEnvVars | nindent 10 }}
 {{- end }}

--- a/deploy/helm/sumologic/templates/metrics-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics-statefulset.yaml
@@ -117,13 +117,7 @@ spec:
 {{- end }}
         env:
 {{- $ctx := .Values -}}
-{{- range $key, $source := .Values.sumologic.sources.metrics }}
-        - name: {{ template "terraform.sources.endpoint" (include "terraform.sources.name" (dict "Name" $key "Type" "metrics")) }}
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: {{ template "terraform.sources.config-map-variable" (dict "Type" "metrics" "Context" $ctx "Name" $key) }}
-{{- end }}
+{{ include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "metrics")}}
         {{- if .Values.fluentd.metrics.extraEnvVars }}
 {{ toYaml .Values.fluentd.metrics.extraEnvVars | nindent 10 }}
         {{- end }}

--- a/deploy/helm/sumologic/templates/metrics-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics-statefulset.yaml
@@ -117,12 +117,12 @@ spec:
 {{- end }}
         env:
 {{- $ctx := .Values -}}
-{{- range $key, $source := .Values.sumologic.sources }}
-        - name: {{ template "terraform.sources.endpoint" (include "terraform.sources.name_metrics" $key) }}
+{{- range $key, $source := .Values.sumologic.sources.metrics }}
+        - name: {{ template "terraform.sources.endpoint" (include "terraform.sources.name" (dict "Name" $key "Type" "metrics")) }}
           valueFrom:
             secretKeyRef:
               name: sumologic
-              key: {{ template "terraform.sources.config-map-variable" (dict "Context" $ctx "Name" $key) }}
+              key: {{ template "terraform.sources.config-map-variable" (dict "Type" "metrics" "Context" $ctx "Name" $key) }}
 {{- end }}
         {{- if .Values.sumologic.traces.enabled }}
         - name: SUMO_ENDPOINT_TRACES

--- a/deploy/helm/sumologic/templates/metrics-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics-statefulset.yaml
@@ -124,10 +124,6 @@ spec:
               name: sumologic
               key: {{ template "terraform.sources.config-map-variable" (dict "Type" "metrics" "Context" $ctx "Name" $key) }}
 {{- end }}
-        {{- if .Values.sumologic.traces.enabled }}
-        - name: SUMO_ENDPOINT_TRACES
-          value: {{ .Values.sumologic.traces.endpoint }}
-        {{- end }}
         {{- if .Values.fluentd.metrics.extraEnvVars }}
 {{ toYaml .Values.fluentd.metrics.extraEnvVars | nindent 10 }}
         {{- end }}

--- a/deploy/helm/sumologic/templates/otelcol-deployment.yaml
+++ b/deploy/helm/sumologic/templates/otelcol-deployment.yaml
@@ -39,6 +39,8 @@ spec:
         env:
         - name: GOGC
           value: "80"
+{{- $ctx := .Values -}}
+{{ include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "traces")}}
         resources:
           {{- toYaml .Values.otelcol.deployment.resources | nindent 10 }}
         ports:

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -120,20 +120,11 @@ spec:
 {{- if .Values.fluentd.logs.extraVolumeMounts }}
 {{ toYaml .Values.fluentd.logs.extraVolumeMounts | indent 8 }}
 {{- end }}
+        env:
 {{- $ctx := .Values -}}
-{{- range $key, $source := .Values.sumologic.sources.logs }}
-        - name: {{ template "terraform.sources.endpoint" (include "terraform.sources.name" (dict "Name" $key "Type" "logs")) }}
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: {{ template "terraform.sources.config-map-variable" (dict "Type" "logs" "Context" $ctx "Name" $key) }}
-{{- end }}
-{{- range $key, $source := .Values.sumologic.sources.traces }}
-        - name: {{ template "terraform.sources.endpoint" (include "terraform.sources.name" (dict "Name" $key "Type" "traces")) }}
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: {{ template "terraform.sources.config-map-variable" (dict "Type" "traces" "Context" $ctx "Name" $key) }}
+{{ include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "logs")}}
+{{- if .Values.sumologic.traces.enabled }}
+{{ include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "traces")}}
 {{- end }}
         {{- if .Values.fluentd.logs.extraEnvVars }}
 {{ toYaml .Values.fluentd.logs.extraEnvVars | nindent 8 }}

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -120,12 +120,14 @@ spec:
 {{- if .Values.fluentd.logs.extraVolumeMounts }}
 {{ toYaml .Values.fluentd.logs.extraVolumeMounts | indent 8 }}
 {{- end }}
-        env:
-        - name: {{ template "terraform.sources.endpoint" (include "terraform.sources.name" "logs") }}
+{{- $ctx := .Values -}}
+{{- range $key, $source := .Values.sumologic.sources.logs }}
+        - name: {{ template "terraform.sources.endpoint" (include "terraform.sources.name" (dict "Name" $key "Type" "logs")) }}
           valueFrom:
             secretKeyRef:
               name: sumologic
-              key: {{ template "terraform.sources.config-map-variable" (dict "Context" .Values "Endpoint" "endpoint-logs") }}
+              key: {{ template "terraform.sources.config-map-variable" (dict "Type" "logs" "Context" $ctx "Name" $key) }}
+{{- end }}
         {{- if .Values.sumologic.traces.enabled }}
         - name: SUMO_ENDPOINT_TRACES
           value: {{ .Values.sumologic.traces.endpoint }}

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -128,13 +128,16 @@ spec:
               name: sumologic
               key: {{ template "terraform.sources.config-map-variable" (dict "Type" "logs" "Context" $ctx "Name" $key) }}
 {{- end }}
-        {{- if .Values.sumologic.traces.enabled }}
-        - name: SUMO_ENDPOINT_TRACES
-          value: {{ .Values.sumologic.traces.endpoint }}
-        {{- end }}
-{{- if .Values.fluentd.logs.extraEnvVars }}
-{{ toYaml .Values.fluentd.logs.extraEnvVars | indent 8 }}
+{{- range $key, $source := .Values.sumologic.sources.traces }}
+        - name: {{ template "terraform.sources.endpoint" (include "terraform.sources.name" (dict "Name" $key "Type" "traces")) }}
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: {{ template "terraform.sources.config-map-variable" (dict "Type" "traces" "Context" $ctx "Name" $key) }}
 {{- end }}
+        {{- if .Values.fluentd.logs.extraEnvVars }}
+{{ toYaml .Values.fluentd.logs.extraEnvVars | nindent 8 }}
+        {{- end }}
         - name: ADDITIONAL_PLUGINS
           value: {{ join " " .Values.fluentd.additionalPlugins | quote }}
 {{- if .Values.fluentd.persistence.enabled }}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -140,6 +140,12 @@ sumologic:
         name: events
         config-name: endpoint-events
         category: true
+    traces:
+      default:
+        name: traces
+        config-name: endpoint-traces
+        properties:
+          content_type: Zipkin
 
   # Traces configuration
   # This is experimental feature and may be unavailable for your account

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -107,29 +107,39 @@ sumologic:
   ## name: source name visible in sumologic platform
   ## config-name: This is mostly for backward compatibility
   sources:
-    default:
-      name: (default-metrics)
-      config-name: endpoint-metrics
-    apiserver:
-      name: apiserver-metrics
-      config-name: endpoint-metrics-apiserver
-    controller:
-      name: kube-controller-manager-metrics
-      config-name: endpoint-metrics-kube-controller-manager
-    scheduler:
-      name: kube-scheduler-metrics
-      config-name: endpoint-metrics-kube-scheduler
-    state:
-      name: kube-state-metrics
-      config-name: endpoint-metrics-kube-state
-    kubelet:
-      name: kubelet-metrics
-      config-name: endpoint-metrics-kubelet
-    node:
-      name: node-exporter-metrics
-      config-name: endpoint-metrics-node-exporter
-    control-plane:
-      name: control-plane-metrics
+    metrics:
+      default:
+        name: (default-metrics)
+        config-name: endpoint-metrics
+      apiserver:
+        name: apiserver-metrics
+        config-name: endpoint-metrics-apiserver
+      controller:
+        name: kube-controller-manager-metrics
+        config-name: endpoint-metrics-kube-controller-manager
+      scheduler:
+        name: kube-scheduler-metrics
+        config-name: endpoint-metrics-kube-scheduler
+      state:
+        name: kube-state-metrics
+        config-name: endpoint-metrics-kube-state
+      kubelet:
+        name: kubelet-metrics
+        config-name: endpoint-metrics-kubelet
+      node:
+        name: node-exporter-metrics
+        config-name: endpoint-metrics-node-exporter
+      control-plane:
+        name: control-plane-metrics
+    logs:
+      default:
+        name: logs
+        config-name: endpoint-logs
+    events:
+      default:
+        name: events
+        config-name: endpoint-events
+        category: true
 
   # Traces configuration
   # This is experimental feature and may be unavailable for your account
@@ -488,7 +498,7 @@ fluentd:
     ## Output configuration
     ## tag: tag for fluentd match
     ## id: sumologic output @id
-    ## endpoint: [optional] [output key by default] It should match the sumologic.sources[].endpoint
+    ## endpoint: [optional] [output key by default] It should match the sumologic.sources.metrics[].endpoint
     ## drop: [optional] [false by default] Change it to true to drop traffic for specific output
     ## weight: [optional [0 by default] Order of fluentd output (lower means higher priority)
     ## The weight has meaning in case of fluentd matches

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -100,7 +100,7 @@ data:
   logs.output.conf: |-
     data_type logs
     log_key log
-    endpoint "#{ENV['SUMO_ENDPOINT_LOGS_SOURCE']}"
+    endpoint "#{ENV['SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE']}"
     verify_ssl "true"
     log_format "fields"
     add_timestamp "true"
@@ -286,7 +286,7 @@ data:
       @type sumologic
       @id sumologic.endpoint.events
       sumo_client "k8s_1.0.0"
-      endpoint "#{ENV['SUMO_ENDPOINT_EVENTS_SOURCE']}"
+      endpoint "#{ENV['SUMO_ENDPOINT_DEFAULT_EVENTS_SOURCE']}"
       data_type logs
       disable_cookies true
       verify_ssl "true"
@@ -774,7 +774,7 @@ spec:
           initialDelaySeconds: 30
           periodSeconds: 5
         env:
-        - name: SUMO_ENDPOINT_EVENTS_SOURCE
+        - name: SUMO_ENDPOINT_DEFAULT_EVENTS_SOURCE
           valueFrom:
             secretKeyRef:
               name: sumologic
@@ -994,7 +994,7 @@ spec:
         - name: pos-files
           mountPath: /mnt/pos/
         env:
-        - name: SUMO_ENDPOINT_LOGS_SOURCE
+        - name: SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE
           valueFrom:
             secretKeyRef:
               name: sumologic

--- a/deploy/kubernetes/setup-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/setup-sumologic.yaml.tmpl
@@ -33,7 +33,8 @@ data:
   
     # Sumo Collector and HTTP sources
     terraform import sumologic_collector.collector "$COLLECTOR_NAME"
-    
+    terraform import sumologic_http_source.default_events_source "$COLLECTOR_NAME/events"
+    terraform import sumologic_http_source.default_logs_source "$COLLECTOR_NAME/logs"
     terraform import sumologic_http_source.apiserver_metrics_source "$COLLECTOR_NAME/apiserver-metrics"
     terraform import sumologic_http_source.control_plane_metrics_source "$COLLECTOR_NAME/control-plane-metrics"
     terraform import sumologic_http_source.controller_metrics_source "$COLLECTOR_NAME/kube-controller-manager-metrics"
@@ -42,8 +43,6 @@ data:
     terraform import sumologic_http_source.node_metrics_source "$COLLECTOR_NAME/node-exporter-metrics"
     terraform import sumologic_http_source.scheduler_metrics_source "$COLLECTOR_NAME/kube-scheduler-metrics"
     terraform import sumologic_http_source.state_metrics_source "$COLLECTOR_NAME/kube-state-metrics"
-    terraform import sumologic_http_source.logs_source "$COLLECTOR_NAME/logs"
-    terraform import sumologic_http_source.events_source "$COLLECTOR_NAME/events"
   
   
     # Kubernetes Namespace and Secret
@@ -73,6 +72,8 @@ data:
     }
   
     locals {
+      default_events_source                       = "events"
+      default_logs_source                         = "logs"
       apiserver_metrics_source                    = "apiserver-metrics"
       control_plane_metrics_source                = "control-plane-metrics"
       controller_metrics_source                   = "kube-controller-manager-metrics"
@@ -81,8 +82,6 @@ data:
       node_metrics_source                         = "node-exporter-metrics"
       scheduler_metrics_source                    = "kube-scheduler-metrics"
       state_metrics_source                        = "kube-state-metrics"
-      logs_source                                 = "logs"
-      events_source                               = "events"
     }
   
     provider "sumologic" {}
@@ -92,6 +91,17 @@ data:
         fields  = {
           cluster = var.cluster_name
         }
+    }
+    
+    resource "sumologic_http_source" "default_events_source" {
+        name         = local.default_events_source
+        collector_id = sumologic_collector.collector.id
+        category     = "${var.cluster_name}/${local.default_events_source}"
+    }
+    
+    resource "sumologic_http_source" "default_logs_source" {
+        name         = local.default_logs_source
+        collector_id = sumologic_collector.collector.id
     }
     
     resource "sumologic_http_source" "apiserver_metrics_source" {
@@ -133,17 +143,6 @@ data:
         name         = local.state_metrics_source
         collector_id = sumologic_collector.collector.id
     }
-    
-    resource "sumologic_http_source" "logs_source" {
-        name         = local.logs_source
-        collector_id = sumologic_collector.collector.id
-    }
-    
-    resource "sumologic_http_source" "events_source" {
-        name         = local.events_source
-        collector_id = sumologic_collector.collector.id
-        category     = "${var.cluster_name}/${local.events_source}"
-    }
   
     provider "kubernetes" {
     
@@ -166,6 +165,8 @@ data:
       }
   
       data = {
+        endpoint-events                           = sumologic_http_source.default_events_source.url
+        endpoint-logs                             = sumologic_http_source.default_logs_source.url
         endpoint-metrics-apiserver                = sumologic_http_source.apiserver_metrics_source.url
         endpoint-control_plane_metrics_source     = sumologic_http_source.control_plane_metrics_source.url
         endpoint-metrics-kube-controller-manager  = sumologic_http_source.controller_metrics_source.url
@@ -174,8 +175,6 @@ data:
         endpoint-metrics-node-exporter            = sumologic_http_source.node_metrics_source.url
         endpoint-metrics-kube-scheduler           = sumologic_http_source.scheduler_metrics_source.url
         endpoint-metrics-kube-state               = sumologic_http_source.state_metrics_source.url
-        endpoint-logs                             = sumologic_http_source.logs_source.url
-        endpoint-events                           = sumologic_http_source.events_source.url
       }
   
       type = "Opaque"

--- a/tests/terraform/static/all_fields.input.yaml
+++ b/tests/terraform/static/all_fields.input.yaml
@@ -1,37 +1,38 @@
 sumologic:
   sources:
-    test_source:
-      name: "(Test source)"
-      properties:
-        description: "This is complex test"
-        category: "custom/category"
-        host_name: "localhost"
-        timezone: "local timezone"
-        automatic_date_parsing: false
-        multiline_processing_enabled: true
-        use_autoline_matching: false
-        manual_prefix_regexp: '.*'
-        force_timezone: true
-        default_date_formats:
-          - format: format_1
-            locator: locator_1
-          - format: format_2
-            locator: locator_2
-        filters:
-          - name: filter.no1
-            filter_type: Include
-            regexp: '[a-z]+'
-            mask: 'some_mask'
-          - name: filter.no2
-            filter_type: Exclude
-            regexp: '.+'
-            mask: 'another_mask'
-        cutoff_timestamp: 40
-        cutoff_relative_time: 'some value'
-        fields:
-          some_field: some_value
-          another_field: other_value
-        content_type: 'application/json'
-        test_list:
-          - point_1
-          - point_2
+    metrics:
+      test_source:
+        name: "(Test source)"
+        properties:
+          description: "This is complex test"
+          category: "custom/category"
+          host_name: "localhost"
+          timezone: "local timezone"
+          automatic_date_parsing: false
+          multiline_processing_enabled: true
+          use_autoline_matching: false
+          manual_prefix_regexp: '.*'
+          force_timezone: true
+          default_date_formats:
+            - format: format_1
+              locator: locator_1
+            - format: format_2
+              locator: locator_2
+          filters:
+            - name: filter.no1
+              filter_type: Include
+              regexp: '[a-z]+'
+              mask: 'some_mask'
+            - name: filter.no2
+              filter_type: Exclude
+              regexp: '.+'
+              mask: 'another_mask'
+          cutoff_timestamp: 40
+          cutoff_relative_time: 'some value'
+          fields:
+            some_field: some_value
+            another_field: other_value
+          content_type: 'application/json'
+          test_list:
+            - point_1
+            - point_2

--- a/tests/terraform/static/all_fields.output.yaml
+++ b/tests/terraform/static/all_fields.output.yaml
@@ -32,7 +32,8 @@ data:
   
     # Sumo Collector and HTTP sources
     terraform import sumologic_collector.collector "$COLLECTOR_NAME"
-    
+    terraform import sumologic_http_source.default_events_source "$COLLECTOR_NAME/events"
+    terraform import sumologic_http_source.default_logs_source "$COLLECTOR_NAME/logs"
     terraform import sumologic_http_source.apiserver_metrics_source "$COLLECTOR_NAME/apiserver-metrics"
     terraform import sumologic_http_source.control_plane_metrics_source "$COLLECTOR_NAME/control-plane-metrics"
     terraform import sumologic_http_source.controller_metrics_source "$COLLECTOR_NAME/kube-controller-manager-metrics"
@@ -42,8 +43,6 @@ data:
     terraform import sumologic_http_source.scheduler_metrics_source "$COLLECTOR_NAME/kube-scheduler-metrics"
     terraform import sumologic_http_source.state_metrics_source "$COLLECTOR_NAME/kube-state-metrics"
     terraform import sumologic_http_source.test_source_metrics_source "$COLLECTOR_NAME/(Test source)"
-    terraform import sumologic_http_source.logs_source "$COLLECTOR_NAME/logs"
-    terraform import sumologic_http_source.events_source "$COLLECTOR_NAME/events"
   
   
     # Kubernetes Namespace and Secret
@@ -73,6 +72,8 @@ data:
     }
   
     locals {
+      default_events_source                       = "events"
+      default_logs_source                         = "logs"
       apiserver_metrics_source                    = "apiserver-metrics"
       control_plane_metrics_source                = "control-plane-metrics"
       controller_metrics_source                   = "kube-controller-manager-metrics"
@@ -82,8 +83,6 @@ data:
       scheduler_metrics_source                    = "kube-scheduler-metrics"
       state_metrics_source                        = "kube-state-metrics"
       test_source_metrics_source                  = "(Test source)"
-      logs_source                                 = "logs"
-      events_source                               = "events"
     }
   
     provider "sumologic" {}
@@ -93,6 +92,17 @@ data:
         fields  = {
           cluster = var.cluster_name
         }
+    }
+    
+    resource "sumologic_http_source" "default_events_source" {
+        name         = local.default_events_source
+        collector_id = sumologic_collector.collector.id
+        category     = "${var.cluster_name}/${local.default_events_source}"
+    }
+    
+    resource "sumologic_http_source" "default_logs_source" {
+        name         = local.default_logs_source
+        collector_id = sumologic_collector.collector.id
     }
     
     resource "sumologic_http_source" "apiserver_metrics_source" {
@@ -179,17 +189,6 @@ data:
         timezone                     = "local timezone"
         use_autoline_matching        = false
     }
-    
-    resource "sumologic_http_source" "logs_source" {
-        name         = local.logs_source
-        collector_id = sumologic_collector.collector.id
-    }
-    
-    resource "sumologic_http_source" "events_source" {
-        name         = local.events_source
-        collector_id = sumologic_collector.collector.id
-        category     = "${var.cluster_name}/${local.events_source}"
-    }
   
     provider "kubernetes" {
     
@@ -212,6 +211,8 @@ data:
       }
   
       data = {
+        endpoint-events                           = sumologic_http_source.default_events_source.url
+        endpoint-logs                             = sumologic_http_source.default_logs_source.url
         endpoint-metrics-apiserver                = sumologic_http_source.apiserver_metrics_source.url
         endpoint-control_plane_metrics_source     = sumologic_http_source.control_plane_metrics_source.url
         endpoint-metrics-kube-controller-manager  = sumologic_http_source.controller_metrics_source.url
@@ -221,8 +222,6 @@ data:
         endpoint-metrics-kube-scheduler           = sumologic_http_source.scheduler_metrics_source.url
         endpoint-metrics-kube-state               = sumologic_http_source.state_metrics_source.url
         endpoint-test_source_metrics_source       = sumologic_http_source.test_source_metrics_source.url
-        endpoint-logs                             = sumologic_http_source.logs_source.url
-        endpoint-events                           = sumologic_http_source.events_source.url
       }
   
       type = "Opaque"

--- a/tests/terraform/static/collector_fields.output.yaml
+++ b/tests/terraform/static/collector_fields.output.yaml
@@ -32,7 +32,8 @@ data:
   
     # Sumo Collector and HTTP sources
     terraform import sumologic_collector.collector "$COLLECTOR_NAME"
-    
+    terraform import sumologic_http_source.default_events_source "$COLLECTOR_NAME/events"
+    terraform import sumologic_http_source.default_logs_source "$COLLECTOR_NAME/logs"
     terraform import sumologic_http_source.apiserver_metrics_source "$COLLECTOR_NAME/apiserver-metrics"
     terraform import sumologic_http_source.control_plane_metrics_source "$COLLECTOR_NAME/control-plane-metrics"
     terraform import sumologic_http_source.controller_metrics_source "$COLLECTOR_NAME/kube-controller-manager-metrics"
@@ -41,8 +42,6 @@ data:
     terraform import sumologic_http_source.node_metrics_source "$COLLECTOR_NAME/node-exporter-metrics"
     terraform import sumologic_http_source.scheduler_metrics_source "$COLLECTOR_NAME/kube-scheduler-metrics"
     terraform import sumologic_http_source.state_metrics_source "$COLLECTOR_NAME/kube-state-metrics"
-    terraform import sumologic_http_source.logs_source "$COLLECTOR_NAME/logs"
-    terraform import sumologic_http_source.events_source "$COLLECTOR_NAME/events"
   
   
     # Kubernetes Namespace and Secret
@@ -72,6 +71,8 @@ data:
     }
   
     locals {
+      default_events_source                       = "events"
+      default_logs_source                         = "logs"
       apiserver_metrics_source                    = "apiserver-metrics"
       control_plane_metrics_source                = "control-plane-metrics"
       controller_metrics_source                   = "kube-controller-manager-metrics"
@@ -80,8 +81,6 @@ data:
       node_metrics_source                         = "node-exporter-metrics"
       scheduler_metrics_source                    = "kube-scheduler-metrics"
       state_metrics_source                        = "kube-state-metrics"
-      logs_source                                 = "logs"
-      events_source                               = "events"
     }
   
     provider "sumologic" {}
@@ -93,6 +92,17 @@ data:
           here_is_very_long_field_name = "another_value"
           test_fields                  = "test_value"
         }
+    }
+    
+    resource "sumologic_http_source" "default_events_source" {
+        name         = local.default_events_source
+        collector_id = sumologic_collector.collector.id
+        category     = "${var.cluster_name}/${local.default_events_source}"
+    }
+    
+    resource "sumologic_http_source" "default_logs_source" {
+        name         = local.default_logs_source
+        collector_id = sumologic_collector.collector.id
     }
     
     resource "sumologic_http_source" "apiserver_metrics_source" {
@@ -134,17 +144,6 @@ data:
         name         = local.state_metrics_source
         collector_id = sumologic_collector.collector.id
     }
-    
-    resource "sumologic_http_source" "logs_source" {
-        name         = local.logs_source
-        collector_id = sumologic_collector.collector.id
-    }
-    
-    resource "sumologic_http_source" "events_source" {
-        name         = local.events_source
-        collector_id = sumologic_collector.collector.id
-        category     = "${var.cluster_name}/${local.events_source}"
-    }
   
     provider "kubernetes" {
     
@@ -167,6 +166,8 @@ data:
       }
   
       data = {
+        endpoint-events                           = sumologic_http_source.default_events_source.url
+        endpoint-logs                             = sumologic_http_source.default_logs_source.url
         endpoint-metrics-apiserver                = sumologic_http_source.apiserver_metrics_source.url
         endpoint-control_plane_metrics_source     = sumologic_http_source.control_plane_metrics_source.url
         endpoint-metrics-kube-controller-manager  = sumologic_http_source.controller_metrics_source.url
@@ -175,8 +176,6 @@ data:
         endpoint-metrics-node-exporter            = sumologic_http_source.node_metrics_source.url
         endpoint-metrics-kube-scheduler           = sumologic_http_source.scheduler_metrics_source.url
         endpoint-metrics-kube-state               = sumologic_http_source.state_metrics_source.url
-        endpoint-logs                             = sumologic_http_source.logs_source.url
-        endpoint-events                           = sumologic_http_source.events_source.url
       }
   
       type = "Opaque"

--- a/tests/terraform/static/conditional_sources.input.yaml
+++ b/tests/terraform/static/conditional_sources.input.yaml
@@ -1,0 +1,9 @@
+sumologic:
+  metrics:
+    enabled: false
+  logs:
+    enabled: false
+  traces:
+    enabled: false
+  events:
+    enabled: false

--- a/tests/terraform/static/conditional_sources.output.yaml
+++ b/tests/terraform/static/conditional_sources.output.yaml
@@ -26,7 +26,7 @@ data:
     export HTTP_PROXY=${HTTP_PROXY:=""}
     export HTTPS_PROXY=${HTTPS_PROXY:=""}
   
-    COLLECTOR_NAME=kubernetes
+    COLLECTOR_NAME="kubernetes"
   
     terraform init
   
@@ -40,6 +40,12 @@ data:
   
     terraform apply -auto-approve
   sumo-k8s.tf: |-
+    terraform {
+      required_providers {
+        sumologic  = "~> 2.0.3"
+        kubernetes = "~> 1.11.3"
+      }
+    }
     variable "cluster_name" {
       type  = string
       default = "kubernetes"
@@ -68,9 +74,10 @@ data:
   
     provider "kubernetes" {
     
-        cluster_ca_certificate    = "${file("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")}"
+        cluster_ca_certificate    = file("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
         host                      = "https://kubernetes.default.svc"
-        token                     = "${file("/var/run/secrets/kubernetes.io/serviceaccount/token")}"
+        load_config_file          = "false"
+        token                     = file("/var/run/secrets/kubernetes.io/serviceaccount/token")
     }
   
     resource "kubernetes_namespace" "sumologic_collection_namespace" {

--- a/tests/terraform/static/conditional_sources.output.yaml
+++ b/tests/terraform/static/conditional_sources.output.yaml
@@ -1,0 +1,92 @@
+---
+# Source: sumologic/templates/setup/setup-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name:  RELEASE-NAME-sumologic-setup
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "2"
+  labels:
+    app: RELEASE-NAME-sumologic
+    chart: "sumologic-1.0.0"
+    release: "RELEASE-NAME"
+    heritage: "Helm"
+data:
+  setup.sh: |-
+    #!/bin/sh
+    cp /etc/terraform/sumo-k8s.tf /terraform
+    cd /terraform
+  
+    # Fix URL to remove "v1" or "v1/"
+    export SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL%v1*}
+  
+    # Support proxy for terraform
+    export HTTP_PROXY=${HTTP_PROXY:=""}
+    export HTTPS_PROXY=${HTTPS_PROXY:=""}
+  
+    COLLECTOR_NAME=kubernetes
+  
+    terraform init
+  
+    # Sumo Collector and HTTP sources
+    terraform import sumologic_collector.collector "$COLLECTOR_NAME"
+  
+  
+    # Kubernetes Namespace and Secret
+    terraform import kubernetes_namespace.sumologic_collection_namespace default
+    terraform import kubernetes_secret.sumologic_collection_secret default/sumologic
+  
+    terraform apply -auto-approve
+  sumo-k8s.tf: |-
+    variable "cluster_name" {
+      type  = string
+      default = "kubernetes"
+    }
+    variable "collector_name" {
+      type  = string
+      default = "kubernetes"
+    }
+  
+    variable "namespace_name" {
+      type  = string
+      default = "default"
+    }
+  
+    locals {
+    }
+  
+    provider "sumologic" {}
+  
+    resource "sumologic_collector" "collector" {
+        name  = var.collector_name
+        fields  = {
+          cluster = var.cluster_name
+        }
+    }
+  
+    provider "kubernetes" {
+    
+        cluster_ca_certificate    = "${file("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")}"
+        host                      = "https://kubernetes.default.svc"
+        token                     = "${file("/var/run/secrets/kubernetes.io/serviceaccount/token")}"
+    }
+  
+    resource "kubernetes_namespace" "sumologic_collection_namespace" {
+      metadata {
+        name = var.namespace_name
+      }
+    }
+  
+    resource "kubernetes_secret" "sumologic_collection_secret" {
+      metadata {
+        name = "sumologic"
+        namespace = var.namespace_name
+      }
+  
+      data = {
+      }
+  
+      type = "Opaque"
+    }

--- a/tests/terraform/static/default.output.yaml
+++ b/tests/terraform/static/default.output.yaml
@@ -32,7 +32,8 @@ data:
   
     # Sumo Collector and HTTP sources
     terraform import sumologic_collector.collector "$COLLECTOR_NAME"
-    
+    terraform import sumologic_http_source.default_events_source "$COLLECTOR_NAME/events"
+    terraform import sumologic_http_source.default_logs_source "$COLLECTOR_NAME/logs"
     terraform import sumologic_http_source.apiserver_metrics_source "$COLLECTOR_NAME/apiserver-metrics"
     terraform import sumologic_http_source.control_plane_metrics_source "$COLLECTOR_NAME/control-plane-metrics"
     terraform import sumologic_http_source.controller_metrics_source "$COLLECTOR_NAME/kube-controller-manager-metrics"
@@ -41,8 +42,6 @@ data:
     terraform import sumologic_http_source.node_metrics_source "$COLLECTOR_NAME/node-exporter-metrics"
     terraform import sumologic_http_source.scheduler_metrics_source "$COLLECTOR_NAME/kube-scheduler-metrics"
     terraform import sumologic_http_source.state_metrics_source "$COLLECTOR_NAME/kube-state-metrics"
-    terraform import sumologic_http_source.logs_source "$COLLECTOR_NAME/logs"
-    terraform import sumologic_http_source.events_source "$COLLECTOR_NAME/events"
   
   
     # Kubernetes Namespace and Secret
@@ -72,6 +71,8 @@ data:
     }
   
     locals {
+      default_events_source                       = "events"
+      default_logs_source                         = "logs"
       apiserver_metrics_source                    = "apiserver-metrics"
       control_plane_metrics_source                = "control-plane-metrics"
       controller_metrics_source                   = "kube-controller-manager-metrics"
@@ -80,8 +81,6 @@ data:
       node_metrics_source                         = "node-exporter-metrics"
       scheduler_metrics_source                    = "kube-scheduler-metrics"
       state_metrics_source                        = "kube-state-metrics"
-      logs_source                                 = "logs"
-      events_source                               = "events"
     }
   
     provider "sumologic" {}
@@ -91,6 +90,17 @@ data:
         fields  = {
           cluster = var.cluster_name
         }
+    }
+    
+    resource "sumologic_http_source" "default_events_source" {
+        name         = local.default_events_source
+        collector_id = sumologic_collector.collector.id
+        category     = "${var.cluster_name}/${local.default_events_source}"
+    }
+    
+    resource "sumologic_http_source" "default_logs_source" {
+        name         = local.default_logs_source
+        collector_id = sumologic_collector.collector.id
     }
     
     resource "sumologic_http_source" "apiserver_metrics_source" {
@@ -132,17 +142,6 @@ data:
         name         = local.state_metrics_source
         collector_id = sumologic_collector.collector.id
     }
-    
-    resource "sumologic_http_source" "logs_source" {
-        name         = local.logs_source
-        collector_id = sumologic_collector.collector.id
-    }
-    
-    resource "sumologic_http_source" "events_source" {
-        name         = local.events_source
-        collector_id = sumologic_collector.collector.id
-        category     = "${var.cluster_name}/${local.events_source}"
-    }
   
     provider "kubernetes" {
     
@@ -165,6 +164,8 @@ data:
       }
   
       data = {
+        endpoint-events                           = sumologic_http_source.default_events_source.url
+        endpoint-logs                             = sumologic_http_source.default_logs_source.url
         endpoint-metrics-apiserver                = sumologic_http_source.apiserver_metrics_source.url
         endpoint-control_plane_metrics_source     = sumologic_http_source.control_plane_metrics_source.url
         endpoint-metrics-kube-controller-manager  = sumologic_http_source.controller_metrics_source.url
@@ -173,8 +174,6 @@ data:
         endpoint-metrics-node-exporter            = sumologic_http_source.node_metrics_source.url
         endpoint-metrics-kube-scheduler           = sumologic_http_source.scheduler_metrics_source.url
         endpoint-metrics-kube-state               = sumologic_http_source.state_metrics_source.url
-        endpoint-logs                             = sumologic_http_source.logs_source.url
-        endpoint-events                           = sumologic_http_source.events_source.url
       }
   
       type = "Opaque"

--- a/tests/terraform/static/strip_extrapolation.output.yaml
+++ b/tests/terraform/static/strip_extrapolation.output.yaml
@@ -32,7 +32,8 @@ data:
   
     # Sumo Collector and HTTP sources
     terraform import sumologic_collector.collector "$COLLECTOR_NAME"
-    
+    terraform import sumologic_http_source.default_events_source "$COLLECTOR_NAME/events"
+    terraform import sumologic_http_source.default_logs_source "$COLLECTOR_NAME/logs"
     terraform import sumologic_http_source.apiserver_metrics_source "$COLLECTOR_NAME/apiserver-metrics"
     terraform import sumologic_http_source.control_plane_metrics_source "$COLLECTOR_NAME/control-plane-metrics"
     terraform import sumologic_http_source.controller_metrics_source "$COLLECTOR_NAME/kube-controller-manager-metrics"
@@ -41,8 +42,6 @@ data:
     terraform import sumologic_http_source.node_metrics_source "$COLLECTOR_NAME/node-exporter-metrics"
     terraform import sumologic_http_source.scheduler_metrics_source "$COLLECTOR_NAME/kube-scheduler-metrics"
     terraform import sumologic_http_source.state_metrics_source "$COLLECTOR_NAME/kube-state-metrics"
-    terraform import sumologic_http_source.logs_source "$COLLECTOR_NAME/logs"
-    terraform import sumologic_http_source.events_source "$COLLECTOR_NAME/events"
   
   
     # Kubernetes Namespace and Secret
@@ -72,6 +71,8 @@ data:
     }
   
     locals {
+      default_events_source                       = "events"
+      default_logs_source                         = "logs"
       apiserver_metrics_source                    = "apiserver-metrics"
       control_plane_metrics_source                = "control-plane-metrics"
       controller_metrics_source                   = "kube-controller-manager-metrics"
@@ -80,8 +81,6 @@ data:
       node_metrics_source                         = "node-exporter-metrics"
       scheduler_metrics_source                    = "kube-scheduler-metrics"
       state_metrics_source                        = "kube-state-metrics"
-      logs_source                                 = "logs"
-      events_source                               = "events"
     }
   
     provider "sumologic" {}
@@ -91,6 +90,17 @@ data:
         fields  = {
           cluster = var.cluster_name
         }
+    }
+    
+    resource "sumologic_http_source" "default_events_source" {
+        name         = local.default_events_source
+        collector_id = sumologic_collector.collector.id
+        category     = "${var.cluster_name}/${local.default_events_source}"
+    }
+    
+    resource "sumologic_http_source" "default_logs_source" {
+        name         = local.default_logs_source
+        collector_id = sumologic_collector.collector.id
     }
     
     resource "sumologic_http_source" "apiserver_metrics_source" {
@@ -132,17 +142,6 @@ data:
         name         = local.state_metrics_source
         collector_id = sumologic_collector.collector.id
     }
-    
-    resource "sumologic_http_source" "logs_source" {
-        name         = local.logs_source
-        collector_id = sumologic_collector.collector.id
-    }
-    
-    resource "sumologic_http_source" "events_source" {
-        name         = local.events_source
-        collector_id = sumologic_collector.collector.id
-        category     = "${var.cluster_name}/${local.events_source}"
-    }
   
     provider "kubernetes" {
     
@@ -166,6 +165,8 @@ data:
       }
   
       data = {
+        endpoint-events                           = sumologic_http_source.default_events_source.url
+        endpoint-logs                             = sumologic_http_source.default_logs_source.url
         endpoint-metrics-apiserver                = sumologic_http_source.apiserver_metrics_source.url
         endpoint-control_plane_metrics_source     = sumologic_http_source.control_plane_metrics_source.url
         endpoint-metrics-kube-controller-manager  = sumologic_http_source.controller_metrics_source.url
@@ -174,8 +175,6 @@ data:
         endpoint-metrics-node-exporter            = sumologic_http_source.node_metrics_source.url
         endpoint-metrics-kube-scheduler           = sumologic_http_source.scheduler_metrics_source.url
         endpoint-metrics-kube-state               = sumologic_http_source.state_metrics_source.url
-        endpoint-logs                             = sumologic_http_source.logs_source.url
-        endpoint-events                           = sumologic_http_source.events_source.url
       }
   
       type = "Opaque"

--- a/tests/terraform/static/traces.input.yaml
+++ b/tests/terraform/static/traces.input.yaml
@@ -1,0 +1,9 @@
+sumologic:
+  metrics:
+    enabled: false
+  logs:
+    enabled: false
+  traces:
+    enabled: true
+  events:
+    enabled: false

--- a/tests/terraform/static/traces.output.yaml
+++ b/tests/terraform/static/traces.output.yaml
@@ -1,0 +1,101 @@
+---
+# Source: sumologic/templates/setup/setup-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name:  RELEASE-NAME-sumologic-setup
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "2"
+  labels:
+    app: RELEASE-NAME-sumologic
+    chart: "sumologic-1.0.0"
+    release: "RELEASE-NAME"
+    heritage: "Helm"
+data:
+  setup.sh: |-
+    #!/bin/sh
+    cp /etc/terraform/sumo-k8s.tf /terraform
+    cd /terraform
+  
+    # Fix URL to remove "v1" or "v1/"
+    export SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL%v1*}
+  
+    # Support proxy for terraform
+    export HTTP_PROXY=${HTTP_PROXY:=""}
+    export HTTPS_PROXY=${HTTPS_PROXY:=""}
+  
+    COLLECTOR_NAME=kubernetes
+  
+    terraform init
+  
+    # Sumo Collector and HTTP sources
+    terraform import sumologic_collector.collector "$COLLECTOR_NAME"
+    terraform import sumologic_http_source.default_traces_source "$COLLECTOR_NAME/traces"
+  
+  
+    # Kubernetes Namespace and Secret
+    terraform import kubernetes_namespace.sumologic_collection_namespace default
+    terraform import kubernetes_secret.sumologic_collection_secret default/sumologic
+  
+    terraform apply -auto-approve
+  sumo-k8s.tf: |-
+    variable "cluster_name" {
+      type  = string
+      default = "kubernetes"
+    }
+    variable "collector_name" {
+      type  = string
+      default = "kubernetes"
+    }
+  
+    variable "namespace_name" {
+      type  = string
+      default = "default"
+    }
+  
+    locals {
+      default_traces_source                       = "traces"
+    }
+  
+    provider "sumologic" {}
+  
+    resource "sumologic_collector" "collector" {
+        name  = var.collector_name
+        fields  = {
+          cluster = var.cluster_name
+        }
+    }
+    
+    resource "sumologic_http_source" "default_traces_source" {
+        name         = local.default_traces_source
+        collector_id = "${sumologic_collector.collector.id}"
+        content_type = "Zipkin"
+    }
+  
+    provider "kubernetes" {
+    
+        cluster_ca_certificate    = "${file("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")}"
+        host                      = "https://kubernetes.default.svc"
+        token                     = "${file("/var/run/secrets/kubernetes.io/serviceaccount/token")}"
+    }
+  
+    resource "kubernetes_namespace" "sumologic_collection_namespace" {
+      metadata {
+        name = var.namespace_name
+      }
+    }
+  
+    resource "kubernetes_secret" "sumologic_collection_secret" {
+      metadata {
+        name = "sumologic"
+        namespace = var.namespace_name
+      }
+  
+      data = {
+        endpoint-traces                           = "${sumologic_http_source.default_traces_source.url}"
+      }
+  
+      type = "Opaque"
+    }

--- a/tests/terraform/static/traces.output.yaml
+++ b/tests/terraform/static/traces.output.yaml
@@ -26,7 +26,7 @@ data:
     export HTTP_PROXY=${HTTP_PROXY:=""}
     export HTTPS_PROXY=${HTTPS_PROXY:=""}
   
-    COLLECTOR_NAME=kubernetes
+    COLLECTOR_NAME="kubernetes"
   
     terraform init
   
@@ -41,6 +41,12 @@ data:
   
     terraform apply -auto-approve
   sumo-k8s.tf: |-
+    terraform {
+      required_providers {
+        sumologic  = "~> 2.0.3"
+        kubernetes = "~> 1.11.3"
+      }
+    }
     variable "cluster_name" {
       type  = string
       default = "kubernetes"
@@ -70,15 +76,16 @@ data:
     
     resource "sumologic_http_source" "default_traces_source" {
         name         = local.default_traces_source
-        collector_id = "${sumologic_collector.collector.id}"
+        collector_id = sumologic_collector.collector.id
         content_type = "Zipkin"
     }
   
     provider "kubernetes" {
     
-        cluster_ca_certificate    = "${file("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")}"
+        cluster_ca_certificate    = file("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
         host                      = "https://kubernetes.default.svc"
-        token                     = "${file("/var/run/secrets/kubernetes.io/serviceaccount/token")}"
+        load_config_file          = "false"
+        token                     = file("/var/run/secrets/kubernetes.io/serviceaccount/token")
     }
   
     resource "kubernetes_namespace" "sumologic_collection_namespace" {
@@ -94,7 +101,7 @@ data:
       }
   
       data = {
-        endpoint-traces                           = "${sumologic_http_source.default_traces_source.url}"
+        endpoint-traces                           = sumologic_http_source.default_traces_source.url
       }
   
       type = "Opaque"


### PR DESCRIPTION
###### Description

Auto-generate logs, events and traces endpoints in terraform
It doesn't add automatic usage of these sources in fluentd. It has to be done manually

This PR is made almost on the top of the #705 

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
