### PR TITLE
Bump Prometheus chart version to latest

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -61,7 +61,8 @@ The following matrix displays the tested package versions for our Helm chart.
 
 Sumo Logic Helm Chart | Prometheus Operator | Fluent Bit | Falco  | Metrics Server
 |:-------- |:-------- |:-------- |:-------- |:--------
-1.0.0 - Latest | 8.2.0 | 2.8.1 | 1.1.6 | 2.7.0
+1.1.0 - Latest | 8.15.12 | 2.8.1 | 1.1.6 | 2.7.0
+1.0.0 | 8.2.0 | 2.8.1 | 1.1.6 | 2.7.0
 0.17.0 - 0.17.1 | 8.2.0 | 2.8.1 | 1.1.0 | 2.7.0
 0.14.0 - 0.16.0 | 8.2.0 | 2.8.1 | 1.1.1 | 2.7.0
 0.13.0 | 8.2.0 | 2.8.1 | 1.0.11 | 2.7.0

--- a/deploy/helm/sumologic/requirements.yaml
+++ b/deploy/helm/sumologic/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: fluent-bit.enabled,sumologic.logs.enabled
   - name: prometheus-operator
-    version: 8.13.8
+    version: 8.15.12
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: prometheus-operator.enabled,sumologic.metrics.enabled
   - name: falco


### PR DESCRIPTION
###### Description

This will bump the actual Prometheus version to `2.17.2` (operator version to `0.38.1`)
https://hub.helm.sh/charts/stable/prometheus-operator/8.15.12

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
