### PR TITLE
Fix handling api versions in fluent-plugin-enhance-k8s-metadata

### DIFF
--- a/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
@@ -33,7 +33,7 @@ module Fluent
       # Need different clients to access different API groups/versions
       # https://github.com/abonas/kubeclient/issues/208
       config_param :core_api_versions, :array, default: ['v1']
-      config_param :api_groups, :hash, default: {'apps':'v1', 'extensions':'v1beta1'}
+      config_param :api_groups, :array, default: ["apps/v1", "extensions/v1beta1"]
       # if `ca_file` is for an intermediate CA, or otherwise we do not have the
       # root CA and want to trust the intermediate CA certs we do have, set this
       # to `true` - this corresponds to the openssl s_client -partial_chain flag

--- a/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/connector.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/connector.rb
@@ -18,16 +18,19 @@ module SumoLogic
       end
 
       def group_clients
-        @api_groups.map do |elem|
-          # elem should have base as key e.g. 'extensions' and version as values e.g. 'v1beta1'
-          if elem.length < 2
+        ret = {}
+        @api_groups.each do |api_ver|
+          elems = api_ver.split("/")
+          # elems should have base as first element e.g. 'extensions' and version as second element e.g. 'v1beta1'
+          if elems.length < 2
             continue
           end
 
-          base = elem[0].to_s
-          ver = elem[1]
-          [base + "/" + ver, create_client('apis/' + base, ver)]
-        end.to_h
+          base = elems[0]
+          ver = elems[1]
+          ret[ base + "/" + ver ] = create_client('apis/' + base, ver)
+        end
+        ret
       end
 
       def create_client(base, ver)

--- a/fluent-plugin-enhance-k8s-metadata/test/helper.rb
+++ b/fluent-plugin-enhance-k8s-metadata/test/helper.rb
@@ -62,5 +62,5 @@ def init_globals
   @cache_size = 1000
   @cache_ttl = 60 * 60
   @core_api_versions = ['v1']
-  @api_groups = {'apps':'v1', 'extensions':'v1beta1'}
+  @api_groups = ['apps/v1', 'extensions/v1beta1']
 end


### PR DESCRIPTION
###### Description

Because of using arrays in configuration, e.g. here https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/bc3f0db72011c0b797edddc7f794d0ca58e9e37c/deploy/kubernetes/fluentd-sumologic.yaml.tmpl#L102

let's roll back `hash` to `array` and change code accordingly.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
