### PR TITLE
Fix incorrectly indented podAnnotations

### DIFF
--- a/deploy/helm/sumologic/templates/events-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/events-statefulset.yaml
@@ -16,13 +16,13 @@ spec:
     metadata:
       annotations:
 {{- if .Values.sumologic.podAnnotations }}
-{{ toYaml .Values.sumologic.podAnnotations | indent 6 }}
+{{ toYaml .Values.sumologic.podAnnotations | indent 8 }}
 {{- end }}
 {{- if .Values.fluentd.podAnnotations }}
-{{ toYaml .Values.fluentd.podAnnotations | indent 6 }}
+{{ toYaml .Values.fluentd.podAnnotations | indent 8 }}
 {{- end }}
 {{- if .Values.fluentd.events.statefulset.podAnnotations }}
-{{ toYaml .Values.fluentd.events.statefulset.podAnnotations | indent 6 }}
+{{ toYaml .Values.fluentd.events.statefulset.podAnnotations | indent 8 }}
 {{- end }}
       labels:
         app: {{ template "sumologic.labels.app.events.pod" . }}

--- a/deploy/helm/sumologic/templates/metrics-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics-statefulset.yaml
@@ -17,13 +17,13 @@ spec:
     metadata:
       annotations:
 {{- if .Values.sumologic.podAnnotations }}
-{{ toYaml .Values.sumologic.podAnnotations | indent 6 }}
+{{ toYaml .Values.sumologic.podAnnotations | indent 8 }}
 {{- end }}
 {{- if .Values.fluentd.podAnnotations }}
-{{ toYaml .Values.fluentd.podAnnotations | indent 6 }}
+{{ toYaml .Values.fluentd.podAnnotations | indent 8 }}
 {{- end }}
 {{- if .Values.fluentd.metrics.statefulset.podAnnotations }}
-{{ toYaml .Values.fluentd.metrics.statefulset.podAnnotations | indent 6 }}
+{{ toYaml .Values.fluentd.metrics.statefulset.podAnnotations | indent 8 }}
 {{- end }}
       labels:
         app: {{ template "sumologic.labels.app.metrics.pod" . }}

--- a/deploy/helm/sumologic/templates/otelcol-deployment.yaml
+++ b/deploy/helm/sumologic/templates/otelcol-deployment.yaml
@@ -23,10 +23,10 @@ spec:
     metadata:
       annotations:
 {{- if .Values.sumologic.podAnnotations }}
-{{ toYaml .Values.sumologic.podAnnotations | indent 6 }}
+{{ toYaml .Values.sumologic.podAnnotations | indent 8 }}
 {{- end }}
 {{- if .Values.otelcol.deployment.podAnnotations }}
-{{ toYaml .Values.otelcol.deployment.podAnnotations | indent 6 }}
+{{ toYaml .Values.otelcol.deployment.podAnnotations | indent 8 }}
 {{- end }}
       labels:
         app: {{ template "sumologic.labels.app.otelcol.pod" . }}

--- a/deploy/helm/sumologic/templates/setup/setup-job.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-job.yaml
@@ -4,17 +4,20 @@ kind: Job
 metadata:
   name: {{ template "sumologic.metadata.name.setup.job" . }}
   namespace: {{ .Release.Namespace }}
-  annotations:
-{{ include "sumologic.annotations.app.setup.helmsh" "3" | indent 4 }}
-{{- if .Values.sumologic.podAnnotations }}
-{{ toYaml .Values.sumologic.podAnnotations | indent 2 }}
-{{- end }}
   labels:
     app: {{ template "sumologic.labels.app.setup.job" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   template:
     metadata:
+      annotations:
+{{ include "sumologic.annotations.app.setup.helmsh" "3" | indent 8 }}
+{{- if .Values.sumologic.podAnnotations }}
+{{ toYaml .Values.sumologic.podAnnotations | indent 8 }}
+{{- end }}
+{{- if .Values.sumologic.setup.job.podAnnotations }}
+{{ toYaml .Values.sumologic.setup.job.podAnnotations | indent 8 }}
+{{- end }}
       labels:
 {{- if .Values.sumologic.podLabels }}
 {{ toYaml .Values.sumologic.podLabels | indent 8 }}

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -17,13 +17,13 @@ spec:
     metadata:
       annotations:
 {{- if .Values.sumologic.podAnnotations }}
-{{ toYaml .Values.sumologic.podAnnotations | indent 6 }}
+{{ toYaml .Values.sumologic.podAnnotations | indent 8 }}
 {{- end }}
 {{- if .Values.fluentd.podAnnotations }}
-{{ toYaml .Values.fluentd.podAnnotations | indent 6 }}
+{{ toYaml .Values.fluentd.podAnnotations | indent 8 }}
 {{- end }}
 {{- if .Values.fluentd.logs.statefulset.podAnnotations }}
-{{ toYaml .Values.fluentd.logs.statefulset.podAnnotations | indent 6 }}
+{{ toYaml .Values.fluentd.logs.statefulset.podAnnotations | indent 8 }}
 {{- end }}
       labels:
         app: {{ template "sumologic.labels.app.logs.pod" . }}


### PR DESCRIPTION
###### Description

Previously add `podAnnotations` weren't properly indented everywhere producing things like:

```
# Source: sumologic/templates/setup/setup-job.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: RELEASE-NAME-sumologic-setup
  namespace: default
  annotations:
    helm.sh/hook: pre-install,pre-upgrade
    helm.sh/hook-weight: "3"
    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
  annotationforall: value1 ## <--- This should be indented with 2 more spaces
  labels:
    app: RELEASE-NAME-sumologic
    chart: "sumologic-1.2.0-beta.1"
    release: "RELEASE-NAME"
    heritage: "Helm"
spec:
  template:
    metadata:
      labels:
    spec:
...
```

This PR addresses that.

Additionally it fixes annotations in `deploy/helm/sumologic/templates/setup/setup-job.yaml` by moving it from `metadata.annotations` to `metadata.spec.template.metadata.annotations`.

To test the solution, I've perfomed not `helm template` as before which doesn't validate the yaml against the cluster but with `helm template --validate` to check the templates and yaml against the running k8s cluster.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
