### PR TITLE
Don't scrape from headless services

### DIFF
--- a/deploy/helm/sumologic/templates/events-service-headless.yaml
+++ b/deploy/helm/sumologic/templates/events-service-headless.yaml
@@ -5,7 +5,6 @@ metadata:
   name: {{ template "sumologic.metadata.name.events.service-headless" . }}
   labels:
     app: {{ template "sumologic.labels.app.events.service-headless" . }}
-    {{- include "sumologic.labels.events" . | nindent 4 }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:

--- a/deploy/helm/sumologic/templates/metrics-service-headless.yaml
+++ b/deploy/helm/sumologic/templates/metrics-service-headless.yaml
@@ -5,7 +5,6 @@ metadata:
   name: {{ template "sumologic.metadata.name.metrics.service-headless" . }}
   labels:
     app: {{ template "sumologic.labels.app.metrics.service-headless" . }}
-    {{- include "sumologic.labels.metrics" . | nindent 4 }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:

--- a/deploy/helm/sumologic/templates/service-headless.yaml
+++ b/deploy/helm/sumologic/templates/service-headless.yaml
@@ -5,7 +5,6 @@ metadata:
   name: {{ template "sumologic.metadata.name.logs.service-headless" . }}
   labels:
     app: {{ template "sumologic.labels.app.logs.service-headless" . }}
-    {{- include "sumologic.labels.logs" . | nindent 4 }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -622,8 +622,6 @@ metadata:
   name: collection-sumologic-fluentd-events-headless
   labels:
     app: collection-sumologic-fluentd-events-headless
-    sumologic.com/app: fluentd-events
-    sumologic.com/component: events
     
 spec:
   selector:
@@ -663,8 +661,6 @@ metadata:
   name: collection-sumologic-fluentd-metrics-headless
   labels:
     app: collection-sumologic-fluentd-metrics-headless
-    sumologic.com/app: fluentd-metrics
-    sumologic.com/component: metrics
     
 spec:
   selector:
@@ -714,8 +710,6 @@ metadata:
   name: collection-sumologic-fluentd-logs-headless
   labels:
     app: collection-sumologic-fluentd-logs-headless
-    sumologic.com/app: fluentd-logs
-    sumologic.com/component: logs
     
 spec:
   selector:


### PR DESCRIPTION
###### Description

This prevents prometheus double scraping fluentd pods by removing the annotations from headless services.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
