### PR TITLE
Add OTLP HTTP port

### DIFF
--- a/deploy/helm/sumologic/templates/otelcol-deployment.yaml
+++ b/deploy/helm/sumologic/templates/otelcol-deployment.yaml
@@ -77,7 +77,8 @@ spec:
         - containerPort: 14267 # Default endpoint for Jaeger TChannel receiver.
         - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
         - containerPort: 55678 # Default endpoint for Opencensus receiver.
-        - containerPort: 55680 # Default endpoint for OTLP receiver.
+        - containerPort: 55680 # Default endpoint for OTLP gRPC receiver.
+        - containerPort: 55681 # Default endpoint for OTLP HTTP receiver.
         volumeMounts:
         - name: otel-collector-config-vol
           mountPath: /conf


### PR DESCRIPTION
###### Description

It's a https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1086 backport.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
