### PR TITLE
Increase memory limits for thanos-sidecar to 32Mi to prevent restarts

### DIFF
--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -170,7 +170,7 @@ prometheus:
       resources:
         limits:
           cpu: 10m
-          memory: 16Mi
+          memory: 32Mi
         requests:
           cpu: 1m
           memory: 8Mi

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1008,7 +1008,7 @@ prometheus-operator:
         resources:
           limits:
             cpu: 10m
-            memory: 16Mi
+            memory: 32Mi
           requests:
             cpu: 1m
             memory: 8Mi


### PR DESCRIPTION
###### Description

Using `values.yaml` from the repository without any scaling changes it seems that `thanos-sidecar` gets OOMKilled every ~~15min.
This PR addresses that by increasing the memory limit to `32Mi`.

With that it seems that memory usage stabilize at around `18Mi` for the "default" setup.

![image](https://user-images.githubusercontent.com/69143962/93902364-c0ccf280-fcf7-11ea-95a5-b5c042185f81.png)

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
