### PR TITLE
Remove unsupported AKS 1.15 and GKE 1.14 from the docs

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -46,8 +46,8 @@ Name | Version
 -------- | -----
 K8s with EKS | 1.14<br/>1.15<br/>1.16<br/>1.17
 K8s with Kops | 1.16<br/>1.17<br/>1.18
-K8s with GKE | 1.14<br/>1.15<br/>1.16
-K8s with AKS | 1.15<br/>1.16<br/>1.17
+K8s with GKE | 1.15<br/>1.16
+K8s with AKS | 1.16<br/>1.17
 Helm | 2.14.13 (Linux)
 kubectl | 1.15.0
 


### PR DESCRIPTION
###### Description

Fill in your description here.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
