### PR TITLE
Fix grafana installation in vagrant

### DIFF
--- a/vagrant/values.yaml
+++ b/vagrant/values.yaml
@@ -19,6 +19,9 @@ prometheus-operator:
       prometheusSpec:
         externalLabels:
           cluster: microk8s
+    sidecar:
+      image:
+        sha: ''
 sumologic:
   accessId: dummy
   accessKey: dummy


### PR DESCRIPTION
Fix grafana installation
```
Error: UPGRADE FAILED: template: sumologic/charts/prometheus-operator/charts/grafana/templates/deployment.yaml:46:10: executing "sumologic/charts/prometheus-operator/charts/grafana/templates/deployment.yaml" at <include "grafana.pod" .>: error calling include: template: sumologic/charts/prometheus-operator/charts/grafana/templates/_pod.tpl:75:18: executing "grafana.pod" at <.Values.sidecar.image.sha>: can't evaluate field sha in type interface {}
```