### PR TITLE
Set text compress as default

### DIFF
--- a/deploy/docs/v1_conf_examples.md
+++ b/deploy/docs/v1_conf_examples.md
@@ -136,7 +136,7 @@ fluentd:
 The following config parameters are set by default and their values can be set by changing the respective config in `values.yaml`. 
 
 ```bash
-compress gzip
+compress {{ .Values.fluentd.buffer.compress | quote }}
 flush_interval {{ .Values.fluentd.buffer.flushInterval | quote }}
 flush_thread_count {{ .Values.fluentd.buffer.numThreads | quote }}
 chunk_limit_size {{ .Values.fluentd.buffer.chunkLimitSize | quote }}

--- a/deploy/helm/sumologic/conf/buffer.output.conf
+++ b/deploy/helm/sumologic/conf/buffer.output.conf
@@ -1,4 +1,4 @@
-compress gzip
+compress {{ .Values.fluentd.buffer.compress | quote }}
 flush_interval {{ .Values.fluentd.buffer.flushInterval | quote }}
 flush_thread_count {{ .Values.fluentd.buffer.numThreads | quote }}
 chunk_limit_size {{ .Values.fluentd.buffer.chunkLimitSize | quote }}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -211,6 +211,9 @@ fluentd:
     totalLimitSize: "128m"
     retryMaxInterval: "10m"
     retryForever: true
+    ## usage of the gzip compression is highly not recommended due to fluentd issue:
+    ## rel: https://github.com/fluent/fluentd/issues/3056
+    compress: text
 
     ## File paths to buffer to, if Fluentd buffer type is specified as file above.
     ## Each sumologic output plugin buffers to its own unique file.

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -24,7 +24,7 @@ data:
     @include common.conf
     @include logs.conf
   buffer.output.conf: |-
-    compress gzip
+    compress "text"
     flush_interval "5s"
     flush_thread_count "8"
     chunk_limit_size "1m"
@@ -323,7 +323,7 @@ data:
     </system>
   
   buffer.output.conf: |-
-    compress gzip
+    compress "text"
     flush_interval "5s"
     flush_thread_count "8"
     chunk_limit_size "1m"
@@ -349,7 +349,7 @@ data:
     @include common.conf
     @include metrics.conf
   buffer.output.conf: |-
-    compress gzip
+    compress "text"
     flush_interval "5s"
     flush_thread_count "8"
     chunk_limit_size "1m"


### PR DESCRIPTION
###### Description

Set text compress as default due to https://github.com/fluent/fluentd/issues/3110

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
