### PR TITLE
Increase cache refresh interval to 1 hour

### DIFF
--- a/deploy/helm/sumologic/README.md
+++ b/deploy/helm/sumologic/README.md
@@ -53,8 +53,8 @@ Parameter | Description | Default
 `fluentd.buffer.filePaths` | File paths to buffer to, if Fluentd buffer type is specified as file above. Each sumologic output plugin buffers to its own unique file. | `{"events":"/fluentd/buffer/events","logs":{"containers":"/fluentd/buffer/logs.containers","default":"/fluentd/buffer/logs.default","kubelet":"/fluentd/buffer/logs.kubelet","systemd":"/fluentd/buffer/logs.systemd"},"metrics":{"apiserver":"/fluentd/buffer/metrics.apiserver","container":"/fluentd/buffer/metrics.container","controller":"/fluentd/buffer/metrics.controller","default":"/fluentd/buffer/metrics.default","kubelet":"/fluentd/buffer/metrics.kubelet","node":"/fluentd/buffer/metrics.node","scheduler":"/fluentd/buffer/metrics.scheduler","state":"/fluentd/buffer/metrics.state"},"traces":"/fluentd/buffer/traces"}`
 `fluentd.buffer.extraConf` | Additional config for buffer settings | `Nil`
 `fluentd.metadata.cacheSize` | Option to control the enabling of metadata filter plugin cache_size. | `10000`
-`fluentd.metadata.cacheTtl` | Option to control the enabling of metadata filter plugin cache_ttl (in seconds). | `3600`
-`fluentd.metadata.cacheRefresh` | Option to control the interval at which metadata cache is asynchronously refreshed (in seconds). | `1800`
+`fluentd.metadata.cacheTtl` | Option to control the enabling of metadata filter plugin cache_ttl (in seconds). | `7200`
+`fluentd.metadata.cacheRefresh` | Option to control the interval at which metadata cache is asynchronously refreshed (in seconds). | `3600`
 `fluentd.metadata.pluginLogLevel` | Option to give plugin specific log level. | `error`
 `fluentd.logs.enabled` | Flag to control deploying the Fluentd logs statefulsets. | `true`
 `fluentd.logs.statefulset.nodeSelector` | Node selector for Fluentd log statefulset. | `{}`

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -253,9 +253,9 @@ fluentd:
     cacheSize: "10000"
     ## Option to control the enabling of metadata filter plugin cache_ttl (in seconds).
     ## ref: https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter#configuration
-    cacheTtl: "3600"
+    cacheTtl: "7200"
     ## Option to control the interval at which metadata cache is asynchronously refreshed (in seconds).
-    cacheRefresh: "1800"
+    cacheRefresh: "3600"
     ## Option to give plugin specific log level
     pluginLogLevel: "error"
     ## Option to specify K8s API versions

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -94,8 +94,8 @@ data:
     @include logs.source.default.conf
   logs.enhance.k8s.metadata.filter.conf: |-
     cache_size  "10000"
-    cache_ttl  "3600"
-    cache_refresh "1800"
+    cache_ttl  "7200"
+    cache_refresh "3600"
     in_namespace_path '$.kubernetes.namespace_name'
     in_pod_path '$.kubernetes.pod_name'
     core_api_versions v1
@@ -111,7 +111,7 @@ data:
     client_key ""
     bearer_token_file ""
     cache_size "10000"
-    cache_ttl "3600"
+    cache_ttl "7200"
     tag_to_kubernetes_name_regexp '.+?\.containers\.(?<pod_name>[^_]+)_(?<namespace>[^_]+)_(?<container_name>.+)-(?<docker_id>[a-z0-9]{64})\.log$'
   logs.kubernetes.sumologic.filter.conf: |-
     source_name "%{namespace}.%{pod}.%{container}"
@@ -442,8 +442,8 @@ data:
       <filter prometheus.metrics**>
         @type enhance_k8s_metadata
         cache_size  "10000"
-        cache_ttl  "3600"
-        cache_refresh "1800"
+        cache_ttl  "7200"
+        cache_refresh "3600"
         core_api_versions v1
         api_groups apps/v1,extensions/v1beta1
       </filter>

--- a/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
@@ -41,8 +41,8 @@ module Fluent
       config_param :ssl_partial_chain, :bool, default: false
 
       config_param :cache_size, :integer, default: 1000
-      config_param :cache_ttl, :integer, default: 60 * 60
-      config_param :cache_refresh, :integer, default: 60 * 30
+      config_param :cache_ttl, :integer, default: 60 * 60 * 2
+      config_param :cache_refresh, :integer, default: 60 * 60
 
       def configure(conf)
         super


### PR DESCRIPTION
The cache TTL was increased as well because it always needs
to be greater than the refresh interval, to prevent a situation where
there is no cached value for a resource.