### PR TITLE
Use fixed kubeclient version 4.9.0 for fluent-plugin-enhance-k8s-meta…

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -13,7 +13,7 @@ COPY gems/fluent-plugin*.gem ./
 # Fluentd plugin dependencies
 RUN gem install concurrent-ruby -v 1.1.5 \
        && gem install google-protobuf -v 3.9.2 \
-       && gem install kubeclient -v 4.5.0 \
+       && gem install kubeclient -v 4.9.0 \
        && gem install lru_redux -v 1.1.0 \
        && gem install snappy -v 0.0.17
 

--- a/fluent-plugin-enhance-k8s-metadata/fluent-plugin-enhance-k8s-metadata.gemspec
+++ b/fluent-plugin-enhance-k8s-metadata/fluent-plugin-enhance-k8s-metadata.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.1'
   spec.add_runtime_dependency 'fluentd', ['>= 0.14.10', '< 2']
-  spec.add_runtime_dependency 'kubeclient', '~> 4.4'
+  spec.add_runtime_dependency 'kubeclient', '4.9.0'
   spec.add_runtime_dependency 'lru_redux', '~> 1.1.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'

--- a/fluent-plugin-events/fluent-plugin-events.gemspec
+++ b/fluent-plugin-events/fluent-plugin-events.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "test-unit", "~> 3.0"
   spec.add_runtime_dependency "fluentd", [">= 0.14.10", "< 2"]
-  spec.add_runtime_dependency 'kubeclient', '~> 4.2'
+  spec.add_runtime_dependency 'kubeclient', '4.9.0'
   spec.add_development_dependency 'webmock', '~> 3.0'
   spec.add_development_dependency 'mocha'
 end


### PR DESCRIPTION
…data

###### Description

When newer version of kubeclient is used we get the following error:
```
Error: test: fetch_pod_metadata get labels(ReaderTest):
  WebMock::NetConnectNotAllowedError: Real HTTP connections are disabled. Unregistered request: GET http://localhost:8080/apis/api/extensions/v1beta1/namespaces/sumologic/replicasets/curl-byi-5bf5d48c57 with headers {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Host'=>'localhost:8080', 'User-Agent'=>'rest-client/2.1.0 (linux-gnu x86_64) ruby/2.5.1p57'}
```

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
