### PR TITLE
Add ignore_older documentation

### DIFF
--- a/deploy/helm/fluent-bit-overrides.yaml
+++ b/deploy/helm/fluent-bit-overrides.yaml
@@ -69,7 +69,7 @@ rawConfig: |-
     Skip_Long_Lines  On
     DB               /tail-db/tail-containers-state-sumo.db
     DB.Sync          Normal
-    Ignore_Older     24h
+
   [INPUT]
     Name            systemd
     Tag             host.*

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -697,7 +697,7 @@ fluent-bit:
       Skip_Long_Lines  On
       DB               /tail-db/tail-containers-state-sumo.db
       DB.Sync          Normal
-      Ignore_Older     24h
+
     [INPUT]
       Name            systemd
       Tag             host.*


### PR DESCRIPTION
###### Description

- Add documentation to configure `Ignore_Older` parameter
- Remove setting `Ignore_Older` by default in `values.yaml` file

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
