### PR TITLE
CI bugfix: use relative path for the helm sync dir

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -95,7 +95,7 @@ function push_docker_image() {
 function push_helm_chart() {
   local version="$1"
 
-  local sync_dir="${TRAVIS_BUILD_DIR}-helm-sync"
+  local sync_dir="./tmp-helm-sync"
 
   echo "Pushing new Helm Chart release ${version}"
   set -x


### PR DESCRIPTION
###### Description

helm-sync directory was created outside of helm -> docker scope what was causing no such file or directory error during merging indexes

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
