### PR TITLE
Bump terraform providers

### DIFF
--- a/deploy/helm/sumologic/conf/setup/main.tf
+++ b/deploy/helm/sumologic/conf/setup/main.tf
@@ -1,6 +1,6 @@
 terraform {
   required_providers {
-    sumologic  = "~> 2.3.0"
-    kubernetes = "~> 1.11.3"
+    sumologic  = "~> 2.4.0"
+    kubernetes = "~> 1.13.0"
   }
 }

--- a/deploy/kubernetes/setup-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/setup-sumologic.yaml.tmpl
@@ -97,8 +97,8 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.3.0"
-        kubernetes = "~> 1.11.3"
+        sumologic  = "~> 2.4.0"
+        kubernetes = "~> 1.13.0"
       }
     }
   providers.tf: |-

--- a/tests/terraform/static/all_fields.output.yaml
+++ b/tests/terraform/static/all_fields.output.yaml
@@ -66,8 +66,8 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.3.0"
-        kubernetes = "~> 1.11.3"
+        sumologic  = "~> 2.4.0"
+        kubernetes = "~> 1.13.0"
       }
     }
   providers.tf: |-

--- a/tests/terraform/static/collector_fields.output.yaml
+++ b/tests/terraform/static/collector_fields.output.yaml
@@ -65,8 +65,8 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.3.0"
-        kubernetes = "~> 1.11.3"
+        sumologic  = "~> 2.4.0"
+        kubernetes = "~> 1.13.0"
       }
     }
   providers.tf: |-

--- a/tests/terraform/static/conditional_sources.output.yaml
+++ b/tests/terraform/static/conditional_sources.output.yaml
@@ -55,8 +55,8 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.3.0"
-        kubernetes = "~> 1.11.3"
+        sumologic  = "~> 2.4.0"
+        kubernetes = "~> 1.13.0"
       }
     }
   providers.tf: |-

--- a/tests/terraform/static/custom.output.yaml
+++ b/tests/terraform/static/custom.output.yaml
@@ -55,8 +55,8 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.3.0"
-        kubernetes = "~> 1.11.3"
+        sumologic  = "~> 2.4.0"
+        kubernetes = "~> 1.13.0"
       }
     }
   providers.tf: |-

--- a/tests/terraform/static/default.output.yaml
+++ b/tests/terraform/static/default.output.yaml
@@ -65,8 +65,8 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.3.0"
-        kubernetes = "~> 1.11.3"
+        sumologic  = "~> 2.4.0"
+        kubernetes = "~> 1.13.0"
       }
     }
   providers.tf: |-

--- a/tests/terraform/static/disable_default_metrics.output.yaml
+++ b/tests/terraform/static/disable_default_metrics.output.yaml
@@ -64,8 +64,8 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.3.0"
-        kubernetes = "~> 1.11.3"
+        sumologic  = "~> 2.4.0"
+        kubernetes = "~> 1.13.0"
       }
     }
   providers.tf: |-

--- a/tests/terraform/static/strip_extrapolation.output.yaml
+++ b/tests/terraform/static/strip_extrapolation.output.yaml
@@ -65,8 +65,8 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.3.0"
-        kubernetes = "~> 1.11.3"
+        sumologic  = "~> 2.4.0"
+        kubernetes = "~> 1.13.0"
       }
     }
   providers.tf: |-

--- a/tests/terraform/static/traces.output.yaml
+++ b/tests/terraform/static/traces.output.yaml
@@ -56,8 +56,8 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.3.0"
-        kubernetes = "~> 1.11.3"
+        sumologic  = "~> 2.4.0"
+        kubernetes = "~> 1.13.0"
       }
     }
   providers.tf: |-


### PR DESCRIPTION
###### Description

* sumologic 2.3.3 -> [2.4.0](https://github.com/SumoLogic/terraform-provider-sumologic/releases/tag/v2.4.0)
* kubernetes 1.11.4 -> [1.13.2](https://github.com/hashicorp/terraform-provider-kubernetes/releases/tag/v1.13.2)

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
