### PR TITLE
Add shellcheck to vagrant

### DIFF
--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -80,6 +80,7 @@ done
 snap install ruby --channel=2.6/stable --classic
 gem install bundler
 apt install -y gcc g++ libsnappy-dev
+snap install shellcheck
 
 # Init helm tiller
 sudo -H -u vagrant -i helm2 init --wait


### PR DESCRIPTION
###### Description

Using `snap` instead of `apt` as the version of `shellcheck` packaged by `snap` is a bit more up to date (`0.7.0` vs `0.4.6-1` as of now).

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
