### PR TITLE
Update autoscaling/v1 to autoscaling/v2beta2

### DIFF
--- a/deploy/helm/sumologic/templates/hpa.yaml
+++ b/deploy/helm/sumologic/templates/hpa.yaml
@@ -13,5 +13,19 @@ spec:
     name: {{ template "sumologic.metadata.name.logs.statefulset" . }}
   minReplicas: {{ .Values.fluentd.logs.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.fluentd.logs.autoscaling.maxReplicas }}
-  metrics: {{ toYaml .Values.fluentd.logs.autoscaling.metrics | nindent 2 }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.fluentd.logs.autoscaling.targetCPUUtilizationPercentage }}
+{{- if .Values.fluentd.logs.autoscaling.targetMemoryUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.fluentd.logs.autoscaling.targetMemoryUtilizationPercentage }}
+{{- end -}}
 {{- end -}}

--- a/deploy/helm/sumologic/templates/hpa.yaml
+++ b/deploy/helm/sumologic/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.fluentd.logs.autoscaling.enabled}}
-apiVersion: autoscaling/v1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "sumologic.metadata.name.logs.hpa" . }}
@@ -13,5 +13,5 @@ spec:
     name: {{ template "sumologic.metadata.name.logs.statefulset" . }}
   minReplicas: {{ .Values.fluentd.logs.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.fluentd.logs.autoscaling.maxReplicas }}
-  targetCPUUtilizationPercentage: {{ .Values.fluentd.logs.autoscaling.targetCPUUtilizationPercentage }}
+  metrics: {{ toYaml .Values.fluentd.logs.autoscaling.metrics | nindent 2 }}
 {{- end -}}

--- a/deploy/helm/sumologic/templates/metrics-hpa.yaml
+++ b/deploy/helm/sumologic/templates/metrics-hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.fluentd.metrics.autoscaling.enabled}}
-apiVersion: autoscaling/v1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "sumologic.metadata.name.metrics.hpa" . }}
@@ -13,5 +13,5 @@ spec:
     name: {{ template "sumologic.metadata.name.metrics.statefulset" . }}
   minReplicas: {{ .Values.fluentd.metrics.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.fluentd.metrics.autoscaling.maxReplicas }}
-  targetCPUUtilizationPercentage: {{ .Values.fluentd.metrics.autoscaling.targetCPUUtilizationPercentage }}
+  metrics: {{ toYaml .Values.fluentd.metrics.autoscaling.metrics | nindent 2 }}
 {{- end -}}

--- a/deploy/helm/sumologic/templates/metrics-hpa.yaml
+++ b/deploy/helm/sumologic/templates/metrics-hpa.yaml
@@ -13,5 +13,19 @@ spec:
     name: {{ template "sumologic.metadata.name.metrics.statefulset" . }}
   minReplicas: {{ .Values.fluentd.metrics.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.fluentd.metrics.autoscaling.maxReplicas }}
-  metrics: {{ toYaml .Values.fluentd.metrics.autoscaling.metrics | nindent 2 }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.fluentd.metrics.autoscaling.targetCPUUtilizationPercentage }}
+{{- if .Values.fluentd.metrics.autoscaling.targetMemoryUtilizationPercentage }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.fluentd.metrics.autoscaling.targetMemoryUtilizationPercentage }}
+{{- end -}}
 {{- end -}}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -322,7 +322,13 @@ fluentd:
       enabled: false
       minReplicas: 3
       maxReplicas: 10
-      targetCPUUtilizationPercentage: 50
+      metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 50
 
     ## Option to specify PodDisrutionBudgets
     ## You can specify only one of maxUnavailable and minAvailable in a single PodDisruptionBudget
@@ -558,7 +564,13 @@ fluentd:
       enabled: false
       minReplicas: 3
       maxReplicas: 10
-      targetCPUUtilizationPercentage: 50
+      metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 50
 
     ## Option to specify PodDisrutionBudgets
     ## You can specify only one of maxUnavailable and minAvailable in a single PodDisruptionBudget

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -322,13 +322,8 @@ fluentd:
       enabled: false
       minReplicas: 3
       maxReplicas: 10
-      metrics:
-      - type: Resource
-        resource:
-          name: cpu
-          target:
-            type: Utilization
-            averageUtilization: 50
+      targetCPUUtilizationPercentage: 50
+      # targetMemoryUtilizationPercentage: 50
 
     ## Option to specify PodDisrutionBudgets
     ## You can specify only one of maxUnavailable and minAvailable in a single PodDisruptionBudget
@@ -564,13 +559,8 @@ fluentd:
       enabled: false
       minReplicas: 3
       maxReplicas: 10
-      metrics:
-      - type: Resource
-        resource:
-          name: cpu
-          target:
-            type: Utilization
-            averageUtilization: 50
+      targetCPUUtilizationPercentage: 50
+      # targetMemoryUtilizationPercentage: 50
 
     ## Option to specify PodDisrutionBudgets
     ## You can specify only one of maxUnavailable and minAvailable in a single PodDisruptionBudget


### PR DESCRIPTION
###### Description

Update autoscaling/v1 to autoscaling/v2beta2 in order to enable custom metrics autoscaling and autoscaling based on memory utilization.

This PR adds `targetMemoryUtilizationPercentage` key to enable autoscaling based on memory utilization.

ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#autoscaling-on-multiple-metrics-and-custom-metrics

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
