### PR TITLE
CI: add retries to curl, update image and install helm from tar.gz

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 lang: ruby
-# Somehow focal (20.04) is available for amd64 but when
-# ran on travis it falls back to xenial (16.04) so just use bionic (18.04)
-dist: bionic
+dist: focal
 arch: amd64
 services: docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,24 @@
 lang: ruby
+# Somehow focal (20.04) is available for amd64 but when
+# ran on travis it falls back to xenial (16.04) so just use bionic (18.04)
+dist: bionic
+arch: amd64
 services: docker
+
 before_install:
   - rm -f ./Gemfile.lock
   - gem install bundler
-  - sudo apt update
-  - sudo apt install snapd
-  - sudo snap install helm --channel=2.16/stable --classic
-  - sudo curl https://github.com/mikefarah/yq/releases/download/3.2.1/yq_linux_amd64 -L -o /usr/local/bin/yq-3.2.1
+  # helm
+  - curl --retry 10 --retry-max-time 120 --retry-delay 5 -Lo- https://get.helm.sh/helm-v2.16.12-linux-amd64.tar.gz | tar xvzf -
+  - sudo mv ./linux-amd64/helm /usr/local/bin/
+  # yq
+  - curl --retry 10 --retry-max-time 120 --retry-delay 5 -L --remote-name https://github.com/mikefarah/yq/releases/download/3.2.1/yq_linux_amd64
+  - sudo mv yq_linux_amd64 /usr/local/bin/yq-3.2.1
   - sudo chmod +x /usr/local/bin/yq-3.2.1
   - sudo ln -s /usr/local/bin/yq-3.2.1 /usr/local/bin/yq
-  - curl -Lo- https://github.com/koalaman/shellcheck/releases/download/v0.7.1/shellcheck-v0.7.1.linux.x86_64.tar.xz | tar -xJf -
+  # shellcheck
+  - curl --retry 10 --retry-max-time 120 --retry-delay 5 -Lo- https://github.com/koalaman/shellcheck/releases/download/v0.7.1/shellcheck-v0.7.1.linux.x86_64.tar.xz | tar -xJf -
   - sudo cp shellcheck-v0.7.1/shellcheck /usr/local/bin
-  - rm -rf shellcheck-v0.7.1/
 branches:
   only:
   - master


### PR DESCRIPTION
###### Description

* Add retries to `curl` when installing dependencies in CI.
* Update travis image to `bionic`
* Install `helm` from `tar.gz` not via `snap` (way faster)

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
