### PR TITLE
fix: remove adding new resources limits and requests from 1.3

### DIFF
--- a/deploy/helm/prometheus-overrides.yaml
+++ b/deploy/helm/prometheus-overrides.yaml
@@ -155,13 +155,13 @@ prometheus:
       labels: {}
       annotations: {}
     ## Define resources requests and limits for single Pods.
-    resources:
-      limits:
-        cpu: 2000m
-        memory: 8Gi
-      requests:
-        cpu: 1000m
-        memory: 2Gi
+    resources: {}
+    # limits:
+    #   cpu: 2000m
+    #   memory: 8Gi
+    # requests:
+    #   cpu: 1000m
+    #   memory: 2Gi
     thanos:
       baseImage: quay.io/thanos/thanos
       version: v0.10.0
@@ -171,9 +171,9 @@ prometheus:
         limits:
           cpu: 10m
           memory: 32Mi
-        requests:
-          cpu: 1m
-          memory: 8Mi
+          # requests:
+          #   cpu: 1m
+          #   memory: 8Mi
     containers:
     - name: "prometheus-config-reloader"
       env:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -83,9 +83,9 @@ sumologic:
         limits:
           memory: 256Mi
           cpu: 2000m
-        requests:
-          memory: 128Mi
-          cpu: 200m
+        # requests:
+        #   memory: 128Mi
+        #   cpu: 200m
       nodeSelector: {}
       ## Add custom labels only to setup job pod
       podLabels: {}
@@ -1007,13 +1007,13 @@ prometheus-operator:
         labels: {}
         annotations: {}
       ## Define resources requests and limits for single Pods.
-      resources:
-        limits:
-          cpu: 2000m
-          memory: 8Gi
-        requests:
-          cpu: 1000m
-          memory: 2Gi
+      resources: {}
+        # limits:
+        #   cpu: 2000m
+        #   memory: 8Gi
+        # requests:
+        #   cpu: 1000m
+        #   memory: 2Gi
       thanos:
         baseImage: quay.io/thanos/thanos
         version: v0.10.0
@@ -1023,9 +1023,9 @@ prometheus-operator:
           limits:
             cpu: 10m
             memory: 32Mi
-          requests:
-            cpu: 1m
-            memory: 8Mi
+          # requests:
+          #   cpu: 1m
+          #   memory: 8Mi
       containers:
       - name: "prometheus-config-reloader"
         env:

--- a/deploy/kubernetes/setup-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/setup-sumologic.yaml.tmpl
@@ -273,9 +273,6 @@ spec:
           limits:
             cpu: 2000m
             memory: 256Mi
-          requests:
-            cpu: 200m
-            memory: 128Mi
           
         volumeMounts:
         - name: setup


### PR DESCRIPTION
I propose to remove resources from Prometheus in `1.3` release and reintroduce it in `2.0`.
It has been added as a fix for https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/885

I see adding `resources` for Prometheus were wrong values can break the solution as a breaking change.

The same story with `setup job` and for `Thanos`.

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
