### PR TITLE
Include OpenTelemetry Collector logs by default

### DIFF
--- a/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
@@ -36,7 +36,7 @@
 {{- end }}
 
 {{ if .Values.otelcol.logLevelFilter }}
- {{ printf "<filter **%s-otelcol**>" (include "sumologic.fullname" .) }}
+ {{ printf "<filter **%s**>" (include "sumologic.metadata.name.otelcol.deployment" .) }}
    @type grep
    <regexp>
      key log

--- a/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
@@ -36,7 +36,7 @@
 {{- end }}
 
 {{ if .Values.otelcol.logLevelFilter }}
- {{ printf "<filter **%s**>" (include "sumologic.metadata.name.otelcol.deployment" .) }}
+ {{ printf "<filter **%s**>" (include "sumologic.metadata.name.otelcol" .) }}
    @type grep
    <regexp>
      key log

--- a/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
@@ -25,7 +25,7 @@
   #  only match fluentd logs based on fluentd container name. by default, this is
   #  <filter **collection-sumologic**>
 {{ if .Values.fluentd.logLevelFilter }}
-  {{ printf "<filter **%s**>" (include "sumologic.fullname" .) }}
+  {{ printf "<filter **%s-fluentd**>" (include "sumologic.fullname" .) }}
     # only ingest fluentd logs of levels: {error, fatal} and warning messages if buffer is full
     @type grep
     <regexp>
@@ -34,6 +34,18 @@
     </regexp>
   </filter>
 {{- end }}
+
+{{ if .Values.otelcol.logLevelFilter }}
+ {{ printf "<filter **%s-otelcol**>" (include "sumologic.fullname" .) }}
+   @type grep
+   <regexp>
+     key log
+     # Select only known error/warning/fatal/panic levels or logs coming from one of the source known to provide useful data
+     pattern /\"level\":\"(error|warning|fatal|panic|dpanic)\"|\"caller\":\"(builder|service|kube|static)/
+   </regexp>
+ </filter>
+{{- end }}
+
   # third-party kubernetes metadata  filter plugin
   <filter containers.**>
     @type kubernetes_metadata

--- a/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
@@ -22,9 +22,9 @@
   @label @NORMAL
 </match>
 <label @NORMAL>
-  #  only match fluentd logs based on fluentd container name. by default, this is
-  #  <filter **collection-sumologic**>
 {{ if .Values.fluentd.logLevelFilter }}
+  # only match fluentd logs based on fluentd container log file name.
+  # by default, this is <filter **collection-sumologic-fluentd**>
   {{ printf "<filter **%s**>" (include "sumologic.metadata.name.fluentd" .) }}
     # only ingest fluentd logs of levels: {error, fatal} and warning messages if buffer is full
     @type grep

--- a/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
@@ -25,7 +25,7 @@
   #  only match fluentd logs based on fluentd container name. by default, this is
   #  <filter **collection-sumologic**>
 {{ if .Values.fluentd.logLevelFilter }}
-  {{ printf "<filter **%s**>" (include "sumologic.labels.app.fluentd" .) }}
+  {{ printf "<filter **%s**>" (include "sumologic.metadata.name.fluentd" .) }}
     # only ingest fluentd logs of levels: {error, fatal} and warning messages if buffer is full
     @type grep
     <regexp>

--- a/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.source.containers.conf
@@ -25,7 +25,7 @@
   #  only match fluentd logs based on fluentd container name. by default, this is
   #  <filter **collection-sumologic**>
 {{ if .Values.fluentd.logLevelFilter }}
-  {{ printf "<filter **%s-fluentd**>" (include "sumologic.fullname" .) }}
+  {{ printf "<filter **%s**>" (include "sumologic.labels.app.fluentd" .) }}
     # only ingest fluentd logs of levels: {error, fatal} and warning messages if buffer is full
     @type grep
     <regexp>

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -205,8 +205,12 @@ helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 {{- template "sumologic.fullname" . }}-scc
 {{- end -}}
 
+{{- define "sumologic.metadata.name.fluentd" -}}
+{{ template "sumologic.fullname" . }}-fluentd
+{{- end -}}
+
 {{- define "sumologic.metadata.name.logs" -}}
-{{ template "sumologic.labels.app.fluentd" . }}-logs
+{{ template "sumologic.metadata.name.fluentd" . }}-logs
 {{- end -}}
 
 {{- define "sumologic.metadata.name.logs.service" -}}
@@ -230,7 +234,7 @@ helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 {{- end -}}
 
 {{- define "sumologic.metadata.name.metrics" -}}
-{{ template "sumologic.labels.app.fluentd" . }}-metrics
+{{ template "sumologic.metadata.name.fluentd" . }}-metrics
 {{- end -}}
 
 {{- define "sumologic.metadata.name.metrics.service" -}}
@@ -254,7 +258,7 @@ helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 {{- end -}}
 
 {{- define "sumologic.metadata.name.events" -}}
-{{ template "sumologic.labels.app.fluentd" . }}-events
+{{ template "sumologic.metadata.name.fluentd" . }}-events
 {{- end -}}
 
 {{- define "sumologic.metadata.name.events.service" -}}

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -35,8 +35,12 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- template "sumologic.fullname" . }}
 {{- end -}}
 
+{{- define "sumologic.labels.app.fluentd" -}}
+{{- template "sumologic.fullname" . }}-fluentd
+{{- end -}}
+
 {{- define "sumologic.labels.app.logs" -}}
-{{- template "sumologic.fullname" . }}-fluentd-logs
+{{- template "sumologic.labels.app.fluentd" . }}-logs
 {{- end -}}
 
 {{- define "sumologic.labels.app.logs.pod" -}}
@@ -64,7 +68,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "sumologic.labels.app.metrics" -}}
-{{- template "sumologic.fullname" . }}-fluentd-metrics
+{{- template "sumologic.labels.app.fluentd" . }}-metrics
 {{- end -}}
 
 {{- define "sumologic.labels.app.metrics.pod" -}}
@@ -92,7 +96,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "sumologic.labels.app.events" -}}
-{{- template "sumologic.fullname" . }}-fluentd-events
+{{- template "sumologic.labels.app.fluentd" . }}-events
 {{- end -}}
 
 {{- define "sumologic.labels.app.events.pod" -}}
@@ -202,7 +206,7 @@ helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 {{- end -}}
 
 {{- define "sumologic.metadata.name.logs" -}}
-{{ template "sumologic.fullname" . }}-fluentd-logs
+{{ template "sumologic.labels.app.fluentd" . }}-logs
 {{- end -}}
 
 {{- define "sumologic.metadata.name.logs.service" -}}
@@ -226,7 +230,7 @@ helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 {{- end -}}
 
 {{- define "sumologic.metadata.name.metrics" -}}
-{{ template "sumologic.fullname" . }}-fluentd-metrics
+{{ template "sumologic.labels.app.fluentd" . }}-metrics
 {{- end -}}
 
 {{- define "sumologic.metadata.name.metrics.service" -}}
@@ -250,7 +254,7 @@ helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 {{- end -}}
 
 {{- define "sumologic.metadata.name.events" -}}
-{{ template "sumologic.fullname" . }}-fluentd-events
+{{ template "sumologic.labels.app.fluentd" . }}-events
 {{- end -}}
 
 {{- define "sumologic.metadata.name.events.service" -}}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1582,6 +1582,8 @@ otelcol:
       pullPolicy: IfNotPresent
     ## Option to define priorityClassName to assign a priority class to pods.
     priorityClassName:
+  # To enable collecting all logs, set to false
+  logLevelFilter: true
   config:
     receivers:
       jaeger:

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -153,10 +153,10 @@ data:
       @label @NORMAL
     </match>
     <label @NORMAL>
-      #  only match fluentd logs based on fluentd container name. by default, this is
-      #  <filter **collection-sumologic**>
     
-      <filter **collection-sumologic**>
+      # only match fluentd logs based on fluentd container log file name.
+      # by default, this is <filter **collection-sumologic-fluentd**>
+      <filter **collection-sumologic-fluentd**>
         # only ingest fluentd logs of levels: {error, fatal} and warning messages if buffer is full
         @type grep
         <regexp>
@@ -164,6 +164,17 @@ data:
           pattern /\[error\]|\[fatal\]|drop_oldest_chunk|retry succeeded/
         </regexp>
       </filter>
+  
+    
+     <filter **collection-sumologic-otelcol**>
+       @type grep
+       <regexp>
+         key log
+         # Select only known error/warning/fatal/panic levels or logs coming from one of the source known to provide useful data
+         pattern /\"level\":\"(error|warning|fatal|panic|dpanic)\"|\"caller\":\"(builder|service|kube|static)/
+       </regexp>
+     </filter>
+  
       # third-party kubernetes metadata  filter plugin
       <filter containers.**>
         @type kubernetes_metadata


### PR DESCRIPTION
Splits the filter commonly assigned to Fluentd and OTC into two separate filters.
For OTC, select logs with warning or error level, as well as some of the other logs
from selected components. That way we e.g. skip logging exporter logs (which could
flood the ingest)

###### Description

Fill in your description here.

###### Testing performed

- [ ] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
