### PR TITLE
Set Prometheus data retention to 1 day (#793)

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1033,6 +1033,8 @@ prometheus-operator:
       ## Prometheus default scrape interval, default from upstream Prometheus Operator Helm chart
       ## NOTE changing the scrape interval to be >1m can result in metrics from recording rules to be missing and empty panels in Sumo Logic Kubernetes apps.
       scrapeInterval: "30s"
+      ## Prometheus data retention period
+      retention: "1d"
       ## Add custom pod annotations and labels to prometheus pods
       podMetadata:
         labels: {}


### PR DESCRIPTION
###### Description

Set Prometheus data retention to 1 day 

###### Testing performed

- [x] ci/build.sh
- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
