### PR TITLE
Allow custom pod annotations for kube-state and prometheus

### DIFF
--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -66,6 +66,8 @@ prometheusOperator:
 kube-state-metrics:
   ## Custom labels to apply to service, deployment and pods
   customLabels: {}
+  ## Additional annotations for pods in the DaemonSet
+  podAnnotations: {}
   resources: {}
   # limits:
   #   cpu: 100m
@@ -148,6 +150,10 @@ prometheus:
     ## Prometheus default scrape interval, default from upstream Prometheus Operator Helm chart
     ## NOTE changing the scrape interval to be >1m can result in metrics from recording rules to be missing and empty panels in Sumo Logic Kubernetes apps.
     scrapeInterval: "30s"
+    ## Add custom pod annotations and labels to prometheus pods
+    podMetadata:
+      labels: {}
+      annotations: {}
     ## Define resources requests and limits for single Pods.
     resources: {}
     # limits:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -838,6 +838,8 @@ prometheus-operator:
   kube-state-metrics:
     ## Custom labels to apply to service, deployment and pods
     customLabels: {}
+    ## Additional annotations for pods in the DaemonSet
+    podAnnotations: {}
     resources: {}
       # limits:
       #   cpu: 100m
@@ -920,6 +922,10 @@ prometheus-operator:
       ## Prometheus default scrape interval, default from upstream Prometheus Operator Helm chart
       ## NOTE changing the scrape interval to be >1m can result in metrics from recording rules to be missing and empty panels in Sumo Logic Kubernetes apps.
       scrapeInterval: "30s"
+      ## Add custom pod annotations and labels to prometheus pods
+      podMetadata:
+        labels: {}
+        annotations: {}
       ## Define resources requests and limits for single Pods.
       resources: {}
       # limits:


### PR DESCRIPTION
###### Description

This PR adds possibility to add custom:
* annotations for `kube-state` pods (as described in https://github.com/helm/charts/tree/master/stable/kube-state-metrics#configuration) 
* annotations and labels for `prometheus` pods (as described in https://github.com/helm/charts/tree/master/stable/prometheus-operator#prometheus)

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
