### PR TITLE
Use variables in documentation for additional prometheus metrics

### DIFF
--- a/deploy/docs/additional_prometheus_configuration.md
+++ b/deploy/docs/additional_prometheus_configuration.md
@@ -19,7 +19,7 @@ prometheus-operator:  # For values.yaml
         # ...
         remoteWrite:
           # ...
-          - url: http://collection-sumologic.sumologic.svc.cluster.local/prometheus.metrics.<some_label>
+          - url: http://$(CHART).$(NAMESPACE).svc.cluster.local/prometheus.metrics.<some_label>
             writeRelabelConfigs:
             - action: keep
               regex: <metric1>|<metric2>|...
@@ -214,7 +214,7 @@ prometheus-operator:  # For values.yaml
         # ...
         remoteWrite:
           # ...
-          - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.YOUR_TAG
+          - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.YOUR_TAG
             writeRelabelConfigs:
             - action: keep
               regex: <YOUR_CUSTOM_MATCHER>
@@ -232,7 +232,7 @@ prometheus-operator:  # For values.yaml
         # ...
         remoteWrite:
           # ...
-          - url: http://collection-sumologic.sumologic.svc.cluster.local:9888/prometheus.metrics.YOUR_TAG
+          - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.YOUR_TAG
             writeRelabelConfigs:
             - action: keep
               regex: 'example-metrics'


### PR DESCRIPTION
###### Description

Use variables in documentation for additional prometheus metrics. The current service name used in the docs is out of date

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
