### PR TITLE
Fix CI on master: always provide the branch name to checkout

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -12,13 +12,22 @@ err_report() {
 }
 trap 'err_report $LINENO' ERR
 
+function get_branch_to_checkout() {
+  [[ "${TRAVIS_EVENT_TYPE}" == pull_request ]] \
+    && echo "${TRAVIS_PULL_REQUEST_BRANCH}" \
+    || echo "${TRAVIS_BRANCH}"
+}
+
 # Set up Github
 if [ -n "$GITHUB_TOKEN" ]; then
   git config --global user.email "travis@travis-ci.org"
   git config --global user.name "Travis CI"
   git remote add origin-repo "https://${GITHUB_TOKEN}@github.com/SumoLogic/sumologic-kubernetes-collection.git" > /dev/null 2>&1
   git fetch --unshallow origin-repo
-  git checkout "$TRAVIS_PULL_REQUEST_BRANCH"
+
+  readonly branch_to_checkout="$(get_branch_to_checkout)"
+  echo "Checking out the ${branch_to_checkout} branch..."
+  git checkout "${branch_to_checkout}"
 fi
 
 ## check the build script with shellcheck


### PR DESCRIPTION
We had a bug in our build script which was revealed when we double-quoted all the variables:
https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/911/files#diff-78b1794b72c7105dbabbe466019395d6R21

It was working previously because the `git checkout` command can work without the argument where it just takes the current branch.
But it can't work with an empty argument (see below):
```
$ git checkout
Your branch is up to date with 'origin/master'.

$ git checkout ""
fatal: empty string is not a valid pathspec. please use . instead if you meant to match all paths

$ git checkout "master"
Already on 'master'
Your branch is up to date with 'origin/master'.
```

The problem could not occur during the PR phase, it would only show itself on master (and release) branch build, hence the broken build. 

This fix is to make sure we always set branch name to checkout.

###### Testing performed

- [ ] ci/build.sh
