### PR TITLE
override fluent bit image to 1.6.0 for helm chart version 1.3

### DIFF
--- a/deploy/helm/fluent-bit-overrides.yaml
+++ b/deploy/helm/fluent-bit-overrides.yaml
@@ -1,4 +1,8 @@
 # This file is auto-generated.
+image:
+  fluent_bit:
+    repository: fluent/fluent-bit
+    tag: 1.6.0
 ## Resource limits for fluent-bit
 resources: {}
 # limits:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -702,6 +702,10 @@ metrics-server:
 ## Configure fluent-bit
 ## ref: https://github.com/helm/charts/blob/master/stable/fluent-bit/values.yaml
 fluent-bit:
+  image:
+    fluent_bit:
+      repository: fluent/fluent-bit
+      tag: 1.6.0
   ## Resource limits for fluent-bit
   resources: {}
     # limits:


### PR DESCRIPTION
###### Description

Fill in your description here.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
