### PR TITLE
Add Terraform variables section to terraform documentation

### DIFF
--- a/deploy/docs/Terraform.md
+++ b/deploy/docs/Terraform.md
@@ -49,11 +49,11 @@ sumologic:
   # ...
   sources:
     # ...
-    logs: # can be one of: logs/metrics/events/traces
+    logs: # source type, can be one of: logs/metrics/events/traces
       example-source: # source reference name
         name: # name of the source (visible on the sumologic platform)
         config-name: # name which be used in secret to store the url. This is backward-compatibility option
-        category: # this is backward compatibility property.
+        category: # this is backward compatibility property. It's deprecated and it's going to be removed in version 2.0
                   # Sets source category to "${var.cluster_name}/${local.default_events_source}" if true
                   # To overwrite category, please use `sumologic.sources[].properties.category`
         properties: # Additional terraform properties like fields or content_type
@@ -83,5 +83,23 @@ sumologic:
             node: hornetq-livestream-9
             deployment: sumologic
 ```
+
+#### Terraform variables
+
+You can use terraform extrapolation for properties:
+
+```yaml
+sumologic:
+  sources:
+    logs:
+      example-source:
+        properties:
+          category: "${var.cluster_name}/my-name"
+```
+
+List of available variables:
+ * var.cluster_name
+ * var.namespace_name
+ * var.collector_name
 
 **Note** You have to manually activate fields using the Sumo Logic service.

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -104,6 +104,7 @@ sumologic:
     enabled: true
 
   ## Configuration of http sources
+  ## See docs/Terraform.md for more information
   ## name: source name visible in sumologic platform
   ## config-name: This is mostly for backward compatibility
   sources:

--- a/deploy/kubernetes/setup-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/setup-sumologic.yaml.tmpl
@@ -104,16 +104,10 @@ data:
         collector_id = sumologic_collector.collector.id
     }
   
-    resource "kubernetes_namespace" "sumologic_collection_namespace" {
-      metadata {
-        name = var.namespace_name
-      }
-    }
-  
     resource "kubernetes_secret" "sumologic_collection_secret" {
       metadata {
         name = "sumologic"
-        namespace = kubernetes_namespace.sumologic_collection_namespace.metadata[0].name
+        namespace = var.namespace_name
       }
   
       data = {
@@ -161,8 +155,7 @@ data:
     terraform import sumologic_http_source.state_metrics_source "$COLLECTOR_NAME/kube-state-metrics"
   
   
-    # Kubernetes Namespace and Secret
-    terraform import kubernetes_namespace.sumologic_collection_namespace $NAMESPACE
+    # Kubernetes Secret
     terraform import kubernetes_secret.sumologic_collection_secret $NAMESPACE/sumologic
   
     terraform apply -auto-approve


### PR DESCRIPTION
###### Description

Add Terraform variables section to terraform documentation

I didn't add information about `local`, as it is just alias for source name which is took from values.yaml

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
