### PR TITLE
Bump k8s in vagrant to 1.18

### DIFF
--- a/vagrant/forwarding/forward-dashboard.sh
+++ b/vagrant/forwarding/forward-dashboard.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+DASHBOARD_POD="$(kubectl get pods --all-namespaces | grep -i kubernetes-dashboard | awk '{print $2}')"
+
+kubectl -n kube-system port-forward $DASHBOARD_POD --address 0.0.0.0 8443:8443

--- a/vagrant/forwarding/forward-prometheus.sh
+++ b/vagrant/forwarding/forward-prometheus.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+PROM_POD="$(kubectl get pods --all-namespaces | grep -i prometheus-0 | awk '{print $2}')"
+
+kubectl -n sumologic port-forward $PROM_POD --address 0.0.0.0 9090:9090

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -x
 
@@ -9,7 +9,7 @@ apt-get --yes install apt-transport-https
 
 echo "export EDITOR=vim" >> /home/vagrant/.bashrc
 
-snap install microk8s --classic --channel=1.15/stable
+snap install microk8s --classic --channel=1.16/stable
 microk8s.status --wait-ready
 ufw allow in on cbr0
 ufw allow out on cbr0
@@ -19,12 +19,12 @@ microk8s.enable dashboard
 microk8s.enable registry
 microk8s.enable storage
 microk8s.enable dns
-
-snap install helm --classic --channel=2.16
+microk8s.enable helm
 
 microk8s.kubectl config view --raw > /sumologic/.kube-config
 
 snap alias microk8s.kubectl kubectl
+snap alias microk8s.helm helm
 
 # allow privileged
 echo "--allow-privileged=true" >> /var/snap/microk8s/current/args/kube-apiserver
@@ -36,9 +36,6 @@ iptables -P FORWARD ACCEPT
 apt-get install --yes iptables-persistent
 # Somehow persistent iptables doesn't work - let's use this ugly hack to force iptables reload on every bash login
 echo "sudo iptables -P FORWARD ACCEPT" >> /home/vagrant/.bashrc
-
-#snap alias microk8s.helm helm
-sudo -H -u vagrant -i helm init --wait
 
 usermod -a -G microk8s vagrant
 
@@ -58,7 +55,16 @@ add-apt-repository \
 apt-get install -y docker-ce docker-ce-cli containerd.io
 usermod -aG docker vagrant
 
-set +x
+# K8s needs some time to bootstrap
+while true; do
+  kubectl -n kube-system get services 1>/dev/null 2>&1 && break
+  echo 'Waiting for k8s server'
+  sleep 1
+done
+
+# Init helm tiller
+sudo -H -u vagrant -i helm init --wait
+
 echo Dashboard local in-vagrant IP:
 kubectl -n kube-system get services | grep -i kubernetes-dashboard | awk '{print $3}'
 echo

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -9,22 +9,24 @@ apt-get --yes install apt-transport-https
 
 echo "export EDITOR=vim" >> /home/vagrant/.bashrc
 
-snap install microk8s --classic --channel=1.16/stable
+snap install microk8s --classic --channel=1.18/stable
 microk8s.status --wait-ready
 ufw allow in on cbr0
 ufw allow out on cbr0
 ufw default allow routed
 
-microk8s.enable dashboard
-microk8s.enable registry
-microk8s.enable storage
-microk8s.enable dns
-microk8s.enable helm
+microk8s enable dashboard
+microk8s enable registry
+microk8s enable storage
+microk8s enable dns
+microk8s enable helm
+microk8s enable helm3
 
 microk8s.kubectl config view --raw > /sumologic/.kube-config
 
 snap alias microk8s.kubectl kubectl
-snap alias microk8s.helm helm
+snap alias microk8s.helm helm2
+snap alias microk8s.helm3 helm
 
 # allow privileged
 echo "--allow-privileged=true" >> /var/snap/microk8s/current/args/kube-apiserver
@@ -63,7 +65,7 @@ while true; do
 done
 
 # Init helm tiller
-sudo -H -u vagrant -i helm init --wait
+sudo -H -u vagrant -i helm2 init --wait
 
 echo Dashboard local in-vagrant IP:
 kubectl -n kube-system get services | grep -i kubernetes-dashboard | awk '{print $3}'


### PR DESCRIPTION
###### Description

Bump k8s in vagrant to 1.16

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
