### PR TITLE
Bump fluentd and enable gzip compression by default

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluent/fluentd:v1.11.1-debian-1.0 AS builder
+FROM fluent/fluentd:v1.11.3-debian-1.0 AS builder
 
 # Use root account to use apt
 USER root
@@ -62,7 +62,7 @@ RUN gem install \
         --local fluent-plugin-events
 
 # Start with fresh image
-FROM fluent/fluentd:v1.11.1-debian-1.0
+FROM fluent/fluentd:v1.11.3-debian-1.0
 
 USER root
 

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -228,9 +228,7 @@ fluentd:
     totalLimitSize: "128m"
     retryMaxInterval: "10m"
     retryForever: true
-    ## usage of the gzip compression is highly not recommended due to fluentd issue:
-    ## rel: https://github.com/fluent/fluentd/issues/3056
-    compress: text
+    compress: gzip
 
     ## File paths to buffer to, if Fluentd buffer type is specified as file above.
     ## Each sumologic output plugin buffers to its own unique file.

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -48,7 +48,7 @@ data:
     @include common.conf
     @include logs.conf
   buffer.output.conf: |-
-    compress "text"
+    compress "gzip"
     flush_interval "5s"
     flush_thread_count "8"
     chunk_limit_size "1m"
@@ -367,7 +367,7 @@ data:
     </system>
   
   buffer.output.conf: |-
-    compress "text"
+    compress "gzip"
     flush_interval "5s"
     flush_thread_count "8"
     chunk_limit_size "1m"
@@ -393,7 +393,7 @@ data:
     @include common.conf
     @include metrics.conf
   buffer.output.conf: |-
-    compress "text"
+    compress "gzip"
     flush_interval "5s"
     flush_thread_count "8"
     chunk_limit_size "1m"


### PR DESCRIPTION
###### Description

Bump fluentd and enable gzip compression by default

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
