### PR TITLE
Use sumologic.com as prefix for internal labels

### DIFF
--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -78,7 +78,7 @@ prometheus:
   additionalServiceMonitors:
     - name: collection-sumologic-fluentd-logs
       additionalLabels:
-        sumologic/app: fluentd-logs
+        sumologic.com/app: fluentd-logs
       endpoints:
         - port: metrics
       namespaceSelector:
@@ -86,10 +86,10 @@ prometheus:
           - $(NAMESPACE)
       selector:
         matchLabels:
-          sumologic/app: fluentd-logs
+          sumologic.com/app: fluentd-logs
     - name: collection-sumologic-fluentd-metrics
       additionalLabels:
-        sumologic/app: fluentd-metrics
+        sumologic.com/app: fluentd-metrics
       endpoints:
         - port: metrics
       namespaceSelector:
@@ -97,10 +97,10 @@ prometheus:
           - $(NAMESPACE)
       selector:
         matchLabels:
-          sumologic/app: fluentd-metrics
+          sumologic.com/app: fluentd-metrics
     - name: collection-sumologic-fluentd-events
       additionalLabels:
-        sumologic/app: fluentd-events
+        sumologic.com/app: fluentd-events
       endpoints:
         - port: metrics
       namespaceSelector:
@@ -108,7 +108,7 @@ prometheus:
           - $(NAMESPACE)
       selector:
         matchLabels:
-          sumologic/app: fluentd-events
+          sumologic.com/app: fluentd-events
     - name: collection-fluent-bit
       additionalLabels:
         app: collection-fluent-bit
@@ -123,7 +123,7 @@ prometheus:
           app: fluent-bit
     - name: collection-sumologic-otelcol
       additionalLabels:
-        sumologic/app: otelcol
+        sumologic.com/app: otelcol
       endpoints:
         - port: metrics
       namespaceSelector:
@@ -131,7 +131,7 @@ prometheus:
           - $(NAMESPACE)
       selector:
         matchLabels:
-          sumologic/app: otelcol
+          sumologic.com/app: otelcol
   prometheusSpec:
     ## Prometheus default scrape interval, default from upstream Prometheus Operator Helm chart
     ## NOTE changing the scrape interval to be >1m can result in metrics from recording rules to be missing and empty panels in Sumo Logic Kubernetes apps.

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -272,23 +272,23 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "sumologic.labels.logs" -}}
-sumologic/app: fluentd-logs
-sumologic/component: logs
+sumologic.com/app: fluentd-logs
+sumologic.com/component: logs
 {{- end -}}
 
 {{- define "sumologic.labels.metrics" -}}
-sumologic/app: fluentd-metrics
-sumologic/component: metrics
+sumologic.com/app: fluentd-metrics
+sumologic.com/component: metrics
 {{- end -}}
 
 {{- define "sumologic.labels.events" -}}
-sumologic/app: fluentd-events
-sumologic/component: events
+sumologic.com/app: fluentd-events
+sumologic.com/component: events
 {{- end -}}
 
 {{- define "sumologic.labels.traces" -}}
-sumologic/app: otelcol
-sumologic/component: traces
+sumologic.com/app: otelcol
+sumologic.com/component: traces
 {{- end -}}
 
 {{/*

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -809,7 +809,7 @@ prometheus-operator:
     additionalServiceMonitors:
       - name: collection-sumologic-fluentd-logs
         additionalLabels:
-          sumologic/app: fluentd-logs
+          sumologic.com/app: fluentd-logs
         endpoints:
         - port: metrics
         namespaceSelector:
@@ -817,10 +817,10 @@ prometheus-operator:
           - $(NAMESPACE)
         selector:
           matchLabels:
-            sumologic/app: fluentd-logs
+            sumologic.com/app: fluentd-logs
       - name: collection-sumologic-fluentd-metrics
         additionalLabels:
-          sumologic/app: fluentd-metrics
+          sumologic.com/app: fluentd-metrics
         endpoints:
         - port: metrics
         namespaceSelector:
@@ -828,10 +828,10 @@ prometheus-operator:
           - $(NAMESPACE)
         selector:
           matchLabels:
-            sumologic/app: fluentd-metrics
+            sumologic.com/app: fluentd-metrics
       - name: collection-sumologic-fluentd-events
         additionalLabels:
-          sumologic/app: fluentd-events
+          sumologic.com/app: fluentd-events
         endpoints:
           - port: metrics
         namespaceSelector:
@@ -839,7 +839,7 @@ prometheus-operator:
             - $(NAMESPACE)
         selector:
           matchLabels:
-            sumologic/app: fluentd-events
+            sumologic.com/app: fluentd-events
       - name: collection-fluent-bit
         additionalLabels:
           app: collection-fluent-bit
@@ -854,7 +854,7 @@ prometheus-operator:
             app: fluent-bit
       - name: collection-sumologic-otelcol
         additionalLabels:
-          sumologic/app: otelcol
+          sumologic.com/app: otelcol
         endpoints:
           - port: metrics
         namespaceSelector:
@@ -862,7 +862,7 @@ prometheus-operator:
             - $(NAMESPACE)
         selector:
           matchLabels:
-            sumologic/app: otelcol
+            sumologic.com/app: otelcol
     prometheusSpec:
       ## Prometheus default scrape interval, default from upstream Prometheus Operator Helm chart
       ## NOTE changing the scrape interval to be >1m can result in metrics from recording rules to be missing and empty panels in Sumo Logic Kubernetes apps.

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -618,8 +618,8 @@ metadata:
   name: collection-sumologic-fluentd-events-headless
   labels:
     app: collection-sumologic-fluentd-events-headless
-    sumologic/app: fluentd-events
-    sumologic/component: events
+    sumologic.com/app: fluentd-events
+    sumologic.com/component: events
     
 spec:
   selector:
@@ -639,8 +639,8 @@ metadata:
   name: collection-sumologic-fluentd-events
   labels:
     app: collection-sumologic-fluentd-events
-    sumologic/app: fluentd-events
-    sumologic/component: events
+    sumologic.com/app: fluentd-events
+    sumologic.com/component: events
     
 spec:
   selector:
@@ -659,8 +659,8 @@ metadata:
   name: collection-sumologic-fluentd-metrics-headless
   labels:
     app: collection-sumologic-fluentd-metrics-headless
-    sumologic/app: fluentd-metrics
-    sumologic/component: metrics
+    sumologic.com/app: fluentd-metrics
+    sumologic.com/component: metrics
     
 spec:
   selector:
@@ -685,8 +685,8 @@ metadata:
   name: collection-sumologic-fluentd-metrics
   labels:
     app: collection-sumologic-fluentd-metrics
-    sumologic/app: fluentd-metrics
-    sumologic/component: metrics
+    sumologic.com/app: fluentd-metrics
+    sumologic.com/component: metrics
     
 spec:
   selector:
@@ -710,8 +710,8 @@ metadata:
   name: collection-sumologic-fluentd-logs-headless
   labels:
     app: collection-sumologic-fluentd-logs-headless
-    sumologic/app: fluentd-logs
-    sumologic/component: logs
+    sumologic.com/app: fluentd-logs
+    sumologic.com/component: logs
     
 spec:
   selector:
@@ -736,8 +736,8 @@ metadata:
   name: collection-sumologic-fluentd-logs
   labels:
     app: collection-sumologic-fluentd-logs
-    sumologic/app: fluentd-logs
-    sumologic/component: logs
+    sumologic.com/app: fluentd-logs
+    sumologic.com/component: logs
     
 spec:
   selector:


### PR DESCRIPTION
###### Description

I observed during review that we already use 'sumologic.com/' prefix in annotations so it would be better to stick that convention for internal labels

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
