### PR TITLE
Fix vagrant values.yaml and add limits for prometheus

### DIFF
--- a/vagrant/values.yaml
+++ b/vagrant/values.yaml
@@ -15,13 +15,20 @@ prometheus-operator:
           editable: true
           options:
             path: /var/lib/grafana/dashboards/default
-    prometheus:
-      prometheusSpec:
-        externalLabels:
-          cluster: microk8s
     sidecar:
       image:
         sha: ''
+  prometheus:
+    prometheusSpec:
+      externalLabels:
+        cluster: microk8s
+      resources:
+        limits:
+          cpu: 4000m
+          memory: 12Gi
+        requests:
+          cpu: 500m
+          memory: 512Mi
 sumologic:
   accessId: dummy
   accessKey: dummy


### PR DESCRIPTION
###### Description

* `prometheus` key was under `grafana` key which according to `helm show values prometheus-community/kube-prometheus-stack` doesn't exist (yet it exists under `prometheus-operator`'s root key)
* add somewhat relaxes limits to vagrant prometheus to prevent OOMs

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
