### PR TITLE
Don't mount and don't define pos volumes for fluentd

### DIFF
--- a/deploy/helm/sumologic/templates/events-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/events-statefulset.yaml
@@ -47,10 +47,6 @@ spec:
 {{ toYaml .Values.fluentd.events.statefulset.tolerations | indent 8 }}
 {{- end }}
       volumes:
-      - name: pos-files
-        hostPath:
-          path: /var/run/fluentd-pos
-          type: ""
       - name: config-volume
         configMap:
           name: {{ template "sumologic.metadata.name.events.configmap" . }}
@@ -68,8 +64,6 @@ spec:
         volumeMounts:
         - name: config-volume
           mountPath: /fluentd/etc/
-        - name: pos-files
-          mountPath: /mnt/pos/
 {{- if .Values.fluentd.persistence.enabled }}
         - name: buffer
           mountPath: "/fluentd/buffer"

--- a/deploy/helm/sumologic/templates/metrics-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics-statefulset.yaml
@@ -87,10 +87,6 @@ spec:
 {{- end }}
 {{- end }}
       volumes:
-      - name: pos-files
-        hostPath:
-          path: /var/run/fluentd-pos
-          type: ""
       - name: config-volume
         configMap:
           name: {{ template "sumologic.metadata.name.metrics.configmap" . }}
@@ -125,8 +121,6 @@ spec:
         volumeMounts:
         - name: config-volume
           mountPath: /fluentd/etc/
-        - name: pos-files
-          mountPath: /mnt/pos/
 {{- if .Values.fluentd.persistence.enabled }}
         - name: buffer
           mountPath: "/fluentd/buffer"

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -87,10 +87,6 @@ spec:
 {{- end }}
 {{- end }}
       volumes:
-      - name: pos-files
-        hostPath:
-          path: /var/run/fluentd-pos
-          type: ""
       - name: config-volume
         configMap:
           name: {{ template "sumologic.metadata.name.logs.configmap" . }}
@@ -130,8 +126,6 @@ spec:
         volumeMounts:
         - name: config-volume
           mountPath: /fluentd/etc/
-        - name: pos-files
-          mountPath: /mnt/pos/
 {{- if .Values.fluentd.persistence.enabled }}
         - name: buffer
           mountPath: "/fluentd/buffer"

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -781,10 +781,6 @@ spec:
     spec:
       serviceAccountName: collection-sumologic
       volumes:
-      - name: pos-files
-        hostPath:
-          path: /var/run/fluentd-pos
-          type: ""
       - name: config-volume
         configMap:
           name: collection-sumologic-fluentd-events
@@ -805,8 +801,6 @@ spec:
         volumeMounts:
         - name: config-volume
           mountPath: /fluentd/etc/
-        - name: pos-files
-          mountPath: /mnt/pos/
         livenessProbe:
           httpGet:
             path: /fluentd.pod.healthcheck?json=%7B%22log%22%3A+%22health+check%22%7D
@@ -869,10 +863,6 @@ spec:
                   - prometheus-operator-prometheus
               topologyKey: "kubernetes.io/hostname"
       volumes:
-      - name: pos-files
-        hostPath:
-          path: /var/run/fluentd-pos
-          type: ""
       - name: config-volume
         configMap:
           name: collection-sumologic-fluentd-metrics
@@ -910,8 +900,6 @@ spec:
         volumeMounts:
         - name: config-volume
           mountPath: /fluentd/etc/
-        - name: pos-files
-          mountPath: /mnt/pos/
         env:
         - name: SUMO_ENDPOINT_APISERVER_METRICS_SOURCE
           valueFrom:
@@ -999,10 +987,6 @@ spec:
                   - prometheus-operator-prometheus
               topologyKey: "kubernetes.io/hostname"
       volumes:
-      - name: pos-files
-        hostPath:
-          path: /var/run/fluentd-pos
-          type: ""
       - name: config-volume
         configMap:
           name: collection-sumologic-fluentd-logs
@@ -1040,8 +1024,6 @@ spec:
         volumeMounts:
         - name: config-volume
           mountPath: /fluentd/etc/
-        - name: pos-files
-          mountPath: /mnt/pos/
         env:
         - name: SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE
           valueFrom:


### PR DESCRIPTION
###### Description

We're not using fluentd's [`tail` input plugin](https://docs.fluentd.org/input/tail) so don't define pos files volumes.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
