### PR TITLE
Use SUMO_ENDPOINT_DEFAULT_TRACES_SOURCE env

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1333,7 +1333,7 @@ otelcol:
       health_check: {}
     exporters:
       zipkin:
-        url: "exporters.zipkin.url_replace"
+        url: ${SUMO_ENDPOINT_DEFAULT_TRACES_SOURCE}
       # Following generates verbose logs with span content, useful to verify what
       # metadata is being tagged. To enable, uncomment and add "logging" to exporters below.
       # There are two levels that could be used: `debug` and `info` with the former


### PR DESCRIPTION
###### Description

Use **SUMO_ENDPOINT_DEFAULT_TRACES_SOURCE** environment as default Zipkin exporter URL.

![image](https://user-images.githubusercontent.com/58699800/87660416-4ca62980-c75f-11ea-9e0f-92781201cf65.png)

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
