### PR TITLE
add crio parser to fluent-bit

### DIFF
--- a/deploy/helm/fluent-bit-overrides.yaml
+++ b/deploy/helm/fluent-bit-overrides.yaml
@@ -57,6 +57,11 @@ parsers:
   regex:
   - name: multi_line
     regex: (?<log>^{"log":"\d{4}-\d{1,2}-\d{1,2}.\d{2}:\d{2}:\d{2}.*)
+    ## cri-o parser
+  - name: crio
+    regex: ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<log>.*)$
+    timeKey: time
+    timeFormat: "%Y-%m-%dT%H:%M:%S.%L%z"
 rawConfig: |-
   @INCLUDE fluent-bit-service.conf
 

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -760,6 +760,12 @@ fluent-bit:
     regex:
       - name: multi_line
         regex: (?<log>^{"log":"\d{4}-\d{1,2}-\d{1,2}.\d{2}:\d{2}:\d{2}.*)
+        ## cri-o parser
+      - name: crio
+        regex: ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<log>.*)$
+        timeKey: time
+        timeFormat: %Y-%m-%dT%H:%M:%S.%L%z
+        
 
   rawConfig: |-
     @INCLUDE fluent-bit-service.conf

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -764,7 +764,7 @@ fluent-bit:
       - name: crio
         regex: ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<log>.*)$
         timeKey: time
-        timeFormat: %Y-%m-%dT%H:%M:%S.%L%z
+        timeFormat: "%Y-%m-%dT%H:%M:%S.%L%z"
         
 
   rawConfig: |-


### PR DESCRIPTION
###### Description

The default `cri` parser defined in fluent-bit uses `message` as the key, instead of `log`. This PR defines a custom `crio` parser which uses the `log` key instead, so that the Sumo Logic apps do not break.

![image (24)](https://user-images.githubusercontent.com/56007827/94287385-12010000-ff0b-11ea-80c8-2060ad4e96a5.png)
Example of `CRI`format log with `message` key attached.
 
###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
