### PR TITLE
Bump telegraf-operator to 1.1.6 (official 1.1.5 with helm2 support)(#1008 Backport)

### DIFF
--- a/deploy/helm/sumologic/requirements.yaml
+++ b/deploy/helm/sumologic/requirements.yaml
@@ -17,6 +17,6 @@ dependencies:
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: metrics-server.enabled
   - name: telegraf-operator
-    version: 1.1.4
+    version: 1.1.6
     repository: https://sumologic.github.io/influxdata-helm-charts
     condition: telegraf-operator.enabled


### PR DESCRIPTION
###### Description

Bump telegraf-operator to 1.1.6 (official 1.1.5 with helm2 support) #1008 Backport

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
