### PR TITLE
Revert "Revert to using helm stable for Prometheus Operator chart"

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -123,6 +123,7 @@ if [ -n "$GITHUB_TOKEN" ] && [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]; then
   echo "# This file is auto-generated." > deploy/kubernetes/fluentd-sumologic.yaml.tmpl
   sudo helm init --client-only
   sudo helm repo add falcosecurity https://falcosecurity.github.io/charts
+  sudo helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
   cd deploy/helm/sumologic || exit 1
   sudo helm dependency update
   cd ../../../ || exit 1
@@ -217,6 +218,7 @@ function push_helm_chart() {
   git checkout -- .
   sudo helm init --client-only
   sudo helm repo add falcosecurity https://falcosecurity.github.io/charts
+  sudo helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
   sudo helm package deploy/helm/sumologic --dependency-update --version="$version" --app-version="$version"
   git fetch origin-repo
   git checkout gh-pages

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -53,9 +53,9 @@ kubectl | 1.15.0
 
 The following matrix displays the tested package versions for our Helm chart.
 
-Sumo Logic Helm Chart | Prometheus Operator | FluentD | Fluent Bit | Falco  | Metrics Server | Telegraf Operator
+Sumo Logic Helm Chart | kube-prometheus-stack/Prometheus Operator | FluentD | Fluent Bit | Falco  | Metrics Server | Telegraf Operator
 |:-------- |:-------- |:-------- |:-------- |:-------- |:-------- |:--------
-1.3.0 - Latest | 8.13.8 | 1.11.1 | 2.10.1 | 1.4.0 | 2.11.2 | 1.1.4
+1.3.0 - Latest | 9.3.4 | 1.11.1 | 2.10.1 | 1.4.0 | 2.11.2 | 1.1.4
 1.2.0 - 1.2.3 | 8.13.8 | 1.11.1 | 2.8.14 | 1.1.8 | 2.11.1 | -
 1.1.0 | 8.13.8 | 1.8.1 | 2.8.14 | 1.1.8 | 2.11.1 | -
 1.0.0 | 8.2.0 | 1.8.1 | 2.8.1 | 1.1.6 | 2.7.0 | -

--- a/deploy/docs/existingPrometheusDoc.md
+++ b/deploy/docs/existingPrometheusDoc.md
@@ -118,13 +118,13 @@ If you have customized your Prometheus configuration, follow these steps to merg
 Helm supports providing multiple configuration files, and priority will be given to the last (right-most) file specified. You can obtain your current prometheus configuration by running
 
 ```bash
-helm get values prometheus-operator > current-values.yaml
+helm get values $PROMETHEUS_OPERATOR_CHART_NAME > current-values.yaml
 ```
 
 Any section of `current-values.yaml` that conflicts with sections of our `prometheus-overrides.yaml` will have to be removed from the `prometheus-overrides.yaml` file and appended to `current-values.yaml` in relevant sections. For any config that doesn’t conflict, you can leave them in `prometheus-overrides.yaml`. Then run
 
 ```bash
-helm upgrade prometheus-operator stable/prometheus-operator -f current-values.yaml -f prometheus-overrides.yaml
+helm upgrade $PROMETHEUS_OPERATOR_CHART_NAME stable/prometheus-operator -f current-values.yaml -f prometheus-overrides.yaml
 ```
 
 __NOTE__ To filter or add custom metrics to Prometheus, [please refer to this document](additional_prometheus_configuration.md)

--- a/deploy/helm/sumologic/README.md
+++ b/deploy/helm/sumologic/README.md
@@ -2,7 +2,7 @@
 To see all available configuration for our sub-charts, please refer to their documentation.
 
   * [Falco](https://github.com/helm/charts/tree/master/stable/falco#configuration) - All Falco properties should be prefixed with `falco.` in our values.yaml to override a property not listed below.
-  * [Prometheus Operator](https://github.com/helm/charts/tree/master/stable/prometheus-operator#configuration) - All Prometheus Operator properties should be prefixed with `prometheus-operator.` in our values.yaml to override a property not listed below.
+  * [Kube-Prometheus-Stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#configuration) - All `kube-sprometheus-stack` properties should be prefixed with `prometheus-operator.` in our values.yaml to override a property not listed below.
   * [Fluent-bit](https://github.com/helm/charts/tree/master/stable/fluent-bit#configuration) - All Fluent-bit properties should be prefixed with `fluent-bit.` in our values.yaml to override a property not listed below.
   * [Metrics Server](https://github.com/helm/charts/tree/master/stable/metrics-server#configuration) - All Metrics Server properties should be prefixed with `metrics-server.` in our values.yaml to override a property not listed below.
   

--- a/deploy/helm/sumologic/requirements.yaml
+++ b/deploy/helm/sumologic/requirements.yaml
@@ -3,9 +3,10 @@ dependencies:
     version: 2.10.1
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: fluent-bit.enabled,sumologic.logs.enabled
-  - name: prometheus-operator
-    version: 8.13.8
-    repository: https://kubernetes-charts.storage.googleapis.com/
+  - name: kube-prometheus-stack
+    version: 9.3.4
+    repository: https://prometheus-community.github.io/helm-charts
+    alias: prometheus-operator
     condition: prometheus-operator.enabled,sumologic.metrics.enabled
   - name: falco
     version: 1.4.0

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -837,8 +837,9 @@ fluent-bit:
 
     @INCLUDE fluent-bit-output.conf
 
-## Configure prometheus-operator
-## ref: https://github.com/helm/charts/blob/master/stable/prometheus-operator/values.yaml
+## Configure kube-prometheus-stack
+## We are using an alias prometheus-operator for the kube-prometheus-stack helm chart for backward compatibility. This will be changed in v2.0.
+## ref: https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml
 prometheus-operator:
   ## Labels to apply to all prometheus operator resources
   commonLabels: {}


### PR DESCRIPTION
This reverts commit 12916f9c93c61dec6ba4856a5c757e8f8af5e611.

###### Description

Fill in your description here.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
