### PR TITLE
add custom labels to fluentd sts and setup job pods

### DIFF
--- a/deploy/helm/fluent-bit-overrides.yaml
+++ b/deploy/helm/fluent-bit-overrides.yaml
@@ -12,6 +12,9 @@ resources: {}
 ## Comment it out if you wish to have the fluent-bit dependency installed.
 ## Setting the flag to true instead of commenting out will break other functionality.
 # enabled: false
+
+## Add custom pod labels to fluent-bit daemonset pods
+podLabels: {}
 service:
   flush: 5
 metrics:

--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -1,4 +1,6 @@
 # This file is auto-generated.
+## Labels to apply to all pormetheus operator resources
+commonLabels: {}
 ## NOTE changing the serviceMonitor scrape interval to be >1m can result in metrics from recording rules to be missing and empty panels in Sumo Logic Kubernetes apps.
 kubeApiServer:
   serviceMonitor:
@@ -44,6 +46,8 @@ grafana:
   enabled: false
   defaultDashboardsEnabled: false
 prometheusOperator:
+  ## Labels to add to the operator pod
+  podLabels: {}
   ## Resource limits for prometheus operator
   resources: {}
   # limits:
@@ -67,6 +71,8 @@ prometheusOperator:
     #   memory: 200Mi
   ## Resource limits for prometheus node exporter
   prometheus-node-exporter:
+    ## Additional labels for pods in the DaemonSet
+    podLabels: {}
     resources: {}
     # limits:
     #   cpu: 200m

--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -1,5 +1,5 @@
 # This file is auto-generated.
-## Labels to apply to all pormetheus operator resources
+## Labels to apply to all prometheus operator resources
 commonLabels: {}
 ## NOTE changing the serviceMonitor scrape interval to be >1m can result in metrics from recording rules to be missing and empty panels in Sumo Logic Kubernetes apps.
 kubeApiServer:

--- a/deploy/helm/sumologic/templates/events-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/events-statefulset.yaml
@@ -10,6 +10,12 @@ spec:
   selector:
     matchLabels:
       app: {{ template "sumologic.labels.app.events.pod" . }}
+{{- if .Values.fluentd.podLabels }}
+{{ toYaml .Values.fluentd.podLabels | indent 6 }}
+{{- end }}
+{{- if .Values.fluentd.events.statefulset.podLabels }}
+{{ toYaml .Values.fluentd.events.statefulset.podLabels | indent 6 }}
+{{- end }}
   serviceName: {{ template "sumologic.metadata.name.events.service-headless" . }}
   podManagementPolicy: "Parallel"
   template:
@@ -17,6 +23,12 @@ spec:
       labels:
         app: {{ template "sumologic.labels.app.events.pod" . }}
         {{- include "sumologic.labels.common" . | nindent 8 }}
+{{- if .Values.fluentd.podLabels }}
+{{ toYaml .Values.fluentd.podLabels | indent 8 }}
+{{- end }}
+{{- if .Values.fluentd.events.statefulset.podLabels }}
+{{ toYaml .Values.fluentd.events.statefulset.podLabels | indent 8 }}
+{{- end }}
     spec:
       serviceAccountName: {{ template "sumologic.metadata.name.roles.serviceaccount" . }}
 {{- if .Values.fluentd.events.statefulset.nodeSelector }}

--- a/deploy/helm/sumologic/templates/events-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/events-statefulset.yaml
@@ -10,6 +10,9 @@ spec:
   selector:
     matchLabels:
       app: {{ template "sumologic.labels.app.events.pod" . }}
+{{- if .Values.sumologic.podLabels }}
+{{ toYaml .Values.sumologic.podLabels | indent 6 }}
+{{- end }}
 {{- if .Values.fluentd.podLabels }}
 {{ toYaml .Values.fluentd.podLabels | indent 6 }}
 {{- end }}
@@ -23,6 +26,9 @@ spec:
       labels:
         app: {{ template "sumologic.labels.app.events.pod" . }}
         {{- include "sumologic.labels.common" . | nindent 8 }}
+{{- if .Values.sumologic.podLabels }}
+{{ toYaml .Values.sumologic.podLabels | indent 8 }}
+{{- end }}
 {{- if .Values.fluentd.podLabels }}
 {{ toYaml .Values.fluentd.podLabels | indent 8 }}
 {{- end }}

--- a/deploy/helm/sumologic/templates/metrics-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics-statefulset.yaml
@@ -10,6 +10,9 @@ spec:
   selector:
     matchLabels:
       app: {{ template "sumologic.labels.app.metrics.pod" . }}
+{{- if .Values.sumologic.podLabels }}
+{{ toYaml .Values.sumologic.podLabels | indent 6 }}
+{{- end }}
 {{- if .Values.fluentd.podLabels }}
 {{ toYaml .Values.fluentd.podLabels | indent 6 }}
 {{- end }}
@@ -24,6 +27,9 @@ spec:
       labels:
         app: {{ template "sumologic.labels.app.metrics.pod" . }}
         {{- include "sumologic.labels.common" . | nindent 8 }}
+{{- if .Values.sumologic.podLabels }}
+{{ toYaml .Values.sumologic.podLabels | indent 8 }}
+{{- end }}
 {{- if .Values.fluentd.podLabels }}
 {{ toYaml .Values.fluentd.podLabels | indent 8 }}
 {{- end }}

--- a/deploy/helm/sumologic/templates/metrics-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics-statefulset.yaml
@@ -10,6 +10,12 @@ spec:
   selector:
     matchLabels:
       app: {{ template "sumologic.labels.app.metrics.pod" . }}
+{{- if .Values.fluentd.podLabels }}
+{{ toYaml .Values.fluentd.podLabels | indent 6 }}
+{{- end }}
+{{- if .Values.fluentd.metrics.statefulset.podLabels }}
+{{ toYaml .Values.fluentd.metrics.statefulset.podLabels | indent 6 }}
+{{- end }}
   serviceName: {{ template "sumologic.metadata.name.metrics.service-headless" . }}
   podManagementPolicy: "Parallel"
   replicas: {{ .Values.fluentd.metrics.statefulset.replicaCount }}
@@ -18,6 +24,12 @@ spec:
       labels:
         app: {{ template "sumologic.labels.app.metrics.pod" . }}
         {{- include "sumologic.labels.common" . | nindent 8 }}
+{{- if .Values.fluentd.podLabels }}
+{{ toYaml .Values.fluentd.podLabels | indent 8 }}
+{{- end }}
+{{- if .Values.fluentd.metrics.statefulset.podLabels }}
+{{ toYaml .Values.fluentd.metrics.statefulset.podLabels | indent 8 }}
+{{- end }}
     spec:
       serviceAccountName: {{ template "sumologic.metadata.name.roles.serviceaccount" . }}
 {{- if .Values.fluentd.metrics.statefulset.nodeSelector }}

--- a/deploy/helm/sumologic/templates/otelcol-deployment.yaml
+++ b/deploy/helm/sumologic/templates/otelcol-deployment.yaml
@@ -13,11 +13,23 @@ spec:
   selector:
     matchLabels:
       app: {{ template "sumologic.labels.app.otelcol.pod" . }}
+{{- if .Values.sumologic.podLabels }}
+{{ toYaml .Values.sumologic.podLabels | indent 6 }}
+{{- end }}
+{{- if .Values.otelcol.deployment.podLabels }}
+{{ toYaml .Values.otelcol.deployment.podLabels | indent 6 }}
+{{- end }}
   template:
     metadata:
       labels:
         app: {{ template "sumologic.labels.app.otelcol.pod" . }}
         {{- include "sumologic.labels.common" . | nindent 8 }}
+{{- if .Values.sumologic.podLabels }}
+{{ toYaml .Values.sumologic.podLabels | indent 8 }}
+{{- end }}
+{{- if .Values.otelcol.deployment.podLabels }}
+{{ toYaml .Values.otelcol.deployment.podLabels | indent 6 }}
+{{- end }}
     spec:
       serviceAccountName: {{ template "sumologic.metadata.name.roles.serviceaccount" . }}
       {{- if .Values.otelcol.deployment.nodeSelector }}

--- a/deploy/helm/sumologic/templates/setup/setup-job.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-job.yaml
@@ -9,7 +9,9 @@ metadata:
   labels:
     app: {{ template "sumologic.labels.app.setup.job" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
+{{- if .Values.sumologic.setup.job.podLabels }}
 {{ toYaml .Values.sumologic.setup.job.podLabels | indent 4 }}
+{{- end }}
 spec:
   template:
     spec:

--- a/deploy/helm/sumologic/templates/setup/setup-job.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-job.yaml
@@ -9,6 +9,9 @@ metadata:
   labels:
     app: {{ template "sumologic.labels.app.setup.job" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
+{{- if .Values.sumologic.podLabels }}
+{{ toYaml .Values.sumologic.podLabels | indent 4 }}
+{{- end }}
 {{- if .Values.sumologic.setup.job.podLabels }}
 {{ toYaml .Values.sumologic.setup.job.podLabels | indent 4 }}
 {{- end }}

--- a/deploy/helm/sumologic/templates/setup/setup-job.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-job.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     app: {{ template "sumologic.labels.app.setup.job" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
+{{ toYaml .Values.sumologic.setup.job.podLabels | indent 4 }}
 spec:
   template:
     spec:

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -10,6 +10,12 @@ spec:
   selector:
     matchLabels:
       app: {{ template "sumologic.labels.app.logs.pod" . }}
+{{- if .Values.fluentd.podLabels }}
+{{ toYaml .Values.fluentd.podLabels | indent 6 }}
+{{- end }}
+{{- if .Values.fluentd.logs.statefulset.podLabels }}
+{{ toYaml .Values.fluentd.logs.statefulset.podLabels | indent 6 }}
+{{- end }}
   serviceName: {{ template "sumologic.metadata.name.logs.service-headless" . }}
   podManagementPolicy: "Parallel"
   replicas: {{ .Values.fluentd.logs.statefulset.replicaCount }}
@@ -18,6 +24,12 @@ spec:
       labels:
         app: {{ template "sumologic.labels.app.logs.pod" . }}
         {{- include "sumologic.labels.common" . | nindent 8 }}
+{{- if .Values.fluentd.podLabels }}
+{{ toYaml .Values.fluentd.podLabels | indent 8 }}
+{{- end }}
+{{- if .Values.fluentd.logs.statefulset.podLabels }}
+{{ toYaml .Values.fluentd.logs.statefulset.podLabels | indent 8 }}
+{{- end }}
     spec:
       serviceAccountName: {{ template "sumologic.metadata.name.roles.serviceaccount" . }}
 {{- if .Values.fluentd.logs.statefulset.nodeSelector }}

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -10,6 +10,9 @@ spec:
   selector:
     matchLabels:
       app: {{ template "sumologic.labels.app.logs.pod" . }}
+{{- if .Values.sumologic.podLabels }}
+{{ toYaml .Values.sumologic.podLabels | indent 6 }}
+{{- end }}
 {{- if .Values.fluentd.podLabels }}
 {{ toYaml .Values.fluentd.podLabels | indent 6 }}
 {{- end }}
@@ -24,6 +27,9 @@ spec:
       labels:
         app: {{ template "sumologic.labels.app.logs.pod" . }}
         {{- include "sumologic.labels.common" . | nindent 8 }}
+{{- if .Values.sumologic.podLabels }}
+{{ toYaml .Values.sumologic.podLabels | indent 8 }}
+{{- end }}
 {{- if .Values.fluentd.podLabels }}
 {{ toYaml .Values.fluentd.podLabels | indent 8 }}
 {{- end }}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -61,6 +61,9 @@ sumologic:
 
   #  If you set it to false, it would set EXCLUDE_NAMESPACE=<release-namespace> and not add the fluentD/fluent-bit logs and Prometheus remotestorage metrics.
   collectionMonitoring: true
+  
+  ## Add custom labels to the following sumologic resources(fluentd sts, setup job, otelcol deployment)
+  podLabels: {}
 
   setup:
     clusterRole:
@@ -1225,6 +1228,8 @@ otelcol:
       requests:
         memory: 384Mi
         cpu: "200m"
+    ## Add custom labels only to otelcol deployment.
+    podLabels: {}
     # Memory Ballast size should be max 1/3 to 1/2 of memory.
     memBallastSizeMib: "683"
     image:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -637,6 +637,9 @@ fluent-bit:
   ## Setting the flag to true instead of commenting out will break other functionality.
   # enabled: false
 
+  ## Add custom pod labels to fluent-bit daemonset pods
+  podLabels: {}
+
   service:
     flush: 5
   metrics:
@@ -756,6 +759,8 @@ fluent-bit:
 ## Configure prometheus-operator
 ## ref: https://github.com/helm/charts/blob/master/stable/prometheus-operator/values.yaml
 prometheus-operator:
+  ## Labels to apply to all pormetheus operator resources
+  commonLabels: {}
   ## NOTE changing the serviceMonitor scrape interval to be >1m can result in metrics from recording rules to be missing and empty panels in Sumo Logic Kubernetes apps.
   kubeApiServer:
     serviceMonitor:
@@ -803,6 +808,8 @@ prometheus-operator:
     enabled: false
     defaultDashboardsEnabled: false
   prometheusOperator:
+    ## Labels to add to the operator pod
+    podLabels: {}
     ## Resource limits for prometheus operator
     resources: {}
       # limits:
@@ -826,6 +833,8 @@ prometheus-operator:
         #   memory: 200Mi
     ## Resource limits for prometheus node exporter
     prometheus-node-exporter:
+      ## Additional labels for pods in the DaemonSet
+      podLabels: {}
       resources: {}
         # limits:
         #   cpu: 200m

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -759,7 +759,7 @@ fluent-bit:
 ## Configure prometheus-operator
 ## ref: https://github.com/helm/charts/blob/master/stable/prometheus-operator/values.yaml
 prometheus-operator:
-  ## Labels to apply to all pormetheus operator resources
+  ## Labels to apply to all prometheus operator resources
   commonLabels: {}
   ## NOTE changing the serviceMonitor scrape interval to be >1m can result in metrics from recording rules to be missing and empty panels in Sumo Logic Kubernetes apps.
   kubeApiServer:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -83,6 +83,8 @@ sumologic:
         helm.sh/hook: pre-install,pre-upgrade
         helm.sh/hook-weight: "3"
         helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+      ## Add custom labels only to setup job pod
+      podLabels: {}
     serviceAccount:
       annotations:
         helm.sh/hook: pre-install,pre-upgrade
@@ -176,6 +178,9 @@ fluentd:
   securityContext:
     ## The group ID of all processes in the statefulset containers. By default this needs to be fluent(999).
     fsGroup: 999
+  
+  ## Add custom labels to all fluentd sts pods(logs, metrics, events)
+  podLabels: {}
 
   ## Persist data to a persistent volume; When enabled, fluentd uses the file buffer instead of memory buffer.
   persistence:
@@ -277,7 +282,9 @@ fluentd:
         requests:
           memory: 768Mi
           cpu: 0.5
-
+      ## Add custom labels only to logs fluentd sts pods
+      podLabels: {}
+    
     ## Option to turn autoscaling on for fluentd and specify params for HPA.
     ## Autoscaling needs metrics-server to access cpu metrics.
     autoscaling:
@@ -465,6 +472,8 @@ fluentd:
         requests:
           memory: 768Mi
           cpu: 0.5
+      ## Add custom labels only to metrics fluentd sts pods
+      podLabels: {}
 
     ## Option to turn autoscaling on for fluentd and specify params for HPA.
     ## Autoscaling needs metrics-server to access cpu metrics.
@@ -568,6 +577,8 @@ fluentd:
         requests:
           memory: 256Mi
           cpu: "100m"
+      ## Add custom labels only to events fluentd sts pods
+      podLabels: {}
 
     # Source category for the Events source. Default: "{clusterName}/events"
     sourceCategory: ""


### PR DESCRIPTION
###### Description

- Users will be able to add labels to all fluentd pods and setup job.
- There is a common property to apply to all fluentd pods together, as well as the ability to add to each individually.
- expose the ability to add labels on fluent-bit and Prometheus

Configs:
- `sumologic.podLabels` -> add labels to fluentd sts, setup job, otelcol deployment
- `fluentd.podLabels` -> add labels to all fluentd sts.
- `fluentd.logs.statefulset.podLabels` -> add labels only to logs fluentd sts.
- `fluentd.metrics.statefulset.podLabels` -> add labels only to metrics fluentd sts.
- `fluentd.events.statefulsetpodLabels` -> add labels only to events fluentd sts.
- `otelcol.deployment.podLabels` -> add labels only to otelcol deployment.
- `sumologic.setup.job.podLabels` -> add labels only to setup job.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
