### PR TITLE
Severity1 fix 741

### DIFF
--- a/deploy/helm/sumologic/conf/setup/resources.tf
+++ b/deploy/helm/sumologic/conf/setup/resources.tf
@@ -18,16 +18,10 @@ resource "sumologic_collector" "collector" {
 {{- end }}
 {{- end }}
 
-data "kubernetes_namespace" "sumologic_collection_namespace" {
-  metadata {
-    name = var.namespace_name
-  }
-}
-
 resource "kubernetes_secret" "sumologic_collection_secret" {
   metadata {
     name = "sumologic"
-    namespace = data.kubernetes_namespace.sumologic_collection_namespace.metadata[0].name
+    namespace = var.namespace_name
   }
 
   data = {

--- a/deploy/helm/sumologic/conf/setup/resources.tf
+++ b/deploy/helm/sumologic/conf/setup/resources.tf
@@ -18,7 +18,7 @@ resource "sumologic_collector" "collector" {
 {{- end }}
 {{- end }}
 
-resource "kubernetes_namespace" "sumologic_collection_namespace" {
+data "kubernetes_namespace" "sumologic_collection_namespace" {
   metadata {
     name = var.namespace_name
   }
@@ -27,7 +27,7 @@ resource "kubernetes_namespace" "sumologic_collection_namespace" {
 resource "kubernetes_secret" "sumologic_collection_secret" {
   metadata {
     name = "sumologic"
-    namespace = kubernetes_namespace.sumologic_collection_namespace.metadata[0].name
+    namespace = data.kubernetes_namespace.sumologic_collection_namespace.metadata[0].name
   }
 
   data = {

--- a/deploy/helm/sumologic/conf/setup/setup.sh
+++ b/deploy/helm/sumologic/conf/setup/setup.sh
@@ -25,8 +25,7 @@ terraform import sumologic_http_source.{{ template "terraform.sources.name" (dic
 {{- end }}
 
 
-# Kubernetes Namespace and Secret
-terraform import kubernetes_namespace.sumologic_collection_namespace {{ .Release.Namespace }}
+# Kubernetes Secret
 terraform import kubernetes_secret.sumologic_collection_secret {{ .Release.Namespace }}/sumologic
 
 terraform apply -auto-approve


### PR DESCRIPTION
###### Description

Normally in helm the namespace is created automatically or beforehand, in most cases organizations will want to add metadata to their namespace for auditing and automating purposes. Sumologic's helm setup job makes this impossible as it recreates the namespace thus removing all the metadata added beforehand. This PR's intention is to remove this responsibility from sumologic's helm.
