### PR TITLE
Scrap metrics from pods basing on annotations

### DIFF
--- a/deploy/docs/additional_prometheus_configuration.md
+++ b/deploy/docs/additional_prometheus_configuration.md
@@ -71,6 +71,8 @@ There are many pre-built libraries that the community has built to expose these,
 
 ### Set up a service monitor so that Prometheus pulls the data
 
+#### ServiceMonitor
+
 To expose metrics to prometheus, you need to have some service. Let's say here is our example service configuration:
 
 ```yaml
@@ -146,6 +148,20 @@ prometheus-operator:  # For values.yaml
           matchLabels:
             app: example-metrics
 ```
+
+#### Annotations
+
+Alternatively to Service and ServiceMonitor you can use dedicated annotations in your pod:
+
+```yaml
+# ...
+annotations:
+  prometheus.io/port: 8000 # Port which metrics should be scraped from
+  prometheus.io/scrape: true # Set if metrics should be scraped from this pod
+  prometheus.io/path: "/metrics" # Path which metrics should be scraped from
+```
+
+**Note: This solution works only to scrape metrics from one container within the pod**
 
 ### Create a new HTTP source in Sumo Logic.
 

--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -180,6 +180,70 @@ prometheus:
             key: fluentdNamespace
     ## Enable WAL compression to reduce Prometheus memory consumption
     walCompression: true
+    ## prometheus scrape config
+    additionalScrapeConfigs:
+    - ## scraping metrics basing on annotations:
+      ##   - prometheus.io/scrape: true - to scrape metrics from the pod
+      ##   - prometheus.io/path: /metrics - path which the metric should be scrape from
+      ##   - prometheus.io/port: 9113 - port which the metric should be scrape from
+      ## rel: https://github.com/prometheus-operator/kube-prometheus/pull/16#issuecomment-424318647
+      job_name: 'kubernetes-pods'
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+        action: keep
+        regex: true
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+        action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        target_label: __address__
+      - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
+        separator: ;
+        regex: Node;(.*)
+        target_label: node
+        replacement: ${1}
+        action: replace
+      - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
+        separator: ;
+        regex: Pod;(.*)
+        target_label: pod
+        replacement: ${1}
+        action: replace
+      - source_labels: [__metrics_path__]
+        separator: ;
+        regex: (.*)
+        target_label: endpoint
+        replacement: $1
+        action: replace
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - source_labels: [__meta_kubernetes_service_name]
+        separator: ;
+        regex: (.*)
+        target_label: service
+        replacement: $1
+        action: replace
+      - source_labels: [__meta_kubernetes_pod_name]
+        separator: ;
+        regex: (.*)
+        target_label: pod
+        replacement: $1
+        action: replace
+      - source_labels: [__meta_kubernetes_service_name]
+        separator: ;
+        regex: (.*)
+        target_label: job
+        replacement: ${1}
+        action: replace
     remoteWrite:
     - ## kube non pod state metrics
       ## kube_daemonset_status_current_number_scheduled

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -974,6 +974,71 @@ prometheus-operator:
       ## Enable WAL compression to reduce Prometheus memory consumption
       walCompression: true
 
+      ## prometheus scrape config
+      additionalScrapeConfigs:
+        ## scraping metrics basing on annotations:
+        ##   - prometheus.io/scrape: true - to scrape metrics from the pod
+        ##   - prometheus.io/path: /metrics - path which the metric should be scrape from
+        ##   - prometheus.io/port: 9113 - port which the metric should be scrape from
+        ## rel: https://github.com/prometheus-operator/kube-prometheus/pull/16#issuecomment-424318647
+        - job_name: 'kubernetes-pods'
+          kubernetes_sd_configs:
+          - role: pod
+          relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+            action: keep
+            regex: true
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+            action: replace
+            target_label: __metrics_path__
+            regex: (.+)
+          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+            action: replace
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: $1:$2
+            target_label: __address__
+          - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
+            separator: ;
+            regex: Node;(.*)
+            target_label: node
+            replacement: ${1}
+            action: replace
+          - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
+            separator: ;
+            regex: Pod;(.*)
+            target_label: pod
+            replacement: ${1}
+            action: replace
+          - source_labels: [__metrics_path__]
+            separator: ;
+            regex: (.*)
+            target_label: endpoint
+            replacement: $1
+            action: replace
+          - source_labels: [__meta_kubernetes_namespace]
+            action: replace
+            target_label: namespace
+          - action: labelmap
+            regex: __meta_kubernetes_pod_label_(.+)
+          - source_labels: [__meta_kubernetes_service_name]
+            separator: ;
+            regex: (.*)
+            target_label: service
+            replacement: $1
+            action: replace
+          - source_labels: [__meta_kubernetes_pod_name]
+            separator: ;
+            regex: (.*)
+            target_label: pod
+            replacement: $1
+            action: replace
+          - source_labels: [__meta_kubernetes_service_name]
+            separator: ;
+            regex: (.*)
+            target_label: job
+            replacement: ${1}
+            action: replace
+
       remoteWrite:
         ## kube non pod state metrics
         ## kube_daemonset_status_current_number_scheduled


### PR DESCRIPTION
###### Description

Scrap metrics from pods basing on annotations

rel: https://github.com/prometheus-operator/kube-prometheus/pull/16#issuecomment-424318647
rel: https://github.com/prometheus/prometheus/pull/4131

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
