### PR TITLE
fix podLabels

### DIFF
--- a/deploy/helm/sumologic/templates/events-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/events-statefulset.yaml
@@ -10,15 +10,6 @@ spec:
   selector:
     matchLabels:
       app: {{ template "sumologic.labels.app.events.pod" . }}
-{{- if .Values.sumologic.podLabels }}
-{{ toYaml .Values.sumologic.podLabels | indent 6 }}
-{{- end }}
-{{- if .Values.fluentd.podLabels }}
-{{ toYaml .Values.fluentd.podLabels | indent 6 }}
-{{- end }}
-{{- if .Values.fluentd.events.statefulset.podLabels }}
-{{ toYaml .Values.fluentd.events.statefulset.podLabels | indent 6 }}
-{{- end }}
   serviceName: {{ template "sumologic.metadata.name.events.service-headless" . }}
   podManagementPolicy: "Parallel"
   template:

--- a/deploy/helm/sumologic/templates/metrics-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics-statefulset.yaml
@@ -10,15 +10,6 @@ spec:
   selector:
     matchLabels:
       app: {{ template "sumologic.labels.app.metrics.pod" . }}
-{{- if .Values.sumologic.podLabels }}
-{{ toYaml .Values.sumologic.podLabels | indent 6 }}
-{{- end }}
-{{- if .Values.fluentd.podLabels }}
-{{ toYaml .Values.fluentd.podLabels | indent 6 }}
-{{- end }}
-{{- if .Values.fluentd.metrics.statefulset.podLabels }}
-{{ toYaml .Values.fluentd.metrics.statefulset.podLabels | indent 6 }}
-{{- end }}
   serviceName: {{ template "sumologic.metadata.name.metrics.service-headless" . }}
   podManagementPolicy: "Parallel"
   replicas: {{ .Values.fluentd.metrics.statefulset.replicaCount }}

--- a/deploy/helm/sumologic/templates/setup/setup-job.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-job.yaml
@@ -12,14 +12,16 @@ metadata:
   labels:
     app: {{ template "sumologic.labels.app.setup.job" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
-{{- if .Values.sumologic.podLabels }}
-{{ toYaml .Values.sumologic.podLabels | indent 4 }}
-{{- end }}
-{{- if .Values.sumologic.setup.job.podLabels }}
-{{ toYaml .Values.sumologic.setup.job.podLabels | indent 4 }}
-{{- end }}
 spec:
   template:
+    metadata:
+      labels:
+{{- if .Values.sumologic.podLabels }}
+{{ toYaml .Values.sumologic.podLabels | indent 8 }}
+{{- end }}
+{{- if .Values.sumologic.setup.job.podLabels }}
+{{ toYaml .Values.sumologic.setup.job.podLabels | indent 8 }}
+{{- end }}
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ template "sumologic.metadata.name.setup.roles.serviceaccount" . }}

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -10,15 +10,6 @@ spec:
   selector:
     matchLabels:
       app: {{ template "sumologic.labels.app.logs.pod" . }}
-{{- if .Values.sumologic.podLabels }}
-{{ toYaml .Values.sumologic.podLabels | indent 6 }}
-{{- end }}
-{{- if .Values.fluentd.podLabels }}
-{{ toYaml .Values.fluentd.podLabels | indent 6 }}
-{{- end }}
-{{- if .Values.fluentd.logs.statefulset.podLabels }}
-{{ toYaml .Values.fluentd.logs.statefulset.podLabels | indent 6 }}
-{{- end }}
   serviceName: {{ template "sumologic.metadata.name.logs.service-headless" . }}
   podManagementPolicy: "Parallel"
   replicas: {{ .Values.fluentd.logs.statefulset.replicaCount }}

--- a/deploy/kubernetes/setup-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/setup-sumologic.yaml.tmpl
@@ -252,6 +252,8 @@ metadata:
     
 spec:
   template:
+    metadata:
+      labels:
     spec:
       restartPolicy: OnFailure
       serviceAccountName: collection-sumologic-setup


### PR DESCRIPTION
###### Description

- add labels to `template.metadata` for setup job
- remove labels from the `selector` for all the sts as `updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden`

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
- [X] Verified labels are being added to setup pods as well as sts pods.