### PR TITLE
Bump sumologic-terraform-provider to 2.3.3

### DIFF
--- a/deploy/helm/sumologic/conf/setup/main.tf
+++ b/deploy/helm/sumologic/conf/setup/main.tf
@@ -1,6 +1,6 @@
 terraform {
   required_providers {
-    sumologic  = "= 2.3.3"
+    sumologic  = "~> 2.3.0"
     kubernetes = "~> 1.11.3"
   }
 }

--- a/deploy/helm/sumologic/conf/setup/main.tf
+++ b/deploy/helm/sumologic/conf/setup/main.tf
@@ -1,6 +1,6 @@
 terraform {
   required_providers {
-    sumologic  = "= 2.3.0"
+    sumologic  = "= 2.3.3"
     kubernetes = "~> 1.11.3"
   }
 }

--- a/deploy/kubernetes/setup-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/setup-sumologic.yaml.tmpl
@@ -30,7 +30,7 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "= 2.3.0"
+        sumologic  = "~> 2.3.0"
         kubernetes = "~> 1.11.3"
       }
     }

--- a/tests/terraform/static/all_fields.output.yaml
+++ b/tests/terraform/static/all_fields.output.yaml
@@ -31,7 +31,7 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "= 2.3.0"
+        sumologic  = "~> 2.3.0"
         kubernetes = "~> 1.11.3"
       }
     }

--- a/tests/terraform/static/collector_fields.output.yaml
+++ b/tests/terraform/static/collector_fields.output.yaml
@@ -30,7 +30,7 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "= 2.3.0"
+        sumologic  = "~> 2.3.0"
         kubernetes = "~> 1.11.3"
       }
     }

--- a/tests/terraform/static/conditional_sources.output.yaml
+++ b/tests/terraform/static/conditional_sources.output.yaml
@@ -20,7 +20,7 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "= 2.3.0"
+        sumologic  = "~> 2.3.0"
         kubernetes = "~> 1.11.3"
       }
     }

--- a/tests/terraform/static/default.output.yaml
+++ b/tests/terraform/static/default.output.yaml
@@ -30,7 +30,7 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "= 2.3.0"
+        sumologic  = "~> 2.3.0"
         kubernetes = "~> 1.11.3"
       }
     }

--- a/tests/terraform/static/strip_extrapolation.output.yaml
+++ b/tests/terraform/static/strip_extrapolation.output.yaml
@@ -30,7 +30,7 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "= 2.3.0"
+        sumologic  = "~> 2.3.0"
         kubernetes = "~> 1.11.3"
       }
     }

--- a/tests/terraform/static/traces.output.yaml
+++ b/tests/terraform/static/traces.output.yaml
@@ -21,7 +21,7 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "= 2.3.0"
+        sumologic  = "~> 2.3.0"
         kubernetes = "~> 1.11.3"
       }
     }


### PR DESCRIPTION
###### Description

Bump to https://github.com/SumoLogic/terraform-provider-sumologic/releases/tag/v2.3.3

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
