### PR TITLE
Fix helm chart requirements conditions

### DIFF
--- a/deploy/helm/fluent-bit-overrides.yaml
+++ b/deploy/helm/fluent-bit-overrides.yaml
@@ -9,7 +9,7 @@ resources: {}
 #   memory: 8Mi
 
 ## Set the enabled flag to false to not install fluent-bit helm chart as a dependency along with this helm chart
-# enabled: true
+# enabled: false
 service:
   flush: 5
 metrics:

--- a/deploy/helm/fluent-bit-overrides.yaml
+++ b/deploy/helm/fluent-bit-overrides.yaml
@@ -8,6 +8,8 @@ resources: {}
 #   cpu: 10m
 #   memory: 8Mi
 
+## Set the enabled flag to false to not install fluent-bit helm chart as a dependency along with this helm chart
+# enabled: true
 service:
   flush: 5
 metrics:

--- a/deploy/helm/fluent-bit-overrides.yaml
+++ b/deploy/helm/fluent-bit-overrides.yaml
@@ -8,7 +8,9 @@ resources: {}
 #   cpu: 10m
 #   memory: 8Mi
 
-## Set the enabled flag to false to not install fluent-bit helm chart as a dependency along with this helm chart
+## Uncomment the flag below to not install fluent-bit helm chart as a dependency along with this helm chart.
+## Comment it out if you wish to have the fluent-bit dependency installed.
+## Setting the flag to true instead of commenting out will break other functionality. 
 # enabled: false
 service:
   flush: 5

--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -34,10 +34,8 @@ nodeExporter:
     interval:
 # Ensure we use pre 1.14 recording rules consistently as current content depends on them.
 kubeTargetVersionOverride: 1.13.0-0
-## Set the enabled flag to false for either of the below two purposes:
-## 1. Not install prometheus operator helm chart as a dependency along with this helm chart
-## 2. Disable metrics collection altogether
-enabled: true
+## Set the enabled flag to false to not install prometheus operator helm chart as a dependency along with this helm chart
+# enabled: true
 alertmanager:
   enabled: false
 grafana:

--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -35,7 +35,7 @@ nodeExporter:
 # Ensure we use pre 1.14 recording rules consistently as current content depends on them.
 kubeTargetVersionOverride: 1.13.0-0
 ## Set the enabled flag to false to not install prometheus operator helm chart as a dependency along with this helm chart
-# enabled: true
+# enabled: false
 alertmanager:
   enabled: false
 grafana:

--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -34,7 +34,9 @@ nodeExporter:
     interval:
 # Ensure we use pre 1.14 recording rules consistently as current content depends on them.
 kubeTargetVersionOverride: 1.13.0-0
-## Set the enabled flag to false to not install prometheus operator helm chart as a dependency along with this helm chart
+## Uncomment the flag below to not install fluent-bit helm chart as a dependency along with this helm chart.
+## Comment it out if you wish to have the fluent-bit dependency installed.
+## Setting the flag to true instead of commenting out will break other functionality. 
 # enabled: false
 alertmanager:
   enabled: false

--- a/deploy/helm/sumologic/requirements.yaml
+++ b/deploy/helm/sumologic/requirements.yaml
@@ -2,11 +2,11 @@ dependencies:
   - name: fluent-bit
     version: 2.8.14
     repository: https://kubernetes-charts.storage.googleapis.com/
-    condition: sumologic.logs.enabled,fluent-bit.enabled
+    condition: fluent-bit.enabled,sumologic.logs.enabled
   - name: prometheus-operator
     version: 8.13.8
     repository: https://kubernetes-charts.storage.googleapis.com/
-    condition: sumologic.metrics.enabled,prometheus-operator.enabled
+    condition: prometheus-operator.enabled,sumologic.metrics.enabled
   - name: falco
     version: 1.1.8
     repository: https://falcosecurity.github.io/charts

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -608,7 +608,9 @@ fluent-bit:
     #   cpu: 10m
     #   memory: 8Mi
 
-  ## Set the enabled flag to false to not install fluent-bit helm chart as a dependency along with this helm chart
+## Uncomment the flag below to not install fluent-bit helm chart as a dependency along with this helm chart.
+## Comment it out if you wish to have the fluent-bit dependency installed.
+## Setting the flag to true instead of commenting out will break other functionality. 
   # enabled: false
   service:
     flush: 5
@@ -766,7 +768,9 @@ prometheus-operator:
       interval:
   # Ensure we use pre 1.14 recording rules consistently as current content depends on them.
   kubeTargetVersionOverride: 1.13.0-0
-  ## Set the enabled flag to false to not install prometheus operator helm chart as a dependency along with this helm chart
+## Uncomment the flag below to not install fluent-bit helm chart as a dependency along with this helm chart.
+## Comment it out if you wish to have the fluent-bit dependency installed.
+## Setting the flag to true instead of commenting out will break other functionality. 
   # enabled: false
   alertmanager:
     enabled: false

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -609,7 +609,7 @@ fluent-bit:
     #   memory: 8Mi
 
   ## Set the enabled flag to false to not install fluent-bit helm chart as a dependency along with this helm chart
-  # enabled: true
+  # enabled: false
   service:
     flush: 5
   metrics:
@@ -767,7 +767,7 @@ prometheus-operator:
   # Ensure we use pre 1.14 recording rules consistently as current content depends on them.
   kubeTargetVersionOverride: 1.13.0-0
   ## Set the enabled flag to false to not install prometheus operator helm chart as a dependency along with this helm chart
-  # enabled: true
+  # enabled: false
   alertmanager:
     enabled: false
   grafana:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -608,7 +608,8 @@ fluent-bit:
     #   cpu: 10m
     #   memory: 8Mi
 
-  enabled: true
+  ## Set the enabled flag to false to not install fluent-bit helm chart as a dependency along with this helm chart
+  # enabled: true
   service:
     flush: 5
   metrics:
@@ -765,10 +766,8 @@ prometheus-operator:
       interval:
   # Ensure we use pre 1.14 recording rules consistently as current content depends on them.
   kubeTargetVersionOverride: 1.13.0-0
-  ## Set the enabled flag to false for either of the below two purposes:
-  ## 1. Not install prometheus operator helm chart as a dependency along with this helm chart
-  ## 2. Disable metrics collection altogether
-  enabled: true
+  ## Set the enabled flag to false to not install prometheus operator helm chart as a dependency along with this helm chart
+  # enabled: true
   alertmanager:
     enabled: false
   grafana:


### PR DESCRIPTION
###### Description

Multiple conditions works as below:
1. If first value is specified, it decides if the requirement is installed or not
2. If it's not, the second is taken under consideration

due to point 1 we should change order of conditions and comment the `prometheus-operator.enabled`

so for prometheus:

If `prometheus-operator.enabled` is not set, the `metrics.enabled` decides if we enable prometheus or not, otherwise `prometheus-operator.enabled` is decisive

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
