### PR TITLE
Relabel pod and service dimensions for non-pod metrics

### DIFF
--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -181,7 +181,7 @@ prometheus:
     ## Enable WAL compression to reduce Prometheus memory consumption
     walCompression: true
     remoteWrite:
-      ## kube state metrics
+      ## kube non pod state metrics
       ## kube_daemonset_status_current_number_scheduled
       ## kube_daemonset_status_desired_number_scheduled
       ## kube_daemonset_status_number_misscheduled
@@ -193,6 +193,21 @@ prometheus:
       ## kube_node_status_allocatable
       ## kube_node_status_capacity
       ## kube_node_status_condition
+      ## kube_statefulset_metadata_generation
+      ## kube_statefulset_replicas
+      ## kube_statefulset_status_observed_generation
+      ## kube_statefulset_status_replicas
+      - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.state
+        writeRelabelConfigs:
+          - action: keep
+            regex: kube-state-metrics;(?:kube_statefulset_status_observed_generation|kube_statefulset_status_replicas|kube_statefulset_replicas|kube_statefulset_metadata_generation|kube_daemonset_status_current_number_scheduled|kube_daemonset_status_desired_number_scheduled|kube_daemonset_status_number_misscheduled|kube_daemonset_status_number_unavailable|kube_deployment_spec_replicas|kube_deployment_status_replicas_available|kube_deployment_status_replicas_unavailable|kube_node_info|kube_node_status_allocatable|kube_node_status_capacity|kube_node_status_condition)
+            sourceLabels: [job, __name__]
+          - action: labelmap
+            regex: (pod|service)
+            replacement: service_discovery_${1}
+          - action: labeldrop
+            regex: (pod|service)
+      ## kube pod state metrics
       ## kube_pod_container_info
       ## kube_pod_container_resource_limits
       ## kube_pod_container_resource_requests
@@ -201,14 +216,10 @@ prometheus:
       ## kube_pod_container_status_terminated_reason
       ## kube_pod_container_status_waiting_reason
       ## kube_pod_status_phase
-      ## kube_statefulset_metadata_generation
-      ## kube_statefulset_replicas
-      ## kube_statefulset_status_observed_generation
-      ## kube_statefulset_status_replicas
       - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.state
         writeRelabelConfigs:
           - action: keep
-            regex: kube-state-metrics;(?:kube_statefulset_status_observed_generation|kube_statefulset_status_replicas|kube_statefulset_replicas|kube_statefulset_metadata_generation|kube_daemonset_status_current_number_scheduled|kube_daemonset_status_desired_number_scheduled|kube_daemonset_status_number_misscheduled|kube_daemonset_status_number_unavailable|kube_deployment_spec_replicas|kube_deployment_status_replicas_available|kube_deployment_status_replicas_unavailable|kube_node_info|kube_node_status_allocatable|kube_node_status_capacity|kube_node_status_condition|kube_pod_container_info|kube_pod_container_resource_requests|kube_pod_container_resource_limits|kube_pod_container_status_ready|kube_pod_container_status_terminated_reason|kube_pod_container_status_waiting_reason|kube_pod_container_status_restarts_total|kube_pod_status_phase)
+            regex: kube-state-metrics;(?:kube_pod_container_info|kube_pod_container_resource_requests|kube_pod_container_resource_limits|kube_pod_container_status_ready|kube_pod_container_status_terminated_reason|kube_pod_container_status_waiting_reason|kube_pod_container_status_restarts_total|kube_pod_status_phase)
             sourceLabels: [job, __name__]
       ## controller manager metrics
       ## https://kubernetes.io/docs/concepts/cluster-administration/monitoring/#kube-controller-manager-metrics

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -958,7 +958,7 @@ prometheus-operator:
       walCompression: true
 
       remoteWrite:
-        ## kube state metrics
+        ## kube non pod state metrics
         ## kube_daemonset_status_current_number_scheduled
         ## kube_daemonset_status_desired_number_scheduled
         ## kube_daemonset_status_number_misscheduled
@@ -970,6 +970,21 @@ prometheus-operator:
         ## kube_node_status_allocatable
         ## kube_node_status_capacity
         ## kube_node_status_condition
+        ## kube_statefulset_metadata_generation
+        ## kube_statefulset_replicas
+        ## kube_statefulset_status_observed_generation
+        ## kube_statefulset_status_replicas
+        - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.state
+          writeRelabelConfigs:
+            - action: keep
+              regex: kube-state-metrics;(?:kube_statefulset_status_observed_generation|kube_statefulset_status_replicas|kube_statefulset_replicas|kube_statefulset_metadata_generation|kube_daemonset_status_current_number_scheduled|kube_daemonset_status_desired_number_scheduled|kube_daemonset_status_number_misscheduled|kube_daemonset_status_number_unavailable|kube_deployment_spec_replicas|kube_deployment_status_replicas_available|kube_deployment_status_replicas_unavailable|kube_node_info|kube_node_status_allocatable|kube_node_status_capacity|kube_node_status_condition)
+              sourceLabels: [job, __name__]
+            - action: labelmap
+              regex: (pod|service)
+              replacement: service_discovery_${1}
+            - action: labeldrop
+              regex: (pod|service)
+        ## kube pod state metrics
         ## kube_pod_container_info
         ## kube_pod_container_resource_limits
         ## kube_pod_container_resource_requests
@@ -978,14 +993,10 @@ prometheus-operator:
         ## kube_pod_container_status_terminated_reason
         ## kube_pod_container_status_waiting_reason
         ## kube_pod_status_phase
-        ## kube_statefulset_metadata_generation
-        ## kube_statefulset_replicas
-        ## kube_statefulset_status_observed_generation
-        ## kube_statefulset_status_replicas
         - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.state
           writeRelabelConfigs:
             - action: keep
-              regex: kube-state-metrics;(?:kube_statefulset_status_observed_generation|kube_statefulset_status_replicas|kube_statefulset_replicas|kube_statefulset_metadata_generation|kube_daemonset_status_current_number_scheduled|kube_daemonset_status_desired_number_scheduled|kube_daemonset_status_number_misscheduled|kube_daemonset_status_number_unavailable|kube_deployment_spec_replicas|kube_deployment_status_replicas_available|kube_deployment_status_replicas_unavailable|kube_node_info|kube_node_status_allocatable|kube_node_status_capacity|kube_node_status_condition|kube_pod_container_info|kube_pod_container_resource_requests|kube_pod_container_resource_limits|kube_pod_container_status_ready|kube_pod_container_status_terminated_reason|kube_pod_container_status_waiting_reason|kube_pod_container_status_restarts_total|kube_pod_status_phase)
+              regex: kube-state-metrics;(?:kube_pod_container_info|kube_pod_container_resource_requests|kube_pod_container_resource_limits|kube_pod_container_status_ready|kube_pod_container_status_terminated_reason|kube_pod_container_status_waiting_reason|kube_pod_container_status_restarts_total|kube_pod_status_phase)
               sourceLabels: [job, __name__]
         ## controller manager metrics
         ## https://kubernetes.io/docs/concepts/cluster-administration/monitoring/#kube-controller-manager-metrics

--- a/deploy/kubernetes/kube-prometheus-sumo-logic-mixin.libsonnet
+++ b/deploy/kubernetes/kube-prometheus-sumo-logic-mixin.libsonnet
@@ -10,7 +10,29 @@
         writeRelabelConfigs: [
           {
             action: "keep",
-            regex: "kube-state-metrics;(?:kube_statefulset_status_observed_generation|kube_statefulset_status_replicas|kube_statefulset_replicas|kube_statefulset_metadata_generation|kube_daemonset_status_current_number_scheduled|kube_daemonset_status_desired_number_scheduled|kube_daemonset_status_number_misscheduled|kube_daemonset_status_number_unavailable|kube_deployment_spec_replicas|kube_deployment_status_replicas_available|kube_deployment_status_replicas_unavailable|kube_node_info|kube_node_status_allocatable|kube_node_status_capacity|kube_node_status_condition|kube_pod_container_info|kube_pod_container_resource_requests|kube_pod_container_resource_limits|kube_pod_container_status_ready|kube_pod_container_status_terminated_reason|kube_pod_container_status_waiting_reason|kube_pod_container_status_restarts_total|kube_pod_status_phase)",
+            regex: "kube-state-metrics;(?:kube_statefulset_status_observed_generation|kube_statefulset_status_replicas|kube_statefulset_replicas|kube_statefulset_metadata_generation|kube_daemonset_status_current_number_scheduled|kube_daemonset_status_desired_number_scheduled|kube_daemonset_status_number_misscheduled|kube_daemonset_status_number_unavailable|kube_deployment_spec_replicas|kube_deployment_status_replicas_available|kube_deployment_status_replicas_unavailable|kube_node_info|kube_node_status_allocatable|kube_node_status_capacity|kube_node_status_condition)",
+            sourceLabels: [
+              "job",
+              "__name__"
+            ]
+          },
+          {
+            action: "labelmap",
+            regex: "(pod|service)",
+            replacement: "service_discovery_${1}"
+          },
+          {
+            action: "labeldrop",
+            regex: "(pod|service)"
+          }
+        ]
+      },
+      {
+        url: $._config.sumologicCollectorSvc + "prometheus.metrics.state",
+        writeRelabelConfigs: [
+          {
+            action: "keep",
+            regex: "kube-state-metrics;(?:kube_pod_container_info|kube_pod_container_resource_requests|kube_pod_container_resource_limits|kube_pod_container_status_ready|kube_pod_container_status_terminated_reason|kube_pod_container_status_waiting_reason|kube_pod_container_status_restarts_total|kube_pod_status_phase)",
             sourceLabels: [
               "job",
               "__name__"


### PR DESCRIPTION
###### Description

Relabel pod and service dimensions for non-pod metrics

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
