### PR TITLE
Add build target to the vagrant's Makefile

### DIFF
--- a/vagrant/Makefile
+++ b/vagrant/Makefile
@@ -13,6 +13,9 @@ dashboards_path = ${root_dir}vagrant/dashboards
 name = collection
 namespace = sumologic
 
+build:
+	cd ${root_dir} && ${root_dir}ci/build.sh
+
 # Collector section
 ## Collector upgrade
 upgrade:

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -37,6 +37,14 @@ helm2 init --wait
 
 and then run `helm2 version` to make sure everything is OK.
 
+## Build
+
+To perform docker image build and to run tests please use `build` target:
+
+```bash
+/sumologic/vagrant/Makefile build
+```
+
 ## Collector
 
 To install or upgrade collector please type:

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -76,6 +76,11 @@ while true; do
   sleep 1
 done
 
+# install requirements for ci/build.sh
+snap install ruby --channel=2.6/stable --classic
+gem install bundler
+apt install -y gcc g++ libsnappy-dev
+
 # Init helm tiller
 sudo -H -u vagrant -i helm2 init --wait
 


### PR DESCRIPTION
###### Description

Add build target to the vagrant's Makefile

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
