### PR TITLE
Introduce cache refresh variation

### DIFF
--- a/deploy/helm/sumologic/README.md
+++ b/deploy/helm/sumologic/README.md
@@ -60,6 +60,7 @@ Parameter | Description | Default
 `fluentd.metadata.cacheSize` | Option to control the enabling of metadata filter plugin cache_size. | `10000`
 `fluentd.metadata.cacheTtl` | Option to control the enabling of metadata filter plugin cache_ttl (in seconds). | `7200`
 `fluentd.metadata.cacheRefresh` | Option to control the interval at which metadata cache is asynchronously refreshed (in seconds). | `3600`
+`fluentd.metadata.cacheRefreshVariation` | Option to control the variation in seconds by which the cacheRefresh option is changed for each pod separately. For example, if cache refresh is 1 hour and variation is 15 minutes, then actual cache refresh interval will be a random value between 45 minutes and 1 hour 15 minutes, different for each pod. This helps spread the load on API server that the cache refresh induces. Setting this to 0 disables cache refresh variation. | `900`
 `fluentd.metadata.pluginLogLevel` | Option to give plugin specific log level. | `error`
 `fluentd.logs.enabled` | Flag to control deploying the Fluentd logs statefulsets. | `true`
 `fluentd.logs.statefulset.nodeSelector` | Node selector for Fluentd log statefulset. | `{}`

--- a/deploy/helm/sumologic/conf/logs/logs.enhance.k8s.metadata.filter.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.enhance.k8s.metadata.filter.conf
@@ -1,6 +1,7 @@
 cache_size  {{ .Values.fluentd.metadata.cacheSize | quote }}
 cache_ttl  {{ .Values.fluentd.metadata.cacheTtl | quote }}
 cache_refresh {{ .Values.fluentd.metadata.cacheRefresh | quote }}
+cache_refresh_variation {{ .Values.fluentd.metadata.cacheRefreshVariation | quote }}
 in_namespace_path '$.kubernetes.namespace_name'
 in_pod_path '$.kubernetes.pod_name'
 core_api_versions {{ join "," .Values.fluentd.metadata.coreApiVersions }}

--- a/deploy/helm/sumologic/conf/metrics/metrics.conf
+++ b/deploy/helm/sumologic/conf/metrics/metrics.conf
@@ -42,6 +42,7 @@
     cache_size  {{ .Values.fluentd.metadata.cacheSize | quote }}
     cache_ttl  {{ .Values.fluentd.metadata.cacheTtl | quote }}
     cache_refresh {{ .Values.fluentd.metadata.cacheRefresh | quote }}
+    cache_refresh_variation {{ .Values.fluentd.metadata.cacheRefreshVariation | quote }}
     core_api_versions {{ join "," .Values.fluentd.metadata.coreApiVersions }}
     api_groups {{ join "," .Values.fluentd.metadata.apiGroups }}
   </filter>

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -272,6 +272,11 @@ fluentd:
     cacheTtl: "7200"
     ## Option to control the interval at which metadata cache is asynchronously refreshed (in seconds).
     cacheRefresh: "3600"
+    ## Option to control the variation in seconds by which the cacheRefresh option is changed for each pod separately.
+    ## For example, if cache refresh is 1 hour and variation is 15 minutes, then actual cache refresh interval
+    ## will be a random value between 45 minutes and 1 hour 15 minutes, different for each pod. This helps spread
+    ## the load on API server that the cache refresh induces. Setting this to 0 disables cache refresh variation.
+    cacheRefreshVariation: "900"
     ## Option to give plugin specific log level
     pluginLogLevel: "error"
     ## Option to specify K8s API versions

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -96,6 +96,7 @@ data:
     cache_size  "10000"
     cache_ttl  "7200"
     cache_refresh "3600"
+    cache_refresh_variation "900"
     in_namespace_path '$.kubernetes.namespace_name'
     in_pod_path '$.kubernetes.pod_name'
     core_api_versions v1
@@ -445,6 +446,7 @@ data:
         cache_size  "10000"
         cache_ttl  "7200"
         cache_refresh "3600"
+        cache_refresh_variation "900"
         core_api_versions v1
         api_groups apps/v1,extensions/v1beta1
       </filter>

--- a/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
@@ -43,6 +43,7 @@ module Fluent
       config_param :cache_size, :integer, default: 1000
       config_param :cache_ttl, :integer, default: 60 * 60 * 2
       config_param :cache_refresh, :integer, default: 60 * 60
+      config_param :cache_refresh_variation, :integer, default: 60 * 15
 
       def configure(conf)
         super
@@ -124,11 +125,17 @@ module Fluent
         log.debug "bearer_token_file: '#{@bearer_token_file}', exist: #{File.exist?(@bearer_token_file)}"
 
         @cache_ttl = :none if @cache_ttl <= 0
-        log.info "cache_ttl: #{@cache_ttl}, cache_size: #{@cache_size}, cache_refresh: #{@cache_refresh}"
+
+        @cache_refresh_variation = 0 if @cache_refresh_variation < 0
+        @cache_refresh_variation = 2 * @cache_refresh - 1 if @cache_refresh_variation >= @cache_refresh * 2
+
+        log.info "cache_ttl: #{@cache_ttl}, cache_size: #{@cache_size}, cache_refresh: #{@cache_refresh}, cache_refresh_variation: #{@cache_refresh_variation}"
       end
 
       def start_cache_timer
-        timer_execute(:"cache_refresher", @cache_refresh) {
+        cache_refresh_with_variation = apply_variation(@cache_refresh, @cache_refresh_variation)
+        log.info "Will refresh cache every #{format_time(cache_refresh_with_variation)}"
+        timer_execute(:"cache_refresher", cache_refresh_with_variation) {
           entries = @cache.to_a
           log.info "Refreshing metadata for #{entries.count} entries"
 
@@ -145,6 +152,17 @@ module Fluent
             end
           }
         }
+      end
+
+      def apply_variation(value, variation)
+        return value if variation <= 0
+
+        random_variation = rand(variation * 2 + 1) - variation
+        value + random_variation
+      end
+
+      def format_time(seconds)
+        Time.at(seconds).strftime("%Hh %Mm %Ss")
       end
     end
   end


### PR DESCRIPTION
###### Description

This PR introduces a random variation in cache refresh interval for each pod, allowing the load on API server to be spread in time.

By default, there are multiple Fluentd pods running in a cluster, each of the pods maintaining its own version of pod metadata cache. The cache is being refreshed by each Fluentd pod independently in regular intervals specified by the `fluentd.metadata.cacheRefresh` configuration variable. Before this change, the cache refresh interval was equal for all pods, causing all of them to flood API server with queries in approximately the same time.

The introduction of `fluentd.metadata.cacheRefreshVariationRange` configuration variable makes it possible to spread the load on API server by changing the cache refresh interval by a different, randomly assigned value for each pod. For example, if the `cacheRefresh` value is 1 hour and `cacheRefreshVariationRange` is 30 minutes, the actual cache refresh interval for each pod will vary between 45 minutes and 1 hour 15 minutes.

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
