### PR TITLE
Use Otelcol 0.6.1 and corresponding configuration

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1218,7 +1218,7 @@ otelcol:
     memBallastSizeMib: "683"
     image:
       name: "sumologic/opentelemetry-collector"
-      tag: "0.4.0.0"
+      tag: "0.6.1.0"
       pullPolicy: IfNotPresent
   config:
     receivers:
@@ -1235,7 +1235,9 @@ otelcol:
       opencensus:
         endpoint: "0.0.0.0:55678"
       otlp:
-        endpoint: "0.0.0.0:55680"
+        protocols:
+          grpc:
+            endpoint: "0.0.0.0:55680"
       zipkin:
         endpoint: "0.0.0.0:9411"
     processors:
@@ -1324,14 +1326,14 @@ otelcol:
         # Number of spans after which a batch will be sent regardless of time
         send_batch_size: 256
         # Never more than this many spans are being sent in a batch
-        send_batch_hard_limit: 512
+        send_batch_max_size: 512
         # Time duration after which a batch will be sent regardless of size
         timeout: 5s
     extensions:
       health_check: {}
     exporters:
       zipkin:
-        url: ${SUMO_ENDPOINT_DEFAULT_TRACES_SOURCE}
+        endpoint: ${SUMO_ENDPOINT_DEFAULT_TRACES_SOURCE}
       # Following generates verbose logs with span content, useful to verify what
       # metadata is being tagged. To enable, uncomment and add "logging" to exporters below.
       # There are two levels that could be used: `debug` and `info` with the former


### PR DESCRIPTION
###### Description

Otelcol is bumped to 0.6.1 and config updated accordingly

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
