### PR TITLE
Install shellcheck with apt in vagrant

### DIFF
--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -79,8 +79,7 @@ done
 # install requirements for ci/build.sh
 snap install ruby --channel=2.6/stable --classic
 gem install bundler
-apt install -y gcc g++ libsnappy-dev
-snap install shellcheck
+apt install -y gcc g++ libsnappy-dev shellcheck
 
 # Init helm tiller
 sudo -H -u vagrant -i helm2 init --wait


### PR DESCRIPTION
It seems that it isn't as easy as we might think:
`shellcheck`'s snap doesn't have access to all filesystems 

```
snap connections shellcheck
Interface        Plug                        Slot   Notes
home             shellcheck:home             :home  -
removable-media  shellcheck:removable-media  -      -
```

and it doesn't seem that it's easy to allow it to access (in our case) `/sumologic`

https://askubuntu.com/questions/1033344/how-to-give-snaps-access-to-somedir

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
