### PR TITLE
attach node metadata to metrics when not present

### DIFF
--- a/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
@@ -85,6 +85,10 @@ module Fluent
           service = @pods_to_services[pod_name]
           metadata['service'] = {'service' => service.sort!.join('_')} if !(service.nil? || service.empty?)
 
+          if @data_type == 'metrics' && (record['node'].nil? || record['node'] == "")
+            record['node'] = metadata['node']
+          end
+
           ['pod_labels', 'owners', 'service'].each do |metadata_type|
             attachment = metadata[metadata_type]
             if attachment.nil? || attachment.empty?

--- a/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/reader.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/reader.rb
@@ -24,6 +24,9 @@ module SumoLogic
         labels = pod['metadata']['labels']
         metadata['pod_labels'] = {'pod_labels' => labels} if labels.is_a?(Hash)
 
+        node = pod['spec']['nodeName']
+        metadata['node'] = node
+
         owners = fetch_pod_owners(namespace, pod)
         metadata['owners'] = owners if owners.is_a?(Hash)
         metadata

--- a/fluent-plugin-enhance-k8s-metadata/test/plugin/test_filter_enhance_k8s_metadata.rb
+++ b/fluent-plugin-enhance-k8s-metadata/test/plugin/test_filter_enhance_k8s_metadata.rb
@@ -4,6 +4,8 @@ require 'fluent/plugin/filter_enhance_k8s_metadata.rb'
 class EnhanceK8sMetadataFilterTest < Test::Unit::TestCase
   setup do
     Fluent::Test.setup
+    stub_apis
+    @pods_to_services = Concurrent::Map.new {|h, k| h[k] = []}
   end
 
   test 'create driver' do
@@ -13,9 +15,63 @@ class EnhanceK8sMetadataFilterTest < Test::Unit::TestCase
     create_driver(conf)
   end
 
+  sub_test_case 'filter' do
+    test 'get deployment and replicaset for logs' do
+      conf = %{
+        kubernetes_url http://localhost:8080
+        in_namespace_path '$.kubernetes.namespace_name'
+        in_pod_path '$.kubernetes.pod_name'
+        data_type logs
+      }
+      driver = create_driver(conf)
+      record = driver.filter('tag', 'time', get_test_record[0])
+
+      assert_equal 'curl-byi-5bf5d48c57', record['kubernetes']['replicaset']
+      assert_equal 'curl-byi', record['kubernetes']['deployment']
+    end
+
+    test 'get deployment and replicaset and pod labels for metrics' do
+      conf = %{
+        kubernetes_url http://localhost:8080
+        data_type metrics
+      }
+      driver = create_driver(conf)
+      record = driver.filter('tag', 'time', get_test_record[1])
+
+      expected_pod_labels = {"pod-template-hash": "1691804713", "run": "curl-byi"}
+      assert_equal expected_pod_labels.keys.length, record['pod_labels'].keys.length
+      record['pod_labels'].each do |k,v|
+        assert_equal expected_pod_labels[k.to_sym], v
+      end
+
+      assert_equal 'curl-byi-5bf5d48c57', record['replicaset']
+      assert_equal 'curl-byi', record['deployment']
+    end
+
+    test 'attach node metadata to metrics when missing' do
+      conf = %{
+        kubernetes_url http://localhost:8080
+        data_type metrics
+      }
+      driver = create_driver(conf)
+
+      input_record = get_test_record[2]
+      assert_nil input_record['node']
+      record = driver.filter('tag', 'time', input_record)
+
+      assert_equal 'ip-172-20-62-242.us-west-1.compute.internal', record['node']
+    end
+  end
+
   private
 
   def create_driver(conf)
-    Fluent::Test::Driver::Filter.new(Fluent::Plugin::EnhanceK8sMetadataFilter).configure(conf)
+    driver = Fluent::Test::Driver::Filter.new(Fluent::Plugin::EnhanceK8sMetadataFilter).configure(conf).instance
+    driver.instance_variable_set(:@pods_to_services, @pods_to_services)
+    driver
+  end
+
+  def get_test_record
+    JSON.parse(File.read("test/resources/records.json"))['items']
   end
 end

--- a/fluent-plugin-enhance-k8s-metadata/test/resources/records.json
+++ b/fluent-plugin-enhance-k8s-metadata/test/resources/records.json
@@ -1,0 +1,51 @@
+{
+  "items": [
+    {
+      "log": "2015/05/05 19:54:41 \n",
+      "stream": "stderr",
+      "docker": {
+        "id": "f1a679204d61d444e60bbd8752be6f204b2d8902ff50e57db34021252847686d"
+      },
+      "kubernetes": {
+        "host": "ip-172-20-62-242.us-west-1.compute.internal",
+        "pod_name":"curl-byi-5bf5d48c57-74ffs",
+        "pod_id": "1a1e5ad4-7818-11e9-90f1-02324f7e0d1e",
+        "container_name": "curl-byi",
+        "namespace_name": "sumologic",
+        "labels": {
+          "pod-template-hash": "1691804713",
+          "run": "curl-byi"
+        }
+      }
+    },
+    {
+      "endpoint": "http-metrics",
+      "handler": "prometheus",
+      "instance": "172.20.36.191:10251",
+      "job": "kube-scheduler",
+      "namespace": "sumologic",
+      "node": "ip-172-20-62-242.us-west-1.compute.internal",
+      "pod": "curl-byi-5bf5d48c57-74ffs",
+      "prometheus": "monitoring/prometheus-operator-prometheus",
+      "prometheus_replica": "prometheus-prometheus-operator-prometheus-0",
+      "service": "prometheus-operator-kube-scheduler",
+      "@metric": "http_request_size_bytes_sum",
+      "@timestamp": 1550862304339,
+      "@value": 1619905.0
+    },
+    {
+      "endpoint": "http-metrics",
+      "handler": "prometheus",
+      "instance": "172.20.36.191:10251",
+      "job": "kube-scheduler",
+      "namespace": "sumologic",
+      "pod": "curl-byi-5bf5d48c57-74ffs",
+      "prometheus": "monitoring/prometheus-operator-prometheus",
+      "prometheus_replica": "prometheus-prometheus-operator-prometheus-0",
+      "service": "prometheus-operator-kube-scheduler",
+      "@metric": "http_request_size_bytes_sum",
+      "@timestamp": 1550862304339,
+      "@value": 1619905.0
+    }
+  ]
+}


### PR DESCRIPTION
###### Description

Attach node metadata to metrics when it is not already present.

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
