### PR TITLE
Update Falco helm chart to 1.3.0

### DIFF
--- a/deploy/helm/sumologic/requirements.yaml
+++ b/deploy/helm/sumologic/requirements.yaml
@@ -8,7 +8,7 @@ dependencies:
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: prometheus-operator.enabled,sumologic.metrics.enabled
   - name: falco
-    version: 1.1.8
+    version: 1.3.0
     repository: https://falcosecurity.github.io/charts
     condition: falco.enabled
   - name: metrics-server


### PR DESCRIPTION
###### Description

Fixes #811 
Closes #904 

###### Testing performed

Tested with EKS

* k8s `v1.16`
* AMI `ami-016ce7a1ae8ecbc95`
* Sumo Logic chart version 1.2.2 (https://github.com/SumoLogic/sumologic-kubernetes-collection/commit/ee84b7843551a20ffbf78c965c6516da45f39a0a)

Got a successful falco launch:

```
* Setting up /usr/src links from host
* Running falco-driver-loader with: driver=module, compile=yes, download=yes
* Unloading falco module, if present
* Trying to dkms install falco module
* Running dkms build failed, couldn't find /var/lib/dkms/falco/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/build/make.log
* Trying to load a system falco driver, if present
* Trying to find locally a prebuilt falco module for kernel 4.14.193-149.317.amzn2.x86_64, if present
* Trying to download prebuilt module from https://dl.bintray.com/falcosecurity/driver/ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7/falco_amazonlinux2_4.14.193-149.317.amzn2.x86_64_1.ko
* Download succeeded
* Success: falco module loaded
Mon Sep 14 13:00:21 2020: Falco version 0.25.0 (driver version ae104eb20ff0198a5dcb0c91cc36c86e7c3f25c7)
Mon Sep 14 13:00:21 2020: Falco initialized with configuration file /etc/falco/falco.yaml
Mon Sep 14 13:00:21 2020: Loading rules from file /etc/falco/falco_rules.yaml:
Mon Sep 14 13:00:22 2020: Loading rules from file /etc/falco/falco_rules.local.yaml:
Mon Sep 14 13:00:23 2020: Starting internal webserver, listening on port 8765
{"output":"13:00:23.204844000: Notice Privileged container started (user=root command=container:ce4d54ef213c k8s.ns=kube-system k8s.pod=kube-proxy-wjbnk container=ce4d54ef213c image=602401143452.dkr.ecr.eu-west-1.amazonaws.com/eks/kube-proxy:v1.16.13-eksbuild.1) k8s.ns=kube-system k8
s.pod=kube-proxy-wjbnk container=ce4d54ef213c","priority":"Notice","rule":"Launch Privileged Container","time":"2020-09-14T13:00:23.204844000Z", "output_fields": {"container.id":"ce4d54ef213c","container.image.repository":"602401143452.dkr.ecr.eu-west-1.amazonaws.com/eks/kube-proxy",
"container.image.tag":"v1.16.13-eksbuild.1","evt.time":1600088423204844000,"k8s.ns.name"
...
...
```