### PR TITLE
set correct source host for systemd logs

### DIFF
--- a/fluent-plugin-kubernetes-sumologic/lib/fluent/plugin/filter_kubernetes_sumologic.rb
+++ b/fluent-plugin-kubernetes-sumologic/lib/fluent/plugin/filter_kubernetes_sumologic.rb
@@ -129,8 +129,8 @@ module Fluent::Plugin
       end
       sumo_metadata[:category].gsub!("-", @source_category_replace_dash)
 
-      # Check systemd exclude filters
       if record.key?("_SYSTEMD_UNIT") and not record.fetch("_SYSTEMD_UNIT").nil?
+        # Check systemd exclude filters
         unless @exclude_unit_regex.empty?
           return nil if Regexp.compile(@exclude_unit_regex).match(record["_SYSTEMD_UNIT"])
         end
@@ -143,6 +143,9 @@ module Fluent::Plugin
         unless @exclude_host_regex.empty?
           return nil if Regexp.compile(@exclude_host_regex).match(record["_HOSTNAME"])
         end
+
+        # Set correct source host for systemd logs
+        sumo_metadata[:host] = record["_HOSTNAME"]
       end
 
       kubernetes = get_kubernetes(record)


### PR DESCRIPTION
###### Description

After much investigation I found that the `sumologic` output plugin makes the http request for systemd logs with the `X-Sumo-Host` set to empty string. So even after my investigation I have no idea where that ip was coming from 😅 

but this change will set the correct one, as Frank said before, by reading `_HOSTNAME` from the record

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
