### PR TITLE
retry creating kubeclients when error

### DIFF
--- a/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
@@ -47,7 +47,6 @@ module Fluent
       def configure(conf)
         super
         normalize_param
-        connect_kubernetes
         init_cache
         start_cache_timer
         @in_namespace_ac = @in_namespace_path.map { |path| record_accessor_create(path) }
@@ -56,6 +55,7 @@ module Fluent
 
       def start
         super
+        connect_kubernetes
         start_service_monitor
       end
 

--- a/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
@@ -47,6 +47,8 @@ module Fluent
       def configure(conf)
         super
         normalize_param
+        log.info "Initializing kubernetes API clients"
+        connect_kubernetes
         init_cache
         start_cache_timer
         @in_namespace_ac = @in_namespace_path.map { |path| record_accessor_create(path) }
@@ -55,7 +57,6 @@ module Fluent
 
       def start
         super
-        connect_kubernetes
         start_service_monitor
       end
 

--- a/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/connector.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/connector.rb
@@ -41,6 +41,7 @@ module SumoLogic
         client
       rescue StandardError => e
         log.error e
+        nil
       end
 
       def ssl_store

--- a/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/connector.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/connector.rb
@@ -24,24 +24,36 @@ module SumoLogic
       end
 
       def create_client(base, ver)
-        url = "#{@kubernetes_url}/#{base}"
-        log.info "create client with URL: #{url} and apiVersion: #{ver}"
-        client = Kubeclient::Client.new(
-          url,
-          ver,
-          ssl_options: ssl_options,
-          auth_options: auth_options,
-          as: :parsed,
-          timeouts: {
-            open: 5,
-            read: 5
-          }
-        )
-        client.api_valid?
-        client
-      rescue StandardError => e
-        log.error e
-        nil
+        retries = 0
+        begin
+          client = nil
+          unless client
+            url = "#{@kubernetes_url}/#{base}"
+            log.info "create client with URL: #{url} and apiVersion: #{ver}"
+            client = Kubeclient::Client.new(
+              url,
+              ver,
+              ssl_options: ssl_options,
+              auth_options: auth_options,
+              as: :parsed,
+              timeouts: {
+                open: 5,
+                read: 5
+              }
+            )
+            client.api_valid?
+          end
+          client
+        rescue StandardError => e
+          ## retry up to ~4 minutes
+          if (retries += 1) <= 7
+            log.error "Error creating client (#{e}), retrying in #{2 ** retries} second(s)..."
+            sleep(2 ** retries)
+            retry
+          else
+            raise
+          end
+        end
       end
 
       def ssl_store

--- a/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/reader.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/reader.rb
@@ -4,6 +4,8 @@ module SumoLogic
     module Reader
       require_relative 'connector.rb'
 
+      include SumoLogic::Kubernetes::Connector
+
       MAX_BFS_DEPTH = 8
 
       # from https://kubernetes.io/docs/reference/kubectl/overview/#resource-types
@@ -104,14 +106,17 @@ module SumoLogic
 
       def fetch_resource(type, name, namespace, api_version = 'v1')
         log.debug "fetching resource: #{type}, name: #{name}, ns:#{namespace} with API version #{api_version}"
-        if @clients.key?(api_version)
-          resource = @clients[api_version].get_entity(type, name, namespace)
-          log.debug resource.to_s
-          resource
-        else
-          log.warn "No client created for API #{api_version}"
-          nil
+        if !@clients.key?(api_version)
+          log.warn "No client created for API #{api_version}. Please add it to the core_api_versions or api_groups config."
+          return nil
         end
+        if @clients[api_version].nil?
+          log.warn "Client not initialized correctly for API #{api_version}. Attempting to recreate clients now."
+          connect_kubernetes
+        end
+        resource = @clients[api_version].get_entity(type, name, namespace)
+        log.debug resource.to_s
+        resource
       rescue Kubeclient::ResourceNotFoundError => e
         log.warn e
         nil

--- a/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/service_monitor.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/service_monitor.rb
@@ -12,10 +12,6 @@ module SumoLogic
         thread_create(:"watch_endpoints") {
           loop do
             log.debug "Making new watch_endpoints call"
-            if @clients['v1'].nil?
-              log.warn "Client not initialized correctly for API v1. Attempting to recreate clients now."
-              connect_kubernetes
-            end
             params = Hash.new
             params[:as] = :raw
             params[:resource_version] = get_current_service_snapshot_resource_version

--- a/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/service_monitor.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/service_monitor.rb
@@ -12,6 +12,10 @@ module SumoLogic
         thread_create(:"watch_endpoints") {
           loop do
             log.debug "Making new watch_endpoints call"
+            if @clients['v1'].nil?
+              log.warn "Client not initialized correctly for API v1. Attempting to recreate clients now."
+              connect_kubernetes
+            end
             params = Hash.new
             params[:as] = :raw
             params[:resource_version] = get_current_service_snapshot_resource_version

--- a/fluent-plugin-enhance-k8s-metadata/test/plugin/test_filter_enhance_k8s_metadata.rb
+++ b/fluent-plugin-enhance-k8s-metadata/test/plugin/test_filter_enhance_k8s_metadata.rb
@@ -7,7 +7,9 @@ class EnhanceK8sMetadataFilterTest < Test::Unit::TestCase
   end
 
   test 'create driver' do
-    conf = %([])
+    conf = %{
+      kubernetes_url http://localhost:8080
+    }
     create_driver(conf)
   end
 

--- a/fluent-plugin-events/lib/fluent/plugin/in_events.rb
+++ b/fluent-plugin-events/lib/fluent/plugin/in_events.rb
@@ -74,6 +74,11 @@ module Fluent
         now = Time.now.to_i
         watcher_exists = Thread.list.select {|thread| thread.object_id == @watcher_id && thread.alive?}.count > 0
         if now - @last_recreated >= @watch_interval_seconds || !watcher_exists
+
+          if @clients[@api_version].nil? || @clients['v1'].nil?
+            log.warn "Client not initialized correctly. Attempting to recreate clients now."
+            connect_kubernetes
+          end
           
           log.debug "Recreating watcher thread. Use resource version from latest snapshot if watcher is running"
           pull_resource_version if watcher_exists

--- a/fluent-plugin-events/lib/fluent/plugin/in_events.rb
+++ b/fluent-plugin-events/lib/fluent/plugin/in_events.rb
@@ -46,10 +46,12 @@ module Fluent
           if @type_selector.length > @valid_types.length || !@type_selector.any? || !@type_selector.all? {|type| @valid_types.any? {|valid| valid.casecmp?(type)}}
 
         normalize_param
-        connect_kubernetes
       end
 
       def start
+        log.info "Initializing kubernetes API clients"
+        connect_kubernetes
+
         log.info "Starting events collection for #{@resource_name}"
         
         super

--- a/fluent-plugin-events/lib/sumologic/kubernetes/connector.rb
+++ b/fluent-plugin-events/lib/sumologic/kubernetes/connector.rb
@@ -24,18 +24,30 @@ module SumoLogic
       end
 
       def create_client(base, ver)
-        url = "#{@kubernetes_url}/#{base}"
-        log.info "create client with URL: #{url} and apiVersion: #{ver}"
-        client = Kubeclient::Client.new(
-          url, ver,
-          ssl_options: ssl_options,
-          auth_options: auth_options
-        )
-        client.api_valid?
-        client
-      rescue Exception => e
-        log.error e
-        nil
+        retries = 0
+        begin
+          client = nil
+          unless client
+            url = "#{@kubernetes_url}/#{base}"
+            log.info "create client with URL: #{url} and apiVersion: #{ver}"
+            client = Kubeclient::Client.new(
+              url, ver,
+              ssl_options: ssl_options,
+              auth_options: auth_options
+            )
+            client.api_valid?
+          end
+          client
+        rescue StandardError => e
+          ## retry up to ~4 minutes
+          if (retries += 1) <= 7
+            log.error "Error creating client (#{e}), retrying in #{2 ** retries} second(s)..."
+            sleep(2 ** retries)
+            retry
+          else
+            raise
+          end
+        end
       end
 
       def connect_kubernetes

--- a/fluent-plugin-events/lib/sumologic/kubernetes/connector.rb
+++ b/fluent-plugin-events/lib/sumologic/kubernetes/connector.rb
@@ -35,6 +35,7 @@ module SumoLogic
         client
       rescue Exception => e
         log.error e
+        nil
       end
 
       def connect_kubernetes

--- a/fluent-plugin-events/test/plugin/test_in_events.rb
+++ b/fluent-plugin-events/test/plugin/test_in_events.rb
@@ -24,7 +24,8 @@ class EventsInputTest < Test::Unit::TestCase
     driver = Fluent::Test::Driver::Input.new(Fluent::Plugin::EventsInput).configure(conf)
   end
 
-  def configure_test_driver(config = %([]))
+  def configure_test_driver(config = %{})
+    config += %{kubernetes_url http://localhost:8080}
     driver = create_driver(config).instance
     connect_kubernetes_with_api_version(driver)
     driver.instance_variable_set(:@clients, @clients)
@@ -45,9 +46,9 @@ class EventsInputTest < Test::Unit::TestCase
   end
 
   test 'pull_resource_version correctly from eventlist with v1beta1 api version' do
-    config = %([
+    config = %{
       api_version "events.k8s.io/v1beta1"
-    ])
+    }
     driver = configure_test_driver(config)
     mock_get_events('api_list_events_v1beta1.json')
 
@@ -66,9 +67,9 @@ class EventsInputTest < Test::Unit::TestCase
   end
 
   test 'initialize_resource_version correctly for different client' do
-    config = %([
+    config = %{
       api_version "events.k8s.io/v1beta1"
-    ])
+    }
     driver = configure_test_driver(config)
     mock_get_config_map
 
@@ -93,9 +94,9 @@ class EventsInputTest < Test::Unit::TestCase
 
 
   test 'watch_events with customer defined type_selector' do
-    config = %([
+    config = %{
       type_selector ["ADDED", "MODIFIED", "DELETED"]
-    ])
+    }
     driver = configure_test_driver(config)
     mock_watch_events('api_watch_events_v1.txt')
 
@@ -110,28 +111,28 @@ class EventsInputTest < Test::Unit::TestCase
 
   test 'configuration error will be thrown if type_selector is invalid' do
     assert_raise Fluent::ConfigError do 
-      create_driver(%([
+      create_driver(%{
         type_selector ["ADDED", "MODIFIED", "DELETED", "BOOKED"]
-      ]))
+      })
     end
 
     assert_raise Fluent::ConfigError do
-      create_driver(%([
+      create_driver(%{
         type_selector ["ADDED", "MODIFIED", "INVALIDTYPE"]
-      ]))
+      })
     end
 
     assert_raise Fluent::ConfigError do
-      create_driver(%([
+      create_driver(%{
         type_selector []
-      ]))
+      })
     end
   end
 
   test 'watch other resources with default type_selector' do 
-    config = %([
+    config = %{
       resource_name "services"
-    ])
+    }
     driver = configure_test_driver(config)
     mock_watch_services
 
@@ -145,9 +146,9 @@ class EventsInputTest < Test::Unit::TestCase
   end
 
   test 'watch events correctly with v1beta1 api version' do
-    config = %([
+    config = %{
       api_version "events.k8s.io/v1beta1"
-    ])
+    }
     driver = configure_test_driver(config)
     mock_watch_events('api_watch_events_v1beta1.txt')
 


### PR DESCRIPTION
**Edit:** New proposal based on Dominik's comments is to retry for ~4 minutes (with exponential backoff) in the `configure` step. This should hopefully give enough leeway for transient issue, and throw an exception otherwise, causing the Fluentd worker process to die and restart (after having logged the exception). This will make it way easier to understand the issue than the previous `Got exception undefined method`.




Based on the issues that @frankreno mentioned some customers were facing with
```
Got exception undefined method _____ for #<String:0x00007ff19eaf4e60> ______
```

I found that this is because Ruby does a weird thing where if a method returns an exception, Ruby treats that exception as a String type. In this case, inside `connect_kubernetes` we call `create_client` which can return an exception. If for some reason we fail to create this client, we store the exception instead of the client - which means that when we try to call `client.getEntity`, we get the above `undefined method for String` error.

By creating the client in the `configure` step, this means that when the fluentd worker exits and restarts, we never re-initialize the client. ~~By moving `connect_kubernetes` to `start`, we will at least try to re-initialize the client.~~

~~Unfortunately I spent some time trying to figure out why the initial error happens but haven't been able to figure that out, but hopefully this change at least makes it so that fluentd can fix itself if a transient issue ends.~~
