### PR TITLE
Use new stable repo URL

### DIFF
--- a/deploy/helm/sumologic/requirements.yaml
+++ b/deploy/helm/sumologic/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
   - name: fluent-bit
     version: 2.10.1
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable
     condition: fluent-bit.enabled,sumologic.logs.enabled
   - name: kube-prometheus-stack
     version: 9.3.4


### PR DESCRIPTION
###### Description

The old stable charts bucket [will be shut down this month](https://github.com/helm/charts/issues/23742#issuecomment-702128318). Users will be unable to install or upgrade this chart, as the transitive dependency on fluent-bit will fail to resolve.

[There is a new URL that can be used to resolve stable charts](https://helm.sh/blog/new-location-stable-incubator-charts/). This takes advantage of that.

This should close #750, in a non-breaking way.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
