### PR TITLE
Allow HostsPorts for openshift (required for  node-exporter)

### DIFF
--- a/deploy/helm/sumologic/templates/scc.yaml
+++ b/deploy/helm/sumologic/templates/scc.yaml
@@ -15,7 +15,7 @@ allowHostDirVolumePlugin: true
 allowHostIPC: false
 allowHostNetwork: true
 allowHostPID: true
-allowHostPorts: false
+allowHostPorts: true
 allowPrivilegeEscalation: true
 allowPrivilegedContainer: true
 allowedCapabilities: []


### PR DESCRIPTION
###### Description

Allow HostsPorts for openshift (required for node-exporter).

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
