### PR TITLE
Bump fluent-plugin-kubernetes_metadata_filter from 2.4.1 to 2.5.2

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -35,7 +35,7 @@ RUN gem install \
 RUN gem install \
         fluent-plugin-systemd:1.0.2 \
         fluent-plugin-record-modifier:2.0.1 \
-        fluent-plugin-kubernetes_metadata_filter:2.4.1 \
+        fluent-plugin-kubernetes_metadata_filter:2.5.2 \
         fluent-plugin-sumologic_output:1.7.1 \
         fluent-plugin-concat:2.4.0 \
         fluent-plugin-rewrite-tag-filter:2.2.0 \


### PR DESCRIPTION
Fixes #995 by upgrading the Fluent plugin that was causing the issue.

Link to the fix in the plugin: https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter/pull/204