### PR TITLE
expose extra conf for fluentd in_forward

### DIFF
--- a/deploy/helm/sumologic/conf/logs/logs.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.conf
@@ -2,6 +2,7 @@
   @type forward
   port 24321
   bind 0.0.0.0
+{{- .Values.fluentd.logs.input.forwardExtraConf | nindent 4 }}
 </source>
 @include logs.source.containers.conf
 @include logs.source.systemd.conf

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -292,6 +292,12 @@ fluentd:
       @include common.conf
       @include logs.conf
 
+    ## Configuration for the forward input plugin that receives logs from FluentBit
+    ## ref: https://docs.fluentd.org/input/forward
+    input:
+      ## Use to specify additional config, including transport or security options.
+      forwardExtraConf: |-
+
     ## Configuration for sumologic output plugin
     ## ref: https://github.com/SumoLogic/fluentd-output-sumologic
     ## ref: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/master/deploy/helm/sumologic/conf/logs/logs.output.conf

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -62,6 +62,7 @@ data:
       @type forward
       port 24321
       bind 0.0.0.0
+      
     </source>
     @include logs.source.containers.conf
     @include logs.source.systemd.conf


### PR DESCRIPTION
###### Description

Allows the user to specify additional forward plugin config in fluentd for TLS, security, etc.

###### Testing performed

- [x] ran `helm template` with sample config to verify configmap is generated correctly.
