### PR TITLE
Use retry_max_interval instead of retry_timeout for fluentd buffer

### DIFF
--- a/deploy/helm/sumologic/conf/buffer.output.conf
+++ b/deploy/helm/sumologic/conf/buffer.output.conf
@@ -5,6 +5,7 @@ chunk_limit_size {{ .Values.fluentd.buffer.chunkLimitSize | quote }}
 total_limit_size {{ .Values.fluentd.buffer.totalLimitSize | quote }}
 queued_chunks_limit_size {{ .Values.fluentd.buffer.queueChunkLimitSize | quote }}
 overflow_action drop_oldest_chunk
+retry_timeout {{ .Values.fluentd.buffer.retryTimeout | quote }}
 retry_max_interval {{ .Values.fluentd.buffer.retryMaxInterval | quote }}
 retry_forever {{ .Values.fluentd.buffer.retryForever | quote }}
 {{- .Values.fluentd.buffer.extraConf | nindent 2 }}

--- a/deploy/helm/sumologic/conf/buffer.output.conf
+++ b/deploy/helm/sumologic/conf/buffer.output.conf
@@ -5,5 +5,6 @@ chunk_limit_size {{ .Values.fluentd.buffer.chunkLimitSize | quote }}
 total_limit_size {{ .Values.fluentd.buffer.totalLimitSize | quote }}
 queued_chunks_limit_size {{ .Values.fluentd.buffer.queueChunkLimitSize | quote }}
 overflow_action drop_oldest_chunk
-retry_timeout {{ .Values.fluentd.buffer.retryTimeout | quote }}
+retry_max_interval {{ .Values.fluentd.buffer.retryMaxInterval | quote }}
+retry_forever {{ .Values.fluentd.buffer.retryForever | quote }}
 {{- .Values.fluentd.buffer.extraConf | nindent 2 }}

--- a/deploy/helm/sumologic/conf/buffer.output.conf
+++ b/deploy/helm/sumologic/conf/buffer.output.conf
@@ -5,7 +5,6 @@ chunk_limit_size {{ .Values.fluentd.buffer.chunkLimitSize | quote }}
 total_limit_size {{ .Values.fluentd.buffer.totalLimitSize | quote }}
 queued_chunks_limit_size {{ .Values.fluentd.buffer.queueChunkLimitSize | quote }}
 overflow_action drop_oldest_chunk
-retry_timeout {{ .Values.fluentd.buffer.retryTimeout | quote }}
 retry_max_interval {{ .Values.fluentd.buffer.retryMaxInterval | quote }}
 retry_forever {{ .Values.fluentd.buffer.retryForever | quote }}
 {{- .Values.fluentd.buffer.extraConf | nindent 2 }}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -208,6 +208,7 @@ fluentd:
     chunkLimitSize: "1m"
     queueChunkLimitSize: 128
     totalLimitSize: "128m"
+    retryTimeout: "72h"
     retryMaxInterval: "1h"
     retryForever: true
 

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -208,7 +208,8 @@ fluentd:
     chunkLimitSize: "1m"
     queueChunkLimitSize: 128
     totalLimitSize: "128m"
-    retryTimeout: "1h"
+    retryMaxInterval: "1h"
+    retryForever: true
 
     ## File paths to buffer to, if Fluentd buffer type is specified as file above.
     ## Each sumologic output plugin buffers to its own unique file.

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -208,7 +208,6 @@ fluentd:
     chunkLimitSize: "1m"
     queueChunkLimitSize: 128
     totalLimitSize: "128m"
-    retryTimeout: "72h"
     retryMaxInterval: "10m"
     retryForever: true
 

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -209,7 +209,7 @@ fluentd:
     queueChunkLimitSize: 128
     totalLimitSize: "128m"
     retryTimeout: "72h"
-    retryMaxInterval: "1h"
+    retryMaxInterval: "10m"
     retryForever: true
 
     ## File paths to buffer to, if Fluentd buffer type is specified as file above.

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -32,7 +32,7 @@ data:
     queued_chunks_limit_size "128"
     overflow_action drop_oldest_chunk
     retry_timeout "72h"
-    retry_max_interval "1h"
+    retry_max_interval "10m"
     retry_forever "true"
     
   common.conf: |-
@@ -326,7 +326,7 @@ data:
     queued_chunks_limit_size "128"
     overflow_action drop_oldest_chunk
     retry_timeout "72h"
-    retry_max_interval "1h"
+    retry_max_interval "10m"
     retry_forever "true"
     
   
@@ -353,7 +353,7 @@ data:
     queued_chunks_limit_size "128"
     overflow_action drop_oldest_chunk
     retry_timeout "72h"
-    retry_max_interval "1h"
+    retry_max_interval "10m"
     retry_forever "true"
     
   common.conf: |-

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -31,7 +31,9 @@ data:
     total_limit_size "128m"
     queued_chunks_limit_size "128"
     overflow_action drop_oldest_chunk
-    retry_timeout "1h"
+    retry_timeout "72h"
+    retry_max_interval "1h"
+    retry_forever "true"
     
   common.conf: |-
     # Prevent fluentd from handling records containing its own logs.
@@ -323,7 +325,9 @@ data:
     total_limit_size "128m"
     queued_chunks_limit_size "128"
     overflow_action drop_oldest_chunk
-    retry_timeout "1h"
+    retry_timeout "72h"
+    retry_max_interval "1h"
+    retry_forever "true"
     
   
 ---
@@ -348,7 +352,9 @@ data:
     total_limit_size "128m"
     queued_chunks_limit_size "128"
     overflow_action drop_oldest_chunk
-    retry_timeout "1h"
+    retry_timeout "72h"
+    retry_max_interval "1h"
+    retry_forever "true"
     
   common.conf: |-
     # Prevent fluentd from handling records containing its own logs.

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -31,7 +31,6 @@ data:
     total_limit_size "128m"
     queued_chunks_limit_size "128"
     overflow_action drop_oldest_chunk
-    retry_timeout "72h"
     retry_max_interval "10m"
     retry_forever "true"
     
@@ -325,7 +324,6 @@ data:
     total_limit_size "128m"
     queued_chunks_limit_size "128"
     overflow_action drop_oldest_chunk
-    retry_timeout "72h"
     retry_max_interval "10m"
     retry_forever "true"
     
@@ -352,7 +350,6 @@ data:
     total_limit_size "128m"
     queued_chunks_limit_size "128"
     overflow_action drop_oldest_chunk
-    retry_timeout "72h"
     retry_max_interval "10m"
     retry_forever "true"
     


### PR DESCRIPTION
###### Description

Use retry_max_interval instead of retry_timeout for fluentd buffer

https://docs.fluentd.org/configuration/buffer-section#retries-parameters

```
retry_timeout [time]
Default: 72h
The maximum seconds to retry to flush while failing, until plugin discards buffer chunks

retry_forever [bool]
Default: false
If true, plugin will ignore retry_timeout and retry_max_times options and retry flushing forever

retry_max_interval [time]
Default: none
The maximum interval seconds for exponential backoff between retries while failing
```

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
