### PR TITLE
Allow custom pod annotations in helm chart

### DIFF
--- a/deploy/docs/Non_Helm_Installation.md
+++ b/deploy/docs/Non_Helm_Installation.md
@@ -105,7 +105,7 @@ Finally, you can run `kubectl apply` on the file containing the rendered YAML fr
 kubectl apply -f sumologic.yaml
 ```
 
-If you with to install the YAML in a different namespace, you can add the `--namespace` flag.  The following will render the YAML and install in the `my-namespace` namespace.
+If you wish to install the YAML in a different namespace, you can add the `--namespace` flag.  The following will render the YAML and install in the `my-namespace` namespace.
 
 ```bash
 kubectl run tools \
@@ -177,7 +177,36 @@ cat sumo-values.yaml | \
 
 **Note, if you are upgrading to version 1.x of our collection from a version before 1.x, please see our [migration guide](v1_migration_doc.md).**
 
-To upgrade you can simply re-generate the YAML when a new version of the Kubernetes collection is available.  If you wish to upgrade to a specific version, you can pass the `--version` flag when generating the YAML.
+To upgrade you can simply re-generate the YAML when a new version of the Kubernetes collection is available.  You can use the same commands used to create the YAML in the first place.
+
+```bash
+kubectl run tools \
+  -it --quiet --rm \
+  --restart=Never \
+  --image sumologic/kubernetes-tools:1.0.0 -- \
+  template \
+  --namespace 'my-namespace' \
+  --name-template 'collection' \
+  --set sumologic.accessId='<ACCESS_ID>' \
+  --set sumologic.accessKey='<ACCESS_KEY>' \
+  --set sumologic.clusterName='<CLUSTER_NAME>' \
+  | tee sumologic.yaml
+```
+
+If you have made customizations and installed with a `values.yaml`, you can do the same thing command as you did before to generate the YAML.
+
+```bash
+cat sumo-values.yaml | \
+     kubectl run tools \
+       -i --quiet --rm \
+       --restart=Never \
+       --image sumologic/kubernetes-tools:1.0.0 -- \
+       template \
+         --name-template 'collection' \
+         | tee sumologic.yaml
+```
+
+If you wish to upgrade to a specific version, you can pass the `--version` flag when generating the YAML. The following example would use version `1.0.0`.
 
 ```bash
 cat values.yaml | \
@@ -189,6 +218,13 @@ cat values.yaml | \
       --name-template 'collection' \
       --version=1.0.0
       | tee sumologic.yaml
+```
+
+Once you have generated the `sumologic.yaml`, you can run `kubectl apply` on the file containing the rendered YAML from the previous step to upgrade collection. You must change your `kubectl` context to the namespace you wish to install in.
+
+```bash
+kubectl config set-context --current --namespace=my-namespace
+kubectl apply -f sumologic.yaml
 ```
 
 ## Uninstalling Sumo Logic Collection

--- a/deploy/docs/Terraform.md
+++ b/deploy/docs/Terraform.md
@@ -75,6 +75,28 @@ Examples:
 You can set all of the source [properties](https://www.terraform.io/docs/providers/sumologic/r/http_source.html#argument-reference)
 using `sumologic.sources.<logs,traces,metrics,traces>.<source ref name>.properties`.
 
+#### Processing Rules
+
+You can add [Processing Rules](https://help.sumologic.com/Manage/Collection/Processing-Rules) to an HTTP source via values.yaml. Below is an example of an exclude rule to filter `DEBUG` log messages.  All logs from Kubernetes (Systemd, container, and custom logs) will have this filter applied.
+
+```yaml
+sumologic:
+  # ...
+  sources:
+    # ...
+    logs:
+      # ...
+      default:
+        # ...
+        name: logs
+        config-name: endpoint-logs
+        properties:
+          filters:
+            - name: "Test Exclude Debug"
+              filter_type: "Exclude"
+              regexp: ".*DEBUG.*"
+```
+
 #### Fields
 
 The configuration snippet below configures two [fields](https://help.sumologic.com/Manage/Fields), (`node` and `deployment`) for the default logs source:

--- a/deploy/docs/additional_prometheus_configuration.md
+++ b/deploy/docs/additional_prometheus_configuration.md
@@ -105,7 +105,7 @@ metadata:
     release: collection  # ensure this matches the `release` label on your Prometheus pod
 spec:
   selector:
-    matchSelector:
+    matchLabels:
       app: example-metrics
   endpoints:
   - port: "8000"  # Same as service's port name

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -159,6 +159,20 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- template "sumologic.labels.app.setup" . }}
 {{- end -}}
 
+{{/*
+Generate helm.sh annotations. It takes weight as parameter.
+
+Example usage:
+
+{{ include "sumologic.annotations.app.setup.helmsh" "1" }}
+
+*/}}
+{{- define "sumologic.annotations.app.setup.helmsh" -}}
+helm.sh/hook: pre-install,pre-upgrade
+helm.sh/hook-weight: {{ printf "\"%s\"" . }}
+helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+{{- end -}}
+
 {{- define "sumologic.metadata.name.roles.clusterrole" -}}
 {{- template "sumologic.fullname" . }}
 {{- end -}}

--- a/deploy/helm/sumologic/templates/events-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/events-statefulset.yaml
@@ -23,7 +23,6 @@ spec:
   podManagementPolicy: "Parallel"
   template:
     metadata:
-{{- if or .Values.sumologic.podAnnotations .Values.fluentd.podAnnotations .Values.fluentd.events.statefulset.podAnnotations }}
       annotations:
 {{- if .Values.sumologic.podAnnotations }}
 {{ toYaml .Values.sumologic.podAnnotations | indent 6 }}
@@ -33,7 +32,6 @@ spec:
 {{- end }}
 {{- if .Values.fluentd.events.statefulset.podAnnotations }}
 {{ toYaml .Values.fluentd.events.statefulset.podAnnotations | indent 6 }}
-{{- end }}
 {{- end }}
       labels:
         app: {{ template "sumologic.labels.app.events.pod" . }}

--- a/deploy/helm/sumologic/templates/events-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/events-statefulset.yaml
@@ -23,6 +23,7 @@ spec:
   podManagementPolicy: "Parallel"
   template:
     metadata:
+{{- if or .Values.sumologic.podAnnotations .Values.fluentd.podAnnotations .Values.fluentd.events.statefulset.podAnnotations }}
       annotations:
 {{- if .Values.sumologic.podAnnotations }}
 {{ toYaml .Values.sumologic.podAnnotations | indent 6 }}
@@ -32,6 +33,7 @@ spec:
 {{- end }}
 {{- if .Values.fluentd.events.statefulset.podAnnotations }}
 {{ toYaml .Values.fluentd.events.statefulset.podAnnotations | indent 6 }}
+{{- end }}
 {{- end }}
       labels:
         app: {{ template "sumologic.labels.app.events.pod" . }}

--- a/deploy/helm/sumologic/templates/events-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/events-statefulset.yaml
@@ -23,6 +23,16 @@ spec:
   podManagementPolicy: "Parallel"
   template:
     metadata:
+      annotations:
+{{- if .Values.sumologic.podAnnotations }}
+{{ toYaml .Values.sumologic.podAnnotations | indent 6 }}
+{{- end }}
+{{- if .Values.fluentd.podAnnotations }}
+{{ toYaml .Values.fluentd.podAnnotations | indent 6 }}
+{{- end }}
+{{- if .Values.fluentd.events.statefulset.podAnnotations }}
+{{ toYaml .Values.fluentd.events.statefulset.podAnnotations | indent 6 }}
+{{- end }}
       labels:
         app: {{ template "sumologic.labels.app.events.pod" . }}
         {{- include "sumologic.labels.common" . | nindent 8 }}

--- a/deploy/helm/sumologic/templates/metrics-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics-statefulset.yaml
@@ -24,7 +24,6 @@ spec:
   replicas: {{ .Values.fluentd.metrics.statefulset.replicaCount }}
   template:
     metadata:
-{{- if or .Values.sumologic.podAnnotations .Values.fluentd.podAnnotations .Values.fluentd.metrics.statefulset.podAnnotations }}
       annotations:
 {{- if .Values.sumologic.podAnnotations }}
 {{ toYaml .Values.sumologic.podAnnotations | indent 6 }}
@@ -34,7 +33,6 @@ spec:
 {{- end }}
 {{- if .Values.fluentd.metrics.statefulset.podAnnotations }}
 {{ toYaml .Values.fluentd.metrics.statefulset.podAnnotations | indent 6 }}
-{{- end }}
 {{- end }}
       labels:
         app: {{ template "sumologic.labels.app.metrics.pod" . }}

--- a/deploy/helm/sumologic/templates/metrics-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics-statefulset.yaml
@@ -24,6 +24,7 @@ spec:
   replicas: {{ .Values.fluentd.metrics.statefulset.replicaCount }}
   template:
     metadata:
+{{- if or .Values.sumologic.podAnnotations .Values.fluentd.podAnnotations .Values.fluentd.metrics.statefulset.podAnnotations }}
       annotations:
 {{- if .Values.sumologic.podAnnotations }}
 {{ toYaml .Values.sumologic.podAnnotations | indent 6 }}
@@ -33,6 +34,7 @@ spec:
 {{- end }}
 {{- if .Values.fluentd.metrics.statefulset.podAnnotations }}
 {{ toYaml .Values.fluentd.metrics.statefulset.podAnnotations | indent 6 }}
+{{- end }}
 {{- end }}
       labels:
         app: {{ template "sumologic.labels.app.metrics.pod" . }}

--- a/deploy/helm/sumologic/templates/metrics-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics-statefulset.yaml
@@ -24,6 +24,16 @@ spec:
   replicas: {{ .Values.fluentd.metrics.statefulset.replicaCount }}
   template:
     metadata:
+      annotations:
+{{- if .Values.sumologic.podAnnotations }}
+{{ toYaml .Values.sumologic.podAnnotations | indent 6 }}
+{{- end }}
+{{- if .Values.fluentd.podAnnotations }}
+{{ toYaml .Values.fluentd.podAnnotations | indent 6 }}
+{{- end }}
+{{- if .Values.fluentd.metrics.statefulset.podAnnotations }}
+{{ toYaml .Values.fluentd.metrics.statefulset.podAnnotations | indent 6 }}
+{{- end }}
       labels:
         app: {{ template "sumologic.labels.app.metrics.pod" . }}
         {{- include "sumologic.labels.common" . | nindent 8 }}

--- a/deploy/helm/sumologic/templates/otelcol-deployment.yaml
+++ b/deploy/helm/sumologic/templates/otelcol-deployment.yaml
@@ -21,6 +21,13 @@ spec:
 {{- end }}
   template:
     metadata:
+      annotations:
+{{- if .Values.sumologic.podAnnotations }}
+{{ toYaml .Values.sumologic.podAnnotations | indent 6 }}
+{{- end }}
+{{- if .Values.otelcol.deployment.podAnnotations }}
+{{ toYaml .Values.otelcol.deployment.podAnnotations | indent 6 }}
+{{- end }}
       labels:
         app: {{ template "sumologic.labels.app.otelcol.pod" . }}
         {{- include "sumologic.labels.common" . | nindent 8 }}

--- a/deploy/helm/sumologic/templates/setup/setup-clusterrole.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-clusterrole.yaml
@@ -4,7 +4,9 @@ kind: ClusterRole
 metadata:
   name:  {{ template "sumologic.metadata.name.setup.roles.clusterrole" . }}
   annotations:
-{{ toYaml .Values.sumologic.setup.clusterRole.annotations | indent 4 }}
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app: {{ template "sumologic.labels.app.setup.roles.clusterrole" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/setup/setup-clusterrole.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-clusterrole.yaml
@@ -4,9 +4,7 @@ kind: ClusterRole
 metadata:
   name:  {{ template "sumologic.metadata.name.setup.roles.clusterrole" . }}
   annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-weight: "1"
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+{{ include "sumologic.annotations.app.setup.helmsh" "1" | indent 4 }}
   labels:
     app: {{ template "sumologic.labels.app.setup.roles.clusterrole" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/setup/setup-clusterrolebinding.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-clusterrolebinding.yaml
@@ -4,9 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   name:  {{ template "sumologic.metadata.name.setup.roles.clusterrolebinding" . }}
   annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-weight: "2"
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+{{ include "sumologic.annotations.app.setup.helmsh" "2" | indent 4 }}
   labels:
     app: {{ template "sumologic.labels.app.setup.roles.clusterrolebinding" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/setup/setup-clusterrolebinding.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-clusterrolebinding.yaml
@@ -4,7 +4,9 @@ kind: ClusterRoleBinding
 metadata:
   name:  {{ template "sumologic.metadata.name.setup.roles.clusterrolebinding" . }}
   annotations:
-{{ toYaml .Values.sumologic.setup.clusterRoleBinding.annotations | indent 4 }}
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "2"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app: {{ template "sumologic.labels.app.setup.roles.clusterrolebinding" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
@@ -4,9 +4,7 @@ kind: ConfigMap
 metadata:
   name:  {{ template "sumologic.metadata.name.setup.configmap" . }}
   annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-weight: "2"
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+{{ include "sumologic.annotations.app.setup.helmsh" "2" | indent 4 }}
   labels:
     app: {{ template "sumologic.labels.app.setup.configmap" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
@@ -4,7 +4,9 @@ kind: ConfigMap
 metadata:
   name:  {{ template "sumologic.metadata.name.setup.configmap" . }}
   annotations:
-{{ toYaml .Values.sumologic.setup.configMap.annotations | indent 4 }}
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "2"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app: {{ template "sumologic.labels.app.setup.configmap" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/setup/setup-job.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-job.yaml
@@ -5,11 +5,11 @@ metadata:
   name: {{ template "sumologic.metadata.name.setup.job" . }}
   namespace: {{ .Release.Namespace }}
   annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "3"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 {{- if .Values.sumologic.podAnnotations }}
 {{ toYaml .Values.sumologic.podAnnotations | indent 2 }}
-{{- end }}
-{{- if .Values.sumologic.setup.job.podAnnotations }}
-{{ toYaml .Values.sumologic.setup.job.podAnnotations | indent 2 }}
 {{- end }}
   labels:
     app: {{ template "sumologic.labels.app.setup.job" . }}

--- a/deploy/helm/sumologic/templates/setup/setup-job.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-job.yaml
@@ -5,9 +5,7 @@ metadata:
   name: {{ template "sumologic.metadata.name.setup.job" . }}
   namespace: {{ .Release.Namespace }}
   annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-weight: "3"
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+{{ include "sumologic.annotations.app.setup.helmsh" "3" | indent 4 }}
 {{- if .Values.sumologic.podAnnotations }}
 {{ toYaml .Values.sumologic.podAnnotations | indent 2 }}
 {{- end }}

--- a/deploy/helm/sumologic/templates/setup/setup-job.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-job.yaml
@@ -5,7 +5,12 @@ metadata:
   name: {{ template "sumologic.metadata.name.setup.job" . }}
   namespace: {{ .Release.Namespace }}
   annotations:
-{{ toYaml .Values.sumologic.setup.job.annotations | indent 4 }}
+{{- if .Values.sumologic.podAnnotations }}
+{{ toYaml .Values.sumologic.podAnnotations | indent 2 }}
+{{- end }}
+{{- if .Values.sumologic.setup.job.podAnnotations }}
+{{ toYaml .Values.sumologic.setup.job.podAnnotations | indent 2 }}
+{{- end }}
   labels:
     app: {{ template "sumologic.labels.app.setup.job" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/setup/setup-serviceaccount.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-serviceaccount.yaml
@@ -4,9 +4,7 @@ kind: ServiceAccount
 metadata:
   name:  {{ template "sumologic.metadata.name.setup.roles.serviceaccount" . }}
   annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-weight: "0"
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+{{ include "sumologic.annotations.app.setup.helmsh" "0" | indent 4 }}
   labels:
     app: {{ template "sumologic.labels.app.setup.roles.serviceaccount" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/setup/setup-serviceaccount.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-serviceaccount.yaml
@@ -4,7 +4,9 @@ kind: ServiceAccount
 metadata:
   name:  {{ template "sumologic.metadata.name.setup.roles.serviceaccount" . }}
   annotations:
-{{ toYaml .Values.sumologic.setup.serviceAccount.annotations | indent 4 }}
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app: {{ template "sumologic.labels.app.setup.roles.serviceaccount" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -24,7 +24,6 @@ spec:
   replicas: {{ .Values.fluentd.logs.statefulset.replicaCount }}
   template:
     metadata:
-{{- if or .Values.sumologic.podAnnotations .Values.fluentd.podAnnotations .Values.fluentd.logs.statefulset.podAnnotations }}
       annotations:
 {{- if .Values.sumologic.podAnnotations }}
 {{ toYaml .Values.sumologic.podAnnotations | indent 6 }}
@@ -34,7 +33,6 @@ spec:
 {{- end }}
 {{- if .Values.fluentd.logs.statefulset.podAnnotations }}
 {{ toYaml .Values.fluentd.logs.statefulset.podAnnotations | indent 6 }}
-{{- end }}
 {{- end }}
       labels:
         app: {{ template "sumologic.labels.app.logs.pod" . }}

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -24,6 +24,16 @@ spec:
   replicas: {{ .Values.fluentd.logs.statefulset.replicaCount }}
   template:
     metadata:
+      annotations:
+{{- if .Values.sumologic.podAnnotations }}
+{{ toYaml .Values.sumologic.podAnnotations | indent 6 }}
+{{- end }}
+{{- if .Values.fluentd.podAnnotations }}
+{{ toYaml .Values.fluentd.podAnnotations | indent 6 }}
+{{- end }}
+{{- if .Values.fluentd.logs.statefulset.podAnnotations }}
+{{ toYaml .Values.fluentd.logs.statefulset.podAnnotations | indent 6 }}
+{{- end }}
       labels:
         app: {{ template "sumologic.labels.app.logs.pod" . }}
         {{- include "sumologic.labels.common" . | nindent 8 }}

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -24,6 +24,7 @@ spec:
   replicas: {{ .Values.fluentd.logs.statefulset.replicaCount }}
   template:
     metadata:
+{{- if or .Values.sumologic.podAnnotations .Values.fluentd.podAnnotations .Values.fluentd.logs.statefulset.podAnnotations }}
       annotations:
 {{- if .Values.sumologic.podAnnotations }}
 {{ toYaml .Values.sumologic.podAnnotations | indent 6 }}
@@ -33,6 +34,7 @@ spec:
 {{- end }}
 {{- if .Values.fluentd.logs.statefulset.podAnnotations }}
 {{ toYaml .Values.fluentd.logs.statefulset.podAnnotations | indent 6 }}
+{{- end }}
 {{- end }}
       labels:
         app: {{ template "sumologic.labels.app.logs.pod" . }}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -69,35 +69,11 @@ sumologic:
   podAnnotations: {}
 
   setup:
-    clusterRole:
-      annotations:
-        helm.sh/hook: pre-install,pre-upgrade
-        helm.sh/hook-weight: "1"
-        helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
-    clusterRoleBinding:
-      annotations:
-        helm.sh/hook: pre-install,pre-upgrade
-        helm.sh/hook-weight: "2"
-        helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
-    configMap:
-      annotations:
-        helm.sh/hook: pre-install,pre-upgrade
-        helm.sh/hook-weight: "2"
-        helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
     job:
-      annotations:
-        helm.sh/hook: pre-install,pre-upgrade
-        helm.sh/hook-weight: "3"
-        helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
       ## Add custom labels only to setup job pod
       podLabels: {}
       ## Add custom annotations only to setup job pod
       podAnnotations: {}
-    serviceAccount:
-      annotations:
-        helm.sh/hook: pre-install,pre-upgrade
-        helm.sh/hook-weight: "0"
-        helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 
     ## Configuration of additional collector fields
     ## https://help.sumologic.com/Manage/Fields#http-source-fields

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -141,6 +141,12 @@ sumologic:
       default:
         name: logs
         config-name: endpoint-logs
+        # properties can be used to extend default settings, such as processing rules, fields etc
+        #properties:
+          #filters:
+            #- name: "Test Exclude Debug"
+            #filter_type: "Exclude"
+            #regexp: ".*DEBUG.*"
     events:
       default:
         name: events

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -17,10 +17,10 @@ sumologic:
   #envFromSecret: sumo-api-secret
 
   # Sumo access ID
-  accessId: "X"
+  #accessId: ""
 
   # Sumo access key
-  accessKey: "X"
+  #accessKey: ""
 
   # Sumo API endpoint; Leave blank for automatic endpoint discovery and redirection
   # ref: https://help.sumologic.com/APIs/General-API-Information/Sumo-Logic-Endpoints-and-Firewall-Security

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -65,6 +65,9 @@ sumologic:
   ## Add custom labels to the following sumologic resources(fluentd sts, setup job, otelcol deployment)
   podLabels: {}
 
+  ## Add custom annotations to the following sumologic resources(fluentd sts, setup job, otelcol deployment)
+  podAnnotations: {}
+
   setup:
     clusterRole:
       annotations:
@@ -88,6 +91,8 @@ sumologic:
         helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
       ## Add custom labels only to setup job pod
       podLabels: {}
+      ## Add custom annotations only to setup job pod
+      podAnnotations: {}
     serviceAccount:
       annotations:
         helm.sh/hook: pre-install,pre-upgrade
@@ -191,6 +196,9 @@ fluentd:
   ## Add custom labels to all fluentd sts pods(logs, metrics, events)
   podLabels: {}
 
+  ## Add custom annotations to all fluentd sts pods(logs, metrics, events)
+  podAnnotations: {}
+
   ## Persist data to a persistent volume; When enabled, fluentd uses the file buffer instead of memory buffer.
   persistence:
     ## After setting the value to true, run the helm upgrade command with the --force flag.
@@ -293,6 +301,8 @@ fluentd:
           cpu: 0.5
       ## Add custom labels only to logs fluentd sts pods
       podLabels: {}
+      ## Add custom annotations only to logs fluentd sts pods
+      podAnnotations: {}
     
     ## Option to turn autoscaling on for fluentd and specify params for HPA.
     ## Autoscaling needs metrics-server to access cpu metrics.
@@ -483,6 +493,8 @@ fluentd:
           cpu: 0.5
       ## Add custom labels only to metrics fluentd sts pods
       podLabels: {}
+      ## Add custom annotations only to metrics fluentd sts pods
+      podAnnotations: {}
 
     ## Option to turn autoscaling on for fluentd and specify params for HPA.
     ## Autoscaling needs metrics-server to access cpu metrics.
@@ -588,6 +600,8 @@ fluentd:
           cpu: "100m"
       ## Add custom labels only to events fluentd sts pods
       podLabels: {}
+      ## Add custom annotations only to events fluentd sts pods
+      podAnnotations: {}
 
     # Source category for the Events source. Default: "{clusterName}/events"
     sourceCategory: ""
@@ -645,6 +659,9 @@ fluent-bit:
 
   ## Add custom pod labels to fluent-bit daemonset pods
   podLabels: {}
+
+  ## Add custom pod annotations to fluent-bit daemonset pods
+  podAnnotations: {}
 
   service:
     flush: 5
@@ -816,6 +833,8 @@ prometheus-operator:
   prometheusOperator:
     ## Labels to add to the operator pod
     podLabels: {}
+    ## Annotations to add to the operator pod
+    podAnnotations: {}
     ## Resource limits for prometheus operator
     resources: {}
       # limits:
@@ -841,6 +860,8 @@ prometheus-operator:
     prometheus-node-exporter:
       ## Additional labels for pods in the DaemonSet
       podLabels: {}
+      ## Additional annotations for pods in the DaemonSet
+      podAnnotations: {}
       resources: {}
         # limits:
         #   cpu: 200m
@@ -1245,6 +1266,8 @@ otelcol:
         cpu: "200m"
     ## Add custom labels only to otelcol deployment.
     podLabels: {}
+    ## Add custom annotations only to otelcol deployment.
+    podAnnotations: {}
     # Memory Ballast size should be max 1/3 to 1/2 of memory.
     memBallastSizeMib: "683"
     image:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -17,10 +17,10 @@ sumologic:
   #envFromSecret: sumo-api-secret
 
   # Sumo access ID
-  #accessId: ""
+  accessId: "X"
 
   # Sumo access key
-  #accessKey: ""
+  accessKey: "X"
 
   # Sumo API endpoint; Leave blank for automatic endpoint discovery and redirection
   # ref: https://help.sumologic.com/APIs/General-API-Information/Sumo-Logic-Endpoints-and-Firewall-Security


### PR DESCRIPTION
###### Description

Allow custom pod annotations in helm chart

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
