### PR TITLE
Add known k8s api callers to vagrant values.yaml and bump falco chart to 1.5.0

### DIFF
--- a/deploy/helm/sumologic/requirements.yaml
+++ b/deploy/helm/sumologic/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
     alias: prometheus-operator
     condition: prometheus-operator.enabled,sumologic.metrics.enabled
   - name: falco
-    version: 1.4.0
+    version: 1.5.0
     repository: https://falcosecurity.github.io/charts
     condition: falco.enabled
   - name: metrics-server

--- a/vagrant/values.yaml
+++ b/vagrant/values.yaml
@@ -29,3 +29,31 @@ sumologic:
 telegraf-operator:
   enabled: true
   replicaCount: 1
+
+falco:
+  enabled: true
+  customRules:
+    # Mark the following as known k8s api callers:
+    # * fluentd and its plugins
+    # * grafana sidecar
+    # * terraform provider started in setup job
+    # * telegraf operator
+    # * kube state metrics server
+    # * prometheus
+    # * prometheus operator
+    rules_user_known_k8s_api_callers.yaml: |-
+      - macro: user_known_contact_k8s_api_server_activities
+        condition: >
+          (proc.pcmdline = "fluentd /usr/local/bundle/bin/fluentd -c /fluentd/etc/fluent.conf -p /fluentd/plugins") or
+          (proc.cmdline = "fluentd /usr/local/bundle/bin/fluentd -c /fluentd/etc/fluent.conf -p /fluentd/plugins") or
+          (proc.cmdline = "ruby -Eascii-8bit:ascii-8bit /usr/local/bundle/bin/fluentd -c /fluentd/etc/fluent.conf -p /fluentd/plugins --under-supervisor") or
+          (proc.cmdline = "event_loop -Eascii-8bit:ascii-8bit /usr/local/bundle/bin/fluentd -c /fluentd/etc/fluent.conf -p /fluentd/plugins --under-supervisor") or
+          (proc.cmdline = "watch_endpoints -Eascii-8bit:ascii-8bit /usr/local/bundle/bin/fluentd -c /fluentd/etc/fluent.conf -p /fluentd/plugins --under-supervisor") or
+          (proc.cmdline = "watch_events -Eascii-8bit:ascii-8bit /usr/local/bundle/bin/fluentd -c /fluentd/etc/fluent.conf -p /fluentd/plugins --under-supervisor") or
+          (proc.cmdline = "filter_kuberne* /usr/local/bundle/bin/fluentd -c /fluentd/etc/fluent.conf -p /fluentd/plugins") or
+          (proc.cmdline = "python -u /app/sidecar.py") or
+          (proc.cmdline startswith "terraform-provi") or
+          (proc.cmdline startswith "manager --telegraf-default-class=sumologic-prometheus --telegraf-classes-directory=/etc/telegraf-operator --enable-default-internal-plugin --telegraf-image=docker.io/library/telegraf") or
+          (proc.cmdline startswith "kube-state-metr") or
+          (proc.cmdline startswith "prometheus") or
+          (proc.cmdline startswith "operator")


### PR DESCRIPTION
###### Description

* enable falco by default in vagrant
* add known k8s api callers to prevent unnecessary notice logs - https://github.com/falcosecurity/falco/blob/388de273985758afbfc2833885faa24ee5da5703/rules/falco_rules.yaml#L2422-L2436
* bump falco chart from `1.4.0` to `1.5.0` (this bumps falco from `0.25.0` to `0.26.1`)

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
