### PR TITLE
Add possibility to disable metrics coming from OTC

### DIFF
--- a/deploy/helm/sumologic/README.md
+++ b/deploy/helm/sumologic/README.md
@@ -205,6 +205,7 @@ Parameter | Description | Default
 `telegraf-operator.data` | Telegraf sidecar configuration. | `{"sumologic-prometheus": "[[outputs.prometheus_client]]\\n          ## Configuration details:\\n          ## https://github.com/influxdata/telegraf/tree/master/plugins/outputs/prometheus_client#configuration\\n          listen = ':9273'\\n          metric_version = 2\\n"}`
 `otelcol.deployment.replicas` | Set the number of OpenTelemetry Collector replicas. | `1`
 `otelcol.deployment.resources.limits.memory` | Sets the OpenTelemetry Collector memory limit. | `2Gi`
+`otelcol.metrics_enabled` | Enable or disable generation of the metrics from Collector. | `false`
 `otelcol.config.service.pipelines.traces.receivers` | Sets the list of enabled receivers. | `{jaeger, opencensus, otlp, zipkin}`
 `otelcol.config.exporters.zipkin.timeout` | Sets the Zipkin (default) exporter timeout. Append the unit, e.g. `s` when setting the parameter | `5s`
 `otelcol.config.exporters.logging.loglevel` | When tracing debug logging exporter is enabled, sets the verbosity level. Use either `info` or `debug`. | `info`

--- a/deploy/helm/sumologic/templates/otelcol-deployment.yaml
+++ b/deploy/helm/sumologic/templates/otelcol-deployment.yaml
@@ -57,6 +57,9 @@ spec:
         command:
           - "/otelcontribcol"
           - "--config=/conf/traces.otelcol.conf.yaml"
+          {{- if eq .Values.sumologic.traces.otc_metrics.enabled false }}
+          - "--metrics-level=none"
+          {{- end }}
           - {{ printf "--mem-ballast-size-mib=%s" .Values.otelcol.deployment.memBallastSizeMib }}
         env:
         - name: GOGC

--- a/deploy/helm/sumologic/templates/otelcol-deployment.yaml
+++ b/deploy/helm/sumologic/templates/otelcol-deployment.yaml
@@ -57,7 +57,7 @@ spec:
         command:
           - "/otelcontribcol"
           - "--config=/conf/traces.otelcol.conf.yaml"
-          {{- if eq .Values.sumologic.traces.otc_metrics.enabled false }}
+          {{- if eq .Values.otelcol.metrics_enabled false }}
           - "--metrics-level=none"
           {{- end }}
           - {{ printf "--mem-ballast-size-mib=%s" .Values.otelcol.deployment.memBallastSizeMib }}

--- a/deploy/helm/sumologic/templates/otelcol-service.yaml
+++ b/deploy/helm/sumologic/templates/otelcol-service.yaml
@@ -19,8 +19,10 @@ spec:
   - name: jaeger-thrift-binary # Default endpoint for Jaeger Thrift Binary receiver.
     port: 6832
     protocol: UDP
+  {{- if eq .Values.sumologic.traces.otc_metrics.enabled true }}
   - name: metrics # Default endpoint for querying metrics.
     port: 8888
+  {{- end }}
   - name: zipkin # Default endpoint for Zipkin receiver.
     port: 9411
   - name: jaeger-grpc  # Default endpoint for Jaeger gRPC

--- a/deploy/helm/sumologic/templates/otelcol-service.yaml
+++ b/deploy/helm/sumologic/templates/otelcol-service.yaml
@@ -19,7 +19,7 @@ spec:
   - name: jaeger-thrift-binary # Default endpoint for Jaeger Thrift Binary receiver.
     port: 6832
     protocol: UDP
-  {{- if eq .Values.sumologic.traces.otc_metrics.enabled true }}
+  {{- if eq .Values.otelcol.metrics_enabled true }}
   - name: metrics # Default endpoint for querying metrics.
     port: 8888
   {{- end }}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -168,6 +168,9 @@ sumologic:
     fluentd_stdout: false
     ## How many spans per request should be send to receiver
     spans_per_request: 100
+    ## Metrics from Traces Collector
+    otc_metrics:
+      enabled: false
 
 fluentd:
   ## Specifies whether a PodSecurityPolicy should be created

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1588,7 +1588,7 @@ otelcol:
   # To enable collecting all logs, set to false
   logLevelFilter: true
   # Metrics from Collector
-  metrics_enabled: false
+  metrics_enabled: true
   # Collector configuration
   config:
     receivers:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -168,9 +168,6 @@ sumologic:
     fluentd_stdout: false
     ## How many spans per request should be send to receiver
     spans_per_request: 100
-    ## Metrics from Traces Collector
-    otc_metrics:
-      enabled: false
 
 fluentd:
   ## Specifies whether a PodSecurityPolicy should be created
@@ -1588,6 +1585,9 @@ otelcol:
     priorityClassName:
   # To enable collecting all logs, set to false
   logLevelFilter: true
+  # Metrics from Collector
+  metrics_enabled: false
+  # Collector configuration
   config:
     receivers:
       jaeger:


### PR DESCRIPTION
**###### Description**

New variable `otelcol.metrics_enabled` gives possibility to disable or enable (false/true) metrics coming from OpenTelemetry Collector. Changes are touching otc-service configuration (ports), otc-deployment (additional argument in command), values.yaml (default value).

**Expected log when metrics are enabled:**
`{"level":"info","ts":1602188423.6246598,"caller":"service/service.go:256","msg":"Setting up own telemetry..."}
{"level":"info","ts":1602188423.6251273,"caller":"service/telemetry.go:100","msg":"Serving Prometheus metrics","address":":8888","legacy_metrics":false,"new_metrics":true,"level":3,"service.instance.id":"c8020a8f-9ccb-4d98-8619-b0ddf1f24331"}
{"level":"info","ts":1602188423.6261094,"caller":"service/service.go:293","msg":"Loading configuration..."}`

**Expected log when metrics are disabled:**
`{"level":"info","ts":1602188357.0610797,"caller":"service/service.go:256","msg":"Setting up own telemetry..."}
{"level":"info","ts":1602188357.0619454,"caller":"service/service.go:293","msg":"Loading configuration..."}
{"level":"info","ts":1602188357.0664148,"caller":"service/service.go:304","msg":"Applying configuration..."}`


**###### Testing performed**

Tested on test cluster.
