### PR TITLE
Override Fluent Bit image to fluent/fluent-bit:1.6.0

### DIFF
--- a/deploy/helm/fluent-bit-overrides.yaml
+++ b/deploy/helm/fluent-bit-overrides.yaml
@@ -1,4 +1,8 @@
 # This file is auto-generated.
+image:
+  fluent_bit:
+    repository: fluent/fluent-bit
+    tag: 1.6.0
 ## Resource limits for fluent-bit
 resources: {}
 # limits:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -702,6 +702,10 @@ metrics-server:
 ## Configure fluent-bit
 ## ref: https://github.com/helm/charts/blob/master/stable/fluent-bit/values.yaml
 fluent-bit:
+  image:
+    fluent_bit:
+      repository: fluent/fluent-bit
+      tag: 1.6.0
   ## Resource limits for fluent-bit
   resources: {}
     # limits:


### PR DESCRIPTION
###### Description

Override Fluent Bit image to 1.6.0

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
