### PR TITLE
fix: HPA for FluentDs

### DIFF
--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -191,6 +191,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{ template "sumologic.metadata.name.logs" . }}
 {{- end -}}
 
+{{- define "sumologic.metadata.name.logs.hpa" -}}
+{{- template "sumologic.metadata.name.logs" . }}
+{{- end -}}
+
 {{- define "sumologic.metadata.name.metrics" -}}
 {{ template "sumologic.fullname" . }}-fluentd-metrics
 {{- end -}}
@@ -209,6 +213,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 
 {{- define "sumologic.metadata.name.metrics.statefulset" -}}
 {{ template "sumologic.metadata.name.metrics" . }}
+{{- end -}}
+
+{{- define "sumologic.metadata.name.metrics.hpa" -}}
+{{- template "sumologic.metadata.name.metrics" . }}
 {{- end -}}
 
 {{- define "sumologic.metadata.name.events" -}}


### PR DESCRIPTION
When enabled HPA throws the following error:
template "sumologic.metadata.name.metrics.hpa" not defined
template "sumologic.metadata.name.logs.hpa" not defined

###### Description

Fill in your description here.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
