### PR TITLE
Do not proxy kubernetes internal traffic

### DIFF
--- a/deploy/helm/sumologic/conf/setup/setup.sh
+++ b/deploy/helm/sumologic/conf/setup/setup.sh
@@ -8,6 +8,7 @@ export SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL%v1*}
 # Support proxy for terraform
 export HTTP_PROXY=${HTTP_PROXY:=""}
 export HTTPS_PROXY=${HTTPS_PROXY:=""}
+export NO_PROXY=${NO_PROXY:=""}
 
 COLLECTOR_NAME="{{- if .Values.sumologic.collectorName }}{{ .Values.sumologic.collectorName }}{{- else}}{{ .Values.sumologic.clusterName }}{{- end}}"
 

--- a/deploy/helm/sumologic/templates/setup/setup-job.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-job.yaml
@@ -62,5 +62,7 @@ spec:
           value: {{ .Values.sumologic.httpProxy }}
         - name: HTTPS_PROXY
           value: {{ .Values.sumologic.httpsProxy }}
+        - name: NO_PROXY
+          value: {{ .Values.sumologic.noProxy }}
         {{ end }}
 {{- end }}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -32,6 +32,8 @@ sumologic:
   ## proxy urls
   httpProxy: ""
   httpsProxy: ""
+  ## Exclude kubernetes internal traffic from proxy
+  noProxy: kubernetes.default.svc
 
   ## Collector name
   #collectorName: ""

--- a/deploy/kubernetes/setup-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/setup-sumologic.yaml.tmpl
@@ -135,6 +135,7 @@ data:
     # Support proxy for terraform
     export HTTP_PROXY=${HTTP_PROXY:=""}
     export HTTPS_PROXY=${HTTPS_PROXY:=""}
+    export NO_PROXY=${NO_PROXY:=""}
   
     COLLECTOR_NAME="$COLLECTOR_NAME"
   
@@ -282,5 +283,7 @@ spec:
           value: 
         - name: HTTPS_PROXY
           value: 
+        - name: NO_PROXY
+          value: kubernetes.default.svc
         
 

--- a/tests/terraform/static/all_fields.output.yaml
+++ b/tests/terraform/static/all_fields.output.yaml
@@ -182,6 +182,7 @@ data:
     # Support proxy for terraform
     export HTTP_PROXY=${HTTP_PROXY:=""}
     export HTTPS_PROXY=${HTTPS_PROXY:=""}
+    export NO_PROXY=${NO_PROXY:=""}
   
     COLLECTOR_NAME="kubernetes"
   

--- a/tests/terraform/static/collector_fields.output.yaml
+++ b/tests/terraform/static/collector_fields.output.yaml
@@ -137,6 +137,7 @@ data:
     # Support proxy for terraform
     export HTTP_PROXY=${HTTP_PROXY:=""}
     export HTTPS_PROXY=${HTTPS_PROXY:=""}
+    export NO_PROXY=${NO_PROXY:=""}
   
     COLLECTOR_NAME="kubernetes"
   

--- a/tests/terraform/static/conditional_sources.output.yaml
+++ b/tests/terraform/static/conditional_sources.output.yaml
@@ -64,6 +64,7 @@ data:
     # Support proxy for terraform
     export HTTP_PROXY=${HTTP_PROXY:=""}
     export HTTPS_PROXY=${HTTPS_PROXY:=""}
+    export NO_PROXY=${NO_PROXY:=""}
   
     COLLECTOR_NAME="kubernetes"
   

--- a/tests/terraform/static/default.output.yaml
+++ b/tests/terraform/static/default.output.yaml
@@ -135,6 +135,7 @@ data:
     # Support proxy for terraform
     export HTTP_PROXY=${HTTP_PROXY:=""}
     export HTTPS_PROXY=${HTTPS_PROXY:=""}
+    export NO_PROXY=${NO_PROXY:=""}
   
     COLLECTOR_NAME="kubernetes"
   

--- a/tests/terraform/static/strip_extrapolation.output.yaml
+++ b/tests/terraform/static/strip_extrapolation.output.yaml
@@ -136,6 +136,7 @@ data:
     # Support proxy for terraform
     export HTTP_PROXY=${HTTP_PROXY:=""}
     export HTTPS_PROXY=${HTTPS_PROXY:=""}
+    export NO_PROXY=${NO_PROXY:=""}
   
     COLLECTOR_NAME="kubernetes"
   

--- a/tests/terraform/static/traces.output.yaml
+++ b/tests/terraform/static/traces.output.yaml
@@ -72,6 +72,7 @@ data:
     # Support proxy for terraform
     export HTTP_PROXY=${HTTP_PROXY:=""}
     export HTTPS_PROXY=${HTTPS_PROXY:=""}
+    export NO_PROXY=${NO_PROXY:=""}
   
     COLLECTOR_NAME="kubernetes"
   


### PR DESCRIPTION
###### Description

Do not proxy kubernetes internal traffic

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
