### PR TITLE
Adding namespace key/val

### DIFF
--- a/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name:  {{ template "sumologic.metadata.name.setup.configmap" . }}
+  namespace: {{ .Release.Namespace }}
   annotations:
 {{ include "sumologic.annotations.app.setup.helmsh" "2" | indent 4 }}
   labels:

--- a/deploy/helm/sumologic/templates/setup/setup-serviceaccount.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name:  {{ template "sumologic.metadata.name.setup.roles.serviceaccount" . }}
+  namespace: {{ .Release.Namespace }}
   annotations:
 {{ include "sumologic.annotations.app.setup.helmsh" "0" | indent 4 }}
   labels:


### PR DESCRIPTION
Fixes this issue:  https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/985

I am installing this chart into a namespace called `monitoring`.  This chart is currently creating the `serviceaccount` and `configmaps` in the `default` namespace:

```
2wire609-v:ht-devops garlandkan$ kubectl -n default get serviceaccounts
NAME                        SECRETS   AGE
default                     1         558d
sumologic-sumologic-setup   1         33m
2wire609-v:ht-devops garlandkan$ kubectl -n default get cm
NAME                              DATA   AGE
fluentd-config-resource-version   1      24m
sumologic-sumologic-setup         6      34m
```