### PR TITLE
Fix broken setup job helm.sh annotations

### DIFF
--- a/deploy/helm/sumologic/templates/setup/setup-job.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-job.yaml
@@ -4,6 +4,8 @@ kind: Job
 metadata:
   name: {{ template "sumologic.metadata.name.setup.job" . }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+{{ include "sumologic.annotations.app.setup.helmsh" "3" | indent 4 }}
   labels:
     app: {{ template "sumologic.labels.app.setup.job" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
@@ -11,7 +13,6 @@ spec:
   template:
     metadata:
       annotations:
-{{ include "sumologic.annotations.app.setup.helmsh" "3" | indent 8 }}
 {{- if .Values.sumologic.podAnnotations }}
 {{ toYaml .Values.sumologic.podAnnotations | indent 8 }}
 {{- end }}

--- a/deploy/kubernetes/setup-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/setup-sumologic.yaml.tmpl
@@ -243,6 +243,10 @@ kind: Job
 metadata:
   name: collection-sumologic-setup
   namespace: $NAMESPACE
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "3"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     app: collection-sumologic
     
@@ -250,9 +254,6 @@ spec:
   template:
     metadata:
       annotations:
-        helm.sh/hook: pre-install,pre-upgrade
-        helm.sh/hook-weight: "3"
-        helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
       labels:
     spec:
       restartPolicy: OnFailure


### PR DESCRIPTION
###### Description

It seems that [previous PR](https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/843) managed to break setup-job by moving the helm.sh annotations to pod spec. This PR address that.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
