### PR TITLE
Add cleanup to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - gem install bundler
   # helm
   - curl --retry 10 --retry-max-time 120 --retry-delay 5 -Lo- https://get.helm.sh/helm-v2.16.12-linux-amd64.tar.gz | tar xvzf -
-  - sudo mv ./linux-amd64/helm /usr/local/bin/
+  - sudo mv ./linux-amd64/helm /usr/local/bin/ && rm -rf ./linux-amd64
   # yq
   - curl --retry 10 --retry-max-time 120 --retry-delay 5 -L --remote-name https://github.com/mikefarah/yq/releases/download/3.2.1/yq_linux_amd64
   - sudo mv yq_linux_amd64 /usr/local/bin/yq-3.2.1
@@ -16,7 +16,7 @@ before_install:
   - sudo ln -s /usr/local/bin/yq-3.2.1 /usr/local/bin/yq
   # shellcheck
   - curl --retry 10 --retry-max-time 120 --retry-delay 5 -Lo- https://github.com/koalaman/shellcheck/releases/download/v0.7.1/shellcheck-v0.7.1.linux.x86_64.tar.xz | tar -xJf -
-  - sudo cp shellcheck-v0.7.1/shellcheck /usr/local/bin
+  - sudo cp shellcheck-v0.7.1/shellcheck /usr/local/bin && rm -rf shellcheck-v0.7.1
 branches:
   only:
   - master


### PR DESCRIPTION
###### Description

`before_install` left files which provides to Ci error and prevents from publishing new helm chart

https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/1055

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
