### PR TITLE
Migrate off of the legacy pre-1.14 recording rules

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1531,10 +1531,10 @@ kube-prometheus-stack:
         ## :node_memory_utilisation:
         ## :node_net_saturation:sum_irate
         ## :node_net_utilisation:sum_irate
-        ## cluster_quantile:apiserver_request_latencies:histogram_quantile
-        ## cluster_quantile:scheduler_binding_latency:histogram_quantile
-        ## cluster_quantile:scheduler_e2e_scheduling_latency:histogram_quantile
-        ## cluster_quantile:scheduler_scheduling_algorithm_latency:histogram_quantile
+        ## cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
+        ## cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile
+        ## cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
+        ## cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
         ## instance:node_filesystem_usage:sum
         ## instance:node_network_receive_bytes:rate:sum
         ## node:cluster_cpu_utilisation:ratio
@@ -1559,7 +1559,7 @@ kube-prometheus-stack:
         - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.operator.rule
           writeRelabelConfigs:
             - action: keep
-              regex: 'cluster_quantile:apiserver_request_latencies:histogram_quantile|instance:node_filesystem_usage:sum|instance:node_network_receive_bytes:rate:sum|cluster_quantile:scheduler_e2e_scheduling_latency:histogram_quantile|cluster_quantile:scheduler_scheduling_algorithm_latency:histogram_quantile|cluster_quantile:scheduler_binding_latency:histogram_quantile|node_namespace_pod:kube_pod_info:|:kube_pod_info_node_count:|node:node_num_cpu:sum|:node_cpu_utilisation:avg1m|node:node_cpu_utilisation:avg1m|node:cluster_cpu_utilisation:ratio|:node_cpu_saturation_load1:|node:node_cpu_saturation_load1:|:node_memory_utilisation:|node:node_memory_bytes_total:sum|node:node_memory_utilisation:ratio|node:cluster_memory_utilisation:ratio|:node_memory_swap_io_bytes:sum_rate|node:node_memory_utilisation:|node:node_memory_utilisation_2:|node:node_memory_swap_io_bytes:sum_rate|:node_disk_utilisation:avg_irate|node:node_disk_utilisation:avg_irate|:node_disk_saturation:avg_irate|node:node_disk_saturation:avg_irate|node:node_filesystem_usage:|node:node_filesystem_avail:|:node_net_utilisation:sum_irate|node:node_net_utilisation:sum_irate|:node_net_saturation:sum_irate|node:node_net_saturation:sum_irate|node:node_inodes_total:|node:node_inodes_free:'
+              regex: 'cluster_quantile:apiserver_request_duration_seconds:histogram_quantile|instance:node_filesystem_usage:sum|instance:node_network_receive_bytes:rate:sum|cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile|cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile|cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile|node_namespace_pod:kube_pod_info:|:kube_pod_info_node_count:|node:node_num_cpu:sum|:node_cpu_utilisation:avg1m|node:node_cpu_utilisation:avg1m|node:cluster_cpu_utilisation:ratio|:node_cpu_saturation_load1:|node:node_cpu_saturation_load1:|:node_memory_utilisation:|node:node_memory_bytes_total:sum|node:node_memory_utilisation:ratio|node:cluster_memory_utilisation:ratio|:node_memory_swap_io_bytes:sum_rate|node:node_memory_utilisation:|node:node_memory_utilisation_2:|node:node_memory_swap_io_bytes:sum_rate|:node_disk_utilisation:avg_irate|node:node_disk_utilisation:avg_irate|:node_disk_saturation:avg_irate|node:node_disk_saturation:avg_irate|node:node_filesystem_usage:|node:node_filesystem_avail:|:node_net_utilisation:sum_irate|node:node_net_utilisation:sum_irate|:node_net_saturation:sum_irate|node:node_net_saturation:sum_irate|node:node_inodes_total:|node:node_inodes_free:'
               sourceLabels: [__name__]
         ## health
         ## fluentbit_input_bytes_total

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -912,11 +912,204 @@ fluent-bit:
 ## Configure kube-prometheus-stack
 ## ref: https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml
 kube-prometheus-stack:
-  ## Labels to apply to all prometheus operator resources
+
+  ## Uncomment the flag below to not install kube-prometheus-stack helm chart
+  ## as a dependency along with this helm chart.
+  ## Comment it out if you wish to have the prometheus-operator dependency installed.
+  ## Setting the flag to true instead of commenting out will break other functionality.
+  # enabled: false
+
+  # global:
+    ## Reference to one or more secrets to be used when pulling images
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # imagePullSecrets:
+    #   - name: "image-pull-secret"
+
+  ## Labels to apply to all kube-prometheus-stack resources
   commonLabels: {}
-  ## NOTE changing the serviceMonitor scrape interval to be >1m can result
-  ## in metrics from recording rules to be missing and empty panels in
-  ## Sumo Logic Kubernetes apps.
+
+  ## k8s pre-1.14 prometheus recording rules
+  additionalPrometheusRulesMap:
+    pre-1.14-node-rules:
+      groups:
+      - name: node-pre-1.14.rules
+        rules:
+        - expr: 1 - avg(rate(node_cpu_seconds_total{job="node-exporter",mode="idle"}[1m]))
+          record: :node_cpu_utilisation:avg1m
+        - expr: |-
+            1 - avg by (node) (
+              rate(node_cpu_seconds_total{job="node-exporter",mode="idle"}[1m])
+            * on (namespace, pod) group_left(node)
+              node_namespace_pod:kube_pod_info:)
+          record: node:node_cpu_utilisation:avg1m
+        - expr: |-
+            1 -
+            sum(node_memory_MemFree_bytes{job="node-exporter"} + node_memory_Cached_bytes{job="node-exporter"} + node_memory_Buffers_bytes{job="node-exporter"})
+            /
+            sum(node_memory_MemTotal_bytes{job="node-exporter"})
+          record: ':node_memory_utilisation:'
+        - expr: |-
+            (node:node_memory_bytes_total:sum - node:node_memory_bytes_available:sum)
+            /
+            node:node_memory_bytes_total:sum
+          record: node:node_memory_utilisation:ratio
+        - expr: |-
+            1 -
+            sum by (node) (
+              (node_memory_MemFree_bytes{job="node-exporter"} + node_memory_Cached_bytes{job="node-exporter"} + node_memory_Buffers_bytes{job="node-exporter"})
+            * on (namespace, pod) group_left(node)
+              node_namespace_pod:kube_pod_info:
+            )
+            /
+            sum by (node) (
+              node_memory_MemTotal_bytes{job="node-exporter"}
+            * on (namespace, pod) group_left(node)
+              node_namespace_pod:kube_pod_info:
+            )
+          record: 'node:node_memory_utilisation:'
+        - expr: 1 - (node:node_memory_bytes_available:sum / node:node_memory_bytes_total:sum)
+          record: 'node:node_memory_utilisation_2:'
+        - expr: |-
+            max by (instance, namespace, pod, device) ((node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"}
+            - node_filesystem_avail_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"})
+            / node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"})
+          record: 'node:node_filesystem_usage:'
+        - expr: |-
+            sum by (node) (
+              node_memory_MemTotal_bytes{job="node-exporter"}
+              * on (namespace, pod) group_left(node)
+                node_namespace_pod:kube_pod_info:
+            )
+          record: node:node_memory_bytes_total:sum
+        - expr: |-
+            sum(irate(node_network_receive_bytes_total{job="node-exporter",device!~"veth.+"}[1m])) +
+            sum(irate(node_network_transmit_bytes_total{job="node-exporter",device!~"veth.+"}[1m]))
+          record: :node_net_utilisation:sum_irate
+        - expr: |-
+            sum by (node) (
+              (irate(node_network_receive_bytes_total{job="node-exporter",device!~"veth.+"}[1m]) +
+              irate(node_network_transmit_bytes_total{job="node-exporter",device!~"veth.+"}[1m]))
+            * on (namespace, pod) group_left(node)
+              node_namespace_pod:kube_pod_info:
+            )
+          record: node:node_net_utilisation:sum_irate
+        - expr: |-
+            sum(irate(node_network_receive_drop_total{job="node-exporter",device!~"veth.+"}[1m])) +
+            sum(irate(node_network_transmit_drop_total{job="node-exporter",device!~"veth.+"}[1m]))
+          record: :node_net_saturation:sum_irate
+        - expr: |-
+            sum by (node) (
+              (irate(node_network_receive_drop_total{job="node-exporter",device!~"veth.+"}[1m]) +
+              irate(node_network_transmit_drop_total{job="node-exporter",device!~"veth.+"}[1m]))
+            * on (namespace, pod) group_left(node)
+              node_namespace_pod:kube_pod_info:
+            )
+          record: node:node_net_saturation:sum_irate
+        - expr: |-
+            max by (instance, namespace, pod, device) ((node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"}
+            - node_filesystem_avail_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"})
+            / node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"})
+          record: 'node:node_filesystem_usage:'
+        - expr: |-
+            sum(node_load1{job="node-exporter"})
+            /
+            sum(node:node_num_cpu:sum)
+          record: ':node_cpu_saturation_load1:'
+        - expr: |-
+            sum by (node) (
+              node_load1{job="node-exporter"}
+            * on (namespace, pod) group_left(node)
+              node_namespace_pod:kube_pod_info:
+            )
+            /
+            node:node_num_cpu:sum
+          record: 'node:node_cpu_saturation_load1:'
+        - expr: avg(irate(node_disk_io_time_weighted_seconds_total{job="node-exporter",device=~"nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+"}[1m]))
+          record: :node_disk_saturation:avg_irate
+        - expr: |-
+            avg by (node) (
+              irate(node_disk_io_time_weighted_seconds_total{job="node-exporter",device=~"nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+"}[1m])
+            * on (namespace, pod) group_left(node)
+              node_namespace_pod:kube_pod_info:
+            )
+          record: node:node_disk_saturation:avg_irate
+        - expr: avg(irate(node_disk_io_time_seconds_total{job="node-exporter",device=~"nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+"}[1m]))
+          record: :node_disk_utilisation:avg_irate
+        - expr: |-
+            avg by (node) (
+              irate(node_disk_io_time_seconds_total{job="node-exporter",device=~"nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+"}[1m])
+            * on (namespace, pod) group_left(node)
+              node_namespace_pod:kube_pod_info:
+            )
+          record: node:node_disk_utilisation:avg_irate
+        - expr: |-
+            1e3 * sum(
+              (rate(node_vmstat_pgpgin{job="node-exporter"}[1m])
+            + rate(node_vmstat_pgpgout{job="node-exporter"}[1m]))
+            )
+          record: :node_memory_swap_io_bytes:sum_rate
+        - expr: |-
+            1e3 * sum by (node) (
+              (rate(node_vmstat_pgpgin{job="node-exporter"}[1m])
+            + rate(node_vmstat_pgpgout{job="node-exporter"}[1m]))
+            * on (namespace, pod) group_left(node)
+              node_namespace_pod:kube_pod_info:
+            )
+          record: node:node_memory_swap_io_bytes:sum_rate
+        - expr: |-
+            node:node_cpu_utilisation:avg1m
+              *
+            node:node_num_cpu:sum
+              /
+            scalar(sum(node:node_num_cpu:sum))
+          record: node:cluster_cpu_utilisation:ratio
+        - expr: |-
+            (node:node_memory_bytes_total:sum - node:node_memory_bytes_available:sum)
+            /
+            scalar(sum(node:node_memory_bytes_total:sum))
+          record: node:cluster_memory_utilisation:ratio
+        - expr: |-
+            sum by (node) (
+              node_load1{job="node-exporter"}
+            * on (namespace, pod) group_left(node)
+              node_namespace_pod:kube_pod_info:
+            )
+            /
+            node:node_num_cpu:sum
+          record: 'node:node_cpu_saturation_load1:'
+        - expr: max by (instance, namespace, pod, device) (node_filesystem_avail_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"} / node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"})
+          record: 'node:node_filesystem_avail:'
+        - expr: |-
+            max by (instance, namespace, pod, device) ((node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"}
+            - node_filesystem_avail_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"})
+            / node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"})
+          record: 'node:node_filesystem_usage:'
+        - expr: |-
+            max(
+              max(
+                kube_pod_info{job="kube-state-metrics", host_ip!=""}
+              ) by (node, host_ip)
+              * on (host_ip) group_right (node)
+              label_replace(
+                (max(node_filesystem_files{job="node-exporter", mountpoint="/"}) by (instance)), "host_ip", "$1", "instance", "(.*):.*"
+              )
+            ) by (node)
+          record: 'node:node_inodes_total:'
+        - expr: |-
+            max(
+              max(
+                kube_pod_info{job="kube-state-metrics", host_ip!=""}
+              ) by (node, host_ip)
+              * on (host_ip) group_right (node)
+              label_replace(
+                (max(node_filesystem_files_free{job="node-exporter", mountpoint="/"}) by (instance)), "host_ip", "$1", "instance", "(.*):.*"
+              )
+            ) by (node)
+          record: 'node:node_inodes_free:'
+
+  ## NOTE changing the serviceMonitor scrape interval to be >1m can result in metrics from recording
+  ## rules to be missing and empty panels in Sumo Logic Kubernetes apps.
   kubeApiServer:
     serviceMonitor:
       ## Scrape interval. If not set, the Prometheus default scrape interval is used.
@@ -951,20 +1144,6 @@ kube-prometheus-stack:
     serviceMonitor:
       ## Scrape interval. If not set, the Prometheus default scrape interval is used.
       interval:
-  ## Ensure we use pre 1.14 recording rules consistently as current content depends on them.
-  kubeTargetVersionOverride: 1.13.0-0
-
-  # global:
-    ## Reference to one or more secrets to be used when pulling images
-    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-    ##
-    # imagePullSecrets:
-    #   - name: "image-pull-secret"
-
-  ## Uncomment the flag below to not install prometheus-operator helm chart as a dependency along with this helm chart.
-  ## Comment it out if you wish to have the prometheus-operator dependency installed.
-  ## Setting the flag to true instead of commenting out will break other functionality.
-  # enabled: false
 
   alertmanager:
     enabled: false

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -933,180 +933,199 @@ kube-prometheus-stack:
   additionalPrometheusRulesMap:
     pre-1.14-node-rules:
       groups:
-      - name: node-pre-1.14.rules
-        rules:
-        - expr: 1 - avg(rate(node_cpu_seconds_total{job="node-exporter",mode="idle"}[1m]))
-          record: :node_cpu_utilisation:avg1m
-        - expr: |-
-            1 - avg by (node) (
-              rate(node_cpu_seconds_total{job="node-exporter",mode="idle"}[1m])
-            * on (namespace, pod) group_left(node)
-              node_namespace_pod:kube_pod_info:)
-          record: node:node_cpu_utilisation:avg1m
-        - expr: |-
-            1 -
-            sum(node_memory_MemFree_bytes{job="node-exporter"} + node_memory_Cached_bytes{job="node-exporter"} + node_memory_Buffers_bytes{job="node-exporter"})
-            /
-            sum(node_memory_MemTotal_bytes{job="node-exporter"})
-          record: ':node_memory_utilisation:'
-        - expr: |-
-            (node:node_memory_bytes_total:sum - node:node_memory_bytes_available:sum)
-            /
-            node:node_memory_bytes_total:sum
-          record: node:node_memory_utilisation:ratio
-        - expr: |-
-            1 -
-            sum by (node) (
-              (node_memory_MemFree_bytes{job="node-exporter"} + node_memory_Cached_bytes{job="node-exporter"} + node_memory_Buffers_bytes{job="node-exporter"})
-            * on (namespace, pod) group_left(node)
-              node_namespace_pod:kube_pod_info:
-            )
-            /
-            sum by (node) (
-              node_memory_MemTotal_bytes{job="node-exporter"}
-            * on (namespace, pod) group_left(node)
-              node_namespace_pod:kube_pod_info:
-            )
-          record: 'node:node_memory_utilisation:'
-        - expr: 1 - (node:node_memory_bytes_available:sum / node:node_memory_bytes_total:sum)
-          record: 'node:node_memory_utilisation_2:'
-        - expr: |-
-            max by (instance, namespace, pod, device) ((node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"}
-            - node_filesystem_avail_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"})
-            / node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"})
-          record: 'node:node_filesystem_usage:'
-        - expr: |-
-            sum by (node) (
-              node_memory_MemTotal_bytes{job="node-exporter"}
-              * on (namespace, pod) group_left(node)
-                node_namespace_pod:kube_pod_info:
-            )
-          record: node:node_memory_bytes_total:sum
-        - expr: |-
-            sum(irate(node_network_receive_bytes_total{job="node-exporter",device!~"veth.+"}[1m])) +
-            sum(irate(node_network_transmit_bytes_total{job="node-exporter",device!~"veth.+"}[1m]))
-          record: :node_net_utilisation:sum_irate
-        - expr: |-
-            sum by (node) (
-              (irate(node_network_receive_bytes_total{job="node-exporter",device!~"veth.+"}[1m]) +
-              irate(node_network_transmit_bytes_total{job="node-exporter",device!~"veth.+"}[1m]))
-            * on (namespace, pod) group_left(node)
-              node_namespace_pod:kube_pod_info:
-            )
-          record: node:node_net_utilisation:sum_irate
-        - expr: |-
-            sum(irate(node_network_receive_drop_total{job="node-exporter",device!~"veth.+"}[1m])) +
-            sum(irate(node_network_transmit_drop_total{job="node-exporter",device!~"veth.+"}[1m]))
-          record: :node_net_saturation:sum_irate
-        - expr: |-
-            sum by (node) (
-              (irate(node_network_receive_drop_total{job="node-exporter",device!~"veth.+"}[1m]) +
-              irate(node_network_transmit_drop_total{job="node-exporter",device!~"veth.+"}[1m]))
-            * on (namespace, pod) group_left(node)
-              node_namespace_pod:kube_pod_info:
-            )
-          record: node:node_net_saturation:sum_irate
-        - expr: |-
-            max by (instance, namespace, pod, device) ((node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"}
-            - node_filesystem_avail_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"})
-            / node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"})
-          record: 'node:node_filesystem_usage:'
-        - expr: |-
-            sum(node_load1{job="node-exporter"})
-            /
-            sum(node:node_num_cpu:sum)
-          record: ':node_cpu_saturation_load1:'
-        - expr: |-
-            sum by (node) (
-              node_load1{job="node-exporter"}
-            * on (namespace, pod) group_left(node)
-              node_namespace_pod:kube_pod_info:
-            )
-            /
-            node:node_num_cpu:sum
-          record: 'node:node_cpu_saturation_load1:'
-        - expr: avg(irate(node_disk_io_time_weighted_seconds_total{job="node-exporter",device=~"nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+"}[1m]))
-          record: :node_disk_saturation:avg_irate
-        - expr: |-
-            avg by (node) (
-              irate(node_disk_io_time_weighted_seconds_total{job="node-exporter",device=~"nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+"}[1m])
-            * on (namespace, pod) group_left(node)
-              node_namespace_pod:kube_pod_info:
-            )
-          record: node:node_disk_saturation:avg_irate
-        - expr: avg(irate(node_disk_io_time_seconds_total{job="node-exporter",device=~"nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+"}[1m]))
-          record: :node_disk_utilisation:avg_irate
-        - expr: |-
-            avg by (node) (
-              irate(node_disk_io_time_seconds_total{job="node-exporter",device=~"nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+"}[1m])
-            * on (namespace, pod) group_left(node)
-              node_namespace_pod:kube_pod_info:
-            )
-          record: node:node_disk_utilisation:avg_irate
-        - expr: |-
-            1e3 * sum(
-              (rate(node_vmstat_pgpgin{job="node-exporter"}[1m])
-            + rate(node_vmstat_pgpgout{job="node-exporter"}[1m]))
-            )
-          record: :node_memory_swap_io_bytes:sum_rate
-        - expr: |-
-            1e3 * sum by (node) (
-              (rate(node_vmstat_pgpgin{job="node-exporter"}[1m])
-            + rate(node_vmstat_pgpgout{job="node-exporter"}[1m]))
-            * on (namespace, pod) group_left(node)
-              node_namespace_pod:kube_pod_info:
-            )
-          record: node:node_memory_swap_io_bytes:sum_rate
-        - expr: |-
-            node:node_cpu_utilisation:avg1m
-              *
-            node:node_num_cpu:sum
-              /
-            scalar(sum(node:node_num_cpu:sum))
-          record: node:cluster_cpu_utilisation:ratio
-        - expr: |-
-            (node:node_memory_bytes_total:sum - node:node_memory_bytes_available:sum)
-            /
-            scalar(sum(node:node_memory_bytes_total:sum))
-          record: node:cluster_memory_utilisation:ratio
-        - expr: |-
-            sum by (node) (
-              node_load1{job="node-exporter"}
-            * on (namespace, pod) group_left(node)
-              node_namespace_pod:kube_pod_info:
-            )
-            /
-            node:node_num_cpu:sum
-          record: 'node:node_cpu_saturation_load1:'
-        - expr: max by (instance, namespace, pod, device) (node_filesystem_avail_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"} / node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"})
-          record: 'node:node_filesystem_avail:'
-        - expr: |-
-            max by (instance, namespace, pod, device) ((node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"}
-            - node_filesystem_avail_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"})
-            / node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"})
-          record: 'node:node_filesystem_usage:'
-        - expr: |-
-            max(
-              max(
-                kube_pod_info{job="kube-state-metrics", host_ip!=""}
-              ) by (node, host_ip)
-              * on (host_ip) group_right (node)
-              label_replace(
-                (max(node_filesystem_files{job="node-exporter", mountpoint="/"}) by (instance)), "host_ip", "$1", "instance", "(.*):.*"
-              )
-            ) by (node)
-          record: 'node:node_inodes_total:'
-        - expr: |-
-            max(
-              max(
-                kube_pod_info{job="kube-state-metrics", host_ip!=""}
-              ) by (node, host_ip)
-              * on (host_ip) group_right (node)
-              label_replace(
-                (max(node_filesystem_files_free{job="node-exporter", mountpoint="/"}) by (instance)), "host_ip", "$1", "instance", "(.*):.*"
-              )
-            ) by (node)
-          record: 'node:node_inodes_free:'
+        - name: node-pre-1.14.rules
+          rules:
+            - expr: 1 - avg(rate(node_cpu_seconds_total{job="node-exporter",mode="idle"}[1m]))
+              record: :node_cpu_utilisation:avg1m
+            - expr: |-
+                1 - avg by (node) (
+                  rate(node_cpu_seconds_total{job="node-exporter",mode="idle"}[1m])
+                * on (namespace, pod) group_left(node)
+                  node_namespace_pod:kube_pod_info:)
+              record: node:node_cpu_utilisation:avg1m
+            - expr: |-
+                1 -
+                sum(
+                  node_memory_MemFree_bytes{job="node-exporter"} +
+                  node_memory_Cached_bytes{job="node-exporter"} +
+                  node_memory_Buffers_bytes{job="node-exporter"}
+                )
+                /
+                sum(node_memory_MemTotal_bytes{job="node-exporter"})
+              record: ':node_memory_utilisation:'
+            - expr: |-
+                (node:node_memory_bytes_total:sum - node:node_memory_bytes_available:sum)
+                /
+                node:node_memory_bytes_total:sum
+              record: node:node_memory_utilisation:ratio
+            - expr: |-
+                1 -
+                sum by (node) (
+                  (
+                    node_memory_MemFree_bytes{job="node-exporter"} +
+                    node_memory_Cached_bytes{job="node-exporter"} +
+                    node_memory_Buffers_bytes{job="node-exporter"}
+                  )
+                * on (namespace, pod) group_left(node)
+                  node_namespace_pod:kube_pod_info:
+                )
+                /
+                sum by (node) (
+                  node_memory_MemTotal_bytes{job="node-exporter"}
+                * on (namespace, pod) group_left(node)
+                  node_namespace_pod:kube_pod_info:
+                )
+              record: 'node:node_memory_utilisation:'
+            - expr: 1 - (node:node_memory_bytes_available:sum / node:node_memory_bytes_total:sum)
+              record: 'node:node_memory_utilisation_2:'
+            - expr: |-
+                max by (instance, namespace, pod, device) ((node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"}
+                - node_filesystem_avail_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"})
+                / node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"})
+              record: 'node:node_filesystem_usage:'
+            - expr: |-
+                sum by (node) (
+                  node_memory_MemTotal_bytes{job="node-exporter"}
+                  * on (namespace, pod) group_left(node)
+                    node_namespace_pod:kube_pod_info:
+                )
+              record: node:node_memory_bytes_total:sum
+            - expr: |-
+                sum(irate(node_network_receive_bytes_total{job="node-exporter",device!~"veth.+"}[1m])) +
+                sum(irate(node_network_transmit_bytes_total{job="node-exporter",device!~"veth.+"}[1m]))
+              record: :node_net_utilisation:sum_irate
+            - expr: |-
+                sum by (node) (
+                  (irate(node_network_receive_bytes_total{job="node-exporter",device!~"veth.+"}[1m]) +
+                  irate(node_network_transmit_bytes_total{job="node-exporter",device!~"veth.+"}[1m]))
+                * on (namespace, pod) group_left(node)
+                  node_namespace_pod:kube_pod_info:
+                )
+              record: node:node_net_utilisation:sum_irate
+            - expr: |-
+                sum(irate(node_network_receive_drop_total{job="node-exporter",device!~"veth.+"}[1m])) +
+                sum(irate(node_network_transmit_drop_total{job="node-exporter",device!~"veth.+"}[1m]))
+              record: :node_net_saturation:sum_irate
+            - expr: |-
+                sum by (node) (
+                  (irate(node_network_receive_drop_total{job="node-exporter",device!~"veth.+"}[1m]) +
+                  irate(node_network_transmit_drop_total{job="node-exporter",device!~"veth.+"}[1m]))
+                * on (namespace, pod) group_left(node)
+                  node_namespace_pod:kube_pod_info:
+                )
+              record: node:node_net_saturation:sum_irate
+            - expr: |-
+                max by (instance, namespace, pod, device) ((node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"}
+                - node_filesystem_avail_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"})
+                / node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"})
+              record: 'node:node_filesystem_usage:'
+            - expr: |-
+                sum(node_load1{job="node-exporter"})
+                /
+                sum(node:node_num_cpu:sum)
+              record: ':node_cpu_saturation_load1:'
+            - expr: |-
+                sum by (node) (
+                  node_load1{job="node-exporter"}
+                * on (namespace, pod) group_left(node)
+                  node_namespace_pod:kube_pod_info:
+                )
+                /
+                node:node_num_cpu:sum
+              record: 'node:node_cpu_saturation_load1:'
+            - expr: avg(irate(node_disk_io_time_weighted_seconds_total{job="node-exporter",device=~"nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+"}[1m]))
+              record: :node_disk_saturation:avg_irate
+            - expr: |-
+                avg by (node) (
+                  irate(node_disk_io_time_weighted_seconds_total{job="node-exporter",device=~"nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+"}[1m])
+                * on (namespace, pod) group_left(node)
+                  node_namespace_pod:kube_pod_info:
+                )
+              record: node:node_disk_saturation:avg_irate
+            - expr: avg(irate(node_disk_io_time_seconds_total{job="node-exporter",device=~"nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+"}[1m]))
+              record: :node_disk_utilisation:avg_irate
+            - expr: |-
+                avg by (node) (
+                  irate(node_disk_io_time_seconds_total{job="node-exporter",device=~"nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+"}[1m])
+                * on (namespace, pod) group_left(node)
+                  node_namespace_pod:kube_pod_info:
+                )
+              record: node:node_disk_utilisation:avg_irate
+            - expr: |-
+                1e3 * sum(
+                  (rate(node_vmstat_pgpgin{job="node-exporter"}[1m])
+                + rate(node_vmstat_pgpgout{job="node-exporter"}[1m]))
+                )
+              record: :node_memory_swap_io_bytes:sum_rate
+            - expr: |-
+                1e3 * sum by (node) (
+                  (rate(node_vmstat_pgpgin{job="node-exporter"}[1m])
+                + rate(node_vmstat_pgpgout{job="node-exporter"}[1m]))
+                * on (namespace, pod) group_left(node)
+                  node_namespace_pod:kube_pod_info:
+                )
+              record: node:node_memory_swap_io_bytes:sum_rate
+            - expr: |-
+                node:node_cpu_utilisation:avg1m
+                  *
+                node:node_num_cpu:sum
+                  /
+                scalar(sum(node:node_num_cpu:sum))
+              record: node:cluster_cpu_utilisation:ratio
+            - expr: |-
+                (node:node_memory_bytes_total:sum - node:node_memory_bytes_available:sum)
+                /
+                scalar(sum(node:node_memory_bytes_total:sum))
+              record: node:cluster_memory_utilisation:ratio
+            - expr: |-
+                sum by (node) (
+                  node_load1{job="node-exporter"}
+                * on (namespace, pod) group_left(node)
+                  node_namespace_pod:kube_pod_info:
+                )
+                /
+                node:node_num_cpu:sum
+              record: 'node:node_cpu_saturation_load1:'
+            - expr: |-
+                max by (instance, namespace, pod, device) (
+                  node_filesystem_avail_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"}
+                  /
+                  node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"}
+                  )
+              record: 'node:node_filesystem_avail:'
+            - expr: |-
+                max by (instance, namespace, pod, device) ((node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"}
+                - node_filesystem_avail_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"})
+                / node_filesystem_size_bytes{fstype=~"ext[234]|btrfs|xfs|zfs"})
+              record: 'node:node_filesystem_usage:'
+            - expr: |-
+                max(
+                  max(
+                    kube_pod_info{job="kube-state-metrics", host_ip!=""}
+                  ) by (node, host_ip)
+                  * on (host_ip) group_right (node)
+                  label_replace(
+                    (
+                      max(node_filesystem_files{job="node-exporter", mountpoint="/"})
+                      by (instance)
+                    ), "host_ip", "$1", "instance", "(.*):.*"
+                  )
+                ) by (node)
+              record: 'node:node_inodes_total:'
+            - expr: |-
+                max(
+                  max(
+                    kube_pod_info{job="kube-state-metrics", host_ip!=""}
+                  ) by (node, host_ip)
+                  * on (host_ip) group_right (node)
+                  label_replace(
+                    (
+                      max(node_filesystem_files_free{job="node-exporter", mountpoint="/"})
+                      by (instance)
+                    ), "host_ip", "$1", "instance", "(.*):.*"
+                  )
+                ) by (node)
+              record: 'node:node_inodes_free:'
 
   ## NOTE changing the serviceMonitor scrape interval to be >1m can result in metrics from recording
   ## rules to be missing and empty panels in Sumo Logic Kubernetes apps.


### PR DESCRIPTION
###### Description
- Removed the flag `kubeTargetVersionOverride: 1.13.0-0`
- following node rule metrics have been removed in from 1.14, so we have to add them to our values file.

| Metrics                                      	|
|----------------------------------------------	|
| :node_cpu_saturation_load1:                  	|
| :node_cpu_utilisation:avg1m                  	|
| :node_disk_saturation:avg_irate              	|
| :node_disk_utilisation:avg_irate             	|
| :node_memory_swap_io_bytes:sum_rate          	|
| :node_memory_utilisation:                    	|
| :node_net_saturation:sum_irate               	|
| :node_net_utilisation:sum_irate              	|
| node:cluster_cpu_utilisation:ratio           	|
| node:cluster_memory_utilisation:ratio        	|
| node:node_cpu_saturation_load1:              	|
| node:node_cpu_utilisation:avg1m              	|
| node:node_disk_saturation:avg_irate          	|
| node:node_disk_utilisation:avg_irate         	|
| node:node_filesystem_avail:                  	|
| node:node_filesystem_usage:                  	|
| node:node_inodes_free:                       	|
| node:node_inodes_total:                      	|
| node:node_memory_bytes_total:sum             	|
| node:node_memory_swap_io_bytes:sum_rate      	|
| node:node_memory_utilisation:                	|
| node:node_memory_utilisation:ratio           	|
| node:node_memory_utilisation_2:              	|
| node:node_net_saturation:sum_irate           	|
| node:node_net_utilisation:sum_irate          	|

- following `apiserver` and `kube-scheduler` have been replaced/renamed in 1.14

| Pre-1.14 apiserver and kube-scheduler recording rules 	| Post-1.14 apiserver and kube-scheduler recording rules 	|
|:-:	|:-:	|
| cluster_quantile:apiserver_request_latencies:histogram_quantile 	| cluster_quantile:apiserver_request_duration_seconds:histogram_quantile 	|
| cluster_quantile:scheduler_binding_latency:histogram_quantile 	| cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile 	|
| cluster_quantile:scheduler_e2e_scheduling_latency:histogram_quantile 	| cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile 	|
| cluster_quantile:scheduler_scheduling_algorithm_latency:histogram_quantile 	| cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile 	|
###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
