### PR TITLE
Migrate to new fluent-bit chart

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -76,6 +76,7 @@ if [ -n "$GITHUB_TOKEN" ] && [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]; then
   echo "# This file is auto-generated." > deploy/kubernetes/fluentd-sumologic.yaml.tmpl
   sudo helm init --client-only
   sudo helm repo add falcosecurity https://falcosecurity.github.io/charts
+  sudo helm repo add fluent https://fluent.github.io/helm-charts
   cd deploy/helm/sumologic
   sudo helm dependency update
   cd ../../../
@@ -170,6 +171,7 @@ function push_helm_chart() {
   git checkout -- .
   sudo helm init --client-only
   sudo helm repo add falcosecurity https://falcosecurity.github.io/charts
+  sudo helm repo add fluent https://fluent.github.io/helm-charts
   sudo helm package deploy/helm/sumologic --dependency-update --version=$version --app-version=$version
   git fetch origin-repo
   git checkout gh-pages

--- a/deploy/helm/fluent-bit-overrides.yaml
+++ b/deploy/helm/fluent-bit-overrides.yaml
@@ -12,10 +12,6 @@ resources: {}
 ## Comment it out if you wish to have the fluent-bit dependency installed.
 ## Setting the flag to true instead of commenting out will break other functionality. 
 # enabled: false
-service:
-  flush: 5
-metrics:
-  enabled: true
 env:
   - name: CHART
     valueFrom:
@@ -26,98 +22,112 @@ env:
     valueFrom:
       fieldRef:
         fieldPath: metadata.namespace
-backend:
-  type: forward
-  forward:
-    # NOTE: Requires trailing "." for fully-qualified name resolution
-    host: ${CHART}.${NAMESPACE}.svc.cluster.local.
-    port: 24321
-    tls: "off"
-    tls_verify: "on"
-    tls_debug: 1
-    shared_key:
-trackOffsets: true
+serviceMonitor:
+  enabled: true
+  interval: 30s
+  scrapeTimeout: 30s
 tolerations:
   - effect: NoSchedule
     operator: Exists
-input:
-  systemd:
-    enabled: true
-parsers:
-  enabled: true
-  # This regex matches the first line of a multiline log starting with a date of the format :  "2019-11-17 07:14:12" or "2019-11-17T07:14:12"
-  regex:
-    - name: multi_line
-      regex: (?<log>^{"log":"\d{4}-\d{1,2}-\d{1,2}.\d{2}:\d{2}:\d{2}.*)
-rawConfig: |-
-  @INCLUDE fluent-bit-service.conf
-
-  [INPUT]
-    Name             tail
-    Path             /var/log/containers/*.log
-    Multiline        On
-    Parser_Firstline multi_line
-    Tag              containers.*
-    Refresh_Interval 1
-    Rotate_Wait      60
-    Mem_Buf_Limit    5MB
-    Skip_Long_Lines  On
-    DB               /tail-db/tail-containers-state-sumo.db
-    DB.Sync          Normal
-    Ignore_Older     24h
-  [INPUT]
-    Name            systemd
-    Tag             host.*
-    DB              /tail-db/systemd-state-sumo.db
-    Systemd_Filter  _SYSTEMD_UNIT=addon-config.service
-    Systemd_Filter  _SYSTEMD_UNIT=addon-run.service
-    Systemd_Filter  _SYSTEMD_UNIT=cfn-etcd-environment.service
-    Systemd_Filter  _SYSTEMD_UNIT=cfn-signal.service
-    Systemd_Filter  _SYSTEMD_UNIT=clean-ca-certificates.service
-    Systemd_Filter  _SYSTEMD_UNIT=containerd.service
-    Systemd_Filter  _SYSTEMD_UNIT=coreos-metadata.service
-    Systemd_Filter  _SYSTEMD_UNIT=coreos-setup-environment.service
-    Systemd_Filter  _SYSTEMD_UNIT=coreos-tmpfiles.service
-    Systemd_Filter  _SYSTEMD_UNIT=dbus.service
-    Systemd_Filter  _SYSTEMD_UNIT=docker.service
-    Systemd_Filter  _SYSTEMD_UNIT=efs.service
-    Systemd_Filter  _SYSTEMD_UNIT=etcd-member.service
-    Systemd_Filter  _SYSTEMD_UNIT=etcd.service
-    Systemd_Filter  _SYSTEMD_UNIT=etcd2.service
-    Systemd_Filter  _SYSTEMD_UNIT=etcd3.service
-    Systemd_Filter  _SYSTEMD_UNIT=etcdadm-check.service
-    Systemd_Filter  _SYSTEMD_UNIT=etcdadm-reconfigure.service
-    Systemd_Filter  _SYSTEMD_UNIT=etcdadm-save.service
-    Systemd_Filter  _SYSTEMD_UNIT=etcdadm-update-status.service
-    Systemd_Filter  _SYSTEMD_UNIT=flanneld.service
-    Systemd_Filter  _SYSTEMD_UNIT=format-etcd2-volume.service
-    Systemd_Filter  _SYSTEMD_UNIT=kube-node-taint-and-uncordon.service
-    Systemd_Filter  _SYSTEMD_UNIT=kubelet.service
-    Systemd_Filter  _SYSTEMD_UNIT=ldconfig.service
-    Systemd_Filter  _SYSTEMD_UNIT=locksmithd.service
-    Systemd_Filter  _SYSTEMD_UNIT=logrotate.service
-    Systemd_Filter  _SYSTEMD_UNIT=lvm2-monitor.service
-    Systemd_Filter  _SYSTEMD_UNIT=mdmon.service
-    Systemd_Filter  _SYSTEMD_UNIT=nfs-idmapd.service
-    Systemd_Filter  _SYSTEMD_UNIT=nfs-mountd.service
-    Systemd_Filter  _SYSTEMD_UNIT=nfs-server.service
-    Systemd_Filter  _SYSTEMD_UNIT=nfs-utils.service
-    Systemd_Filter  _SYSTEMD_UNIT=node-problem-detector.service
-    Systemd_Filter  _SYSTEMD_UNIT=ntp.service
-    Systemd_Filter  _SYSTEMD_UNIT=oem-cloudinit.service
-    Systemd_Filter  _SYSTEMD_UNIT=rkt-gc.service
-    Systemd_Filter  _SYSTEMD_UNIT=rkt-metadata.service
-    Systemd_Filter  _SYSTEMD_UNIT=rpc-idmapd.service
-    Systemd_Filter  _SYSTEMD_UNIT=rpc-mountd.service
-    Systemd_Filter  _SYSTEMD_UNIT=rpc-statd.service
-    Systemd_Filter  _SYSTEMD_UNIT=rpcbind.service
-    Systemd_Filter  _SYSTEMD_UNIT=set-aws-environment.service
-    Systemd_Filter  _SYSTEMD_UNIT=system-cloudinit.service
-    Systemd_Filter  _SYSTEMD_UNIT=systemd-timesyncd.service
-    Systemd_Filter  _SYSTEMD_UNIT=update-ca-certificates.service
-    Systemd_Filter  _SYSTEMD_UNIT=user-cloudinit.service
-    Systemd_Filter  _SYSTEMD_UNIT=var-lib-etcd2.service
-    Max_Entries     1000
-    Read_From_Tail  true
-
-  @INCLUDE fluent-bit-output.conf
+extraVolumeMounts:
+  - mountPath: /tail-db
+    name: tail-db
+extraVolumes:
+  - hostPath:
+      path: /var/lib/fluent-bit
+      type: DirectoryOrCreate
+    name: tail-db
+config:
+  service: |
+    [SERVICE]
+        Flush        5   #new fluent-bit uses deault of 1
+        Daemon       Off
+        Log_Level    info
+        Parsers_File parsers.conf
+        Parsers_File custom_parsers.conf
+        HTTP_Server  On
+        HTTP_Listen  0.0.0.0
+        HTTP_Port    2020
+  inputs: |
+    [INPUT]
+        Name             tail
+        Path             /var/log/containers/*.log
+        Multiline        On
+        Parser_Firstline docker
+        Tag              containers.*
+        Refresh_Interval 1
+        Rotate_Wait      60
+        Mem_Buf_Limit    5MB
+        Skip_Long_Lines  On
+        DB               /tail-db/tail-containers-state-sumo.db
+        DB.Sync          Normal
+        Ignore_Older     24h
+    [INPUT]
+        Name            systemd
+        Tag             host.*
+        DB              /tail-db/systemd-state-sumo.db
+        Systemd_Filter  _SYSTEMD_UNIT=addon-config.service
+        Systemd_Filter  _SYSTEMD_UNIT=addon-run.service
+        Systemd_Filter  _SYSTEMD_UNIT=cfn-etcd-environment.service
+        Systemd_Filter  _SYSTEMD_UNIT=cfn-signal.service
+        Systemd_Filter  _SYSTEMD_UNIT=clean-ca-certificates.service
+        Systemd_Filter  _SYSTEMD_UNIT=containerd.service
+        Systemd_Filter  _SYSTEMD_UNIT=coreos-metadata.service
+        Systemd_Filter  _SYSTEMD_UNIT=coreos-setup-environment.service
+        Systemd_Filter  _SYSTEMD_UNIT=coreos-tmpfiles.service
+        Systemd_Filter  _SYSTEMD_UNIT=dbus.service
+        Systemd_Filter  _SYSTEMD_UNIT=docker.service
+        Systemd_Filter  _SYSTEMD_UNIT=efs.service
+        Systemd_Filter  _SYSTEMD_UNIT=etcd-member.service
+        Systemd_Filter  _SYSTEMD_UNIT=etcd.service
+        Systemd_Filter  _SYSTEMD_UNIT=etcd2.service
+        Systemd_Filter  _SYSTEMD_UNIT=etcd3.service
+        Systemd_Filter  _SYSTEMD_UNIT=etcdadm-check.service
+        Systemd_Filter  _SYSTEMD_UNIT=etcdadm-reconfigure.service
+        Systemd_Filter  _SYSTEMD_UNIT=etcdadm-save.service
+        Systemd_Filter  _SYSTEMD_UNIT=etcdadm-update-status.service
+        Systemd_Filter  _SYSTEMD_UNIT=flanneld.service
+        Systemd_Filter  _SYSTEMD_UNIT=format-etcd2-volume.service
+        Systemd_Filter  _SYSTEMD_UNIT=kube-node-taint-and-uncordon.service
+        Systemd_Filter  _SYSTEMD_UNIT=kubelet.service
+        Systemd_Filter  _SYSTEMD_UNIT=ldconfig.service
+        Systemd_Filter  _SYSTEMD_UNIT=locksmithd.service
+        Systemd_Filter  _SYSTEMD_UNIT=logrotate.service
+        Systemd_Filter  _SYSTEMD_UNIT=lvm2-monitor.service
+        Systemd_Filter  _SYSTEMD_UNIT=mdmon.service
+        Systemd_Filter  _SYSTEMD_UNIT=nfs-idmapd.service
+        Systemd_Filter  _SYSTEMD_UNIT=nfs-mountd.service
+        Systemd_Filter  _SYSTEMD_UNIT=nfs-server.service
+        Systemd_Filter  _SYSTEMD_UNIT=nfs-utils.service
+        Systemd_Filter  _SYSTEMD_UNIT=node-problem-detector.service
+        Systemd_Filter  _SYSTEMD_UNIT=ntp.service
+        Systemd_Filter  _SYSTEMD_UNIT=oem-cloudinit.service
+        Systemd_Filter  _SYSTEMD_UNIT=rkt-gc.service
+        Systemd_Filter  _SYSTEMD_UNIT=rkt-metadata.service
+        Systemd_Filter  _SYSTEMD_UNIT=rpc-idmapd.service
+        Systemd_Filter  _SYSTEMD_UNIT=rpc-mountd.service
+        Systemd_Filter  _SYSTEMD_UNIT=rpc-statd.service
+        Systemd_Filter  _SYSTEMD_UNIT=rpcbind.service
+        Systemd_Filter  _SYSTEMD_UNIT=set-aws-environment.service
+        Systemd_Filter  _SYSTEMD_UNIT=system-cloudinit.service
+        Systemd_Filter  _SYSTEMD_UNIT=systemd-timesyncd.service
+        Systemd_Filter  _SYSTEMD_UNIT=update-ca-certificates.service
+        Systemd_Filter  _SYSTEMD_UNIT=user-cloudinit.service
+        Systemd_Filter  _SYSTEMD_UNIT=var-lib-etcd2.service
+        Max_Entries     1000
+        Read_From_Tail  true
+  outputs: |
+    [OUTPUT]
+        Name          forward
+        Match         *
+        Host          ${CHART}.${NAMESPACE}.svc.cluster.local.
+        Port          24321
+        Retry_Limit False
+        tls           off
+        tls.verify    on
+        tls.debug     1
+  customParsers: |
+    [PARSER]
+        Name        multi_line
+        Format      regex
+        Regex       (?<log>^{"log":"\d{4}-\d{1,2}-\d{1,2}.\d{2}:\d{2}:\d{2}.*)

--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -109,18 +109,6 @@ prometheus:
       selector:
         matchLabels:
           sumologic.com/app: fluentd-events
-    - name: collection-fluent-bit
-      additionalLabels:
-        app: collection-fluent-bit
-      endpoints:
-        - port: metrics
-          path: /api/v1/metrics/prometheus
-      namespaceSelector:
-        matchNames:
-          - $(NAMESPACE)
-      selector:
-        matchLabels:
-          app: fluent-bit
     - name: collection-sumologic-otelcol
       additionalLabels:
         sumologic.com/app: otelcol

--- a/deploy/helm/sumologic/requirements.yaml
+++ b/deploy/helm/sumologic/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
   - name: fluent-bit
-    version: 2.8.14
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    version: 0.3.2
+    repository: https://fluent.github.io/helm-charts
     condition: fluent-bit.enabled,sumologic.logs.enabled
   - name: prometheus-operator
     version: 8.13.8

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -597,7 +597,7 @@ metrics-server:
     - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
 
 ## Configure fluent-bit
-## ref: https://github.com/helm/charts/blob/master/stable/fluent-bit/values.yaml
+## ref: https://github.com/fluent/helm-charts/blob/master/charts/fluent-bit/values.yaml
 fluent-bit:
   ## Resource limits for fluent-bit
   resources: {}
@@ -612,10 +612,6 @@ fluent-bit:
 ## Comment it out if you wish to have the fluent-bit dependency installed.
 ## Setting the flag to true instead of commenting out will break other functionality. 
   # enabled: false
-  service:
-    flush: 5
-  metrics:
-    enabled: true
   env:
     - name: CHART
       valueFrom:
@@ -627,106 +623,119 @@ fluent-bit:
         fieldRef:
           fieldPath: metadata.namespace
 
-  backend:
-    type: forward
-    forward:
-      # NOTE: Requires trailing "." for fully-qualified name resolution
-      host: ${CHART}.${NAMESPACE}.svc.cluster.local.
-      port: 24321
-      tls: "off"
-      tls_verify: "on"
-      tls_debug: 1
-      shared_key:
-
-  trackOffsets: true
+  serviceMonitor:
+    enabled: true
+    interval: 30s
+    scrapeTimeout: 30s
 
   tolerations:
     - effect: NoSchedule
       operator: Exists
 
-  input:
-    systemd:
-      enabled: true
+  extraVolumeMounts:
+    - mountPath: /tail-db
+      name: tail-db
 
-  parsers:
-    enabled: true
-    # This regex matches the first line of a multiline log starting with a date of the format :  "2019-11-17 07:14:12" or "2019-11-17T07:14:12"
-    regex:
-      - name: multi_line
-        regex: (?<log>^{"log":"\d{4}-\d{1,2}-\d{1,2}.\d{2}:\d{2}:\d{2}.*)
+  extraVolumes:
+    - hostPath:
+        path: /var/lib/fluent-bit
+        type: DirectoryOrCreate
+      name: tail-db
 
-  rawConfig: |-
-    @INCLUDE fluent-bit-service.conf
-
-    [INPUT]
-      Name             tail
-      Path             /var/log/containers/*.log
-      Multiline        On
-      Parser_Firstline multi_line
-      Tag              containers.*
-      Refresh_Interval 1
-      Rotate_Wait      60
-      Mem_Buf_Limit    5MB
-      Skip_Long_Lines  On
-      DB               /tail-db/tail-containers-state-sumo.db
-      DB.Sync          Normal
-      Ignore_Older     24h
-    [INPUT]
-      Name            systemd
-      Tag             host.*
-      DB              /tail-db/systemd-state-sumo.db
-      Systemd_Filter  _SYSTEMD_UNIT=addon-config.service
-      Systemd_Filter  _SYSTEMD_UNIT=addon-run.service
-      Systemd_Filter  _SYSTEMD_UNIT=cfn-etcd-environment.service
-      Systemd_Filter  _SYSTEMD_UNIT=cfn-signal.service
-      Systemd_Filter  _SYSTEMD_UNIT=clean-ca-certificates.service
-      Systemd_Filter  _SYSTEMD_UNIT=containerd.service
-      Systemd_Filter  _SYSTEMD_UNIT=coreos-metadata.service
-      Systemd_Filter  _SYSTEMD_UNIT=coreos-setup-environment.service
-      Systemd_Filter  _SYSTEMD_UNIT=coreos-tmpfiles.service
-      Systemd_Filter  _SYSTEMD_UNIT=dbus.service
-      Systemd_Filter  _SYSTEMD_UNIT=docker.service
-      Systemd_Filter  _SYSTEMD_UNIT=efs.service
-      Systemd_Filter  _SYSTEMD_UNIT=etcd-member.service
-      Systemd_Filter  _SYSTEMD_UNIT=etcd.service
-      Systemd_Filter  _SYSTEMD_UNIT=etcd2.service
-      Systemd_Filter  _SYSTEMD_UNIT=etcd3.service
-      Systemd_Filter  _SYSTEMD_UNIT=etcdadm-check.service
-      Systemd_Filter  _SYSTEMD_UNIT=etcdadm-reconfigure.service
-      Systemd_Filter  _SYSTEMD_UNIT=etcdadm-save.service
-      Systemd_Filter  _SYSTEMD_UNIT=etcdadm-update-status.service
-      Systemd_Filter  _SYSTEMD_UNIT=flanneld.service
-      Systemd_Filter  _SYSTEMD_UNIT=format-etcd2-volume.service
-      Systemd_Filter  _SYSTEMD_UNIT=kube-node-taint-and-uncordon.service
-      Systemd_Filter  _SYSTEMD_UNIT=kubelet.service
-      Systemd_Filter  _SYSTEMD_UNIT=ldconfig.service
-      Systemd_Filter  _SYSTEMD_UNIT=locksmithd.service
-      Systemd_Filter  _SYSTEMD_UNIT=logrotate.service
-      Systemd_Filter  _SYSTEMD_UNIT=lvm2-monitor.service
-      Systemd_Filter  _SYSTEMD_UNIT=mdmon.service
-      Systemd_Filter  _SYSTEMD_UNIT=nfs-idmapd.service
-      Systemd_Filter  _SYSTEMD_UNIT=nfs-mountd.service
-      Systemd_Filter  _SYSTEMD_UNIT=nfs-server.service
-      Systemd_Filter  _SYSTEMD_UNIT=nfs-utils.service
-      Systemd_Filter  _SYSTEMD_UNIT=node-problem-detector.service
-      Systemd_Filter  _SYSTEMD_UNIT=ntp.service
-      Systemd_Filter  _SYSTEMD_UNIT=oem-cloudinit.service
-      Systemd_Filter  _SYSTEMD_UNIT=rkt-gc.service
-      Systemd_Filter  _SYSTEMD_UNIT=rkt-metadata.service
-      Systemd_Filter  _SYSTEMD_UNIT=rpc-idmapd.service
-      Systemd_Filter  _SYSTEMD_UNIT=rpc-mountd.service
-      Systemd_Filter  _SYSTEMD_UNIT=rpc-statd.service
-      Systemd_Filter  _SYSTEMD_UNIT=rpcbind.service
-      Systemd_Filter  _SYSTEMD_UNIT=set-aws-environment.service
-      Systemd_Filter  _SYSTEMD_UNIT=system-cloudinit.service
-      Systemd_Filter  _SYSTEMD_UNIT=systemd-timesyncd.service
-      Systemd_Filter  _SYSTEMD_UNIT=update-ca-certificates.service
-      Systemd_Filter  _SYSTEMD_UNIT=user-cloudinit.service
-      Systemd_Filter  _SYSTEMD_UNIT=var-lib-etcd2.service
-      Max_Entries     1000
-      Read_From_Tail  true
-
-    @INCLUDE fluent-bit-output.conf
+  config:
+    service: |
+      [SERVICE]
+          Flush        5   #new fluent-bit uses deault of 1
+          Daemon       Off
+          Log_Level    info
+          Parsers_File parsers.conf
+          Parsers_File custom_parsers.conf
+          HTTP_Server  On
+          HTTP_Listen  0.0.0.0
+          HTTP_Port    2020
+    inputs: |
+      [INPUT]
+          Name             tail
+          Path             /var/log/containers/*.log
+          Multiline        On
+          Parser_Firstline docker
+          Tag              containers.*
+          Refresh_Interval 1
+          Rotate_Wait      60
+          Mem_Buf_Limit    5MB
+          Skip_Long_Lines  On
+          DB               /tail-db/tail-containers-state-sumo.db
+          DB.Sync          Normal
+          Ignore_Older     24h
+      [INPUT]
+          Name            systemd
+          Tag             host.*
+          DB              /tail-db/systemd-state-sumo.db
+          Systemd_Filter  _SYSTEMD_UNIT=addon-config.service
+          Systemd_Filter  _SYSTEMD_UNIT=addon-run.service
+          Systemd_Filter  _SYSTEMD_UNIT=cfn-etcd-environment.service
+          Systemd_Filter  _SYSTEMD_UNIT=cfn-signal.service
+          Systemd_Filter  _SYSTEMD_UNIT=clean-ca-certificates.service
+          Systemd_Filter  _SYSTEMD_UNIT=containerd.service
+          Systemd_Filter  _SYSTEMD_UNIT=coreos-metadata.service
+          Systemd_Filter  _SYSTEMD_UNIT=coreos-setup-environment.service
+          Systemd_Filter  _SYSTEMD_UNIT=coreos-tmpfiles.service
+          Systemd_Filter  _SYSTEMD_UNIT=dbus.service
+          Systemd_Filter  _SYSTEMD_UNIT=docker.service
+          Systemd_Filter  _SYSTEMD_UNIT=efs.service
+          Systemd_Filter  _SYSTEMD_UNIT=etcd-member.service
+          Systemd_Filter  _SYSTEMD_UNIT=etcd.service
+          Systemd_Filter  _SYSTEMD_UNIT=etcd2.service
+          Systemd_Filter  _SYSTEMD_UNIT=etcd3.service
+          Systemd_Filter  _SYSTEMD_UNIT=etcdadm-check.service
+          Systemd_Filter  _SYSTEMD_UNIT=etcdadm-reconfigure.service
+          Systemd_Filter  _SYSTEMD_UNIT=etcdadm-save.service
+          Systemd_Filter  _SYSTEMD_UNIT=etcdadm-update-status.service
+          Systemd_Filter  _SYSTEMD_UNIT=flanneld.service
+          Systemd_Filter  _SYSTEMD_UNIT=format-etcd2-volume.service
+          Systemd_Filter  _SYSTEMD_UNIT=kube-node-taint-and-uncordon.service
+          Systemd_Filter  _SYSTEMD_UNIT=kubelet.service
+          Systemd_Filter  _SYSTEMD_UNIT=ldconfig.service
+          Systemd_Filter  _SYSTEMD_UNIT=locksmithd.service
+          Systemd_Filter  _SYSTEMD_UNIT=logrotate.service
+          Systemd_Filter  _SYSTEMD_UNIT=lvm2-monitor.service
+          Systemd_Filter  _SYSTEMD_UNIT=mdmon.service
+          Systemd_Filter  _SYSTEMD_UNIT=nfs-idmapd.service
+          Systemd_Filter  _SYSTEMD_UNIT=nfs-mountd.service
+          Systemd_Filter  _SYSTEMD_UNIT=nfs-server.service
+          Systemd_Filter  _SYSTEMD_UNIT=nfs-utils.service
+          Systemd_Filter  _SYSTEMD_UNIT=node-problem-detector.service
+          Systemd_Filter  _SYSTEMD_UNIT=ntp.service
+          Systemd_Filter  _SYSTEMD_UNIT=oem-cloudinit.service
+          Systemd_Filter  _SYSTEMD_UNIT=rkt-gc.service
+          Systemd_Filter  _SYSTEMD_UNIT=rkt-metadata.service
+          Systemd_Filter  _SYSTEMD_UNIT=rpc-idmapd.service
+          Systemd_Filter  _SYSTEMD_UNIT=rpc-mountd.service
+          Systemd_Filter  _SYSTEMD_UNIT=rpc-statd.service
+          Systemd_Filter  _SYSTEMD_UNIT=rpcbind.service
+          Systemd_Filter  _SYSTEMD_UNIT=set-aws-environment.service
+          Systemd_Filter  _SYSTEMD_UNIT=system-cloudinit.service
+          Systemd_Filter  _SYSTEMD_UNIT=systemd-timesyncd.service
+          Systemd_Filter  _SYSTEMD_UNIT=update-ca-certificates.service
+          Systemd_Filter  _SYSTEMD_UNIT=user-cloudinit.service
+          Systemd_Filter  _SYSTEMD_UNIT=var-lib-etcd2.service
+          Max_Entries     1000
+          Read_From_Tail  true
+    outputs: |
+      [OUTPUT]
+          Name          forward
+          Match         *
+          Host          ${CHART}.${NAMESPACE}.svc.cluster.local.
+          Port          24321
+          Retry_Limit False
+          tls           off
+          tls.verify    on
+          tls.debug     1
+    customParsers: |
+      [PARSER]
+          Name        multi_line
+          Format      regex
+          Regex       (?<log>^{"log":"\d{4}-\d{1,2}-\d{1,2}.\d{2}:\d{2}:\d{2}.*)
 
 ## Configure prometheus-operator
 ## ref: https://github.com/helm/charts/blob/master/stable/prometheus-operator/values.yaml
@@ -841,18 +850,6 @@ prometheus-operator:
         selector:
           matchLabels:
             sumologic.com/app: fluentd-events
-      - name: collection-fluent-bit
-        additionalLabels:
-          app: collection-fluent-bit
-        endpoints:
-          - port: metrics
-            path: /api/v1/metrics/prometheus
-        namespaceSelector:
-          matchNames:
-            - $(NAMESPACE)
-        selector:
-          matchLabels:
-            app: fluent-bit
       - name: collection-sumologic-otelcol
         additionalLabels:
           sumologic.com/app: otelcol

--- a/deploy/kubernetes/setup-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/setup-sumologic.yaml.tmpl
@@ -104,16 +104,10 @@ data:
         collector_id = sumologic_collector.collector.id
     }
   
-    resource "kubernetes_namespace" "sumologic_collection_namespace" {
-      metadata {
-        name = var.namespace_name
-      }
-    }
-  
     resource "kubernetes_secret" "sumologic_collection_secret" {
       metadata {
         name = "sumologic"
-        namespace = kubernetes_namespace.sumologic_collection_namespace.metadata[0].name
+        namespace = var.namespace_name
       }
   
       data = {
@@ -161,8 +155,7 @@ data:
     terraform import sumologic_http_source.state_metrics_source "$COLLECTOR_NAME/kube-state-metrics"
   
   
-    # Kubernetes Namespace and Secret
-    terraform import kubernetes_namespace.sumologic_collection_namespace $NAMESPACE
+    # Kubernetes Secret
     terraform import kubernetes_secret.sumologic_collection_secret $NAMESPACE/sumologic
   
     terraform apply -auto-approve


### PR DESCRIPTION
Description

This PR migrates the fluent-bit chart from helm/stable to its new location. 

TODO:
[] - Need to solve missing `release` label on `ServiceMonitor` which prevents Prometheus from discovering fluent-bit metrics.

Testing performed

 [] - ci/build.sh
 [X] -  Redeploy fluentd and fluentd-events pods
 [X] -  Confirm events, logs, and metrics are coming in
 