### PR TITLE
Revert the FluentD image version to 1.2.3

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -79,13 +79,6 @@ sumologic:
 
   setup:
     job:
-      resources:
-        limits:
-          memory: 256Mi
-          cpu: 2000m
-        # requests:
-        #   memory: 128Mi
-        #   cpu: 200m
       nodeSelector: {}
       ## Add custom labels only to setup job pod
       podLabels: {}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -3,7 +3,7 @@
 
 image:
   repository: sumologic/kubernetes-fluentd
-  tag: 1.3.0-beta.1
+  tag: 1.2.3
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -834,7 +834,7 @@ spec:
         
       containers:
       - name: fluentd-events
-        image: sumologic/kubernetes-fluentd:1.3.0-beta.1
+        image: sumologic/kubernetes-fluentd:1.2.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -917,7 +917,7 @@ spec:
         
       containers:
       - name: fluentd
-        image: sumologic/kubernetes-fluentd:1.3.0-beta.1
+        image: sumologic/kubernetes-fluentd:1.2.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -1042,7 +1042,7 @@ spec:
         
       containers:
       - name: fluentd
-        image: sumologic/kubernetes-fluentd:1.3.0-beta.1
+        image: sumologic/kubernetes-fluentd:1.2.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/deploy/kubernetes/setup-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/setup-sumologic.yaml.tmpl
@@ -266,13 +266,11 @@ spec:
           defaultMode: 0777
       containers:
       - name: setup
-        image: sumologic/kubernetes-fluentd:1.3.0-beta.1
+        image: sumologic/kubernetes-fluentd:1.2.3
         imagePullPolicy: IfNotPresent
         command: ["/etc/terraform/setup.sh"]
         resources:
-          limits:
-            cpu: 2000m
-            memory: 256Mi
+          null
           
         volumeMounts:
         - name: setup


### PR DESCRIPTION
###### Description

Fill in your description here.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
