### PR TITLE
Drop container=pod label when scraping container network metrics

### DIFF
--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -307,8 +307,7 @@ prometheus:
           - action: keep
             regex: kubelet;(?:container_network_receive_bytes_total|container_network_transmit_bytes_total)
             sourceLabels: [job, __name__]
-          - action: drop
-            regex: POD
+          - action: labeldrop
             sourceLabels: [container]
       ## node exporter metrics
       ## node_cpu_seconds_total

--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -307,6 +307,9 @@ prometheus:
           - action: keep
             regex: kubelet;(?:container_network_receive_bytes_total|container_network_transmit_bytes_total)
             sourceLabels: [job, __name__]
+          - action: drop
+            regex: POD
+            sourceLabels: [container]
       ## node exporter metrics
       ## node_cpu_seconds_total
       ## node_load1

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1084,6 +1084,9 @@ prometheus-operator:
             - action: keep
               regex: kubelet;(?:container_network_receive_bytes_total|container_network_transmit_bytes_total)
               sourceLabels: [job, __name__]
+            - action: drop
+              regex: POD
+              sourceLabels: [container]
         ## node exporter metrics
         ## node_cpu_seconds_total
         ## node_load1

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1084,8 +1084,7 @@ prometheus-operator:
             - action: keep
               regex: kubelet;(?:container_network_receive_bytes_total|container_network_transmit_bytes_total)
               sourceLabels: [job, __name__]
-            - action: drop
-              regex: POD
+            - action: labeldrop
               sourceLabels: [container]
         ## node exporter metrics
         ## node_cpu_seconds_total

--- a/deploy/kubernetes/kube-prometheus-sumo-logic-mixin.libsonnet
+++ b/deploy/kubernetes/kube-prometheus-sumo-logic-mixin.libsonnet
@@ -108,8 +108,7 @@
             ]
           },
           {
-            action: "drop",
-            regex: "POD",
+            action: "labeldrop",
             sourceLabels: [
               "container"
             ]

--- a/deploy/kubernetes/kube-prometheus-sumo-logic-mixin.libsonnet
+++ b/deploy/kubernetes/kube-prometheus-sumo-logic-mixin.libsonnet
@@ -106,6 +106,13 @@
               "job",
               "__name__"
             ]
+          },
+          {
+            action: "drop",
+            regex: "POD",
+            sourceLabels: [
+              "container"
+            ]
           }
         ]
       },


### PR DESCRIPTION
###### Description

Fill in your description here.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
