### PR TITLE
Add missing metrics to fluentd

### DIFF
--- a/deploy/helm/sumologic/conf/events/events.conf
+++ b/deploy/helm/sumologic/conf/events/events.conf
@@ -35,23 +35,29 @@
 {{ include "fluentd.prometheus-metrics.input" (dict "Tag" "kubernetes.**") | nindent 2}}
 {{- end }}
 <match kubernetes.**>
-  @type sumologic
-  @id sumologic.endpoint.events
-  sumo_client {{ include "sumologic.sumo_client" . | quote }}
-  endpoint "#{ENV['SUMO_ENDPOINT_DEFAULT_EVENTS_SOURCE']}"
-  data_type logs
-  disable_cookies true
-  verify_ssl {{ .Values.fluentd.verifySsl | quote }}
-  proxy_uri {{ .Values.fluentd.proxyUri | quote }}
-  <buffer>
-    {{- if or .Values.fluentd.persistence.enabled (eq .Values.fluentd.buffer.type "file") }}
-    @type file
-    path {{ .Values.fluentd.buffer.filePaths.events }}
-    {{- else }}
-    @type memory
-    {{- end }}
-    @include buffer.output.conf
-  </buffer>
+  @type copy
+  <store>
+    @type sumologic
+    @id sumologic.endpoint.events
+    sumo_client {{ include "sumologic.sumo_client" . | quote }}
+    endpoint "#{ENV['SUMO_ENDPOINT_DEFAULT_EVENTS_SOURCE']}"
+    data_type logs
+    disable_cookies true
+    verify_ssl {{ .Values.fluentd.verifySsl | quote }}
+    proxy_uri {{ .Values.fluentd.proxyUri | quote }}
+    <buffer>
+      {{- if or .Values.fluentd.persistence.enabled (eq .Values.fluentd.buffer.type "file") }}
+      @type file
+      path {{ .Values.fluentd.buffer.filePaths.events }}
+      {{- else }}
+      @type memory
+      {{- end }}
+      @include buffer.output.conf
+    </buffer>
+  </store>
+  {{- if .Values.fluentd.monitoring.output }}
+  {{ include "fluentd.prometheus-metrics.output" . | nindent 4 }}
+  {{- end }}
 </match>
 {{- if .Values.fluentd.logLevel }}
 <system>

--- a/deploy/helm/sumologic/conf/events/events.conf
+++ b/deploy/helm/sumologic/conf/events/events.conf
@@ -31,6 +31,9 @@
   port 9880
   bind 0.0.0.0
 </source>
+{{- if .Values.fluentd.monitoring.input }}
+{{ include "fluentd.prometheus-metrics.input" (dict "Tag" "kubernetes.**") | nindent 2}}
+{{- end }}
 <match kubernetes.**>
   @type sumologic
   @id sumologic.endpoint.events

--- a/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
@@ -59,20 +59,26 @@
   {{ .Values.fluentd.logs.containers.overrideOutputConf | nindent 4 }}
   {{- else }}
   <match containers.**>
-    @type sumologic
-    @id sumologic.endpoint.logs
-    sumo_client {{ include "sumologic.sumo_client" . | quote }}
-    @log_level {{ .Values.fluentd.logs.output.pluginLogLevel }}
-{{- .Values.fluentd.logs.containers.outputConf | nindent 6 }}
-    <buffer>
-      {{- if or .Values.fluentd.persistence.enabled (eq .Values.fluentd.buffer.type "file") }}
-      @type file
-      path {{ .Values.fluentd.buffer.filePaths.logs.containers }}
-      {{- else }}
-      @type memory
-      {{- end }}
-      @include buffer.output.conf
-    </buffer>
+    @type copy
+    <store>
+      @type sumologic
+      @id sumologic.endpoint.logs
+      sumo_client {{ include "sumologic.sumo_client" . | quote }}
+      @log_level {{ .Values.fluentd.logs.output.pluginLogLevel }}
+      {{- .Values.fluentd.logs.containers.outputConf | nindent 8 }}
+      <buffer>
+        {{- if or .Values.fluentd.persistence.enabled (eq .Values.fluentd.buffer.type "file") }}
+        @type file
+        path {{ .Values.fluentd.buffer.filePaths.logs.containers }}
+        {{- else }}
+        @type memory
+        {{- end }}
+        @include buffer.output.conf
+      </buffer>
+    </store>
+    {{- if .Values.fluentd.monitoring.output }}
+    {{ include "fluentd.prometheus-metrics.output" . | nindent 6 }}
+    {{- end }}
   </match>
   {{- end }}
 </label>

--- a/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
@@ -1,6 +1,9 @@
 {{ if .Values.fluentd.logs.containers.overrideRawConfig }}
 {{ .Values.fluentd.logs.containers.overrideRawConfig | nindent 2}}
-{{- else}}
+{{- else -}}
+{{- if .Values.fluentd.monitoring.input }}
+{{ include "fluentd.prometheus-metrics.input" (dict "Tag" "containers.**") | nindent 2}}
+{{- end }}
 <filter containers.**>
   @type record_transformer
   enable_ruby

--- a/deploy/helm/sumologic/conf/logs/logs.source.default.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.default.conf
@@ -1,6 +1,9 @@
 {{ if .Values.fluentd.logs.default.overrideOutputConf }}
 {{ .Values.fluentd.logs.default.overrideOutputConf | nindent 2}}
-{{- else}}
+{{- else -}}
+{{- if .Values.fluentd.monitoring.input }}
+{{ include "fluentd.prometheus-metrics.input" (dict "Tag" "**") | nindent 2}}
+{{- end }}
 <match **>
   @type sumologic
   @id sumologic.endpoint.logs.default
@@ -16,4 +19,4 @@
     @include buffer.output.conf
   </buffer>
 </match>
-{{- end}}
+{{- end }}

--- a/deploy/helm/sumologic/conf/logs/logs.source.default.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.default.conf
@@ -5,18 +5,24 @@
 {{ include "fluentd.prometheus-metrics.input" (dict "Tag" "**") | nindent 2}}
 {{- end }}
 <match **>
-  @type sumologic
-  @id sumologic.endpoint.logs.default
-  sumo_client {{ include "sumologic.sumo_client" . | quote }}
-{{- .Values.fluentd.logs.default.outputConf | nindent 4 }}
-  <buffer>
-    {{- if or .Values.fluentd.persistence.enabled (eq .Values.fluentd.buffer.type "file") }}
-    @type file
-    path {{ .Values.fluentd.buffer.filePaths.logs.default }}
-    {{- else }}
-    @type memory
-    {{- end }}
-    @include buffer.output.conf
-  </buffer>
+  @type copy
+  <store>
+    @type sumologic
+    @id sumologic.endpoint.logs.default
+    sumo_client {{ include "sumologic.sumo_client" . | quote }}
+    {{- .Values.fluentd.logs.default.outputConf | nindent 6 }}
+    <buffer>
+      {{- if or .Values.fluentd.persistence.enabled (eq .Values.fluentd.buffer.type "file") }}
+      @type file
+      path {{ .Values.fluentd.buffer.filePaths.logs.default }}
+      {{- else }}
+      @type memory
+      {{- end }}
+      @include buffer.output.conf
+    </buffer>
+  </store>
+  {{- if .Values.fluentd.monitoring.output }}
+  {{ include "fluentd.prometheus-metrics.output" . | nindent 4 }}
+  {{- end }}
 </match>
 {{- end }}

--- a/deploy/helm/sumologic/conf/logs/logs.source.systemd.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.systemd.conf
@@ -22,19 +22,25 @@
   {{ .Values.fluentd.logs.kubelet.overrideOutputConf | nindent 4}}
   {{- else}}
   <match **>
-    @type sumologic
-    @id sumologic.endpoint.logs.kubelet
-    sumo_client {{ include "sumologic.sumo_client" . | quote }}
-{{- .Values.fluentd.logs.kubelet.outputConf | nindent 6 }}
-    <buffer>
-      {{- if or .Values.fluentd.persistence.enabled (eq .Values.fluentd.buffer.type "file") }}
-      @type file
-      path {{ .Values.fluentd.buffer.filePaths.logs.kubelet }}
-      {{- else }}
-      @type memory
-      {{- end }}
-      @include buffer.output.conf
-    </buffer>
+    @type copy
+    <store>
+      @type sumologic
+      @id sumologic.endpoint.logs.kubelet
+      sumo_client {{ include "sumologic.sumo_client" . | quote }}
+      {{- .Values.fluentd.logs.kubelet.outputConf | nindent 8 }}
+      <buffer>
+        {{- if or .Values.fluentd.persistence.enabled (eq .Values.fluentd.buffer.type "file") }}
+        @type file
+        path {{ .Values.fluentd.buffer.filePaths.logs.kubelet }}
+        {{- else }}
+        @type memory
+        {{- end }}
+        @include buffer.output.conf
+      </buffer>
+    </store>
+    {{- if .Values.fluentd.monitoring.output }}
+    {{ include "fluentd.prometheus-metrics.output" . | nindent 6 }}
+    {{- end }}
   </match>
   {{- end}}
 </label>
@@ -68,19 +74,25 @@
   {{ .Values.fluentd.logs.systemd.overrideOutputConf | nindent 4 }}
   {{- else}}
   <match **>
-    @type sumologic
-    @id sumologic.endpoint.logs.systemd
-    sumo_client {{ include "sumologic.sumo_client" . | quote }}
-{{- .Values.fluentd.logs.systemd.outputConf | nindent 6 }}
-    <buffer>
-      {{- if or .Values.fluentd.persistence.enabled (eq .Values.fluentd.buffer.type "file") }}
-      @type file
-      path {{ .Values.fluentd.buffer.filePaths.logs.systemd }}
-      {{- else }}
-      @type memory
-      {{- end }}
-      @include buffer.output.conf
-    </buffer>
+    @type copy
+    <store>
+      @type sumologic
+      @id sumologic.endpoint.logs.systemd
+      sumo_client {{ include "sumologic.sumo_client" . | quote }}
+      {{- .Values.fluentd.logs.systemd.outputConf | nindent 8 }}
+      <buffer>
+        {{- if or .Values.fluentd.persistence.enabled (eq .Values.fluentd.buffer.type "file") }}
+        @type file
+        path {{ .Values.fluentd.buffer.filePaths.logs.systemd }}
+        {{- else }}
+        @type memory
+        {{- end }}
+        @include buffer.output.conf
+      </buffer>
+    </store>
+    {{- if .Values.fluentd.monitoring.output }}
+    {{ include "fluentd.prometheus-metrics.output" . | nindent 6 }}
+    {{- end }}
   </match>
   {{- end}}
 </label>

--- a/deploy/helm/sumologic/conf/logs/logs.source.systemd.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.systemd.conf
@@ -1,4 +1,7 @@
 {{ if .Values.fluentd.logs.kubelet.enabled }}
+{{- if .Values.fluentd.monitoring.input }}
+{{ include "fluentd.prometheus-metrics.input" (dict "Tag" "host.kubelet.**") | nindent 2 }}
+{{- end }}
 <match host.kubelet.**>
   @type relabel
   @label @KUBELET
@@ -37,6 +40,9 @@
 </label>
 {{- end}}
 {{ if .Values.fluentd.logs.systemd.enabled }}
+{{- if .Values.fluentd.monitoring.input }}
+{{ include "fluentd.prometheus-metrics.input" (dict "Tag" "host.**") | nindent 2 }}
+{{- end }}
 <match host.**>
   @type relabel
   @label @SYSTEMD

--- a/deploy/helm/sumologic/conf/metrics/metrics.conf
+++ b/deploy/helm/sumologic/conf/metrics/metrics.conf
@@ -5,6 +5,9 @@
     @type protobuf
   </parse>
 </source>
+{{- if .Values.fluentd.monitoring.input }}
+{{ include "fluentd.prometheus-metrics.input" (dict "Tag" "prometheus.metrics**") | nindent 2}}
+{{- end }}
 <match prometheus.metrics**>
   @type datapoint
   @label @DATAPOINT

--- a/deploy/helm/sumologic/conf/traces/traces.conf
+++ b/deploy/helm/sumologic/conf/traces/traces.conf
@@ -29,19 +29,25 @@
   </filter>
 {{- end }}
   <match tracing.**>
-    @type zipkin
-    endpoint "#{ENV['SUMO_ENDPOINT_DEFAULT_TRACES_SOURCE']}"
-    content_type application/json
-    open_timeout 1
-    spans_per_request {{ .Values.sumologic.traces.spans_per_request }}
-    <buffer>
-      {{- if or .Values.fluentd.persistence.enabled (eq .Values.fluentd.buffer.type "file") }}
-      @type file
-      path {{ .Values.fluentd.buffer.filePaths.traces }}
-      {{- else }}
-      @type memory
-      {{- end }}
-      @include buffer.output.conf
-    </buffer>
+    @type copy
+    <store>
+      @type zipkin
+      endpoint "#{ENV['SUMO_ENDPOINT_DEFAULT_TRACES_SOURCE']}"
+      content_type application/json
+      open_timeout 1
+      spans_per_request {{ .Values.sumologic.traces.spans_per_request }}
+      <buffer>
+        {{- if or .Values.fluentd.persistence.enabled (eq .Values.fluentd.buffer.type "file") }}
+        @type file
+        path {{ .Values.fluentd.buffer.filePaths.traces }}
+        {{- else }}
+        @type memory
+        {{- end }}
+        @include buffer.output.conf
+      </buffer>
+    </store>
+    {{- if .Values.fluentd.monitoring.output }}
+    {{ include "fluentd.prometheus-metrics.output" . | nindent 6 }}
+    {{- end }}
   </match>
 </label>

--- a/deploy/helm/sumologic/conf/traces/traces.conf
+++ b/deploy/helm/sumologic/conf/traces/traces.conf
@@ -4,6 +4,9 @@
   port 9411
 </source>
 <label @TRACING>
+{{- if .Values.fluentd.monitoring.input }}
+{{ include "fluentd.prometheus-metrics.input" (dict "Tag" "tracing.**") | nindent 4}}
+{{- end }}
   <filter tracing.**>
     @type kubernetes_sumologic
     tracing_format true

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -384,6 +384,28 @@ Example usage (as one line):
 {{ end -}}
 
 {{/*
+Generate fluentd prometheus filter configuration (input metrics)
+
+Example:
+
+{{ template "fluentd.prometheus-metrics.input" (dict "Tag" "kubernetes.**") }}
+*/}}
+{{- define "fluentd.prometheus-metrics.input" }}
+<filter {{ .Tag }}>
+  @type prometheus
+  <metric>
+    name fluentd_input_status_num_records_total
+    type counter
+    desc The total number of incoming records
+    <labels>
+      tag ${tag}
+      hostname ${hostname}
+    </labels>
+  </metric>
+</filter>
+{{- end -}}
+
+{{/*
 Convert source name to terraform metric name:
  * converts all `-` to `_`
  * adds `_$type_source` suffix

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -233,6 +233,11 @@ fluentd:
     ## Additional config for buffer settings
     extraConf: |-
 
+  # configuration of fluentd monitoring metrics
+  # input -> fluentd_input_status_num_records_total (~5% DPM increase for empty cluster)
+  monitoring:
+    input: false
+
   metadata:
     ## Option to control the enabling of metadata filter plugin cache_size.
     ## ref: https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter#configuration

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -235,8 +235,10 @@ fluentd:
 
   # configuration of fluentd monitoring metrics
   # input -> fluentd_input_status_num_records_total (~5% DPM increase for empty cluster)
+  # output -> fluentd_output_status_num_records_total (~25% DPM increase for empty cluster)
   monitoring:
     input: false
+    output: false
 
   metadata:
     ## Option to control the enabling of metadata filter plugin cache_size.

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -158,28 +158,34 @@ data:
       </filter>
       
       <match containers.**>
-        @type sumologic
-        @id sumologic.endpoint.logs
-        sumo_client "k8s_1.0.0"
-        @log_level error
-        @include logs.output.conf
-        <buffer>
-          @type memory
-          @include buffer.output.conf
-        </buffer>
+        @type copy
+        <store>
+          @type sumologic
+          @id sumologic.endpoint.logs
+          sumo_client "k8s_1.0.0"
+          @log_level error
+          @include logs.output.conf
+          <buffer>
+            @type memory
+            @include buffer.output.conf
+          </buffer>
+        </store>
       </match>
     </label>
   logs.source.default.conf: |-
     
     <match **>
-      @type sumologic
-      @id sumologic.endpoint.logs.default
-      sumo_client "k8s_1.0.0"
-      @include logs.output.conf
-      <buffer>
-        @type memory
-        @include buffer.output.conf
-      </buffer>
+      @type copy
+      <store>
+        @type sumologic
+        @id sumologic.endpoint.logs.default
+        sumo_client "k8s_1.0.0"
+        @include logs.output.conf
+        <buffer>
+          @type memory
+          @include buffer.output.conf
+        </buffer>
+      </store>
     </match>
   logs.source.systemd.conf: |-
     
@@ -201,14 +207,17 @@ data:
       </filter>
       
       <match **>
-        @type sumologic
-        @id sumologic.endpoint.logs.kubelet
-        sumo_client "k8s_1.0.0"
-        @include logs.output.conf
-        <buffer>
-          @type memory
-          @include buffer.output.conf
-        </buffer>
+        @type copy
+        <store>
+          @type sumologic
+          @id sumologic.endpoint.logs.kubelet
+          sumo_client "k8s_1.0.0"
+          @include logs.output.conf
+          <buffer>
+            @type memory
+            @include buffer.output.conf
+          </buffer>
+        </store>
       </match>
     </label>
     
@@ -235,14 +244,17 @@ data:
       </filter>
       
       <match **>
-        @type sumologic
-        @id sumologic.endpoint.logs.systemd
-        sumo_client "k8s_1.0.0"
-        @include logs.output.conf
-        <buffer>
-          @type memory
-          @include buffer.output.conf
-        </buffer>
+        @type copy
+        <store>
+          @type sumologic
+          @id sumologic.endpoint.logs.systemd
+          sumo_client "k8s_1.0.0"
+          @include logs.output.conf
+          <buffer>
+            @type memory
+            @include buffer.output.conf
+          </buffer>
+        </store>
       </match>
     </label>
   
@@ -283,18 +295,21 @@ data:
       bind 0.0.0.0
     </source>
     <match kubernetes.**>
-      @type sumologic
-      @id sumologic.endpoint.events
-      sumo_client "k8s_1.0.0"
-      endpoint "#{ENV['SUMO_ENDPOINT_DEFAULT_EVENTS_SOURCE']}"
-      data_type logs
-      disable_cookies true
-      verify_ssl "true"
-      proxy_uri ""
-      <buffer>
-        @type memory
-        @include buffer.output.conf
-      </buffer>
+      @type copy
+      <store>
+        @type sumologic
+        @id sumologic.endpoint.events
+        sumo_client "k8s_1.0.0"
+        endpoint "#{ENV['SUMO_ENDPOINT_DEFAULT_EVENTS_SOURCE']}"
+        data_type logs
+        disable_cookies true
+        verify_ssl "true"
+        proxy_uri ""
+        <buffer>
+          @type memory
+          @include buffer.output.conf
+        </buffer>
+      </store>
     </match>
     <system>
       log_level info
@@ -399,111 +414,138 @@ data:
       </filter>
       
       <match prometheus.metrics.apiserver**>
-        @type sumologic
-        @id sumologic.endpoint.metrics.apiserver
-        sumo_client "k8s_1.0.0"
-        endpoint "#{ENV['SUMO_ENDPOINT_APISERVER_METRICS_SOURCE']}"
+        @type copy
+        <store>
+          @type sumologic
+          @id sumologic.endpoint.metrics.apiserver
+          sumo_client "k8s_1.0.0"
+          endpoint "#{ENV['SUMO_ENDPOINT_APISERVER_METRICS_SOURCE']}"
         @include metrics.output.conf
-        <buffer>
-          @type memory
-          @include buffer.output.conf
-        </buffer>
+          <buffer>
+            @type memory
+            @include buffer.output.conf
+          </buffer>
+        </store>
       </match>
       
       <match prometheus.metrics.container**>
-        @type sumologic
-        @id sumologic.endpoint.metrics.container
-        sumo_client "k8s_1.0.0"
-        endpoint "#{ENV['SUMO_ENDPOINT_KUBELET_METRICS_SOURCE']}"
+        @type copy
+        <store>
+          @type sumologic
+          @id sumologic.endpoint.metrics.container
+          sumo_client "k8s_1.0.0"
+          endpoint "#{ENV['SUMO_ENDPOINT_KUBELET_METRICS_SOURCE']}"
         @include metrics.output.conf
-        <buffer>
-          @type memory
-          @include buffer.output.conf
-        </buffer>
+          <buffer>
+            @type memory
+            @include buffer.output.conf
+          </buffer>
+        </store>
       </match>
       
       <match prometheus.metrics.control-plane**>
-        @type sumologic
-        @id sumologic.endpoint.metrics.control.plane
-        sumo_client "k8s_1.0.0"
-        endpoint "#{ENV['SUMO_ENDPOINT_CONTROL_PLANE_METRICS_SOURCE']}"
+        @type copy
+        <store>
+          @type sumologic
+          @id sumologic.endpoint.metrics.control.plane
+          sumo_client "k8s_1.0.0"
+          endpoint "#{ENV['SUMO_ENDPOINT_CONTROL_PLANE_METRICS_SOURCE']}"
         @include metrics.output.conf
-        <buffer>
-          @type memory
-          @include buffer.output.conf
-        </buffer>
+          <buffer>
+            @type memory
+            @include buffer.output.conf
+          </buffer>
+        </store>
       </match>
       
       <match prometheus.metrics.controller-manager**>
-        @type sumologic
-        @id sumologic.endpoint.metrics.kube.controller.manager
-        sumo_client "k8s_1.0.0"
-        endpoint "#{ENV['SUMO_ENDPOINT_CONTROLLER_METRICS_SOURCE']}"
+        @type copy
+        <store>
+          @type sumologic
+          @id sumologic.endpoint.metrics.kube.controller.manager
+          sumo_client "k8s_1.0.0"
+          endpoint "#{ENV['SUMO_ENDPOINT_CONTROLLER_METRICS_SOURCE']}"
         @include metrics.output.conf
-        <buffer>
-          @type memory
-          @include buffer.output.conf
-        </buffer>
+          <buffer>
+            @type memory
+            @include buffer.output.conf
+          </buffer>
+        </store>
       </match>
       
       <match prometheus.metrics.kubelet**>
-        @type sumologic
-        @id sumologic.endpoint.metrics.kubelet
-        sumo_client "k8s_1.0.0"
-        endpoint "#{ENV['SUMO_ENDPOINT_KUBELET_METRICS_SOURCE']}"
+        @type copy
+        <store>
+          @type sumologic
+          @id sumologic.endpoint.metrics.kubelet
+          sumo_client "k8s_1.0.0"
+          endpoint "#{ENV['SUMO_ENDPOINT_KUBELET_METRICS_SOURCE']}"
         @include metrics.output.conf
-        <buffer>
-          @type memory
-          @include buffer.output.conf
-        </buffer>
+          <buffer>
+            @type memory
+            @include buffer.output.conf
+          </buffer>
+        </store>
       </match>
       
       <match prometheus.metrics.node**>
-        @type sumologic
-        @id sumologic.endpoint.metrics.node.exporter
-        sumo_client "k8s_1.0.0"
-        endpoint "#{ENV['SUMO_ENDPOINT_NODE_METRICS_SOURCE']}"
+        @type copy
+        <store>
+          @type sumologic
+          @id sumologic.endpoint.metrics.node.exporter
+          sumo_client "k8s_1.0.0"
+          endpoint "#{ENV['SUMO_ENDPOINT_NODE_METRICS_SOURCE']}"
         @include metrics.output.conf
-        <buffer>
-          @type memory
-          @include buffer.output.conf
-        </buffer>
+          <buffer>
+            @type memory
+            @include buffer.output.conf
+          </buffer>
+        </store>
       </match>
       
       <match prometheus.metrics.scheduler**>
-        @type sumologic
-        @id sumologic.endpoint.metrics.kube.scheduler
-        sumo_client "k8s_1.0.0"
-        endpoint "#{ENV['SUMO_ENDPOINT_SCHEDULER_METRICS_SOURCE']}"
+        @type copy
+        <store>
+          @type sumologic
+          @id sumologic.endpoint.metrics.kube.scheduler
+          sumo_client "k8s_1.0.0"
+          endpoint "#{ENV['SUMO_ENDPOINT_SCHEDULER_METRICS_SOURCE']}"
         @include metrics.output.conf
-        <buffer>
-          @type memory
-          @include buffer.output.conf
-        </buffer>
+          <buffer>
+            @type memory
+            @include buffer.output.conf
+          </buffer>
+        </store>
       </match>
       
       <match prometheus.metrics.state**>
-        @type sumologic
-        @id sumologic.endpoint.metrics.kube.state
-        sumo_client "k8s_1.0.0"
-        endpoint "#{ENV['SUMO_ENDPOINT_STATE_METRICS_SOURCE']}"
+        @type copy
+        <store>
+          @type sumologic
+          @id sumologic.endpoint.metrics.kube.state
+          sumo_client "k8s_1.0.0"
+          endpoint "#{ENV['SUMO_ENDPOINT_STATE_METRICS_SOURCE']}"
         @include metrics.output.conf
-        <buffer>
-          @type memory
-          @include buffer.output.conf
-        </buffer>
+          <buffer>
+            @type memory
+            @include buffer.output.conf
+          </buffer>
+        </store>
       </match>
       
       <match prometheus.metrics**>
-        @type sumologic
-        @id sumologic.endpoint.metrics
-        sumo_client "k8s_1.0.0"
-        endpoint "#{ENV['SUMO_ENDPOINT_DEFAULT_METRICS_SOURCE']}"
+        @type copy
+        <store>
+          @type sumologic
+          @id sumologic.endpoint.metrics
+          sumo_client "k8s_1.0.0"
+          endpoint "#{ENV['SUMO_ENDPOINT_DEFAULT_METRICS_SOURCE']}"
         @include metrics.output.conf
-        <buffer>
-          @type memory
-          @include buffer.output.conf
-        </buffer>
+          <buffer>
+            @type memory
+            @include buffer.output.conf
+          </buffer>
+        </store>
       </match>
       
     </label>


### PR DESCRIPTION
###### Description

Adds `fluentd_input_status_num_records_total` and `fluentd_output_status_num_records_total` metrics

Fixes #717

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
