### PR TITLE
Last fixes for values.yaml

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -444,11 +444,11 @@ fluentd:
 
     ## Extra Environment Values - allows yaml definitions
     # extraEnvVars:
-    #  - name: VALUE_FROM_SECRET
-    #    valueFrom:
-    #      secretKeyRef:
-    #        name: secret_name
-    #        key: secret_key
+    #   - name: VALUE_FROM_SECRET
+    #     valueFrom:
+    #       secretKeyRef:
+    #         name: secret_name
+    #         key: secret_key
 
     # extraVolumes:
     #   - name: es-certs
@@ -509,11 +509,11 @@ fluentd:
 
     ## Extra Environment Values - allows yaml definitions
     # extraEnvVars:
-    #  - name: VALUE_FROM_SECRET
-    #    valueFrom:
-    #      secretKeyRef:
-    #        name: secret_name
-    #        key: secret_key
+    #   - name: VALUE_FROM_SECRET
+    #     valueFrom:
+    #       secretKeyRef:
+    #         name: secret_name
+    #         key: secret_key
 
     # extraVolumes:
     #   - name: es-certs
@@ -601,11 +601,11 @@ fluentd:
 
     ## Extra Environment Values - allows yaml definitions
     # extraEnvVars:
-    #  - name: VALUE_FROM_SECRET
-    #    valueFrom:
-    #      secretKeyRef:
-    #        name: secret_name
-    #        key: secret_key
+    #   - name: VALUE_FROM_SECRET
+    #     valueFrom:
+    #       secretKeyRef:
+    #         name: secret_name
+    #         key: secret_key
 
     # extraVolumes:
     #   - name: es-certs


### PR DESCRIPTION
###### Description

Some gold-plating for values.yaml:

* Fix: start text comments with two hash characters - leftovers after c9233bd6e85ebe5c18a847f89644d9b16fd6d51b
* Fix indentation for extraEnvVars examples

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
