### PR TITLE
Fixing the indentation of the processing rule example

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -122,12 +122,12 @@ sumologic:
       default:
         name: logs
         config-name: endpoint-logs
-        # properties can be used to extend default settings, such as processing rules, fields etc
-        #properties:
-          #filters:
-            #- name: "Test Exclude Debug"
-            #filter_type: "Exclude"
-            #regexp: ".*DEBUG.*"
+       # properties can be used to extend default settings, such as processing rules, fields etc
+       # properties:
+         # filters:
+           # - name: "Test Exclude Debug"
+           #   filter_type: "Exclude"
+           #   regexp: ".*DEBUG.*"
     events:
       default:
         name: events


### PR DESCRIPTION
###### Description
The indentation was little off and therefore on uncommenting the code and doing helm upgrade, it was giving the YAML file error.

Fill in your description here.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
