### PR TITLE
Use local changes when building and running locally

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -106,7 +106,9 @@ bundle_fluentd_plugins "${VERSION}" || (echo "Failed bundling fluentd plugins" &
 
 echo "Building docker image with $DOCKER_TAG:local in $(pwd)..."
 cd ./deploy/docker || exit 1
-docker build . -f ./Dockerfile -t "$DOCKER_TAG:local" --no-cache
+readonly no_cache=$([ "$DOCKER_USE_CACHE" == "true" ] && echo "" || echo "--no-cache")
+# shellcheck disable=SC2086
+docker build . -f ./Dockerfile -t "$DOCKER_TAG:local" ${no_cache}
 rm -f ./gems/*.gem
 cd ../.. || exit 1
 

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -106,9 +106,11 @@ bundle_fluentd_plugins "${VERSION}" || (echo "Failed bundling fluentd plugins" &
 
 echo "Building docker image with $DOCKER_TAG:local in $(pwd)..."
 cd ./deploy/docker || exit 1
-readonly no_cache=$([ "$DOCKER_USE_CACHE" == "true" ] && echo "" || echo "--no-cache")
-# shellcheck disable=SC2086
-docker build . -f ./Dockerfile -t "$DOCKER_TAG:local" ${no_cache}
+no_cache="--no-cache"
+if [[ "$DOCKER_USE_CACHE" == "true" ]]; then
+  no_cache=""
+fi
+docker build . -f ./Dockerfile -t "$DOCKER_TAG:local" ${no_cache:+"--no-cache"}
 rm -f ./gems/*.gem
 cd ../.. || exit 1
 

--- a/vagrant/.gitignore
+++ b/vagrant/.gitignore
@@ -1,1 +1,2 @@
 envs.sh
+values.*.yaml

--- a/vagrant/Makefile
+++ b/vagrant/Makefile
@@ -17,6 +17,9 @@ namespace = sumologic
 build:
 	cd ${root_dir} && ${root_dir}ci/build.sh
 
+generate-local-config:
+	${root_dir}vagrant/scripts/generate-local-config.sh
+
 build-local:
 	DOCKER_USE_CACHE=true \
 	${mkfile_path} \

--- a/vagrant/Makefile
+++ b/vagrant/Makefile
@@ -15,15 +15,8 @@ name = collection
 namespace = sumologic
 
 build:
-	cd ${root_dir} && ${root_dir}ci/build.sh
-
-generate-local-config:
-	${root_dir}vagrant/scripts/generate-local-config.sh
-
-build-local:
-	DOCKER_USE_CACHE=true \
+	cd ${root_dir} && DOCKER_USE_CACHE=true ${root_dir}ci/build.sh
 	${mkfile_path} \
-		build \
 		tag-and-push-local
 
 tag-and-push-local:
@@ -31,6 +24,9 @@ tag-and-push-local:
 	docker tag sumologic/kubernetes-fluentd:local localhost:32000/sumologic/kubernetes-fluentd:local-${timestamp}
 	docker push localhost:32000/sumologic/kubernetes-fluentd:local-${timestamp}
 	sed -i 's/^\([[:space:]]\+\)tag:.*$$/\1tag: local-${timestamp}/' ${local_values_file}
+
+generate-local-config:
+	${root_dir}vagrant/scripts/generate-local-config.sh
 
 # Collector section
 ## Collector upgrade

--- a/vagrant/Makefile
+++ b/vagrant/Makefile
@@ -8,6 +8,7 @@ root_dir := $(dir $(abspath $(mkfile_path)/..))
 helm_path = ${root_dir}deploy/helm/sumologic
 k8s_path = ${root_dir}vagrant/k8s
 dashboards_path = ${root_dir}vagrant/dashboards
+local_values_file = ${root_dir}vagrant/values.local.yaml
 
 # Collector configuration
 name = collection
@@ -15,6 +16,18 @@ namespace = sumologic
 
 build:
 	cd ${root_dir} && ${root_dir}ci/build.sh
+
+build-local:
+	DOCKER_USE_CACHE=true \
+	${mkfile_path} \
+		build \
+		tag-and-push-local
+
+tag-and-push-local:
+	$(eval timestamp := $(shell date +%s))
+	docker tag sumologic/kubernetes-fluentd:local localhost:32000/sumologic/kubernetes-fluentd:local-${timestamp}
+	docker push localhost:32000/sumologic/kubernetes-fluentd:local-${timestamp}
+	sed -i 's/^\([[:space:]]\+\)tag:.*$$/\1tag: local-${timestamp}/' ${local_values_file}
 
 # Collector section
 ## Collector upgrade
@@ -44,10 +57,11 @@ helm-dependencies:
 	helm dependency update "${helm_path}"
 
 helm-upgrade:
+	$(eval local_values_param := $(shell [ -f ${local_values_file} ] && echo "-f ${local_values_file}" || echo ""))
 	helm upgrade "${name}" "${helm_path}" \
 		--namespace "${namespace}" \
 		--install \
-		-f "${root_dir}vagrant/values.yaml"
+		-f "${root_dir}vagrant/values.yaml" ${local_values_param}
 
 apply-service-monitors:
 	kubectl apply -f ${k8s_path}/service-monitors.yaml

--- a/vagrant/Makefile
+++ b/vagrant/Makefile
@@ -23,7 +23,9 @@ tag-and-push-local:
 	$(eval timestamp := $(shell date +%s))
 	docker tag sumologic/kubernetes-fluentd:local localhost:32000/sumologic/kubernetes-fluentd:local-${timestamp}
 	docker push localhost:32000/sumologic/kubernetes-fluentd:local-${timestamp}
-	sed -i 's/^\([[:space:]]\+\)tag:.*$$/\1tag: local-${timestamp}/' ${local_values_file}
+	touch ${local_values_file}
+	yq w -i ${local_values_file} image.repository localhost:32000/sumologic/kubernetes-fluentd
+	yq w -i ${local_values_file} image.tag local-${timestamp}
 
 generate-local-config:
 	${root_dir}vagrant/scripts/generate-local-config.sh

--- a/vagrant/scripts/generate-local-config.sh
+++ b/vagrant/scripts/generate-local-config.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
 cat > /sumologic/vagrant/values.local.yaml <<END
-fluentd:
-  metadata:
-    pluginLogLevel: "info"
 image:
   repository: localhost:32000/sumologic/kubernetes-fluentd
   tag: local

--- a/vagrant/scripts/generate-local-config.sh
+++ b/vagrant/scripts/generate-local-config.sh
@@ -1,8 +1,3 @@
 #!/bin/bash
 
-cat > /sumologic/vagrant/values.local.yaml <<END
-image:
-  repository: localhost:32000/sumologic/kubernetes-fluentd
-  tag: local
-  pullPolicy: Always
-END
+touch /sumologic/vagrant/values.local.yaml

--- a/vagrant/scripts/generate-local-values-file.sh
+++ b/vagrant/scripts/generate-local-values-file.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+cat > /sumologic/vagrant/values.local.yaml <<END
+fluentd:
+  metadata:
+    pluginLogLevel: "info"
+image:
+  repository: localhost:32000/sumologic/kubernetes-fluentd
+  tag: local
+  pullPolicy: Always
+END


### PR DESCRIPTION
This is a poor man's try at adding the following improvements:
- When building locally, push the built Docker image to local registry and use it when running locally.
- When building locally, use Docker cache.

Suggestions for improvements are welcome.