### PR TITLE
Add check for vagrant disksize plugin in Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,12 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+unless Vagrant.has_plugin?("vagrant-disksize")
+  puts "vagrant-disksize plugin unavailable\n" +
+       "please install it via 'vagrant plugin install vagrant-disksize'"
+  exit 1
+end
+
 Vagrant.configure('2') do |config|
   config.vm.box = 'ubuntu/bionic64'
   config.disksize.size = '50GB'


### PR DESCRIPTION
###### Description

If user has `vagrant-disksize` plugin missing he'll get an error saying:

```
Bringing machine 'default' up with 'virtualbox' provider...
There are errors in the configuration of this machine. Please fix
the following errors and try again:

Vagrant:
* Unknown configuration section 'disksize'.
```

This PR catches this explicitly and suggests how to install said plugin.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
