### PR TITLE
Change default Fluent Bit config: use Docker_Mode

### DIFF
--- a/deploy/helm/fluent-bit-overrides.yaml
+++ b/deploy/helm/fluent-bit-overrides.yaml
@@ -66,17 +66,17 @@ rawConfig: |-
   @INCLUDE fluent-bit-service.conf
 
   [INPUT]
-    Name             tail
-    Path             /var/log/containers/*.log
-    Multiline        On
-    Parser_Firstline multi_line
-    Tag              containers.*
-    Refresh_Interval 1
-    Rotate_Wait      60
-    Mem_Buf_Limit    5MB
-    Skip_Long_Lines  On
-    DB               /tail-db/tail-containers-state-sumo.db
-    DB.Sync          Normal
+    Name               tail
+    Path               /var/log/containers/*.log
+    Docker_Mode        On
+    Docker_Mode_Parser multi_line
+    Tag                containers.*
+    Refresh_Interval   1
+    Rotate_Wait        60
+    Mem_Buf_Limit      5MB
+    Skip_Long_Lines    On
+    DB                 /tail-db/tail-containers-state-sumo.db
+    DB.Sync            Normal
 
   [INPUT]
     Name            systemd

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -778,17 +778,17 @@ fluent-bit:
     @INCLUDE fluent-bit-service.conf
 
     [INPUT]
-      Name             tail
-      Path             /var/log/containers/*.log
-      Multiline        On
-      Parser_Firstline multi_line
-      Tag              containers.*
-      Refresh_Interval 1
-      Rotate_Wait      60
-      Mem_Buf_Limit    5MB
-      Skip_Long_Lines  On
-      DB               /tail-db/tail-containers-state-sumo.db
-      DB.Sync          Normal
+      Name               tail
+      Path               /var/log/containers/*.log
+      Docker_Mode        On
+      Docker_Mode_Parser multi_line
+      Tag                containers.*
+      Refresh_Interval   1
+      Rotate_Wait        60
+      Mem_Buf_Limit      5MB
+      Skip_Long_Lines    On
+      DB                 /tail-db/tail-containers-state-sumo.db
+      DB.Sync            Normal
 
     [INPUT]
       Name            systemd


### PR DESCRIPTION
###### Description

Use `Docker_Mode_Parser` to support `Docker_Mode` and `Multiline` together.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
