### PR TITLE
Add customLabels for kube-state-metrics

### DIFF
--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -60,26 +60,28 @@ prometheusOperator:
     enabled: false
   tlsProxy:
     enabled: false
-  ## Resource limits for kube-state-metrics
-  kube-state-metrics:
-    resources: {}
-    # limits:
-    #   cpu: 200m
-    #   memory: 200Mi
-    # requests:
-    #   cpu: 200m
-    #   memory: 200Mi
-  ## Resource limits for prometheus node exporter
-  prometheus-node-exporter:
-    ## Additional labels for pods in the DaemonSet
-    podLabels: {}
-    resources: {}
-    # limits:
-    #   cpu: 200m
-    #   memory: 50Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 30Mi
+## Resource limits for kube-state-metrics
+kube-state-metrics:
+  ## Custom labels to apply to service, deployment and pods
+  customLabels: {}
+  resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 64Mi
+  # requests:
+  #   cpu: 10m
+  #   memory: 32Mi
+## Resource limits for prometheus node exporter
+prometheus-node-exporter:
+  ## Additional labels for pods in the DaemonSet
+  podLabels: {}
+  resources: {}
+  # limits:
+  #   cpu: 200m
+  #   memory: 50Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 30Mi
 prometheus:
   additionalServiceMonitors:
     - name: collection-sumologic-fluentd-logs

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -828,26 +828,28 @@ prometheus-operator:
       enabled: false
     tlsProxy:
       enabled: false
-    ## Resource limits for kube-state-metrics
-    kube-state-metrics:
-      resources: {}
-        # limits:
-        #   cpu: 200m
-        #   memory: 200Mi
-        # requests:
-        #   cpu: 200m
-        #   memory: 200Mi
-    ## Resource limits for prometheus node exporter
-    prometheus-node-exporter:
-      ## Additional labels for pods in the DaemonSet
-      podLabels: {}
-      resources: {}
-        # limits:
-        #   cpu: 200m
-        #   memory: 50Mi
-        # requests:
-        #   cpu: 100m
-        #   memory: 30Mi
+  ## Resource limits for kube-state-metrics
+  kube-state-metrics:
+    ## Custom labels to apply to service, deployment and pods
+    customLabels: {}
+    resources: {}
+      # limits:
+      #   cpu: 100m
+      #   memory: 64Mi
+      # requests:
+      #   cpu: 10m
+      #   memory: 32Mi
+  ## Resource limits for prometheus node exporter
+  prometheus-node-exporter:
+    ## Additional labels for pods in the DaemonSet
+    podLabels: {}
+    resources: {}
+      # limits:
+      #   cpu: 200m
+      #   memory: 50Mi
+      # requests:
+      #   cpu: 100m
+      #   memory: 30Mi
   prometheus:
     additionalServiceMonitors:
       - name: collection-sumologic-fluentd-logs


### PR DESCRIPTION
###### Description

- Add custom labels for `kube-state-metrics`.
- Fixed the indentation for `prometheus-node-exporter` and `kube-state-metrics`

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
