### PR TITLE
Fix creation date for helm charts

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -76,7 +76,7 @@ entries:
     version: 2.0.0-dev.0-74-gb464ece2
   - apiVersion: v1
     appVersion: 2.0.0-dev.0-73-g6ec7dcd1
-    created: "2020-11-12T12:10:14.129586691Z"
+    created: "2020-11-10T12:43:25Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 05bad21c51515eb7249cc3bccb0f04c4e68776cc7f6a2ec8d2ea33e0108fbabf
@@ -246,7 +246,7 @@ entries:
     version: 2.0.0-dev.0-63-g3eb92cb6
   - apiVersion: v1
     appVersion: 2.0.0-dev.0-55-g957a0ea5
-    created: "2020-11-02T07:48:13.62418172Z"
+    created: "2020-10-29T14:07:34Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 1ec06ec8569a5226c94d56c7d073284315a9c2fd25ad2c074878285d497c4f14
@@ -416,7 +416,7 @@ entries:
     version: 1.3.2-rc.0
   - apiVersion: v1
     appVersion: 1.3.1
-    created: "2020-10-27T12:01:21.036242467Z"
+    created: "2020-10-26T17:10:41Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: e852e8a11cc9414b5afafc56d18417d9cc37ce1e032a7a151eb71fd3d0767000
@@ -450,7 +450,7 @@ entries:
     version: 1.3.1-rc.0
   - apiVersion: v1
     appVersion: 1.3.1-1-g5cca68de
-    created: "2020-11-10T11:21:16.181085853Z"
+    created: "2020-11-08T01:40:47Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 63f00212c4da7b01ab3bf3c454f6c3537c55e6da342802898c7b5a76e96260f1
@@ -467,7 +467,7 @@ entries:
     version: 1.3.1-1-g5cca68de
   - apiVersion: v1
     appVersion: 1.3.0
-    created: "2020-10-07T17:39:25.899638011Z"
+    created: "2020-10-06T09:33:16Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 4c9b0238adda2a073a8aafb09b3558cb668d15157ab11dc71fcedec3235e16c3
@@ -484,7 +484,7 @@ entries:
     version: 1.3.0
   - apiVersion: v1
     appVersion: 1.3.0-beta.2-2-g16a59c1c
-    created: "2020-10-07T17:39:25.854650924Z"
+    created: "2020-10-05T19:32:41Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 2574d34062a14742f9d29c020e60a649ede874175c721ece41a3e40993914785
@@ -501,7 +501,7 @@ entries:
     version: 1.3.0-beta.2-2-g16a59c1c
   - apiVersion: v1
     appVersion: 1.3.0-beta.2-1-g3658d748
-    created: "2020-10-07T17:39:25.834267073Z"
+    created: "2020-10-06T08:20:11Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 1622a8e900f3eab114cae3d8cdd38fa570f704e8453eb64dc25004e046109d31
@@ -518,7 +518,7 @@ entries:
     version: 1.3.0-beta.2-1-g3658d748
   - apiVersion: v1
     appVersion: 1.3.0-beta.1-9-g51861f89
-    created: "2020-10-07T17:39:25.791075196Z"
+    created: "2020-10-02T17:23:53Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 4fbf9ff68272c8e493e229483ba12c2d31e1dbb3226b824faf7ecc4decd1e3a3
@@ -535,7 +535,7 @@ entries:
     version: 1.3.0-beta.1-9-g51861f89
   - apiVersion: v1
     appVersion: 1.3.0-beta.1-6-g1f5da11
-    created: "2020-10-07T17:39:25.768469289Z"
+    created: "2020-10-02T08:40:18Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 4e28d0a985268526ffcfd75004cbc6d8fae81568b62a9bb0429cee7dc8576b31
@@ -552,7 +552,7 @@ entries:
     version: 1.3.0-beta.1-6-g1f5da11
   - apiVersion: v1
     appVersion: 1.3.0-beta.1-3-gf45bbb3
-    created: "2020-10-07T17:39:25.748153141Z"
+    created: "2020-10-02T07:11:09Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 0ed2e2f0e022893e3058f8ef5da39cf54e92952e58fe3b1c7cdb426c1a415574
@@ -569,7 +569,7 @@ entries:
     version: 1.3.0-beta.1-3-gf45bbb3
   - apiVersion: v1
     appVersion: 1.3.0-beta.1-2-g8db37c5
-    created: "2020-10-07T17:39:25.725899692Z"
+    created: "2020-10-01T10:36:33Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: afabdc69faa37a9a0524221f0d92d0ab810a4b3910d765664953c154748f5e27
@@ -586,7 +586,7 @@ entries:
     version: 1.3.0-beta.1-2-g8db37c5
   - apiVersion: v1
     appVersion: 1.3.0-beta.1-17-gaec44b91
-    created: "2020-10-07T17:39:25.705671649Z"
+    created: "2020-10-02T22:28:13Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 5c4bdd5531ece7e03ef76c41c5c270f5afb8168976ce029dd1df631d7cf23f93
@@ -603,7 +603,7 @@ entries:
     version: 1.3.0-beta.1-17-gaec44b91
   - apiVersion: v1
     appVersion: 1.3.0-beta.1-14-g0b814a27
-    created: "2020-10-07T17:39:25.683541639Z"
+    created: "2020-10-02T21:55:09Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 83c1917c4856440643dba6c0f822cf82ef2cc3e8d59e6257687a58446e30c973
@@ -620,7 +620,7 @@ entries:
     version: 1.3.0-beta.1-14-g0b814a27
   - apiVersion: v1
     appVersion: 1.3.0-beta.1-13-g165d2f73
-    created: "2020-10-07T17:39:25.663097126Z"
+    created: "2020-10-02T18:29:55Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: bfcabf7919450dc60f87434a4d93dd11249d9791e474cc0f9ab55777f01d5c0d
@@ -637,7 +637,7 @@ entries:
     version: 1.3.0-beta.1-13-g165d2f73
   - apiVersion: v1
     appVersion: 1.3.0-beta.0-5-gb5a59ea
-    created: "2020-10-07T17:39:25.614887271Z"
+    created: "2020-09-29T17:24:59Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: ee11a2fb7b56af7b075e06509fa903e3ab22bb0dcfc53fb877974316b391dbb9
@@ -654,7 +654,7 @@ entries:
     version: 1.3.0-beta.0-5-gb5a59ea
   - apiVersion: v1
     appVersion: 1.3.0-beta.0-4-g77d2268
-    created: "2020-10-07T17:39:25.592335853Z"
+    created: "2020-09-29T18:09:44Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 18b23c7510a2a275000c491ed364fdf13d22f840b9674428ed359382a146cfbb
@@ -671,7 +671,7 @@ entries:
     version: 1.3.0-beta.0-4-g77d2268
   - apiVersion: v1
     appVersion: 1.3.0-beta.0-22-g97301a8
-    created: "2020-10-07T17:39:25.571706704Z"
+    created: "2020-09-30T17:30:46Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 1e18f8226f9fd347b5dfbb58d8a1eccaa299f7b6723356bd60c5be5ffc22b823
@@ -688,7 +688,7 @@ entries:
     version: 1.3.0-beta.0-22-g97301a8
   - apiVersion: v1
     appVersion: 1.3.0-beta.0-20-g3f38156
-    created: "2020-10-07T17:39:25.549596549Z"
+    created: "2020-09-30T16:58:47Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 036417dd574e868cac8ac2bc0cec8aafffdcd55c84e334c7369db0567a4883ea
@@ -705,7 +705,7 @@ entries:
     version: 1.3.0-beta.0-20-g3f38156
   - apiVersion: v1
     appVersion: 1.3.0-beta.0-2-g42dab7d
-    created: "2020-10-07T17:39:25.527094737Z"
+    created: "2020-09-29T14:46:53Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: ed3c24a7a9658d07b1f6d0a8bcb386cc229f11396e7bff5a703de8a721cdfbee
@@ -722,7 +722,7 @@ entries:
     version: 1.3.0-beta.0-2-g42dab7d
   - apiVersion: v1
     appVersion: 1.3.0-beta.0-18-ge8949ae
-    created: "2020-10-07T17:39:25.506977165Z"
+    created: "2020-09-30T13:50:52Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: fa9787a489957a2f708609fed7ef8250fd0529456317cbbc39003fda4b1616d0
@@ -739,7 +739,7 @@ entries:
     version: 1.3.0-beta.0-18-ge8949ae
   - apiVersion: v1
     appVersion: 1.3.0-beta.0-10-gbf43c13
-    created: "2020-10-07T17:39:25.484598443Z"
+    created: "2020-09-30T07:56:17Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 59303be0388af82571322f77e7924e0f16f2814695f4bb19670db9e84e406826
@@ -756,7 +756,7 @@ entries:
     version: 1.3.0-beta.0-10-gbf43c13
   - apiVersion: v1
     appVersion: 1.3.0-beta.0-1-g8e0bb5e
-    created: "2020-10-07T17:39:25.464120983Z"
+    created: "2020-09-29T12:54:23Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: cc8e4c9a8e90ac0ccc288a761c98f7b02b80d7e4d635df992d2c159f130efbca
@@ -773,7 +773,7 @@ entries:
     version: 1.3.0-beta.0-1-g8e0bb5e
   - apiVersion: v1
     appVersion: 1.3.0-beta.2
-    created: "2020-10-07T17:39:25.877137822Z"
+    created: "2020-10-02T22:28:13Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 02b5f1d988069d806452746eb8377ada7a80905e463fda99449f9c8314b119d0
@@ -790,7 +790,7 @@ entries:
     version: 1.3.0-beta.2
   - apiVersion: v1
     appVersion: 1.3.0-beta.1
-    created: "2020-10-07T17:39:25.811724174Z"
+    created: "2020-09-30T17:30:46Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 58b0f42440b2aed414ad772fccff1ffa8607fb89a5aa5d4c5183fcd7eb8cdce2
@@ -807,7 +807,7 @@ entries:
     version: 1.3.0-beta.1
   - apiVersion: v1
     appVersion: 1.3.0-beta.0
-    created: "2020-10-07T17:39:25.637934254Z"
+    created: "2020-09-29T12:23:36Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 8d2f7a0373eec10eafeef2aab97568e4054afeb32cc9235fe27ef91b0bcfad22
@@ -909,7 +909,7 @@ entries:
     version: 1.3.0-7-gc76e91db
   - apiVersion: v1
     appVersion: 1.3.0-6-geaa32dbb
-    created: "2020-10-16T10:37:25.100040837Z"
+    created: "2020-10-15T08:10:40Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 4f8226605637f5de185c6cf682b11d2caac27bd89887e90f3d47fbc57bbf1c8e
@@ -926,7 +926,7 @@ entries:
     version: 1.3.0-6-geaa32dbb
   - apiVersion: v1
     appVersion: 1.3.0-6-ge9912c59
-    created: "2020-10-09T07:31:42.652452062Z"
+    created: "2020-10-08T14:32:24Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: c6484936990bb6991cb15583045b6d9b924ebb1b84d24027a7fad738d6f3fb6a
@@ -960,7 +960,7 @@ entries:
     version: 1.3.0-5-gc48698b4
   - apiVersion: v1
     appVersion: 1.3.0-49-g05b6cc55
-    created: "2020-10-27T09:11:39.111966982Z"
+    created: "2020-10-26T18:05:50Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: e6ccf228668e3fa8aa5265badee9afa0332101119c5516d51e18893c78ecc01d
@@ -977,7 +977,7 @@ entries:
     version: 1.3.0-49-g05b6cc55
   - apiVersion: v1
     appVersion: 1.3.0-47-g7a2cd69a
-    created: "2020-10-26T07:35:13.069661156Z"
+    created: "2020-10-23T14:49:22Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 9b089a2e9bd1835bced644c8af743517744b50f2ce3fe9e6da25344d4edec19a
@@ -994,7 +994,7 @@ entries:
     version: 1.3.0-47-g7a2cd69a
   - apiVersion: v1
     appVersion: 1.3.0-46-g4e154189
-    created: "2020-10-23T14:50:28.689829875Z"
+    created: "2020-10-16T11:08:00Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: ba6f7fac95d95879878df05569a4a5933e74f1b2be1c313f9cb8471f7b65516b
@@ -1011,7 +1011,7 @@ entries:
     version: 1.3.0-46-g4e154189
   - apiVersion: v1
     appVersion: 1.3.0-4-g658c081d
-    created: "2020-10-14T09:21:47.341092853Z"
+    created: "2020-10-13T15:51:36Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: a207b52a9e69c780724754502eebe97ddb5a2c80f2e6a04e080f2bbccacd34d8
@@ -1096,7 +1096,7 @@ entries:
     version: 1.3.0-34-ga5c698f6
   - apiVersion: v1
     appVersion: 1.3.0-33-g010786ec
-    created: "2020-10-22T10:25:11.773481927Z"
+    created: "2020-10-21T19:17:42Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 17f3d4c3e3ac593d053485278d2b08602d24f56e64145ff6db819ae4e1a67469
@@ -1215,7 +1215,7 @@ entries:
     version: 1.3.0-24-ga0b4cab7
   - apiVersion: v1
     appVersion: 1.3.0-23-gcd23f3de
-    created: "2020-10-16T08:19:50.51026681Z"
+    created: "2020-10-15T08:10:40Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 481b24dc8a5e997bba1ab86e9812f3dd6d5243d9932f1d6055d5946dcabed8c2
@@ -1232,7 +1232,7 @@ entries:
     version: 1.3.0-23-gcd23f3de
   - apiVersion: v1
     appVersion: 1.3.0-22-g29bcdff4
-    created: "2020-10-15T12:57:33.153068217Z"
+    created: "2020-10-13T14:14:21Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 03baa329e29847c8c1f98896ffded2021a1d8c05dfc8efaa1706c1f709d1eb05
@@ -1334,7 +1334,7 @@ entries:
     version: 1.3.0-16-ga5a40419
   - apiVersion: v1
     appVersion: 1.3.0-14-gaefa57f5
-    created: "2020-10-13T09:36:31.401366221Z"
+    created: "2020-10-12T13:09:29Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 320ec40e80e9822254d3646da02f5fe157f781315534b9ddcd6649f03aa84981
@@ -1351,7 +1351,7 @@ entries:
     version: 1.3.0-14-gaefa57f5
   - apiVersion: v1
     appVersion: 1.3.0-1-g9cc94892
-    created: "2020-10-07T17:39:25.419168852Z"
+    created: "2020-10-06T12:13:32Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 7d72e4a73f901eb6d6f0896ed83193f388fe411e2c79ed7985f3fe34c8879776
@@ -1368,7 +1368,7 @@ entries:
     version: 1.3.0-1-g9cc94892
   - apiVersion: v1
     appVersion: 1.2.3
-    created: "2020-10-07T17:39:25.397067912Z"
+    created: "2020-09-21T11:00:49Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: eabd38e97438a190bfa61797109d6625b727f9edcbb799c5037e1e51e905dc5b
@@ -1385,7 +1385,7 @@ entries:
     version: 1.2.3
   - apiVersion: v1
     appVersion: 1.2.3-2-g1c5c28a
-    created: "2020-10-07T17:39:25.377207179Z"
+    created: "2020-09-23T09:12:06Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: e93137f2815325db0036c2aa2911f7a3e1aa4ac113e69e47f95f5c876737369f
@@ -1402,7 +1402,7 @@ entries:
     version: 1.2.3-2-g1c5c28a
   - apiVersion: v1
     appVersion: 1.2.3-1-gfcd347e
-    created: "2020-10-07T17:39:25.355827177Z"
+    created: "2020-09-18T21:44:51Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: af3fbd7c308c4d93feca91698f1f7fe4ecd46191ccbca20ca51d3854c8294ad6
@@ -1419,7 +1419,7 @@ entries:
     version: 1.2.3-1-gfcd347e
   - apiVersion: v1
     appVersion: 1.2.2
-    created: "2020-10-07T17:39:25.33617525Z"
+    created: "2020-09-11T08:51:21Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: e22bf581eb32d3c37223f9e48a8f0988c28cc61d185e56949990356679265957
@@ -1436,7 +1436,7 @@ entries:
     version: 1.2.2
   - apiVersion: v1
     appVersion: 1.2.2-rc.0-9-g6f8765e
-    created: "2020-10-07T17:39:25.294837238Z"
+    created: "2020-09-11T08:51:21Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 87afef4580bab6aa04a15fbb97d8a4dd2b3e8995707a7293ac53b1e2d72e5bc1
@@ -1453,7 +1453,7 @@ entries:
     version: 1.2.2-rc.0-9-g6f8765e
   - apiVersion: v1
     appVersion: 1.2.2-rc.0-6-g224cab6
-    created: "2020-10-07T17:39:25.270186666Z"
+    created: "2020-09-11T08:32:47Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: b173093acfbbcd74b5c15a68f6a99bd7365d94ac24b9b325aa8e06d6dc66a0fe
@@ -1470,7 +1470,7 @@ entries:
     version: 1.2.2-rc.0-6-g224cab6
   - apiVersion: v1
     appVersion: 1.2.2-rc.0-5-gc5f8174
-    created: "2020-10-07T17:39:25.250443152Z"
+    created: "2020-09-09T10:29:10Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: d3a6883beb6d6eae445e2ab5192c7b1da9850125c9a65378a0e70b33402c80d2
@@ -1487,7 +1487,7 @@ entries:
     version: 1.2.2-rc.0-5-gc5f8174
   - apiVersion: v1
     appVersion: 1.2.2-rc.0-1-g93fdcad
-    created: "2020-10-07T17:39:25.228702296Z"
+    created: "2020-09-08T09:42:56Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: fb1880fe5120bfcbdbddf6a0f07d8b28ce1e4927db26d700ad2f132e45f8576f
@@ -1504,7 +1504,7 @@ entries:
     version: 1.2.2-rc.0-1-g93fdcad
   - apiVersion: v1
     appVersion: 1.2.2-rc.0
-    created: "2020-10-07T17:39:25.314361021Z"
+    created: "2020-09-03T11:38:43Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: d0cccb5d81c1a49682b815d8578e136ef7dcf9b3349974f98f556bd45cd79d78
@@ -1521,7 +1521,7 @@ entries:
     version: 1.2.2-rc.0
   - apiVersion: v1
     appVersion: 1.2.2-91-g4530926
-    created: "2020-10-07T17:39:25.209002529Z"
+    created: "2020-09-29T01:14:32Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 97b29c77504fa379868f51b486f6a13592340113951becceb53da08d2b7fbc52
@@ -1538,7 +1538,7 @@ entries:
     version: 1.2.2-91-g4530926
   - apiVersion: v1
     appVersion: 1.2.2-9-g5ab5d46
-    created: "2020-10-07T17:39:25.186491626Z"
+    created: "2020-09-11T19:29:07Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 62729b91ee246100550921d039f4488a3cb6bba7969f91156cb18a568382380f
@@ -1555,7 +1555,7 @@ entries:
     version: 1.2.2-9-g5ab5d46
   - apiVersion: v1
     appVersion: 1.2.2-88-g8ddcfa1
-    created: "2020-10-07T17:39:25.166841572Z"
+    created: "2020-09-28T16:39:07Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 71dece4e62cc6339dfd813b1de7bf31a6c7aa184c5c9c3afaedaae5f4ddc765f
@@ -1572,7 +1572,7 @@ entries:
     version: 1.2.2-88-g8ddcfa1
   - apiVersion: v1
     appVersion: 1.2.2-85-gd84c31c
-    created: "2020-10-07T17:39:25.144653616Z"
+    created: "2020-09-29T07:52:31Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 42987e1f0fff07df0377767d3dbd60f216d51276605d525c00990aae87c8e567
@@ -1589,7 +1589,7 @@ entries:
     version: 1.2.2-85-gd84c31c
   - apiVersion: v1
     appVersion: 1.2.2-84-g87f1964
-    created: "2020-10-07T17:39:25.124291884Z"
+    created: "2020-09-29T00:10:45Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: f932ec97538a1c7dd3103eebc156b0919746896bfdb24d0adf3119c709e20bdc
@@ -1606,7 +1606,7 @@ entries:
     version: 1.2.2-84-g87f1964
   - apiVersion: v1
     appVersion: 1.2.2-82-g100dc98
-    created: "2020-10-07T17:39:25.102383137Z"
+    created: "2020-09-28T12:29:29Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: f75b878f95d61cd26e6c67b11b089496092eaf9dafe8dc6f373324d3c868bdd8
@@ -1623,7 +1623,7 @@ entries:
     version: 1.2.2-82-g100dc98
   - apiVersion: v1
     appVersion: 1.2.2-81-g38c7ae2
-    created: "2020-10-07T17:39:25.082313756Z"
+    created: "2020-09-28T07:56:25Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 69d3a811bf41264c2bcc36b1bf439c05b5aa8a80d2624c60368bd96b5753a4df
@@ -1640,7 +1640,7 @@ entries:
     version: 1.2.2-81-g38c7ae2
   - apiVersion: v1
     appVersion: 1.2.2-80-g669a9c4
-    created: "2020-10-07T17:39:25.054331675Z"
+    created: "2020-09-28T09:48:31Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 1b4734dc4c3de35ce29f1d85377e8958e73518ca5ccfde56087408a13ee2bfc9
@@ -1657,7 +1657,7 @@ entries:
     version: 1.2.2-80-g669a9c4
   - apiVersion: v1
     appVersion: 1.2.2-78-gf005bba
-    created: "2020-10-07T17:39:25.032134324Z"
+    created: "2020-09-22T20:51:28Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: d20e394c835b7556846c981812dfff3e1e82000c2e0c817b55e84923e276d639
@@ -1674,7 +1674,7 @@ entries:
     version: 1.2.2-78-gf005bba
   - apiVersion: v1
     appVersion: 1.2.2-77-g1301447
-    created: "2020-10-07T17:39:25.011903558Z"
+    created: "2020-09-25T15:44:07Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: b613d8448c15c06ab61db9e43c0e1bbe6248625dc4ebb35feba6201e54ea42b9
@@ -1691,7 +1691,7 @@ entries:
     version: 1.2.2-77-g1301447
   - apiVersion: v1
     appVersion: 1.2.2-76-g413f4ba
-    created: "2020-10-07T17:39:24.991817784Z"
+    created: "2020-09-25T06:57:00Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: fd3040367d7c8eb63cb32b512e601b85243b10b506f66210f7b87c48caffe25c
@@ -1708,7 +1708,7 @@ entries:
     version: 1.2.2-76-g413f4ba
   - apiVersion: v1
     appVersion: 1.2.2-74-g105112b
-    created: "2020-10-07T17:39:24.968738608Z"
+    created: "2020-09-04T10:06:58Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: a92879e37d7e489f34c094c4feb70de3195aa21ba6ef3e5e59120c767a6baa0e
@@ -1725,7 +1725,7 @@ entries:
     version: 1.2.2-74-g105112b
   - apiVersion: v1
     appVersion: 1.2.2-71-g9d36e5e
-    created: "2020-10-07T17:39:24.948783868Z"
+    created: "2020-09-24T12:46:59Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 31517180ec5af049695454470c1f7cb72c7f1e4aeab50972c31ef1a57e64c414
@@ -1742,7 +1742,7 @@ entries:
     version: 1.2.2-71-g9d36e5e
   - apiVersion: v1
     appVersion: 1.2.2-7-g7fb1775
-    created: "2020-10-07T17:39:24.926614941Z"
+    created: "2020-09-11T18:55:46Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 30810e84ef4fe11e4116e1bab0d1332eb5f0deb9defa31ff5b577bfe66f49809
@@ -1759,7 +1759,7 @@ entries:
     version: 1.2.2-7-g7fb1775
   - apiVersion: v1
     appVersion: 1.2.2-69-g98375418
-    created: "2020-10-07T17:39:24.906850729Z"
+    created: "2020-09-24T11:12:59Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 3a8e6da759252fbb5d69a26d4416c7c3b2e7b87200df40e3c9b40ff2921fac40
@@ -1776,7 +1776,7 @@ entries:
     version: 1.2.2-69-g98375418
   - apiVersion: v1
     appVersion: 1.2.2-67-gc2103440
-    created: "2020-10-07T17:39:24.884135682Z"
+    created: "2020-09-24T10:57:51Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: e5783d80742eb92f20e2f133763f0591dbdc460d6f4b7dce42b76ba995c4cb3f
@@ -1793,7 +1793,7 @@ entries:
     version: 1.2.2-67-gc2103440
   - apiVersion: v1
     appVersion: 1.2.2-66-gb20fe380
-    created: "2020-10-07T17:39:24.863991713Z"
+    created: "2020-09-24T10:51:44Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: b8fd5f4135e68c3b37a1dac550fbfd3c86c7c143d580f4c31e962ddb60240cfd
@@ -1810,7 +1810,7 @@ entries:
     version: 1.2.2-66-gb20fe380
   - apiVersion: v1
     appVersion: 1.2.2-65-g086f6d9a
-    created: "2020-10-07T17:39:24.841148217Z"
+    created: "2020-08-27T15:56:25Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 03d67d769fcfc35897ea516686439dfa1400556a873318f0aa86251af8d62c3e
@@ -1827,7 +1827,7 @@ entries:
     version: 1.2.2-65-g086f6d9a
   - apiVersion: v1
     appVersion: 1.2.2-62-g729004d
-    created: "2020-10-07T17:39:24.820973912Z"
+    created: "2020-09-24T08:54:32Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: a5b56dbb73cb38ff265d5afb41116d2e67192b1c45cfb8e615246f9edc999cb1
@@ -1844,7 +1844,7 @@ entries:
     version: 1.2.2-62-g729004d
   - apiVersion: v1
     appVersion: 1.2.2-61-g6e828d7
-    created: "2020-10-07T17:39:24.796072787Z"
+    created: "2020-09-23T16:24:40Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 10b072a42134255a997af24e684b31d710d3e9719c72048fdde3160bb1e045bf
@@ -1861,7 +1861,7 @@ entries:
     version: 1.2.2-61-g6e828d7
   - apiVersion: v1
     appVersion: 1.2.2-60-gdb24c7f
-    created: "2020-10-07T17:39:24.77601617Z"
+    created: "2020-09-22T21:51:38Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 3359f92ecd9ca030f77dc8640adb414fa43545a7f1f3d9439868de8d56feba35
@@ -1878,7 +1878,7 @@ entries:
     version: 1.2.2-60-gdb24c7f
   - apiVersion: v1
     appVersion: 1.2.2-6-g6ad9590
-    created: "2020-10-07T17:39:24.7560817Z"
+    created: "2020-07-16T23:53:51Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 2004efdd81ac59ee7728054fcc0bd97eb623b817a7991dbf7d8a510c925442f5
@@ -1895,7 +1895,7 @@ entries:
     version: 1.2.2-6-g6ad9590
   - apiVersion: v1
     appVersion: 1.2.2-56-g542c748
-    created: "2020-10-07T17:39:24.732213073Z"
+    created: "2020-09-23T15:17:00Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: f089af334d44255407b3dc745abe30db8b61d8b34cc6e8f3a4726e692657dfb1
@@ -1912,7 +1912,7 @@ entries:
     version: 1.2.2-56-g542c748
   - apiVersion: v1
     appVersion: 1.2.2-55-g907ef82
-    created: "2020-10-07T17:39:24.710511362Z"
+    created: "2020-09-23T09:12:06Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 643b63048225f69d5eb74195c50ca04e2fb8a866a1c87f82ba58e7114f545cd8
@@ -1929,7 +1929,7 @@ entries:
     version: 1.2.2-55-g907ef82
   - apiVersion: v1
     appVersion: 1.2.2-54-g46c423a
-    created: "2020-10-07T17:39:24.690463895Z"
+    created: "2020-09-22T15:47:39Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: b98f9cdcaf0e18cdd40d2db87f5cef6983fc86dae9c815c59c6c2154295cb603
@@ -1946,7 +1946,7 @@ entries:
     version: 1.2.2-54-g46c423a
   - apiVersion: v1
     appVersion: 1.2.2-53-g26982f2
-    created: "2020-10-07T17:39:24.668180015Z"
+    created: "2020-09-22T11:12:49Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: a977d0a21f5864239220a62ab26d4263bc2f619ac6f838f1792617b21ab5bd17
@@ -1963,7 +1963,7 @@ entries:
     version: 1.2.2-53-g26982f2
   - apiVersion: v1
     appVersion: 1.2.2-50-g3ac0f91
-    created: "2020-10-07T17:39:24.648001443Z"
+    created: "2020-09-21T16:59:18Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: c5ffe71a13bcd9e7cd4555743d67dc17ad767fc70a13ce708b9c7f64fd67a301
@@ -1980,7 +1980,7 @@ entries:
     version: 1.2.2-50-g3ac0f91
   - apiVersion: v1
     appVersion: 1.2.2-49-gd29d035
-    created: "2020-10-07T17:39:24.626018077Z"
+    created: "2020-09-21T16:40:49Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: c5ed7f0ff2c279dc66a88fa49eae540f76f5ae64dfd7ab4a3b5e90cbb7c30c83
@@ -1997,7 +1997,7 @@ entries:
     version: 1.2.2-49-gd29d035
   - apiVersion: v1
     appVersion: 1.2.2-48-gcb6e8d0
-    created: "2020-10-07T17:39:24.603080419Z"
+    created: "2020-09-21T16:30:48Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 51d2107cccb592f9a2315d9f09f1d0b378f8b484c9811b7a9399783071099c6f
@@ -2014,7 +2014,7 @@ entries:
     version: 1.2.2-48-gcb6e8d0
   - apiVersion: v1
     appVersion: 1.2.2-47-g575b859
-    created: "2020-10-07T17:39:24.580839031Z"
+    created: "2020-09-21T16:09:54Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 840bf515f205791fc8da3d12a076d1476870b852c4235ab7f7ff876652b00c5a
@@ -2031,7 +2031,7 @@ entries:
     version: 1.2.2-47-g575b859
   - apiVersion: v1
     appVersion: 1.2.2-46-ga714e84
-    created: "2020-10-07T17:39:24.560682357Z"
+    created: "2020-09-21T07:59:35Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 7cfd9f0dbe8fda0a8a1776b62e48e30107682db921fa53ac5185f12977abd7b6
@@ -2048,7 +2048,7 @@ entries:
     version: 1.2.2-46-ga714e84
   - apiVersion: v1
     appVersion: 1.2.2-40-gd444caa
-    created: "2020-10-07T17:39:24.538810378Z"
+    created: "2020-09-18T16:40:39Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: ebddbee0808b7d3c684fbd9f7eaed6b73186cd03b31b14c33915fb89a66f054d
@@ -2065,7 +2065,7 @@ entries:
     version: 1.2.2-40-gd444caa
   - apiVersion: v1
     appVersion: 1.2.2-39-g388c1be
-    created: "2020-10-07T17:39:24.518837101Z"
+    created: "2020-09-17T15:24:36Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: ce2e044ed5d87684a1c90427b55ebf51db88129b7b38abc8a709aaefc26f32c0
@@ -2082,7 +2082,7 @@ entries:
     version: 1.2.2-39-g388c1be
   - apiVersion: v1
     appVersion: 1.2.2-38-g4e0443d
-    created: "2020-10-07T17:39:24.498720946Z"
+    created: "2020-09-17T07:52:52Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 79e968448ae2e0f2ee9ce705c3b6465fc01fe3e65638bc0733d8523a29f3e0c7
@@ -2099,7 +2099,7 @@ entries:
     version: 1.2.2-38-g4e0443d
   - apiVersion: v1
     appVersion: 1.2.2-3-g0db5d37
-    created: "2020-10-07T17:39:24.474329736Z"
+    created: "2020-09-18T13:08:23Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 437c297c34b2c121aa98ef91110c493018eb68692737b64803943c6523f403f6
@@ -2116,7 +2116,7 @@ entries:
     version: 1.2.2-3-g0db5d37
   - apiVersion: v1
     appVersion: 1.2.2-28-g0df2530
-    created: "2020-10-07T17:39:24.451838965Z"
+    created: "2020-09-11T13:14:36Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 789501ca00c2d5ffd3caab88fac5fd32d472f1432284a5d1085e61f2b13cdf3a
@@ -2133,7 +2133,7 @@ entries:
     version: 1.2.2-28-g0df2530
   - apiVersion: v1
     appVersion: 1.2.2-27-gcb40430
-    created: "2020-10-07T17:39:24.431569169Z"
+    created: "2020-09-16T10:23:00Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 323cd52ad76f5fccc95e061deb8808fa0e63c38d858df4c0e8aa63778bd6081b
@@ -2150,7 +2150,7 @@ entries:
     version: 1.2.2-27-gcb40430
   - apiVersion: v1
     appVersion: 1.2.2-26-g9aef418
-    created: "2020-10-07T17:39:24.411382037Z"
+    created: "2020-09-16T10:52:18Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: cfec3c028fbca8db360774a70b31e4d66a782d795bcc9b1a954056e71ddad2f6
@@ -2167,7 +2167,7 @@ entries:
     version: 1.2.2-26-g9aef418
   - apiVersion: v1
     appVersion: 1.2.2-25-ge1cd52f
-    created: "2020-10-07T17:39:24.388833677Z"
+    created: "2020-09-15T15:05:57Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: cc2eafeee99531d3bdadc0cc96d972e481b1830e0bd7e20c7fdce599724d8484
@@ -2184,7 +2184,7 @@ entries:
     version: 1.2.2-25-ge1cd52f
   - apiVersion: v1
     appVersion: 1.2.2-24-g5a0c3d5
-    created: "2020-10-07T17:39:24.369435303Z"
+    created: "2020-09-15T09:06:43Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 0805ae95357b50b2707089a2b27d6a40f744c8fc944746c22d5ea751f99cba32
@@ -2201,7 +2201,7 @@ entries:
     version: 1.2.2-24-g5a0c3d5
   - apiVersion: v1
     appVersion: 1.2.2-22-g8f6d215
-    created: "2020-10-07T17:39:24.349861478Z"
+    created: "2020-09-14T22:30:53Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 307211d8e3208f6c3eb6139aca6454df54cdd7160b9938422c4f9f14c11fea9d
@@ -2218,7 +2218,7 @@ entries:
     version: 1.2.2-22-g8f6d215
   - apiVersion: v1
     appVersion: 1.2.2-21-g675d0cb
-    created: "2020-10-07T17:39:24.326287841Z"
+    created: "2020-09-14T16:17:32Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 18471aaa91b4092578383113da8d538031c181c9ac6bdb53674fe7f633a30e61
@@ -2235,7 +2235,7 @@ entries:
     version: 1.2.2-21-g675d0cb
   - apiVersion: v1
     appVersion: 1.2.2-2-g5096bf2
-    created: "2020-10-07T17:39:24.304879213Z"
+    created: "2020-09-11T15:45:55Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: e37d3835605a678e4e0a3ae832171cd7f2289fec551bae2c2f0c49daf6bdd707
@@ -2252,7 +2252,7 @@ entries:
     version: 1.2.2-2-g5096bf2
   - apiVersion: v1
     appVersion: 1.2.2-19-g97c5a2d
-    created: "2020-10-07T17:39:24.285379323Z"
+    created: "2020-09-14T17:55:42Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 1975863bc83cab565b3ead52737627ce4288c6e88713aff3d87cc731c8cf1b4a
@@ -2269,7 +2269,7 @@ entries:
     version: 1.2.2-19-g97c5a2d
   - apiVersion: v1
     appVersion: 1.2.2-18-g248511d
-    created: "2020-10-07T17:39:24.264920844Z"
+    created: "2020-09-14T16:56:56Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: e61504b4c8cf3c0bc8a0d321b7c625dfebc89f7f3e58f087df67a4b3b22cd411
@@ -2286,7 +2286,7 @@ entries:
     version: 1.2.2-18-g248511d
   - apiVersion: v1
     appVersion: 1.2.2-17-ga843f99
-    created: "2020-10-07T17:39:24.243381157Z"
+    created: "2020-09-04T10:30:00Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: e216753bc2197c6ddb62cf8af7142bfc0a2d4eb8626b30c98563edad12eb79b6
@@ -2303,7 +2303,7 @@ entries:
     version: 1.2.2-17-ga843f99
   - apiVersion: v1
     appVersion: 1.2.2-13-g15d0fca
-    created: "2020-10-07T17:39:24.223891615Z"
+    created: "2020-09-14T09:10:00Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 98a1c1e8ee973a8fbf63d8c1400df71ad89b852a204c2721f1eb7502c8b7283c
@@ -2320,7 +2320,7 @@ entries:
     version: 1.2.2-13-g15d0fca
   - apiVersion: v1
     appVersion: 1.2.2-11-gee84b78
-    created: "2020-10-07T17:39:24.201690495Z"
+    created: "2020-09-12T09:49:11Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 464442a75db5c32ea97a0f4a19e412d596e1a27c6077f0638c7b164a0b5be0d1
@@ -2337,7 +2337,7 @@ entries:
     version: 1.2.2-11-gee84b78
   - apiVersion: v1
     appVersion: 1.2.2-10-g66d7b73
-    created: "2020-10-07T17:39:24.181573743Z"
+    created: "2020-09-11T19:29:31Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 79d04d741fabb8aa3c8ce44e3bcb6975d1968b641e6d198ebe8fc74bbc6b048d
@@ -2354,7 +2354,7 @@ entries:
     version: 1.2.2-10-g66d7b73
   - apiVersion: v1
     appVersion: 1.2.2-1-g63ff8ca
-    created: "2020-10-07T17:39:24.159776959Z"
+    created: "2020-09-16T10:23:00Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 61e26d972618e1477a6374ca4a3a5054185ff675a53d6d844492f76d2f86aef7
@@ -2371,7 +2371,7 @@ entries:
     version: 1.2.2-1-g63ff8ca
   - apiVersion: v1
     appVersion: 1.2.2-1-g43ae186
-    created: "2020-10-07T17:39:24.140327456Z"
+    created: "2020-09-11T15:02:49Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 8751d55a25a9a2297625d0e45863e97443a9b69803bfc39ba3e6ffb6a42c6fe7
@@ -2388,7 +2388,7 @@ entries:
     version: 1.2.2-1-g43ae186
   - apiVersion: v1
     appVersion: 1.2.1
-    created: "2020-10-07T17:39:24.118321434Z"
+    created: "2020-08-31T17:13:57Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 8502b460cefe754e2b8c40984618cb1523c20d9adad63769d955eaffbc1771dd
@@ -2405,7 +2405,7 @@ entries:
     version: 1.2.1
   - apiVersion: v1
     appVersion: 1.2.1-9-g6648b63
-    created: "2020-10-07T17:39:24.098828312Z"
+    created: "2020-09-03T11:21:17Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: a7af2e03ce7b7c7a8250b84ed6e251c2b60045e6ac0803ebb8f87bf5458ee027
@@ -2422,7 +2422,7 @@ entries:
     version: 1.2.1-9-g6648b63
   - apiVersion: v1
     appVersion: 1.2.1-8-gbfc5a4d
-    created: "2020-10-07T17:39:24.076537214Z"
+    created: "2020-09-03T07:13:37Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: c016894d81294bc61aa9d719bd82e276b3f5bc8f7feeb4b6763bd49444de5410
@@ -2439,7 +2439,7 @@ entries:
     version: 1.2.1-8-gbfc5a4d
   - apiVersion: v1
     appVersion: 1.2.1-6-g7b852e3
-    created: "2020-10-07T17:39:24.057042299Z"
+    created: "2020-09-02T18:11:01Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: bca81ac437c91272a5b7e796a1379c6cfc7e38de8f83d471f3b05957b5cb4370
@@ -2456,7 +2456,7 @@ entries:
     version: 1.2.1-6-g7b852e3
   - apiVersion: v1
     appVersion: 1.2.1-5-gdb6061d
-    created: "2020-10-07T17:39:24.034978582Z"
+    created: "2020-09-02T17:31:47Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: f13cc8d8d9f4e7ee81de3450dd0772eb35c166fc15fd3c7d8e176b9a91586df4
@@ -2473,7 +2473,7 @@ entries:
     version: 1.2.1-5-gdb6061d
   - apiVersion: v1
     appVersion: 1.2.1-3-g83e407c
-    created: "2020-10-07T17:39:24.015276921Z"
+    created: "2020-09-01T18:29:53Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: e8b71bdde006252d0f4cf834866d2aaf953cbd1ec6761046e19df53ed3fda74b
@@ -2490,7 +2490,7 @@ entries:
     version: 1.2.1-3-g83e407c
   - apiVersion: v1
     appVersion: 1.2.1-2-g28b441d
-    created: "2020-10-07T17:39:23.993688623Z"
+    created: "2020-09-01T14:34:33Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 9e6b34295023cc598b30c06f1c246b02124990c5f6891ce05654a125ffdab588
@@ -2507,7 +2507,7 @@ entries:
     version: 1.2.1-2-g28b441d
   - apiVersion: v1
     appVersion: 1.2.1-14-gb6320c4
-    created: "2020-10-07T17:39:23.974486541Z"
+    created: "2020-09-03T11:38:43Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 534d059edd21c1a27149f8f97992dbffd3b445fa07790ce67ee7628fa4af431b
@@ -2524,7 +2524,7 @@ entries:
     version: 1.2.1-14-gb6320c4
   - apiVersion: v1
     appVersion: 1.2.1-11-g1cae4ff
-    created: "2020-10-07T17:39:23.950489162Z"
+    created: "2020-09-03T14:10:27Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 796d52b8b1ea74e178ac6524a9f1687cf9b20eb43c58172bfbc0668c934b012f
@@ -2541,7 +2541,7 @@ entries:
     version: 1.2.1-11-g1cae4ff
   - apiVersion: v1
     appVersion: 1.2.1-1-g832194c
-    created: "2020-10-07T17:39:23.930872832Z"
+    created: "2020-08-31T19:28:54Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 84061b5a861df9f2821bb145f1aa74f2698620f972b28872832f57722aea4713
@@ -2558,7 +2558,7 @@ entries:
     version: 1.2.1-1-g832194c
   - apiVersion: v1
     appVersion: 1.2.0
-    created: "2020-10-07T17:39:23.910038051Z"
+    created: "2020-08-28T15:17:23Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 3ef96696c7d1cd70c9a5cb704c7e1e003406cbb74d923e33b27c4097d40d6f39
@@ -2575,7 +2575,7 @@ entries:
     version: 1.2.0
   - apiVersion: v1
     appVersion: 1.2.0-beta.2-9-g849487c
-    created: "2020-10-07T17:39:23.868967908Z"
+    created: "2020-08-28T16:15:42Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: a79dfea70130c053eeabd3c84779af6d60852ad5474789318ec0be00eeb73487
@@ -2592,7 +2592,7 @@ entries:
     version: 1.2.0-beta.2-9-g849487c
   - apiVersion: v1
     appVersion: 1.2.0-beta.2-6-ged3a13b
-    created: "2020-10-07T17:39:23.847587128Z"
+    created: "2020-08-28T14:40:24Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 33e63828717ef1ba6b2dfca2a46d834a9c5eed7512606654ddaf87ee2a63c0b2
@@ -2609,7 +2609,7 @@ entries:
     version: 1.2.0-beta.2-6-ged3a13b
   - apiVersion: v1
     appVersion: 1.2.0-beta.2-5-gb377afe
-    created: "2020-10-07T17:39:23.826197536Z"
+    created: "2020-08-28T14:28:17Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 1c135499981914a2270a399d1ac0d4a2eddad89447e227bc56cdf03fcc03906f
@@ -2626,7 +2626,7 @@ entries:
     version: 1.2.0-beta.2-5-gb377afe
   - apiVersion: v1
     appVersion: 1.2.0-beta.2-3-g767b48f
-    created: "2020-10-07T17:39:23.80648625Z"
+    created: "2020-08-27T16:14:28Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 328518ff5d3d43dd4d9cbbbfa75e9010e04e4d557aa30a1d41558ced33be3364
@@ -2643,7 +2643,7 @@ entries:
     version: 1.2.0-beta.2-3-g767b48f
   - apiVersion: v1
     appVersion: 1.2.0-beta.2-12-g4109dd6
-    created: "2020-10-07T17:39:23.78298808Z"
+    created: "2020-08-28T15:17:23Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: c3f0c0bd639fc4c8891dd352da0115036e3cbbcbaed73f40fc0009efb850229f
@@ -2660,7 +2660,7 @@ entries:
     version: 1.2.0-beta.2-12-g4109dd6
   - apiVersion: v1
     appVersion: 1.2.0-beta.2-1-g4019fa7
-    created: "2020-10-07T17:39:23.760991325Z"
+    created: "2020-08-24T17:55:22Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 4afdc570ce8de2e8bcc92a60cfa579f483ae0475f2e13a68b36641104174360e
@@ -2677,7 +2677,7 @@ entries:
     version: 1.2.0-beta.2-1-g4019fa7
   - apiVersion: v1
     appVersion: 1.2.0-beta.1-4-g5fd6a10
-    created: "2020-10-07T17:39:23.719795176Z"
+    created: "2020-08-20T04:13:18Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: bbe38fa71881b061ae9501f0dbfd35c5babd3f80e88e7c91e1e69ee3ab757b62
@@ -2694,7 +2694,7 @@ entries:
     version: 1.2.0-beta.1-4-g5fd6a10
   - apiVersion: v1
     appVersion: 1.2.0-beta.1-34-ga699379
-    created: "2020-10-07T17:39:23.700130992Z"
+    created: "2020-08-26T12:54:58Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: c3710f5ec2faae650987ea0f7b2ab6b6c043e2823f94fe32c30254f0ab37f4ee
@@ -2711,7 +2711,7 @@ entries:
     version: 1.2.0-beta.1-34-ga699379
   - apiVersion: v1
     appVersion: 1.2.0-beta.1-31-g2949a65
-    created: "2020-10-07T17:39:23.675838496Z"
+    created: "2020-08-24T17:50:15Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: f469919f9dfd4bfec5f2466a90f8804fb0da199142508b8ae078dc2e593a33d9
@@ -2728,7 +2728,7 @@ entries:
     version: 1.2.0-beta.1-31-g2949a65
   - apiVersion: v1
     appVersion: 1.2.0-beta.1-3-gc904b9e
-    created: "2020-10-07T17:39:23.655761338Z"
+    created: "2020-08-19T22:22:50Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 572a712344c84760507ed113ce038ca8085552a15025fc9da954a209f9333ef4
@@ -2745,7 +2745,7 @@ entries:
     version: 1.2.0-beta.1-3-gc904b9e
   - apiVersion: v1
     appVersion: 1.2.0-beta.1-29-g8aa071c
-    created: "2020-10-07T17:39:23.636404222Z"
+    created: "2020-08-24T15:27:16Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 34a12798a15d392f6d58e8f496c0ecb5eb9e7081c61bb337568f97d6df18e631
@@ -2762,7 +2762,7 @@ entries:
     version: 1.2.0-beta.1-29-g8aa071c
   - apiVersion: v1
     appVersion: 1.2.0-beta.1-28-gbdf54a7
-    created: "2020-10-07T17:39:23.614338811Z"
+    created: "2020-08-21T23:53:52Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 075391ef1614fb7b8a6631b6965369a370aa258f21ff288bb96d417e2edfe5b6
@@ -2779,7 +2779,7 @@ entries:
     version: 1.2.0-beta.1-28-gbdf54a7
   - apiVersion: v1
     appVersion: 1.2.0-beta.1-27-g13d3cfc
-    created: "2020-10-07T17:39:23.594455817Z"
+    created: "2020-08-21T23:14:56Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: ba959c931aab75bf3f27863e062f8156853738ea99e39a4b7ffb314e7ebcaaaa
@@ -2796,7 +2796,7 @@ entries:
     version: 1.2.0-beta.1-27-g13d3cfc
   - apiVersion: v1
     appVersion: 1.2.0-beta.1-26-g035d9c8
-    created: "2020-10-07T17:39:23.570334143Z"
+    created: "2020-08-21T00:05:57Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: cbeb207ecc98edcbd9688b69769b404cdc4145fe96fd0c7e68b005202a341f66
@@ -2813,7 +2813,7 @@ entries:
     version: 1.2.0-beta.1-26-g035d9c8
   - apiVersion: v1
     appVersion: 1.2.0-beta.1-25-g916efd1
-    created: "2020-10-07T17:39:23.551119328Z"
+    created: "2020-08-24T14:53:48Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 1a27cd52f3c9a447f90d3ef992c83ae5985b54f7eec7cdc87a7976bfd45c5e70
@@ -2830,7 +2830,7 @@ entries:
     version: 1.2.0-beta.1-25-g916efd1
   - apiVersion: v1
     appVersion: 1.2.0-beta.1-24-gcc2ff86
-    created: "2020-10-07T17:39:23.530003844Z"
+    created: "2020-08-21T11:51:38Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 98e0b84a9e11379c0e89b896987eb9f90da25c4dae673b68eafdc39e6dae0568
@@ -2847,7 +2847,7 @@ entries:
     version: 1.2.0-beta.1-24-gcc2ff86
   - apiVersion: v1
     appVersion: 1.2.0-beta.1-22-gbb86883
-    created: "2020-10-07T17:39:23.510724257Z"
+    created: "2020-08-19T10:48:33Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 6cb7d887110ed02029c7104ebbadf8c9127abdb8f46259055c1a0065722d4def
@@ -2864,7 +2864,7 @@ entries:
     version: 1.2.0-beta.1-22-gbb86883
   - apiVersion: v1
     appVersion: 1.2.0-beta.1-20-ge95eb7b
-    created: "2020-10-07T17:39:23.488995369Z"
+    created: "2020-08-21T05:49:31Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: f1acc989af3b5b0c3911dd419302bc768dd7c0bdb12315cba07f09b48a7552fc
@@ -2881,7 +2881,7 @@ entries:
     version: 1.2.0-beta.1-20-ge95eb7b
   - apiVersion: v1
     appVersion: 1.2.0-beta.1-18-g0401db2
-    created: "2020-10-07T17:39:23.46948185Z"
+    created: "2020-08-21T08:45:55Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: e561f1db03422745ab5d1a7d1299c8c86d2cd5ece212f9ba6c07237851bbd5e8
@@ -2898,7 +2898,7 @@ entries:
     version: 1.2.0-beta.1-18-g0401db2
   - apiVersion: v1
     appVersion: 1.2.0-beta.1-16-gc144e66
-    created: "2020-10-07T17:39:23.448138104Z"
+    created: "2020-08-20T07:00:19Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 6bf6584ca3d63b5d52b2c9ce8ab8392b94771fdff587a25a546b15bf52cf0b63
@@ -2915,7 +2915,7 @@ entries:
     version: 1.2.0-beta.1-16-gc144e66
   - apiVersion: v1
     appVersion: 1.2.0-beta.0-7-g4a82e48
-    created: "2020-10-07T17:39:23.406978322Z"
+    created: "2020-08-18T16:09:38Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: d5799a0e27b0b0ab4ea064092fec186500da2f2b8245053854b9c3a0837fe4ef
@@ -2932,7 +2932,7 @@ entries:
     version: 1.2.0-beta.0-7-g4a82e48
   - apiVersion: v1
     appVersion: 1.2.0-beta.0-4-gc3e3872
-    created: "2020-10-07T17:39:23.383318113Z"
+    created: "2020-08-14T18:18:46Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: be6cdbb13c6663e4820a2e1bc39eb0e0cb3c196b869bf8c6f7f8742dc5b6a9c0
@@ -2949,7 +2949,7 @@ entries:
     version: 1.2.0-beta.0-4-gc3e3872
   - apiVersion: v1
     appVersion: 1.2.0-beta.0-1-g4e487e1
-    created: "2020-10-07T17:39:23.363953988Z"
+    created: "2020-08-17T21:51:26Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 2cbf493e306da5ce3530417df72a42b5f72750f2c1060ad17909193a4b410e15
@@ -2966,7 +2966,7 @@ entries:
     version: 1.2.0-beta.0-1-g4e487e1
   - apiVersion: v1
     appVersion: 1.2.0-beta.2
-    created: "2020-10-07T17:39:23.888562589Z"
+    created: "2020-08-26T12:54:58Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 48d257698a121f200da27bd86c337c1af67be0343ab0fbe5cc2b1a43f868a068
@@ -2983,7 +2983,7 @@ entries:
     version: 1.2.0-beta.2
   - apiVersion: v1
     appVersion: 1.2.0-beta.1
-    created: "2020-10-07T17:39:23.741226527Z"
+    created: "2020-08-18T16:09:38Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: e323b8051af4499df3249b615d0fbc6b9f4c9ba9c779a6c93708b932053b930d
@@ -3000,7 +3000,7 @@ entries:
     version: 1.2.0-beta.1
   - apiVersion: v1
     appVersion: 1.2.0-beta.0
-    created: "2020-10-07T17:39:23.426656444Z"
+    created: "2020-08-13T23:25:52Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 6704a1d5f6edddf1729e45ac642ccd3f494a828b87fb8397dbf3a0f32a90f0e8
@@ -3017,7 +3017,7 @@ entries:
     version: 1.2.0-beta.0
   - apiVersion: v1
     appVersion: 1.2.0-9-gc3c9911
-    created: "2020-10-07T17:39:23.3429077Z"
+    created: "2020-08-31T17:13:57Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 42f18090650a9c4c5deadcf6651363d0531dad2f938eecbcb8a42998f4df9faa
@@ -3034,7 +3034,7 @@ entries:
     version: 1.2.0-9-gc3c9911
   - apiVersion: v1
     appVersion: 1.2.0-6-g1e7f946
-    created: "2020-10-07T17:39:23.323339647Z"
+    created: "2020-08-31T15:50:12Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: a64e9634b4e26ac473885767d6a39befac3afadb079432fca8c16ff85db1cb54
@@ -3051,7 +3051,7 @@ entries:
     version: 1.2.0-6-g1e7f946
   - apiVersion: v1
     appVersion: 1.2.0-4-g49dee87
-    created: "2020-10-07T17:39:23.301833955Z"
+    created: "2020-08-31T11:19:02Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: d57e9f35c9c78e3611aefbd87996a3c4959da1c8c276cef7858b86de966807ac
@@ -3068,7 +3068,7 @@ entries:
     version: 1.2.0-4-g49dee87
   - apiVersion: v1
     appVersion: 1.2.0-2-gd67c9f7
-    created: "2020-10-07T17:39:23.281758467Z"
+    created: "2020-08-31T15:48:51Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: da359c48d86c08c67705de6667df800a1a7a0f05f1ff481640a15abbdb9c2ef1
@@ -3085,7 +3085,7 @@ entries:
     version: 1.2.0-2-gd67c9f7
   - apiVersion: v1
     appVersion: 1.2.0-1-ga941fa0
-    created: "2020-10-07T17:39:23.258354113Z"
+    created: "2020-08-28T16:35:58Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 7bc598760ebebbfd8bcae0aaf26133dc1115d53ecbd4005c584fa46b83e471a4
@@ -3102,7 +3102,7 @@ entries:
     version: 1.2.0-1-ga941fa0
   - apiVersion: v1
     appVersion: 1.1.0
-    created: "2020-10-07T17:39:23.238726683Z"
+    created: "2020-07-30T16:44:15Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 78f89e88164c93b8df5f6f170a25f7249e1f4eedc11168a5e5664f093813f4a8
@@ -3119,7 +3119,7 @@ entries:
     version: 1.1.0
   - apiVersion: v1
     appVersion: 1.1.0-rc.1-7-gb505e06
-    created: "2020-10-07T17:39:23.197394042Z"
+    created: "2020-07-30T16:44:15Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: c19637d46c589fc319203a1eb36090c4a3af7d372e2c30344b415f21a47456ad
@@ -3153,7 +3153,7 @@ entries:
     version: 1.1.0-rc.1-5-gbe7c000
   - apiVersion: v1
     appVersion: 1.1.0-rc.1-4-gfc57f96
-    created: "2020-10-07T17:39:23.155970783Z"
+    created: "2020-07-30T16:42:55Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 11a4b34cd173a30a9ce31b8c61a0fd69c92e3bc4896786d4259c4d780cfbf031
@@ -3170,7 +3170,7 @@ entries:
     version: 1.1.0-rc.1-4-gfc57f96
   - apiVersion: v1
     appVersion: 1.1.0-rc.1-3-g8e59251
-    created: "2020-10-07T17:39:23.134354649Z"
+    created: "2020-07-30T16:09:14Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 5698115e755d81473d58bd190f2ac2b7ca79a2f7596546741e2cd3e6f777d694
@@ -3187,7 +3187,7 @@ entries:
     version: 1.1.0-rc.1-3-g8e59251
   - apiVersion: v1
     appVersion: 1.1.0-rc.1-2-g142aa6d
-    created: "2020-10-07T17:39:23.11507038Z"
+    created: "2020-07-30T16:08:49Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 4ba3bf507c826443c7c6be7eba95d3125e0ab65d1daf5dbccd2512034b3b6d1e
@@ -3204,7 +3204,7 @@ entries:
     version: 1.1.0-rc.1-2-g142aa6d
   - apiVersion: v1
     appVersion: 1.1.0-rc.1-1-g4f15ddb
-    created: "2020-10-07T17:39:23.091401237Z"
+    created: "2020-07-29T19:49:16Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 12f8c0fe6551a82a44d2f6c3b8bc4f4edc51a47bc3f6044684a561a84e5ae3ff
@@ -3221,7 +3221,7 @@ entries:
     version: 1.1.0-rc.1-1-g4f15ddb
   - apiVersion: v1
     appVersion: 1.1.0-rc.0-9-g5227320
-    created: "2020-10-07T17:39:23.050482024Z"
+    created: "2020-07-28T17:57:17Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 61793dfde8ddb79bc299bb81c951509d97f1adac64040abe7f8558af60b2c6c1
@@ -3238,7 +3238,7 @@ entries:
     version: 1.1.0-rc.0-9-g5227320
   - apiVersion: v1
     appVersion: 1.1.0-rc.0-8-gceab255
-    created: "2020-10-07T17:39:23.029206839Z"
+    created: "2020-07-28T13:48:00Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: f8fdeebc3b248c41ff3c671a2ec892334393716309893d626fe5c1d968019f74
@@ -3255,7 +3255,7 @@ entries:
     version: 1.1.0-rc.0-8-gceab255
   - apiVersion: v1
     appVersion: 1.1.0-rc.0-6-g21704d8
-    created: "2020-10-07T17:39:23.009595836Z"
+    created: "2020-07-16T15:25:21Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: f76ce5bd3fcf279abcb9d67838f701a59910caef12db27beaef9bc6e8c299c16
@@ -3272,7 +3272,7 @@ entries:
     version: 1.1.0-rc.0-6-g21704d8
   - apiVersion: v1
     appVersion: 1.1.0-rc.0-4-ge0ccfdc
-    created: "2020-10-07T17:39:22.988152191Z"
+    created: "2020-07-24T16:06:07Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 5a81cbd13c25924b6d22c7966f3df433925a63a847c535413b6a12de98924df3
@@ -3289,7 +3289,7 @@ entries:
     version: 1.1.0-rc.0-4-ge0ccfdc
   - apiVersion: v1
     appVersion: 1.1.0-rc.0-3-g420e934
-    created: "2020-10-07T17:39:22.968827791Z"
+    created: "2020-07-14T17:43:02Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 261b25881451f839d8b78e3eda72482b9e1ce46b6879701a0568c904fbfbef5a
@@ -3306,7 +3306,7 @@ entries:
     version: 1.1.0-rc.0-3-g420e934
   - apiVersion: v1
     appVersion: 1.1.0-rc.0-2-g4290622
-    created: "2020-10-07T17:39:22.945476274Z"
+    created: "2020-07-16T10:35:26Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: d6e97800043d6957cd4261606cde63da15894aec9446bae7bb9bdeaa60456b7a
@@ -3323,7 +3323,7 @@ entries:
     version: 1.1.0-rc.0-2-g4290622
   - apiVersion: v1
     appVersion: 1.1.0-rc.0-12-g46a925f
-    created: "2020-10-07T17:39:22.926224726Z"
+    created: "2020-07-29T14:42:54Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 30f45a74b56d4702df5c1300ce84d5b891886798e95aa7359a4762ab987f9382
@@ -3340,7 +3340,7 @@ entries:
     version: 1.1.0-rc.0-12-g46a925f
   - apiVersion: v1
     appVersion: 1.1.0-rc.0-1-g428c227
-    created: "2020-10-07T17:39:22.907058872Z"
+    created: "2020-07-16T10:33:36Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 5061c50c01bf374d761ef6bea8eee14d67ad1325f7bcbf4c827ba19a26711ade
@@ -3357,7 +3357,7 @@ entries:
     version: 1.1.0-rc.0-1-g428c227
   - apiVersion: v1
     appVersion: 1.1.0-rc.1
-    created: "2020-10-07T17:39:23.216953064Z"
+    created: "2020-07-29T14:42:54Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 7264d7443342ef25a62671599661497f4cf4c729dfb1580ed21d6326ab90db25
@@ -3374,7 +3374,7 @@ entries:
     version: 1.1.0-rc.1
   - apiVersion: v1
     appVersion: 1.1.0-rc.0
-    created: "2020-10-07T17:39:23.069693813Z"
+    created: "2020-07-10T15:51:36Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 0b3ec035a1279d2a1a5d03b9ecd3173c2d493611c2e483bcd4a34371144acebb
@@ -3391,7 +3391,7 @@ entries:
     version: 1.1.0-rc.0
   - apiVersion: v1
     appVersion: 1.1.0-beta.2-9-g9c4e52f
-    created: "2020-10-07T17:39:22.86574296Z"
+    created: "2020-06-25T15:49:27Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: a978aabbfc38f0e7b6cd7b1eb52893b88211a89335c9e7857181abd239bdde6e
@@ -3408,7 +3408,7 @@ entries:
     version: 1.1.0-beta.2-9-g9c4e52f
   - apiVersion: v1
     appVersion: 1.1.0-beta.2-8-g951c1de
-    created: "2020-10-07T17:39:22.84405097Z"
+    created: "2020-06-23T16:53:32Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: e5ac019def04792176ec098ca5c16c7500a29766cf27395d706eca068ba9706a
@@ -3425,7 +3425,7 @@ entries:
     version: 1.1.0-beta.2-8-g951c1de
   - apiVersion: v1
     appVersion: 1.1.0-beta.2-3-g2154e34
-    created: "2020-10-07T17:39:22.824832277Z"
+    created: "2020-06-19T01:26:58Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 997f4da5d2d15ecedeed9787c2bb128bd3fde8474e4e76e72087fcde5ffc0e26
@@ -3442,7 +3442,7 @@ entries:
     version: 1.1.0-beta.2-3-g2154e34
   - apiVersion: v1
     appVersion: 1.1.0-beta.2-27-g9244e73
-    created: "2020-10-07T17:39:22.803188804Z"
+    created: "2020-07-10T15:51:36Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 9ec96faf1e635285de89acd5c38c080357c3ed899bd6a6389acbcb47ed31fb73
@@ -3459,7 +3459,7 @@ entries:
     version: 1.1.0-beta.2-27-g9244e73
   - apiVersion: v1
     appVersion: 1.1.0-beta.2-24-g88259b1
-    created: "2020-10-07T17:39:22.783783344Z"
+    created: "2020-07-10T15:56:34Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 9967807f81f5aa6d3215fe9a07fa9ed09290a2ce6efc60328dc83688cb8dccdb
@@ -3476,7 +3476,7 @@ entries:
     version: 1.1.0-beta.2-24-g88259b1
   - apiVersion: v1
     appVersion: 1.1.0-beta.2-23-gdcc1230
-    created: "2020-10-07T17:39:22.760143621Z"
+    created: "2020-07-10T12:53:29Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: c398e95e994010dbe1b4f1f9a871cdfa3498fdcb3d69360fbcc06a757baaf4a5
@@ -3493,7 +3493,7 @@ entries:
     version: 1.1.0-beta.2-23-gdcc1230
   - apiVersion: v1
     appVersion: 1.1.0-beta.2-22-g6776c1b
-    created: "2020-10-07T17:39:22.738650223Z"
+    created: "2020-06-17T09:23:43Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 340b92174bb11ef084078a15e683957ca08455875546babec7c2bdd5c24ff2c9
@@ -3510,7 +3510,7 @@ entries:
     version: 1.1.0-beta.2-22-g6776c1b
   - apiVersion: v1
     appVersion: 1.1.0-beta.2-21-g6e28656
-    created: "2020-10-07T17:39:22.719445718Z"
+    created: "2020-07-08T19:09:28Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 8db518dc9f9282dee108df6fc0bc4081af3fc083429d76a354a988535e823238
@@ -3527,7 +3527,7 @@ entries:
     version: 1.1.0-beta.2-21-g6e28656
   - apiVersion: v1
     appVersion: 1.1.0-beta.2-20-g1ff4517
-    created: "2020-10-07T17:39:22.697946953Z"
+    created: "2020-07-08T09:28:53Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 4187da6bc5bc746b72fc92295fd53722fa98beee544161177071693e88e3122c
@@ -3544,7 +3544,7 @@ entries:
     version: 1.1.0-beta.2-20-g1ff4517
   - apiVersion: v1
     appVersion: 1.1.0-beta.2-2-g3d10caa
-    created: "2020-10-07T17:39:22.678178832Z"
+    created: "2020-06-17T16:16:08Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 0065764ad69e75e46e129c5bb2e79e831ca932feba4105e58f16a4a752ab4549
@@ -3561,7 +3561,7 @@ entries:
     version: 1.1.0-beta.2-2-g3d10caa
   - apiVersion: v1
     appVersion: 1.1.0-beta.2-19-g58d4728
-    created: "2020-10-07T17:39:22.657943236Z"
+    created: "2020-07-07T17:19:39Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 3d742327bc60f7dc13620e001e3890f940f5671c6f1ecc862d57c0772d324c71
@@ -3578,7 +3578,7 @@ entries:
     version: 1.1.0-beta.2-19-g58d4728
   - apiVersion: v1
     appVersion: 1.1.0-beta.2-16-gcff0b2c
-    created: "2020-10-07T17:39:22.636967362Z"
+    created: "2020-07-06T11:36:28Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: bb2128a2d329e98bd99d9cb9e28adb9d708544420b497105b1bab330c9e0977e
@@ -3595,7 +3595,7 @@ entries:
     version: 1.1.0-beta.2-16-gcff0b2c
   - apiVersion: v1
     appVersion: 1.1.0-beta.2-15-gfcc0821
-    created: "2020-10-07T17:39:22.617613281Z"
+    created: "2020-06-30T07:32:11Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: afb9edba99c4eba2bb0a184002469b06e64f3105e9dab9d83db1b4a712073538
@@ -3612,7 +3612,7 @@ entries:
     version: 1.1.0-beta.2-15-gfcc0821
   - apiVersion: v1
     appVersion: 1.1.0-beta.2-14-g17f0505
-    created: "2020-10-07T17:39:22.595588523Z"
+    created: "2020-07-02T16:33:33Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: df8afaf979b014bf860979d5dc640a0c85bf85b7b3f9e0c61ae4a7d8242179ab
@@ -3629,7 +3629,7 @@ entries:
     version: 1.1.0-beta.2-14-g17f0505
   - apiVersion: v1
     appVersion: 1.1.0-beta.2-13-gb4599b6
-    created: "2020-10-07T17:39:22.57470982Z"
+    created: "2020-07-02T15:31:51Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 4759cf08e513ace9ea7c8ab856869312317004c2147b6e61f3dc0d393e3c3a7e
@@ -3646,7 +3646,7 @@ entries:
     version: 1.1.0-beta.2-13-gb4599b6
   - apiVersion: v1
     appVersion: 1.1.0-beta.2-11-g01ae943
-    created: "2020-10-07T17:39:22.553428163Z"
+    created: "2020-06-26T08:03:40Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: f0732d2db862374efea6bd40de31b119fb7c7a0a409df1d4104c6851f12f0d7a
@@ -3663,7 +3663,7 @@ entries:
     version: 1.1.0-beta.2-11-g01ae943
   - apiVersion: v1
     appVersion: 1.1.0-beta.2-1-g8ad20d5
-    created: "2020-10-07T17:39:22.534260892Z"
+    created: "2020-06-15T22:03:38Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 58f3346a19f6340c9c099fda13874ed8b0b886437f095fb2d9fbf868bb9833ca
@@ -3680,7 +3680,7 @@ entries:
     version: 1.1.0-beta.2-1-g8ad20d5
   - apiVersion: v1
     appVersion: 1.1.0-beta.1-7-g668136c
-    created: "2020-10-07T17:39:22.490046562Z"
+    created: "2020-06-16T08:01:21Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 10b8557a2197f4464ad5188f630279bdad6184ebf4d50a409a9fd81b01d6e5ec
@@ -3697,7 +3697,7 @@ entries:
     version: 1.1.0-beta.1-7-g668136c
   - apiVersion: v1
     appVersion: 1.1.0-beta.1-10-gabe12f7
-    created: "2020-10-07T17:39:22.470548538Z"
+    created: "2020-06-16T13:30:53Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 00d5cfb0604cb390a6967be46510ae27c65fa3b03072dab992e9ccdc4c181b69
@@ -3714,7 +3714,7 @@ entries:
     version: 1.1.0-beta.1-10-gabe12f7
   - apiVersion: v1
     appVersion: 1.1.0-beta.1-1-gfeb04fd
-    created: "2020-10-07T17:39:22.450659398Z"
+    created: "2020-06-12T08:00:53Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: de6b061ddfc13879bdb43384246ceaaa5d6146676bbbe63d0bdfc2dd4ae923b1
@@ -3731,7 +3731,7 @@ entries:
     version: 1.1.0-beta.1-1-gfeb04fd
   - apiVersion: v1
     appVersion: 1.1.0-beta.0-2-g0e7be3e
-    created: "2020-10-07T17:39:22.410718594Z"
+    created: "2020-06-10T08:37:19Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 03318142a5bf23a9ab0eba31eae5ba4828b5809a957c7953ccf173949c7379e0
@@ -3748,7 +3748,7 @@ entries:
     version: 1.1.0-beta.0-2-g0e7be3e
   - apiVersion: v1
     appVersion: 1.1.0-beta.0-1-gce996b0
-    created: "2020-10-07T17:39:22.388922115Z"
+    created: "2020-06-09T07:58:11Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 643d13ebf86f3aaeb4dae44c2f600ecd6c982ef29841d235ae4e427d0b76726c
@@ -3765,7 +3765,7 @@ entries:
     version: 1.1.0-beta.0-1-gce996b0
   - apiVersion: v1
     appVersion: 1.1.0-beta.2
-    created: "2020-10-07T17:39:22.884965736Z"
+    created: "2020-06-16T15:46:57Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 5212989f1a5d892caf0433b92537b1f29c6a8fdf7e9bf0ae22abb0f74257784f
@@ -3782,7 +3782,7 @@ entries:
     version: 1.1.0-beta.2
   - apiVersion: v1
     appVersion: 1.1.0-beta.1
-    created: "2020-10-07T17:39:22.511241673Z"
+    created: "2020-06-10T15:54:26Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 7a577a60af6e63603ade2099e386564fdb44bf92a061efda9da49ed87e729ecd
@@ -3799,7 +3799,7 @@ entries:
     version: 1.1.0-beta.1
   - apiVersion: v1
     appVersion: 1.1.0-beta.0
-    created: "2020-10-07T17:39:22.429804073Z"
+    created: "2020-06-10T08:58:51Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 5e4dbd4a891d56f78e69339c939ae17cf701be6a1be89256513956ef578d37f5
@@ -3816,7 +3816,7 @@ entries:
     version: 1.1.0-beta.0
   - apiVersion: v1
     appVersion: 1.1.0-9-g97155eb
-    created: "2020-10-07T17:39:22.369020092Z"
+    created: "2020-08-10T14:11:59Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: e333e3922fe795ee0ecc67c217a3a54cddafa32f8b94184b00f0f72465788bd9
@@ -3833,7 +3833,7 @@ entries:
     version: 1.1.0-9-g97155eb
   - apiVersion: v1
     appVersion: 1.1.0-8-g741334a
-    created: "2020-10-07T17:39:22.348276299Z"
+    created: "2020-08-07T15:04:05Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: e0d1661bfd10b69490c1ef9d1e30636340a55e67d6b5dae7dad1e3a47d655924
@@ -3850,7 +3850,7 @@ entries:
     version: 1.1.0-8-g741334a
   - apiVersion: v1
     appVersion: 1.1.0-7-g5324560
-    created: "2020-10-07T17:39:22.329209678Z"
+    created: "2020-08-07T15:03:06Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: d7b874f3d51d0055f3605a4219319e9469d1e9af1bc14d62392a6bf873239381
@@ -3867,7 +3867,7 @@ entries:
     version: 1.1.0-7-g5324560
   - apiVersion: v1
     appVersion: 1.1.0-6-gf1f0905
-    created: "2020-10-07T17:39:22.307740354Z"
+    created: "2020-08-06T17:00:39Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 1dc720109d65ee79c317bb029be0641a396c761a235745dc98ce52aab5adb48c
@@ -3884,7 +3884,7 @@ entries:
     version: 1.1.0-6-gf1f0905
   - apiVersion: v1
     appVersion: 1.1.0-5-g1d63a97
-    created: "2020-10-07T17:39:22.286943669Z"
+    created: "2020-08-06T08:28:10Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: e7443ee64afd4ff71769ae34568d7aec55921713c3228de5cdabbf78cb6d5161
@@ -3901,7 +3901,7 @@ entries:
     version: 1.1.0-5-g1d63a97
   - apiVersion: v1
     appVersion: 1.1.0-4-g0a488a9
-    created: "2020-10-07T17:39:22.26791323Z"
+    created: "2020-08-03T23:19:04Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 312200bf29df3a02a479b3f0b1ad7a7a2a759d84834fe3984b599d44f2e605e7
@@ -3918,7 +3918,7 @@ entries:
     version: 1.1.0-4-g0a488a9
   - apiVersion: v1
     appVersion: 1.1.0-3-ge987e5d
-    created: "2020-10-07T17:39:22.24481408Z"
+    created: "2020-08-07T15:04:05Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: aa408d9be00d8eb386c7d7a70581a5efe0cb6a62ed6300fc4abf8e27dfcffca1
@@ -3935,7 +3935,7 @@ entries:
     version: 1.1.0-3-ge987e5d
   - apiVersion: v1
     appVersion: 1.1.0-2-g72a38fc
-    created: "2020-10-07T17:39:22.225651124Z"
+    created: "2020-08-04T00:49:35Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: e5796643bb355e2332ceb925fd812aab05d488d9c08f678279ac646b780146e2
@@ -3952,7 +3952,7 @@ entries:
     version: 1.1.0-2-g72a38fc
   - apiVersion: v1
     appVersion: 1.1.0-15-g588211d
-    created: "2020-10-07T17:39:22.204906918Z"
+    created: "2020-08-13T23:25:52Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 47d54bb0bca706856193cb1e0cadd6d2e2254f1b8f4d8a740430566985788ce7
@@ -3969,7 +3969,7 @@ entries:
     version: 1.1.0-15-g588211d
   - apiVersion: v1
     appVersion: 1.1.0-12-gd47e6c6
-    created: "2020-10-07T17:39:22.183434239Z"
+    created: "2020-08-10T16:18:51Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 71b3dda15bb634b293203fc360dc6639d13aff79f43d76d178ac2b3cbdc6aef0
@@ -3986,7 +3986,7 @@ entries:
     version: 1.1.0-12-gd47e6c6
   - apiVersion: v1
     appVersion: 1.1.0-11-gb06bb77
-    created: "2020-10-07T17:39:22.164204812Z"
+    created: "2020-08-08T03:04:23Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 4b53539ada41678468fe105fe420b3819087698db1739269b60b551168e5932b
@@ -4003,7 +4003,7 @@ entries:
     version: 1.1.0-11-gb06bb77
   - apiVersion: v1
     appVersion: 1.1.0-1-gcdf741a
-    created: "2020-10-07T17:39:22.141106571Z"
+    created: "2020-07-31T18:09:16Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: ebf39bc007b9f69d01520825becb7be8b43186f26981b4fee01ba34a15d74ffa
@@ -4020,7 +4020,7 @@ entries:
     version: 1.1.0-1-gcdf741a
   - apiVersion: v1
     appVersion: 1.1.0-1-g16642cf
-    created: "2020-10-07T17:39:22.121934505Z"
+    created: "2020-07-31T18:09:16Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: b76a82524e6cf5ea142795be611a5e853e4d75be084df1d6bc36ca5563567573
@@ -4037,7 +4037,7 @@ entries:
     version: 1.1.0-1-g16642cf
   - apiVersion: v1
     appVersion: 1.0.0
-    created: "2020-10-07T17:39:22.101098374Z"
+    created: "2020-05-21T07:52:49Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 950921140ae0c4b6e1d3e97acdac5d621268aefc1392059708a63eaa3d7cef9a
@@ -4054,7 +4054,7 @@ entries:
     version: 1.0.0
   - apiVersion: v1
     appVersion: 1.0.0-rc.3-5-g4a36549
-    created: "2020-10-07T17:39:22.068630617Z"
+    created: "2020-05-21T07:52:49Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: df2562cb755331c806800154872717ee12042a7cfc1f8036c713232d26b34d1f
@@ -4071,7 +4071,7 @@ entries:
     version: 1.0.0-rc.3-5-g4a36549
   - apiVersion: v1
     appVersion: 1.0.0-rc.2-9-ga339605
-    created: "2020-10-07T17:39:22.034059206Z"
+    created: "2020-05-18T15:47:10Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 9a87d5b9cc9fb9ed0a61d6cb493556e1dd2faed4a1787d60acf767995cdf07f7
@@ -4088,7 +4088,7 @@ entries:
     version: 1.0.0-rc.2-9-ga339605
   - apiVersion: v1
     appVersion: 1.0.0-rc.2-8-g3dd22e4
-    created: "2020-10-07T17:39:22.017741433Z"
+    created: "2020-05-18T15:18:16Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 0a99fe6a9b31f259fc60b3329e2fb4345542b3c569898c84de5836e4d9bc7d6c
@@ -4105,7 +4105,7 @@ entries:
     version: 1.0.0-rc.2-8-g3dd22e4
   - apiVersion: v1
     appVersion: 1.0.0-rc.2-7-g227498b
-    created: "2020-10-07T17:39:21.999402684Z"
+    created: "2020-05-18T07:45:04Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 02c7771e7c11e9eb8242841f5d6e0460def31199a86617dd7303a4b3aab52d56
@@ -4122,7 +4122,7 @@ entries:
     version: 1.0.0-rc.2-7-g227498b
   - apiVersion: v1
     appVersion: 1.0.0-rc.2-6-g2b572d8
-    created: "2020-10-07T17:39:21.982939404Z"
+    created: "2020-05-15T18:58:34Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 99524d4ecfa060b315fb56f1356bab0fa85759ee275210777ac472ed6199a149
@@ -4139,7 +4139,7 @@ entries:
     version: 1.0.0-rc.2-6-g2b572d8
   - apiVersion: v1
     appVersion: 1.0.0-rc.2-5-g8181a04
-    created: "2020-10-07T17:39:21.966414612Z"
+    created: "2020-05-15T14:06:30Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 01ad6dc7cbd2858b7652f3984ff814d4a98f8bc28d05f2c0f933af25c1dcceca
@@ -4156,7 +4156,7 @@ entries:
     version: 1.0.0-rc.2-5-g8181a04
   - apiVersion: v1
     appVersion: 1.0.0-rc.2-40-g71a1c96
-    created: "2020-10-07T17:39:21.947542044Z"
+    created: "2020-05-20T19:30:44Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 1e80753d12080b6f6bef9bca0846bc2848639e8b180df2da2c8483e53d07f5c6
@@ -4173,7 +4173,7 @@ entries:
     version: 1.0.0-rc.2-40-g71a1c96
   - apiVersion: v1
     appVersion: 1.0.0-rc.2-37-g97ebca7
-    created: "2020-10-07T17:39:21.931011259Z"
+    created: "2020-05-20T17:45:25Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: a036e5054f59b59dd3ce7da91ae76b9c02e1404c143d50943ab71b5f5d645e0f
@@ -4190,7 +4190,7 @@ entries:
     version: 1.0.0-rc.2-37-g97ebca7
   - apiVersion: v1
     appVersion: 1.0.0-rc.2-36-g7d3c330
-    created: "2020-10-07T17:39:21.912802077Z"
+    created: "2020-05-20T17:00:02Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: a7f908311e3184a7fcd2c1f409e4263d9e8d123572408ca7e4c7d275bb457047
@@ -4207,7 +4207,7 @@ entries:
     version: 1.0.0-rc.2-36-g7d3c330
   - apiVersion: v1
     appVersion: 1.0.0-rc.2-33-g9c7f602
-    created: "2020-10-07T17:39:21.896591167Z"
+    created: "2020-05-20T16:20:38Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: afd13312c11f686d673fae0b176d13478f95f453543ee4a48da6ba34b60ace88
@@ -4224,7 +4224,7 @@ entries:
     version: 1.0.0-rc.2-33-g9c7f602
   - apiVersion: v1
     appVersion: 1.0.0-rc.2-32-g5c73ad4
-    created: "2020-10-07T17:39:21.880109041Z"
+    created: "2020-05-20T16:34:27Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: bce8aaa111c4a100e3d974c40c7fe270fc999c57ab0e3dedac00277b2892f499
@@ -4241,7 +4241,7 @@ entries:
     version: 1.0.0-rc.2-32-g5c73ad4
   - apiVersion: v1
     appVersion: 1.0.0-rc.2-30-gb1d068d
-    created: "2020-10-07T17:39:21.86156205Z"
+    created: "2020-05-20T09:57:25Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 49615e4f70bb6af0d5ab71cc8f16fb27dc5e701a26aaf0ed98a16bce5650b7d2
@@ -4258,7 +4258,7 @@ entries:
     version: 1.0.0-rc.2-30-gb1d068d
   - apiVersion: v1
     appVersion: 1.0.0-rc.2-29-gf372024
-    created: "2020-10-07T17:39:21.845195912Z"
+    created: "2020-05-19T21:02:25Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 582db8f805c8a518be9705b00dc7b60182cec07c66f7046258c74060c3e4ecc4
@@ -4275,7 +4275,7 @@ entries:
     version: 1.0.0-rc.2-29-gf372024
   - apiVersion: v1
     appVersion: 1.0.0-rc.2-27-g3db2b0d
-    created: "2020-10-07T17:39:21.828531649Z"
+    created: "2020-05-20T08:25:15Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: c0e86d45cc6849a841fd156e952cc274ab93b6f16081855c8875e722742be369
@@ -4292,7 +4292,7 @@ entries:
     version: 1.0.0-rc.2-27-g3db2b0d
   - apiVersion: v1
     appVersion: 1.0.0-rc.2-19-g7dd1e2c
-    created: "2020-10-07T17:39:21.810123123Z"
+    created: "2020-05-19T21:30:15Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 6a00b1b32a0acdfe421c30a02a7ff80bdbe416517fc1c603d457aa72f9fa04b1
@@ -4309,7 +4309,7 @@ entries:
     version: 1.0.0-rc.2-19-g7dd1e2c
   - apiVersion: v1
     appVersion: 1.0.0-rc.2-18-ge0a492f
-    created: "2020-10-07T17:39:21.79369161Z"
+    created: "2020-05-19T20:44:52Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 4a6a1e42e4d1fcfcebed7bd61c46f9db5964f1a88d51570dbe4617cf27960980
@@ -4326,7 +4326,7 @@ entries:
     version: 1.0.0-rc.2-18-ge0a492f
   - apiVersion: v1
     appVersion: 1.0.0-rc.2-16-g08d28c8
-    created: "2020-10-07T17:39:21.777066283Z"
+    created: "2020-05-18T20:30:10Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 53416a27571dc51930101cbe8dc15a097053acb42365b2cb3907422b22c3b2fe
@@ -4343,7 +4343,7 @@ entries:
     version: 1.0.0-rc.2-16-g08d28c8
   - apiVersion: v1
     appVersion: 1.0.0-rc.2-12-g5c2b20f
-    created: "2020-10-07T17:39:21.758469373Z"
+    created: "2020-05-18T17:27:15Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: f53e688495655f8f8640fe1d2c26e26ddd18ef1ee2b4bbd7ce35fa0ae705f64e
@@ -4360,7 +4360,7 @@ entries:
     version: 1.0.0-rc.2-12-g5c2b20f
   - apiVersion: v1
     appVersion: 1.0.0-rc.2-11-g01fd303
-    created: "2020-10-07T17:39:21.742063945Z"
+    created: "2020-05-18T16:33:37Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: df166c5d064070dd776728b01e63388a9c40371d669413633a4d72effd9af767
@@ -4377,7 +4377,7 @@ entries:
     version: 1.0.0-rc.2-11-g01fd303
   - apiVersion: v1
     appVersion: 1.0.0-rc.2-1-g0ded3d6
-    created: "2020-10-07T17:39:21.725049778Z"
+    created: "2020-05-15T15:50:59Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 5215af44c9285082486917770198c5fe20b3b418fc94ad2f6c7f0057e8d63c07
@@ -4394,7 +4394,7 @@ entries:
     version: 1.0.0-rc.2-1-g0ded3d6
   - apiVersion: v1
     appVersion: 1.0.0-rc.0-7-gf1a6111
-    created: "2020-10-07T17:39:21.671242449Z"
+    created: "2020-05-05T16:24:05Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 893efd05c17d17461ad700326a326671e9e9b5406181ddc054fc83ba99677250
@@ -4411,7 +4411,7 @@ entries:
     version: 1.0.0-rc.0-7-gf1a6111
   - apiVersion: v1
     appVersion: 1.0.0-rc.0-6-g7274f00
-    created: "2020-10-07T17:39:21.654765039Z"
+    created: "2020-05-06T20:39:14Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 26547ea6ebec43df6ea6fc7cd4f5fb79bbb63dd74126bdc96d6974166b12f70b
@@ -4428,7 +4428,7 @@ entries:
     version: 1.0.0-rc.0-6-g7274f00
   - apiVersion: v1
     appVersion: 1.0.0-rc.0-5-g939965d
-    created: "2020-10-07T17:39:21.638062898Z"
+    created: "2020-05-06T11:34:51Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 4316d87f866403dfe12eca329c20ac686aa2baa337636073949a220e3ff00a62
@@ -4445,7 +4445,7 @@ entries:
     version: 1.0.0-rc.0-5-g939965d
   - apiVersion: v1
     appVersion: 1.0.0-rc.0-1-g1aa08be
-    created: "2020-10-07T17:39:21.619388173Z"
+    created: "2020-05-05T01:28:52Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: d7a6ec15a24e3c5bbb9c311be9bccc4b6aecf4f60638d74ab940b487317a2a12
@@ -4462,7 +4462,7 @@ entries:
     version: 1.0.0-rc.0-1-g1aa08be
   - apiVersion: v1
     appVersion: 1.0.0-rc.3
-    created: "2020-10-07T17:39:22.084919721Z"
+    created: "2020-05-20T19:30:44Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: f5ecfb7b0bb013303ced6bf94cd7ce14bd57e3e0a4747ff7bf717966ca990154
@@ -4479,7 +4479,7 @@ entries:
     version: 1.0.0-rc.3
   - apiVersion: v1
     appVersion: 1.0.0-rc.2
-    created: "2020-10-07T17:39:22.050337528Z"
+    created: "2020-05-14T17:54:31Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: a2fe1d32f7c25c3979fc7c81d6fa8213635a7fb19092c88db124c595f20bf9e9
@@ -4496,7 +4496,7 @@ entries:
     version: 1.0.0-rc.2
   - apiVersion: v1
     appVersion: 1.0.0-rc.1
-    created: "2020-10-07T17:39:21.706814457Z"
+    created: "2020-05-13T18:21:54Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: e9f6d288b85786740da8e64712d3c2fd46444e5e8cb1b916bdbbd7f044aebdf3
@@ -4513,7 +4513,7 @@ entries:
     version: 1.0.0-rc.1
   - apiVersion: v1
     appVersion: 1.0.0-rc.0
-    created: "2020-10-07T17:39:21.6902405Z"
+    created: "2020-05-05T14:50:58Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: a241f9213608285391afcc0655293d10c0bf55425e37b523d39ce99f9026426d
@@ -4530,7 +4530,7 @@ entries:
     version: 1.0.0-rc.0
   - apiVersion: v1
     appVersion: 1.0.0-beta.2-8-g4d73895
-    created: "2020-10-07T17:39:21.585656727Z"
+    created: "2020-04-10T17:20:45Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 85d59eb6e3834ff37037554d3f164ab8669ae02f770eef1cac4f23cf52990bcf
@@ -4547,7 +4547,7 @@ entries:
     version: 1.0.0-beta.2-8-g4d73895
   - apiVersion: v1
     appVersion: 1.0.0-beta.2-7-g42148ef
-    created: "2020-10-07T17:39:21.565078819Z"
+    created: "2020-04-14T17:31:35Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 262e159d56f86ef90a2aa299015f2e22ad7ed15ce5647424e2be2642c4e25eb6
@@ -4564,7 +4564,7 @@ entries:
     version: 1.0.0-beta.2-7-g42148ef
   - apiVersion: v1
     appVersion: 1.0.0-beta.2-4-gb6770e8
-    created: "2020-10-07T17:39:21.54724909Z"
+    created: "2020-04-09T07:26:09Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 3e87d09faa11edafaa126d918378bf735872ce3bde4426ac35ca58f1136d0532
@@ -4598,7 +4598,7 @@ entries:
     version: 1.0.0-beta.2-32-g2635a3b
   - apiVersion: v1
     appVersion: 1.0.0-beta.2-31-gc79b645
-    created: "2020-10-07T17:39:21.511224683Z"
+    created: "2020-05-04T20:07:08Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 9bc1f776dd76704c7bfdc64507e3bd1edb0839506fa7bb55f3aadc311c5afd55
@@ -4615,7 +4615,7 @@ entries:
     version: 1.0.0-beta.2-31-gc79b645
   - apiVersion: v1
     appVersion: 1.0.0-beta.2-29-g5df1084
-    created: "2020-10-07T17:39:21.495078805Z"
+    created: "2020-05-01T19:16:03Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: bf6bd6c0bfa7f02f7ce478756fa4b0dd468ab3cb852e283588b9bd2427d4c842
@@ -4632,7 +4632,7 @@ entries:
     version: 1.0.0-beta.2-29-g5df1084
   - apiVersion: v1
     appVersion: 1.0.0-beta.2-28-g93b125e
-    created: "2020-10-07T17:39:21.476609337Z"
+    created: "2020-05-04T07:55:46Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: b6d26acc6893d6ee31741a4def2ba3b44c60a21c1d9256016ba37a8e833872c5
@@ -4649,7 +4649,7 @@ entries:
     version: 1.0.0-beta.2-28-g93b125e
   - apiVersion: v1
     appVersion: 1.0.0-beta.2-27-gf513d77
-    created: "2020-10-07T17:39:21.460313694Z"
+    created: "2020-05-04T06:37:39Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: fc9088c77acf9843c2c5c2e1b5b23d5a36f02910fa1bc90b9e699e1b42048a28
@@ -4666,7 +4666,7 @@ entries:
     version: 1.0.0-beta.2-27-gf513d77
   - apiVersion: v1
     appVersion: 1.0.0-beta.2-26-g4d21605
-    created: "2020-10-07T17:39:21.44397049Z"
+    created: "2020-04-30T06:53:12Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 8700489c87a1116af7fbf3a9a1f31022b737f706ee71cd5ab71a48bbd0b958cc
@@ -4683,7 +4683,7 @@ entries:
     version: 1.0.0-beta.2-26-g4d21605
   - apiVersion: v1
     appVersion: 1.0.0-beta.2-21-g3e50bc0
-    created: "2020-10-07T17:39:21.425831854Z"
+    created: "2020-04-29T13:58:08Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 6f79d0f748ef4e4b452a33f2802af1987dc29f275c47e9879c06614f89cdb0b8
@@ -4700,7 +4700,7 @@ entries:
     version: 1.0.0-beta.2-21-g3e50bc0
   - apiVersion: v1
     appVersion: 1.0.0-beta.2-20-gbc2d47b
-    created: "2020-10-07T17:39:21.409486181Z"
+    created: "2020-04-28T09:23:40Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 0198eaf4950ff38dfbd9dd38707352bd4d0fda12b75d469a2d6bd04d6b93d9c6
@@ -4717,7 +4717,7 @@ entries:
     version: 1.0.0-beta.2-20-gbc2d47b
   - apiVersion: v1
     appVersion: 1.0.0-beta.2-2-g9f8384e
-    created: "2020-10-07T17:39:21.391204509Z"
+    created: "2020-04-08T17:24:31Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: d104fce40536898ad32155c503713f7c2e8fa0fb531ae0d37a49a76f5ea10b54
@@ -4734,7 +4734,7 @@ entries:
     version: 1.0.0-beta.2-2-g9f8384e
   - apiVersion: v1
     appVersion: 1.0.0-beta.2-19-gd89cd87
-    created: "2020-10-07T17:39:21.375114089Z"
+    created: "2020-04-24T11:11:42Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 8fc65d5babe85a1c4e68f92ce6b791ca96571994cc94d7ef434b9a60e7bf9ec8
@@ -4785,7 +4785,7 @@ entries:
     version: 1.0.0-beta.2-16-g8367beb
   - apiVersion: v1
     appVersion: 1.0.0-beta.2-16-g74b1556
-    created: "2020-10-07T17:39:21.32397426Z"
+    created: "2020-04-24T08:12:44Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: f34cd935c20c1afd30a89c133fc57139786fe95026a73a84c9e5773b1855dcaf
@@ -4802,7 +4802,7 @@ entries:
     version: 1.0.0-beta.2-16-g74b1556
   - apiVersion: v1
     appVersion: 1.0.0-beta.2-15-gdd099cf
-    created: "2020-10-07T17:39:21.307412298Z"
+    created: "2020-04-22T16:10:33Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 651e41ca9574b7003d985425e4eabe952c06e4a7396ca1f6acf4dbfef9601ade
@@ -4819,7 +4819,7 @@ entries:
     version: 1.0.0-beta.2-15-gdd099cf
   - apiVersion: v1
     appVersion: 1.0.0-beta.2-11-g697e9c8
-    created: "2020-10-07T17:39:21.288371162Z"
+    created: "2020-04-22T06:51:22Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: f051df6b81132e2a7d953c101b0b42a3d9e05a01f45a3d809d939476da8d668f
@@ -4836,7 +4836,7 @@ entries:
     version: 1.0.0-beta.2-11-g697e9c8
   - apiVersion: v1
     appVersion: 1.0.0-beta.2-10-g3ae13c7
-    created: "2020-10-07T17:39:21.27213377Z"
+    created: "2020-04-13T18:54:33Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 76f82953af88b38623082997681493a187c845d88d20950e92c8339d8251799b
@@ -4853,7 +4853,7 @@ entries:
     version: 1.0.0-beta.2-10-g3ae13c7
   - apiVersion: v1
     appVersion: 1.0.0-beta.2-1-g7bc4372
-    created: "2020-10-07T17:39:21.253882442Z"
+    created: "2020-04-08T20:11:28Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: fe012c4a1166f543a303bd3ae17715f00006433d12d45c1ee009952b26cba810
@@ -4870,7 +4870,7 @@ entries:
     version: 1.0.0-beta.2-1-g7bc4372
   - apiVersion: v1
     appVersion: 1.0.0-beta.1-7-g4a6620e
-    created: "2020-10-07T17:39:21.221212391Z"
+    created: "2020-04-07T06:37:28Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 1d00835d395ea48c973127d7b6c8fd15c3fdd80143c21050094d39b03d044564
@@ -4887,7 +4887,7 @@ entries:
     version: 1.0.0-beta.1-7-g4a6620e
   - apiVersion: v1
     appVersion: 1.0.0-beta.1-6-g509724f
-    created: "2020-10-07T17:39:21.202664858Z"
+    created: "2020-04-07T07:04:05Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: d2bb88a64dfa7c791ec5818b44f644af664b07af1e047ac1f5e7beaeff598178
@@ -4904,7 +4904,7 @@ entries:
     version: 1.0.0-beta.1-6-g509724f
   - apiVersion: v1
     appVersion: 1.0.0-beta.1-5-gc3d1ae9
-    created: "2020-10-07T17:39:21.184588922Z"
+    created: "2020-04-06T12:52:29Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 02fb3801775fe28f7d7f6a9151689d619a4f59461380910bdabd1e920ed07fdf
@@ -4921,7 +4921,7 @@ entries:
     version: 1.0.0-beta.1-5-gc3d1ae9
   - apiVersion: v1
     appVersion: 1.0.0-beta.1-4-g7a9f085
-    created: "2020-10-07T17:39:21.168150567Z"
+    created: "2020-04-06T11:01:03Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 49a147a03a616b4e9ddbab78c755c0736af3c443799c1fa3bc7d24c840123b25
@@ -4938,7 +4938,7 @@ entries:
     version: 1.0.0-beta.1-4-g7a9f085
   - apiVersion: v1
     appVersion: 1.0.0-beta.1-2-g2e02ed6
-    created: "2020-10-07T17:39:21.151961809Z"
+    created: "2020-04-01T17:59:37Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 51d516ea2840b5696b6561d5c990b4ccece9a9568b41e87f523c518b91975028
@@ -4955,7 +4955,7 @@ entries:
     version: 1.0.0-beta.1-2-g2e02ed6
   - apiVersion: v1
     appVersion: 1.0.0-beta.0-8-g97e0968
-    created: "2020-10-07T17:39:21.118036113Z"
+    created: "2020-04-01T16:25:54Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: dff9f6b4ae42e8e7e77a2d3a40b04ad4bf1ccb2852063ff2de796ec61e692bb0
@@ -4972,7 +4972,7 @@ entries:
     version: 1.0.0-beta.0-8-g97e0968
   - apiVersion: v1
     appVersion: 1.0.0-beta.0-7-g684bc2e
-    created: "2020-10-07T17:39:21.101755846Z"
+    created: "2020-03-30T21:33:49Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 1ed6e2453704178bb6a6430c2994135265756227655ea4e100c2c68d8fa02ba8
@@ -4989,7 +4989,7 @@ entries:
     version: 1.0.0-beta.0-7-g684bc2e
   - apiVersion: v1
     appVersion: 1.0.0-beta.0-6-g925f0ef
-    created: "2020-10-07T17:39:21.083685618Z"
+    created: "2020-03-31T17:23:44Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 4b9ab30e16f4e453ee2d0eaf932cb0136826627a7538cb2359b6a0a606eee1d2
@@ -5006,7 +5006,7 @@ entries:
     version: 1.0.0-beta.0-6-g925f0ef
   - apiVersion: v1
     appVersion: 1.0.0-beta.0-5-gee7e333
-    created: "2020-10-07T17:39:21.067530901Z"
+    created: "2020-03-30T18:44:33Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 2725a13f710182c73a21966099310ba7c8afb8a05510077e2356eb3093cc562f
@@ -5023,7 +5023,7 @@ entries:
     version: 1.0.0-beta.0-5-gee7e333
   - apiVersion: v1
     appVersion: 1.0.0-beta.0-4-g59f0c65
-    created: "2020-10-07T17:39:21.050996942Z"
+    created: "2020-03-29T02:10:33Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: efc23f0d0ebd0c8c6ca2fbf1d7a7558c625b675cbd924011b71229e5c16f5756
@@ -5040,7 +5040,7 @@ entries:
     version: 1.0.0-beta.0-4-g59f0c65
   - apiVersion: v1
     appVersion: 1.0.0-beta.0-3-g6f6c7b2
-    created: "2020-10-07T17:39:21.032038191Z"
+    created: "2020-03-30T16:31:02Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: c71a6edda2d35f321c689e291203c769841162c54247497a2a0ed021218c64b6
@@ -5057,7 +5057,7 @@ entries:
     version: 1.0.0-beta.0-3-g6f6c7b2
   - apiVersion: v1
     appVersion: 1.0.0-beta.0-24-g0b54f20
-    created: "2020-10-07T17:39:21.015830245Z"
+    created: "2020-04-06T06:38:23Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: f907504fa9f6c3fd2c44398b94b5ef3ec2992958188fba7c5e633ed05589d829
@@ -5074,7 +5074,7 @@ entries:
     version: 1.0.0-beta.0-24-g0b54f20
   - apiVersion: v1
     appVersion: 1.0.0-beta.0-22-gbcc6115
-    created: "2020-10-07T17:39:20.999415611Z"
+    created: "2020-04-03T16:01:35Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 0f656c3c4a0667826d57331de918dd626f0bdc795f211aa89bcd616eb614afb6
@@ -5091,7 +5091,7 @@ entries:
     version: 1.0.0-beta.0-22-gbcc6115
   - apiVersion: v1
     appVersion: 1.0.0-beta.0-2-ge8a76d4
-    created: "2020-10-07T17:39:20.980941397Z"
+    created: "2020-03-27T17:14:11Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: a6354edf429456b3a1cd0f19becbb8a8e79df55ab447c3fd624ea42b6e5ac1f7
@@ -5108,7 +5108,7 @@ entries:
     version: 1.0.0-beta.0-2-ge8a76d4
   - apiVersion: v1
     appVersion: 1.0.0-beta.0-19-g50ea87a
-    created: "2020-10-07T17:39:20.964751817Z"
+    created: "2020-04-03T05:26:55Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 771d821b5a8d170cacf02fb4497172d6ec4339d655b7bcb539f2e15abbc9ea99
@@ -5125,7 +5125,7 @@ entries:
     version: 1.0.0-beta.0-19-g50ea87a
   - apiVersion: v1
     appVersion: 1.0.0-beta.0-15-g97180bd
-    created: "2020-10-07T17:39:20.948544342Z"
+    created: "2020-04-03T01:10:15Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 488b44288ca206375f7593bb775cf585d0bf9e16aa49c3167091ad3d0632bb00
@@ -5142,7 +5142,7 @@ entries:
     version: 1.0.0-beta.0-15-g97180bd
   - apiVersion: v1
     appVersion: 1.0.0-beta.0-14-ga06c243
-    created: "2020-10-07T17:39:20.930316705Z"
+    created: "2020-04-02T14:19:20Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: e0c1309db756cdd22a0ef13edac30fb53c1346bfbf388aad067053d52f110203
@@ -5159,7 +5159,7 @@ entries:
     version: 1.0.0-beta.0-14-ga06c243
   - apiVersion: v1
     appVersion: 1.0.0-beta.0-13-ged85976
-    created: "2020-10-07T17:39:20.914229877Z"
+    created: "2020-04-01T23:20:37Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 86d2bd6acd41474e41ef4789958518205e70d25208771d0c59cafe5dfbe37249
@@ -5176,7 +5176,7 @@ entries:
     version: 1.0.0-beta.0-13-ged85976
   - apiVersion: v1
     appVersion: 1.0.0-beta.0-12-g6eb762c
-    created: "2020-10-07T17:39:20.898263731Z"
+    created: "2020-04-02T01:50:07Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: a7da7f37d1902cf291282c1f5f35afa365ca114d69ec92c3e73dc427aa9ff0f9
@@ -5193,7 +5193,7 @@ entries:
     version: 1.0.0-beta.0-12-g6eb762c
   - apiVersion: v1
     appVersion: 1.0.0-beta.0-11-gd294bb1
-    created: "2020-10-07T17:39:20.879896298Z"
+    created: "2020-04-01T17:36:22Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 861283f2b39d13692dba41fe6ae3095e31bb113cea4ef06afc7cadbf5aae6164
@@ -5210,7 +5210,7 @@ entries:
     version: 1.0.0-beta.0-11-gd294bb1
   - apiVersion: v1
     appVersion: 1.0.0-beta.0-1-g454abb6
-    created: "2020-10-07T17:39:20.863582712Z"
+    created: "2020-03-27T11:49:27Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: cd17ae8b71aa53f26dbc3e6f33e8edc740657bf23521408eb9cfae9fe7bf69ac
@@ -5227,7 +5227,7 @@ entries:
     version: 1.0.0-beta.0-1-g454abb6
   - apiVersion: v1
     appVersion: 1.0.0-beta.2
-    created: "2020-10-07T17:39:21.602410614Z"
+    created: "2020-04-08T06:40:50Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 1bf65785d97326692482f172f036271e736766e1a0163d407750bb816ca001e2
@@ -5244,7 +5244,7 @@ entries:
     version: 1.0.0-beta.2
   - apiVersion: v1
     appVersion: 1.0.0-beta.1
-    created: "2020-10-07T17:39:21.237599171Z"
+    created: "2020-04-03T16:07:41Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: fab0e286cb15dd9e3266411c716e257d5b368244b0f894e6dd7b4dec7d54055d
@@ -5261,7 +5261,7 @@ entries:
     version: 1.0.0-beta.1
   - apiVersion: v1
     appVersion: 1.0.0-beta.0
-    created: "2020-10-07T17:39:21.134211625Z"
+    created: "2020-03-27T10:07:53Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 1d904b87f2e05a80e92ec0619ab543014a4d25505b3e4720c7a9f05f649a0bbc
@@ -5278,7 +5278,7 @@ entries:
     version: 1.0.0-beta.0
   - apiVersion: v1
     appVersion: 1.0.0-98-gc91f52f
-    created: "2020-10-07T17:39:20.847477537Z"
+    created: "2020-06-05T02:09:25Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: e6d8f52722a958b65fd0dd49e6f68c476f86159addf467dab342f52a68390113
@@ -5295,7 +5295,7 @@ entries:
     version: 1.0.0-98-gc91f52f
   - apiVersion: v1
     appVersion: 1.0.0-96-g9fd3367
-    created: "2020-10-07T17:39:20.827528256Z"
+    created: "2020-06-05T13:21:55Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 1551473d5e9f82f179a864d6ee6d9d39e530ec1043111ae4d72967470be717f0
@@ -5312,7 +5312,7 @@ entries:
     version: 1.0.0-96-g9fd3367
   - apiVersion: v1
     appVersion: 1.0.0-95-gc5266f7
-    created: "2020-10-07T17:39:20.8060604Z"
+    created: "2020-06-04T11:09:44Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 3e2bb6064b67a4d0a0d3f135ef90b03bf5dc8ac516e00aaf1c0af05841d6ba85
@@ -5329,7 +5329,7 @@ entries:
     version: 1.0.0-95-gc5266f7
   - apiVersion: v1
     appVersion: 1.0.0-93-g7aedc57
-    created: "2020-10-07T17:39:20.786968229Z"
+    created: "2020-06-04T07:20:11Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: f06a8de5610d2b5e2a8c86105e2e74c7f2df3ddbd6b8346f8b4a4ea2c344e60f
@@ -5346,7 +5346,7 @@ entries:
     version: 1.0.0-93-g7aedc57
   - apiVersion: v1
     appVersion: 1.0.0-92-g5e85ce1
-    created: "2020-10-07T17:39:20.765475347Z"
+    created: "2020-06-03T22:57:41Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 55cca8280be59b723ee2f09d6cf3b42faa7fbee161e978f1ed239170f0a7a442
@@ -5363,7 +5363,7 @@ entries:
     version: 1.0.0-92-g5e85ce1
   - apiVersion: v1
     appVersion: 1.0.0-91-g2d881ab
-    created: "2020-10-07T17:39:20.744954218Z"
+    created: "2020-06-02T17:58:20Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: ef392f916b0f1925b0255f86e7020ee11168b8e5d23f00cdc0f21f887e84bdba
@@ -5380,7 +5380,7 @@ entries:
     version: 1.0.0-91-g2d881ab
   - apiVersion: v1
     appVersion: 1.0.0-89-g04758d3
-    created: "2020-10-07T17:39:20.726074761Z"
+    created: "2020-06-02T11:50:55Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 9d88c56a4dbd5a485fc6511098afd3f16c2e4b10183532f696483f84975359eb
@@ -5397,7 +5397,7 @@ entries:
     version: 1.0.0-89-g04758d3
   - apiVersion: v1
     appVersion: 1.0.0-87-g2b54a9f
-    created: "2020-10-07T17:39:20.706124661Z"
+    created: "2020-06-02T08:06:05Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 7fdf3456afa7dfe0862081f70e91a8dedf612f0692b1ff978fec296d9440e282
@@ -5414,7 +5414,7 @@ entries:
     version: 1.0.0-87-g2b54a9f
   - apiVersion: v1
     appVersion: 1.0.0-48-g7f7c483
-    created: "2020-10-07T17:39:20.685840058Z"
+    created: "2020-05-30T00:02:40Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 33138f3440c369f8d06c7cba4c236f9cf1738d201669c90edf38434818d54013
@@ -5431,7 +5431,7 @@ entries:
     version: 1.0.0-48-g7f7c483
   - apiVersion: v1
     appVersion: 1.0.0-47-g42283fd
-    created: "2020-10-07T17:39:20.664964798Z"
+    created: "2020-05-29T15:24:07Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 22915a4ce824afaf2b45f60183debf8e682393dcd5e3d6ce2af0bb49a857aa50
@@ -5448,7 +5448,7 @@ entries:
     version: 1.0.0-47-g42283fd
   - apiVersion: v1
     appVersion: 1.0.0-42-g30d6bef
-    created: "2020-10-07T17:39:20.646051469Z"
+    created: "2020-05-28T19:00:15Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 135842c125c27aa7a32a1d3cc1a69e7428fc72d99f3ad1a5cebeb2f3f5ca16ed
@@ -5465,7 +5465,7 @@ entries:
     version: 1.0.0-42-g30d6bef
   - apiVersion: v1
     appVersion: 1.0.0-41-g7d049b9
-    created: "2020-10-07T17:39:20.623229038Z"
+    created: "2020-05-28T15:27:38Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 4e2073e19bacb62d3bb35e240e5b7f65202fb655e0b4de2080b53463dc1f1a79
@@ -5482,7 +5482,7 @@ entries:
     version: 1.0.0-41-g7d049b9
   - apiVersion: v1
     appVersion: 1.0.0-40-gbea1ba1
-    created: "2020-10-07T17:39:20.604036922Z"
+    created: "2020-05-28T15:19:53Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 1407e0c153733c35a0594b0d5c21ee9998b76070b6ac9ac56a8552df94551e9b
@@ -5499,7 +5499,7 @@ entries:
     version: 1.0.0-40-gbea1ba1
   - apiVersion: v1
     appVersion: 1.0.0-39-g537b200
-    created: "2020-10-07T17:39:20.582965608Z"
+    created: "2020-05-26T16:00:28Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 2339a6abcf7440576d729539be744fa9ce316b4561bc0226a65b705d30075197
@@ -5516,7 +5516,7 @@ entries:
     version: 1.0.0-39-g537b200
   - apiVersion: v1
     appVersion: 1.0.0-38-ga11f83d
-    created: "2020-10-07T17:39:20.563789534Z"
+    created: "2020-05-26T14:02:34Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: f39daf114d71de7f9e2ebac824fa5a5dc21822ff40b10240a5c596d6266f0382
@@ -5533,7 +5533,7 @@ entries:
     version: 1.0.0-38-ga11f83d
   - apiVersion: v1
     appVersion: 1.0.0-37-g9d3ad56
-    created: "2020-10-07T17:39:20.540912992Z"
+    created: "2020-05-20T18:30:17Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 110c2ba9b1d47b0199b502a002c091ef5c16511cbe2128ab30c6d643a8bc1fd0
@@ -5550,7 +5550,7 @@ entries:
     version: 1.0.0-37-g9d3ad56
   - apiVersion: v1
     appVersion: 1.0.0-35-gb882544
-    created: "2020-10-07T17:39:20.522111926Z"
+    created: "2020-05-26T09:10:54Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: ffb1dd89ce1c414b10b09e43bf85d29ce16716cf4235583bcad1fc9da9bc730d
@@ -5567,7 +5567,7 @@ entries:
     version: 1.0.0-35-gb882544
   - apiVersion: v1
     appVersion: 1.0.0-24-gff99e40
-    created: "2020-10-07T17:39:20.501468784Z"
+    created: "2020-05-26T09:15:02Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 473eed4bb1310d7bb3db53566c139d633c483d31215dd511b012cb820645ca64
@@ -5584,7 +5584,7 @@ entries:
     version: 1.0.0-24-gff99e40
   - apiVersion: v1
     appVersion: 1.0.0-21-g24e77f0
-    created: "2020-10-07T17:39:20.482319791Z"
+    created: "2020-05-21T00:26:14Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 17a0516a328cdf2ac27092bf75af13b826abcb1c0a230b91454c0f4973ec2bf8
@@ -5601,7 +5601,7 @@ entries:
     version: 1.0.0-21-g24e77f0
   - apiVersion: v1
     appVersion: 1.0.0-20-gdf4c541
-    created: "2020-10-07T17:39:20.459526657Z"
+    created: "2020-05-21T00:28:12Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 757ddfb4077e7249225332fba643e50f364e8c3879469240db5453f7260a9d96
@@ -5618,7 +5618,7 @@ entries:
     version: 1.0.0-20-gdf4c541
   - apiVersion: v1
     appVersion: 1.0.0-2-gbd42eae
-    created: "2020-10-07T17:39:20.44286079Z"
+    created: "2020-05-28T20:41:56Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 3f52014c98730bf4ee92db5bf055473a1507bfb6acfda2e5490d5f437cd67d4d
@@ -5635,7 +5635,7 @@ entries:
     version: 1.0.0-2-gbd42eae
   - apiVersion: v1
     appVersion: 1.0.0-19-g0e81334
-    created: "2020-10-07T17:39:20.42436265Z"
+    created: "2020-05-21T00:29:41Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: a607d594c3ff46c0b389f942bc22d71cabbf55288a8c6a72c360a1a9fceab0b3
@@ -5652,7 +5652,7 @@ entries:
     version: 1.0.0-19-g0e81334
   - apiVersion: v1
     appVersion: 1.0.0-18-gacce16c
-    created: "2020-10-07T17:39:20.406205569Z"
+    created: "2020-05-25T11:53:21Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: de31dc4aca6e9db94cf877dd17ad12131eade4d7f3668549bb21fb39f324c003
@@ -5669,7 +5669,7 @@ entries:
     version: 1.0.0-18-gacce16c
   - apiVersion: v1
     appVersion: 1.0.0-16-g5add448
-    created: "2020-10-07T17:39:20.389810594Z"
+    created: "2020-05-21T00:58:17Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 2d0f8e19d9fc706ab229e0ea562518e8a250e50ec848313971f41f44aa674e28
@@ -5686,7 +5686,7 @@ entries:
     version: 1.0.0-16-g5add448
   - apiVersion: v1
     appVersion: 1.0.0-14-gace469e
-    created: "2020-10-07T17:39:20.37322041Z"
+    created: "2020-04-21T08:38:26Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: f0f07311ae22395bf4e946966c397ba6605cb02ea9c7b9d068debf167f2efc42
@@ -5703,7 +5703,7 @@ entries:
     version: 1.0.0-14-gace469e
   - apiVersion: v1
     appVersion: 1.0.0-122-g768e0e7
-    created: "2020-10-07T17:39:20.356997585Z"
+    created: "2020-06-10T08:58:51Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 0fc7dd941988132598806152703b1a5ec7bb276cd40d2f02d12e335732881023
@@ -5720,7 +5720,7 @@ entries:
     version: 1.0.0-122-g768e0e7
   - apiVersion: v1
     appVersion: 1.0.0-119-ga170917
-    created: "2020-10-07T17:39:20.333339944Z"
+    created: "2020-06-10T06:21:17Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 6d5dc81ea8e5d3fd59abe92a3c828e2d8f13cb8a92a337d816790c0d823e2ef2
@@ -5737,7 +5737,7 @@ entries:
     version: 1.0.0-119-ga170917
   - apiVersion: v1
     appVersion: 1.0.0-117-ga460f77
-    created: "2020-10-07T17:39:20.314347245Z"
+    created: "2020-06-09T09:11:27Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: b2c42ac5c719c53112a2182125b4cbac3e4dac060d14f87813bca27d9df08657
@@ -5754,7 +5754,7 @@ entries:
     version: 1.0.0-117-ga460f77
   - apiVersion: v1
     appVersion: 1.0.0-115-gebfbc60
-    created: "2020-10-07T17:39:20.294656511Z"
+    created: "2020-06-08T14:09:29Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: c4f7b0f4209c586bef99075bf9a42241e1816563493a4ea4e7592a766601fe0b
@@ -5771,7 +5771,7 @@ entries:
     version: 1.0.0-115-gebfbc60
   - apiVersion: v1
     appVersion: 1.0.0-112-g27e7e03
-    created: "2020-10-07T17:39:20.272168204Z"
+    created: "2020-06-08T21:54:32Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 8c430cabb57d77daf286adeee91da17ba947548fd7dbbb356e7a1c3a59849558
@@ -5788,7 +5788,7 @@ entries:
     version: 1.0.0-112-g27e7e03
   - apiVersion: v1
     appVersion: 1.0.0-110-gd68ccf7
-    created: "2020-10-07T17:39:20.25304755Z"
+    created: "2020-06-08T08:31:59Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 18ac9a0fe53aab6b227db800b62ce7dce9b96159b3e06fee1fe3c39df5f48deb
@@ -5805,7 +5805,7 @@ entries:
     version: 1.0.0-110-gd68ccf7
   - apiVersion: v1
     appVersion: 1.0.0-104-ga2400bb
-    created: "2020-10-07T17:39:20.231770794Z"
+    created: "2020-06-08T08:53:34Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 01f51f49e7828f0b8bb681d79ba63b28a97f4bb1832dd1bf48da4b5320c20923
@@ -5822,7 +5822,7 @@ entries:
     version: 1.0.0-104-ga2400bb
   - apiVersion: v1
     appVersion: 1.0.0-100-g36bc4e4
-    created: "2020-10-07T17:39:20.212239057Z"
+    created: "2020-06-05T11:42:18Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 68c456a64091d338a2e34b638d4be80bb01ba30519ed0fd58d2f77237269f863
@@ -5839,7 +5839,7 @@ entries:
     version: 1.0.0-100-g36bc4e4
   - apiVersion: v1
     appVersion: 1.0.0-1-g34b924c
-    created: "2020-10-07T17:39:20.190742283Z"
+    created: "2020-05-21T21:03:59Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 965dd13c16d6f5f18e859b75fc4dd330f4a878454db49c87c99dcf6d4b463263
@@ -5856,7 +5856,7 @@ entries:
     version: 1.0.0-1-g34b924c
   - apiVersion: v1
     appVersion: 0.17.4
-    created: "2020-10-07T17:39:20.071043088Z"
+    created: "2020-05-20T18:56:15Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 0b1819db47a967d773f899efc5671e5b7100204974742c5ce267791359c218b4
@@ -5873,7 +5873,7 @@ entries:
     version: 0.17.4
   - apiVersion: v1
     appVersion: 0.17.4-1-gcb5b992
-    created: "2020-10-07T17:39:20.054800029Z"
+    created: "2020-06-30T06:22:19Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 441e58707c6bba8270231b593286126b458e34eb4ec7678bd22372c889feefa1
@@ -5890,7 +5890,7 @@ entries:
     version: 0.17.4-1-gcb5b992
   - apiVersion: v1
     appVersion: 0.17.3
-    created: "2020-10-07T17:39:20.036749032Z"
+    created: "2020-05-13T07:40:18Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 08038a377c49dfe490b7f7f0caf2dfec3b6e93507991d36a607a2ea8fee8e7c5
@@ -5907,7 +5907,7 @@ entries:
     version: 0.17.3
   - apiVersion: v1
     appVersion: 0.17.3-5-g38b0067
-    created: "2020-10-07T17:39:20.020836538Z"
+    created: "2020-05-20T18:56:15Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 548aa15ccfbb7e3ad4998fd0a21df6704cb96d2f8506a44fece59e8be33c9216
@@ -5924,7 +5924,7 @@ entries:
     version: 0.17.3-5-g38b0067
   - apiVersion: v1
     appVersion: 0.17.3-2-gf22bf89
-    created: "2020-10-07T17:39:20.004224928Z"
+    created: "2020-05-20T10:50:41Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 3f6fc5a16f3549121dfd03df0696f6c360ee96e43cdde2c382398e1e6d662564
@@ -5941,7 +5941,7 @@ entries:
     version: 0.17.3-2-gf22bf89
   - apiVersion: v1
     appVersion: 0.17.2
-    created: "2020-10-07T17:39:19.986711825Z"
+    created: "2020-05-05T17:06:32Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 5559bbf03ae2db50a2e145bd20a6734543adf239e7919de527bd3898f1a835c5
@@ -5958,7 +5958,7 @@ entries:
     version: 0.17.2
   - apiVersion: v1
     appVersion: 0.17.2-3-g7322725
-    created: "2020-10-07T17:39:19.968942063Z"
+    created: "2020-05-12T14:24:24Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: bf5e46c831c3654159cc6ea36497c8a0591065c9a07a70ef3436df1c3348b2bb
@@ -5975,7 +5975,7 @@ entries:
     version: 0.17.2-3-g7322725
   - apiVersion: v1
     appVersion: 0.17.2-2-g95cb3c1
-    created: "2020-10-07T17:39:19.953286573Z"
+    created: "2020-05-06T16:48:57Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: ee996e379b508fd0b4296b7433a5cbb5369e63acb9d8015ba24a6a3dae3abae2
@@ -5992,7 +5992,7 @@ entries:
     version: 0.17.2-2-g95cb3c1
   - apiVersion: v1
     appVersion: 0.17.2-1-g24094ac
-    created: "2020-10-07T17:39:19.937138366Z"
+    created: "2020-05-06T09:20:52Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: ba10da2b6f28739afadcd23cfdb031b59074ef6148e460e73a68b4cf419b0158
@@ -6009,7 +6009,7 @@ entries:
     version: 0.17.2-1-g24094ac
   - apiVersion: v1
     appVersion: 0.17.1
-    created: "2020-10-07T17:39:19.919149776Z"
+    created: "2020-03-31T11:56:45Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: ce24df4409672ed7650b5b2b044c7340dd992c9f29a5a7c9bd8b88c0ba861b4a
@@ -6026,7 +6026,7 @@ entries:
     version: 0.17.1
   - apiVersion: v1
     appVersion: 0.17.1-rc.0
-    created: "2020-10-07T17:39:19.90323873Z"
+    created: "2020-03-30T18:56:32Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: eb9ade1c24b71c29a16b3cfa6fbf26c0ed4107c26723ac66db3032ff2edebe55
@@ -6043,7 +6043,7 @@ entries:
     version: 0.17.1-rc.0
   - apiVersion: v1
     appVersion: 0.17.1-9-g1a39f89
-    created: "2020-10-07T17:39:19.885727624Z"
+    created: "2020-03-30T21:33:49Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 0da54feb2f2d11524e8dd456ec633b62fc89dd32800d791847e4e3e4d08854d8
@@ -6060,7 +6060,7 @@ entries:
     version: 0.17.1-9-g1a39f89
   - apiVersion: v1
     appVersion: 0.17.1-13-g6f382dd
-    created: "2020-10-07T17:39:19.86811603Z"
+    created: "2020-05-05T16:24:05Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 3569107a5d0e4ce424efd70b5af1fcd3de6c3963c977853de90fdb9d7280ae6b
@@ -6077,7 +6077,7 @@ entries:
     version: 0.17.1-13-g6f382dd
   - apiVersion: v1
     appVersion: 0.17.1-12-g330c921
-    created: "2020-10-07T17:39:19.850274783Z"
+    created: "2020-04-06T10:49:43Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 3cac163c245f97fc183c58c1c1bd95fcdebcc5987fcb6c0e5fdaa2a99062c71d
@@ -6094,7 +6094,7 @@ entries:
     version: 0.17.1-12-g330c921
   - apiVersion: v1
     appVersion: 0.17.1-11-ge779325
-    created: "2020-10-07T17:39:19.83383951Z"
+    created: "2020-04-04T04:15:00Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: d16687e5b323be242ccd4ab8fa8694078b9e9856945c28e8ec86bdc6b7643215
@@ -6111,7 +6111,7 @@ entries:
     version: 0.17.1-11-ge779325
   - apiVersion: v1
     appVersion: 0.17.1-10-gbffde27
-    created: "2020-10-07T17:39:19.817650706Z"
+    created: "2020-04-01T23:20:37Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: c7a707cb2e01c3afd911a1a72cd5589cd142b37dc12783e8e1a521a2fc36bc1e
@@ -6128,7 +6128,7 @@ entries:
     version: 0.17.1-10-gbffde27
   - apiVersion: v1
     appVersion: 0.17.0
-    created: "2020-10-07T17:39:19.800110557Z"
+    created: "2020-03-17T14:04:50Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: f1139faa82cb575ef09ad2d5e493d768e3e7b4e5f449aa2a161b2f9996acb78b
@@ -6145,7 +6145,7 @@ entries:
     version: 0.17.0
   - apiVersion: v1
     appVersion: 0.17.0-beta.0-4-gff70e74
-    created: "2020-10-07T17:39:19.766823439Z"
+    created: "2020-03-17T14:04:50Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 9994a2926f5c847531f7b6baf4c57779e28cf6eddb2adf0044ebc790e56fa71a
@@ -6162,7 +6162,7 @@ entries:
     version: 0.17.0-beta.0-4-gff70e74
   - apiVersion: v1
     appVersion: 0.17.0-beta.0-1-g6066703
-    created: "2020-10-07T17:39:19.751167964Z"
+    created: "2020-03-16T13:53:21Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: eccc159e7943566d5cdf672d697156a5de6461522651ea1701e68c85166c4ac1
@@ -6179,7 +6179,7 @@ entries:
     version: 0.17.0-beta.0-1-g6066703
   - apiVersion: v1
     appVersion: 0.17.0-beta.0
-    created: "2020-10-07T17:39:19.784600116Z"
+    created: "2020-03-17T08:19:42Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: ceea63797f6da39a83ca6d51b9fbac8ebf8705b95767f323fe875bd48e4a917e
@@ -6196,7 +6196,7 @@ entries:
     version: 0.17.0-beta.0
   - apiVersion: v1
     appVersion: 0.17.0-alpha.0-1-gb4f114e
-    created: "2020-10-07T17:39:19.717343333Z"
+    created: "2020-03-17T08:19:42Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 9db1820770342b270efd7acd8207a622dc9930c40d8fb7bf081ae8354f427f9b
@@ -6213,7 +6213,7 @@ entries:
     version: 0.17.0-alpha.0-1-gb4f114e
   - apiVersion: v1
     appVersion: 0.17.0-alpha.0
-    created: "2020-10-07T17:39:19.735287719Z"
+    created: "2020-03-16T17:58:46Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 6f2abdaf3401095ed41e24647a2e83541e7e3e6a99a6e231bbecd2281a967691
@@ -6230,7 +6230,7 @@ entries:
     version: 0.17.0-alpha.0
   - apiVersion: v1
     appVersion: 0.17.0-9-gb7182e4
-    created: "2020-10-07T17:39:19.701516408Z"
+    created: "2020-03-23T15:54:11Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 4b6934c8ef1ab5c43a375545600849b22522de903a2bd59ab30d9af3a848133e
@@ -6247,7 +6247,7 @@ entries:
     version: 0.17.0-9-gb7182e4
   - apiVersion: v1
     appVersion: 0.17.0-8-g41e719b
-    created: "2020-10-07T17:39:19.684017034Z"
+    created: "2020-03-23T09:15:21Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 98fc545208e2d678c11e696a8c22aeb95983e4deced69c773488888874c42762
@@ -6264,7 +6264,7 @@ entries:
     version: 0.17.0-8-g41e719b
   - apiVersion: v1
     appVersion: 0.17.0-7-gfdfc86a
-    created: "2020-10-07T17:39:19.668042927Z"
+    created: "2020-03-19T23:17:03Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: c0db39f0655970b40c2c5f9527d19e98250d98811251fb78957b1ade4144e615
@@ -6281,7 +6281,7 @@ entries:
     version: 0.17.0-7-gfdfc86a
   - apiVersion: v1
     appVersion: 0.17.0-6-gdb318d7
-    created: "2020-10-07T17:39:19.652090825Z"
+    created: "2020-03-20T03:02:22Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 4ce0481d60cba69f78978bc8d87c1470ba021cec06f8ffcbc40f34dabba3981b
@@ -6298,7 +6298,7 @@ entries:
     version: 0.17.0-6-gdb318d7
   - apiVersion: v1
     appVersion: 0.17.0-4-gd8f1e6b
-    created: "2020-10-07T17:39:19.63392675Z"
+    created: "2020-03-21T11:18:55Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: a4018065a59996f7247305ba24bdc5a976a9d77e234fcb6fb4a4b364e6e55e13
@@ -6315,7 +6315,7 @@ entries:
     version: 0.17.0-4-gd8f1e6b
   - apiVersion: v1
     appVersion: 0.17.0-30-gee9c848
-    created: "2020-10-07T17:39:19.617897723Z"
+    created: "2020-03-26T17:15:24Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: da629db6b0859163416453e29d1164a576ef619987c17086678dd3961d64ec84
@@ -6332,7 +6332,7 @@ entries:
     version: 0.17.0-30-gee9c848
   - apiVersion: v1
     appVersion: 0.17.0-3-ge713842
-    created: "2020-10-07T17:39:19.599547674Z"
+    created: "2020-03-19T07:39:20Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: da0f6052fc7d24d18beefbfa5b36cea8f22af70120f61b49b917ff4047ef9733
@@ -6349,7 +6349,7 @@ entries:
     version: 0.17.0-3-ge713842
   - apiVersion: v1
     appVersion: 0.17.0-26-gbe93b1c
-    created: "2020-10-07T17:39:19.583404715Z"
+    created: "2020-03-25T17:20:06Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 444f58e618416339450fcf7bd3fb023e635e514f4a60e9fb1bb5b50af7e86683
@@ -6366,7 +6366,7 @@ entries:
     version: 0.17.0-26-gbe93b1c
   - apiVersion: v1
     appVersion: 0.17.0-25-g00ac8f6
-    created: "2020-10-07T17:39:19.566810227Z"
+    created: "2020-03-24T09:41:58Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 2f688888ed7cd55d83ab1ef17dd20422c3a2b84e2838421c2e5d2e0bc65d7777
@@ -6383,7 +6383,7 @@ entries:
     version: 0.17.0-25-g00ac8f6
   - apiVersion: v1
     appVersion: 0.17.0-24-g9d957fd
-    created: "2020-10-07T17:39:19.549185406Z"
+    created: "2020-03-25T00:18:00Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 27636c1b77175e4ef8fb8310a8661a08415dd52bda7b7f72c6b4e8b8e8834e79
@@ -6400,7 +6400,7 @@ entries:
     version: 0.17.0-24-g9d957fd
   - apiVersion: v1
     appVersion: 0.17.0-23-g9038f69
-    created: "2020-10-07T17:39:19.533473612Z"
+    created: "2020-03-25T06:30:39Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 580a21e09eb79ed188bbaad4be8eca75ca5b0ca7aaf52563e2dae4381f18a586
@@ -6417,7 +6417,7 @@ entries:
     version: 0.17.0-23-g9038f69
   - apiVersion: v1
     appVersion: 0.17.0-22-g562a139
-    created: "2020-10-07T17:39:19.515854102Z"
+    created: "2020-03-05T19:32:20Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: d98ba0677659b737e505334420378cc1b75366de0adacd82cce5b8c100222980
@@ -6434,7 +6434,7 @@ entries:
     version: 0.17.0-22-g562a139
   - apiVersion: v1
     appVersion: 0.17.0-2-gd85aa67
-    created: "2020-10-07T17:39:19.498383888Z"
+    created: "2020-03-17T21:14:16Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 0dd5fc50e53aaa06a387f6ff659931556d609b01bd58e3c09b42501307313690
@@ -6451,7 +6451,7 @@ entries:
     version: 0.17.0-2-gd85aa67
   - apiVersion: v1
     appVersion: 0.17.0-18-g8c8e961
-    created: "2020-10-07T17:39:19.48262685Z"
+    created: "2020-02-26T18:04:18Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 421104483561f705a07aded15fc1a28c64ce86a29b14971fe93c45c884bfcdd3
@@ -6468,7 +6468,7 @@ entries:
     version: 0.17.0-18-g8c8e961
   - apiVersion: v1
     appVersion: 0.17.0-16-ga38e386
-    created: "2020-10-07T17:39:19.466549966Z"
+    created: "2020-03-04T22:33:30Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 01d9ed9416f7aead3520cb0b4e4e276aeafe3cb0cd378b93d0df99c6989b2669
@@ -6485,7 +6485,7 @@ entries:
     version: 0.17.0-16-ga38e386
   - apiVersion: v1
     appVersion: 0.17.0-15-gba70104
-    created: "2020-10-07T17:39:19.44858461Z"
+    created: "2020-03-24T04:58:23Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 07edc91183b49f58d61f8d55993b8682652af16668d07b9c44adf9e7586e316b
@@ -6502,7 +6502,7 @@ entries:
     version: 0.17.0-15-gba70104
   - apiVersion: v1
     appVersion: 0.17.0-13-g2e68994
-    created: "2020-10-07T17:39:19.430393661Z"
+    created: "2020-03-24T09:20:52Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 59e573ea34c39fa9e022d77b437a95fc194e46403b16c7539ad826bc569e653b
@@ -6519,7 +6519,7 @@ entries:
     version: 0.17.0-13-g2e68994
   - apiVersion: v1
     appVersion: 0.16.0
-    created: "2020-10-07T17:39:19.414389696Z"
+    created: "2020-03-12T12:10:43Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 78e1e3ec0370c989f72a221bb76b8f0355f57155b664764058c2edbec76be093
@@ -6536,7 +6536,7 @@ entries:
     version: 0.16.0
   - apiVersion: v1
     appVersion: 0.16.0-rc.1-1-g0169cca
-    created: "2020-10-07T17:39:19.380220492Z"
+    created: "2020-03-11T21:28:39Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 26ff2e8b067a49edd8db6fba38047db478136e88237cfbf769328e5bbae4f2fd
@@ -6553,7 +6553,7 @@ entries:
     version: 0.16.0-rc.1-1-g0169cca
   - apiVersion: v1
     appVersion: 0.16.0-rc.0-9-g9425ed9
-    created: "2020-10-07T17:39:19.346507483Z"
+    created: "2020-03-11T18:37:13Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: e9d566d366cf9b6ef79fc818e7a827a852dfab1cacfa5c2b60fa3dbd595fc84e
@@ -6570,7 +6570,7 @@ entries:
     version: 0.16.0-rc.0-9-g9425ed9
   - apiVersion: v1
     appVersion: 0.16.0-rc.0-4-gdecbbd1
-    created: "2020-10-07T17:39:19.33063259Z"
+    created: "2020-03-11T20:00:20Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: c29e117747d97c6248e90e2ddeca7f41f24e384c0727f05a357f4aa61ed1efe9
@@ -6587,7 +6587,7 @@ entries:
     version: 0.16.0-rc.0-4-gdecbbd1
   - apiVersion: v1
     appVersion: 0.16.0-rc.0-1-gc6089b3
-    created: "2020-10-07T17:39:19.314099574Z"
+    created: "2020-03-11T16:35:37Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 30962afc2c4ffd5666bf6ae20baad0e1b44f91b121e8501266c0be595e3e94db
@@ -6604,7 +6604,7 @@ entries:
     version: 0.16.0-rc.0-1-gc6089b3
   - apiVersion: v1
     appVersion: 0.16.0-rc.1
-    created: "2020-10-07T17:39:19.396322806Z"
+    created: "2020-03-11T18:37:13Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 25e8cf2ff5976b34a6624eaefc78e3f2b851c9bd1782276c49b343027acbce66
@@ -6621,7 +6621,7 @@ entries:
     version: 0.16.0-rc.1
   - apiVersion: v1
     appVersion: 0.16.0-rc.0
-    created: "2020-10-07T17:39:19.364262062Z"
+    created: "2020-03-10T18:03:17Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: af09af5f33f52a6f39f4dbe81084dc0b6d8cee0deea1e6ea64993de2c99e5299
@@ -6638,7 +6638,7 @@ entries:
     version: 0.16.0-rc.0
   - apiVersion: v1
     appVersion: 0.16.0-beta.3-2-g7cfcf16
-    created: "2020-10-07T17:39:19.279083824Z"
+    created: "2020-03-10T18:03:17Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 9915f89f575ef68d403a3eac87c27bbaa2af7d33748224766e877688d7841e65
@@ -6655,7 +6655,7 @@ entries:
     version: 0.16.0-beta.3-2-g7cfcf16
   - apiVersion: v1
     appVersion: 0.16.0-beta.2-1-ga8eaac0
-    created: "2020-10-07T17:39:19.244456578Z"
+    created: "2020-03-09T16:18:13Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: d78da593cbba1cdbb787ee612b1f2f3c04012cc74884bb2d80c36feec46a8f0a
@@ -6672,7 +6672,7 @@ entries:
     version: 0.16.0-beta.2-1-ga8eaac0
   - apiVersion: v1
     appVersion: 0.16.0-beta.1-1-g2d6fd18
-    created: "2020-10-07T17:39:19.20996842Z"
+    created: "2020-03-10T15:54:36Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: fa8d3ec389aa4be1c367ac50f6fd7b816d4e0df6ab2aafc3b0fe81457de5d20d
@@ -6689,7 +6689,7 @@ entries:
     version: 0.16.0-beta.1-1-g2d6fd18
   - apiVersion: v1
     appVersion: 0.16.0-beta.3
-    created: "2020-10-07T17:39:19.295515614Z"
+    created: "2020-03-09T16:18:13Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 55052c2c68f47c46c90a58d7ab3a5af859c2ae827161d7e6756528df8bd00d2d
@@ -6706,7 +6706,7 @@ entries:
     version: 0.16.0-beta.3
   - apiVersion: v1
     appVersion: 0.16.0-beta.2
-    created: "2020-10-07T17:39:19.260526131Z"
+    created: "2020-03-10T16:04:44Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 32ff17d48afee48b96cd7c291acb33f73b4ec03e2b01f5f6195253270e343ab1
@@ -6723,7 +6723,7 @@ entries:
     version: 0.16.0-beta.2
   - apiVersion: v1
     appVersion: 0.16.0-beta.1
-    created: "2020-10-07T17:39:19.226453159Z"
+    created: "2020-03-10T12:48:39Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 096344b59460b7b86035d60aeaa6018bf354c94cef505ce8490cae2832c2c721
@@ -6740,7 +6740,7 @@ entries:
     version: 0.16.0-beta.1
   - apiVersion: v1
     appVersion: 0.16.0-beta.0
-    created: "2020-10-07T17:39:19.193776049Z"
+    created: "2020-03-10T12:48:39Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: b7e775a89af12bd2ec70fbac8b9cdd45eab16b987a47c826952743b6886186df
@@ -6757,7 +6757,7 @@ entries:
     version: 0.16.0-beta.0
   - apiVersion: v1
     appVersion: 0.16.0-9-g56c58a5
-    created: "2020-10-07T17:39:19.174833705Z"
+    created: "2020-03-06T19:48:14Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 814d1fa4b862d41bed7a550eef037201d7e3c9abf09945c9552220ecb3da47bf
@@ -6774,7 +6774,7 @@ entries:
     version: 0.16.0-9-g56c58a5
   - apiVersion: v1
     appVersion: 0.16.0-6-g908b664
-    created: "2020-10-07T17:39:19.158824864Z"
+    created: "2020-03-10T20:35:15Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 349a26a46d189bb9621cffa6b37d2ed67fd1604426ab94b7567c3bd2a5ebd2a5
@@ -6791,7 +6791,7 @@ entries:
     version: 0.16.0-6-g908b664
   - apiVersion: v1
     appVersion: 0.16.0-5-g0fc5bad
-    created: "2020-10-07T17:39:19.140874114Z"
+    created: "2020-03-16T09:09:58Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 5c310b984800fc946702654d37815f0cce96a7eb747f8546e9fe2e8c3352913a
@@ -6808,7 +6808,7 @@ entries:
     version: 0.16.0-5-g0fc5bad
   - apiVersion: v1
     appVersion: 0.16.0-4-gf3c3572
-    created: "2020-10-07T17:39:19.125036379Z"
+    created: "2020-03-13T19:35:30Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 8f8119c93c210f56917fd7ac00fc5cccc78c19714bc9e0b6abcc6a26226dd33b
@@ -6825,7 +6825,7 @@ entries:
     version: 0.16.0-4-gf3c3572
   - apiVersion: v1
     appVersion: 0.16.0-11-g4a4ef58
-    created: "2020-10-07T17:39:19.107458154Z"
+    created: "2020-03-16T17:58:46Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: f6f47c3b9242fd8a8ac9e9f6d51f732ea1bb8016cac76ab9127699ea34a04a25
@@ -6842,7 +6842,7 @@ entries:
     version: 0.16.0-11-g4a4ef58
   - apiVersion: v1
     appVersion: 0.16.0-1-ga4f8e7f
-    created: "2020-10-07T17:39:19.089913217Z"
+    created: "2020-03-13T10:27:44Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 8b5a5c15ff1cdb6ac5a7ca49fa61cf0cbee919f4b353490960f76f4619ea136e
@@ -6859,7 +6859,7 @@ entries:
     version: 0.16.0-1-ga4f8e7f
   - apiVersion: v1
     appVersion: 0.15.22-alpha-13-gbe4a839
-    created: "2020-10-07T17:39:18.954480057Z"
+    created: "2020-03-10T10:43:31Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: d1e11999e6608863b68aefbb5b5599c988bfc48c95f112c6b3fdd6341d33f069
@@ -6876,7 +6876,7 @@ entries:
     version: 0.15.22-alpha-13-gbe4a839
   - apiVersion: v1
     appVersion: 0.15.22-alpha-12-g4127801
-    created: "2020-10-07T17:39:18.93820521Z"
+    created: "2020-03-10T09:07:20Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 33e2318870b8372985994a56d761e51df4401bdce9d36c236d5394aa65207647
@@ -7148,7 +7148,7 @@ entries:
     version: 0.15.1-alpha
   - apiVersion: v1
     appVersion: 0.15.0
-    created: "2020-10-07T17:39:18.783349866Z"
+    created: "2020-02-21T21:27:19Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 2939d982033689e5571c0407530f5de6a49eb92bff7d22f3045873155b9b57ff
@@ -7165,7 +7165,7 @@ entries:
     version: 0.15.0
   - apiVersion: v1
     appVersion: 0.14.0
-    created: "2020-10-07T17:39:18.767411585Z"
+    created: "2020-02-12T23:20:29Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: a911a4fb8c02cff87c224ef8fd5dddecc7984670ce3ae8e433f4de395142bf9d
@@ -7182,7 +7182,7 @@ entries:
     version: 0.14.0
   - apiVersion: v1
     appVersion: 0.13.0
-    created: "2020-10-07T17:39:18.749662486Z"
+    created: "2020-01-15T21:15:48Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 4f8b9880c1a13aa554480f0f9744e48a02beb09da8552f60da5e6a372b581273
@@ -7199,7 +7199,7 @@ entries:
     version: 0.13.0
   - apiVersion: v1
     appVersion: 0.12.0
-    created: "2020-10-07T17:39:18.733561259Z"
+    created: "2019-12-02T21:27:44Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 7f4311b4e61c931824d1a888b93d962bcc2f462993ad82f5acd80558853d7dd8
@@ -7209,7 +7209,7 @@ entries:
     version: 0.12.0
   - apiVersion: v1
     appVersion: 0.11.0
-    created: "2020-10-07T17:39:18.71751963Z"
+    created: "2019-11-13T21:47:16Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: f8913bdd827f6c6252225f6c8ba7ac7458ec0d254e81c726512e1197a7aee70f
@@ -7219,7 +7219,7 @@ entries:
     version: 0.11.0
   - apiVersion: v1
     appVersion: 0.10.0
-    created: "2020-10-07T17:39:18.705567216Z"
+    created: "2019-10-29T20:18:49Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 98d17bd14bd407105705e710700715e56da607b78073b2b674e40980f7600568
@@ -7229,7 +7229,7 @@ entries:
     version: 0.10.0
   - apiVersion: v1
     appVersion: 0.9.0
-    created: "2020-10-07T17:39:20.17435983Z"
+    created: "2019-10-10T20:06:43Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 539ed695221ec466acdb658b4d028fc94a831dc235f848419c609c3dce505650
@@ -7239,7 +7239,7 @@ entries:
     version: 0.9.0
   - apiVersion: v1
     appVersion: 0.8.0
-    created: "2020-10-07T17:39:20.160655774Z"
+    created: "2019-09-26T18:44:52Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 3022ea4d75ed31ca20381fa01324f0766d6658e13e84cf97d2e89431deddafbe
@@ -7249,7 +7249,7 @@ entries:
     version: 0.8.0
   - apiVersion: v1
     appVersion: 0.7.0
-    created: "2020-10-07T17:39:20.151255333Z"
+    created: "2019-09-24T17:21:27Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 6fc14a6d7c2bc42b6139e7673ee8f3d4750aded5fa1511c64959086779c31a7b
@@ -7259,7 +7259,7 @@ entries:
     version: 0.7.0
   - apiVersion: v1
     appVersion: 0.6.0
-    created: "2020-10-07T17:39:20.137646006Z"
+    created: "2019-09-13T18:53:27Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 8a537e17322d07c559c71f96bd74634f7c18a0963b982fd3e73c9f43adc1896f
@@ -7269,7 +7269,7 @@ entries:
     version: 0.6.0
   - apiVersion: v1
     appVersion: 0.4.0
-    created: "2020-10-07T17:39:20.128336809Z"
+    created: "2019-09-12T22:49:42Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 22583b6ac2077ccff32c928584328ef6bde52cd767e96f4b04ae824a99a37475
@@ -7279,7 +7279,7 @@ entries:
     version: 0.5.0
   - apiVersion: v1
     appVersion: 0.4.0
-    created: "2020-10-07T17:39:20.114562472Z"
+    created: "2019-09-03T18:55:31Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: bc7eed5d028d9f417ac8fb7705c6008194bb1cae6eea75a0617d8bb216b90bfa
@@ -7299,7 +7299,7 @@ entries:
     version: 0.3.1-alpha
   - apiVersion: v1
     appVersion: 0.3.0
-    created: "2020-10-07T17:39:20.093689206Z"
+    created: "2019-08-29T23:02:18Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 1cdf93e9b078bdbeced5e230ff8c50112bfb7deae6f8c8437f9c59e1f3a99246
@@ -7329,7 +7329,7 @@ entries:
     version: 0.1.1
   - apiVersion: v1
     appVersion: 0.0.0
-    created: "2020-10-07T17:39:18.683393669Z"
+    created: "2019-08-08T00:41:31Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 5f0e1d0663bbbeb822ece477a71462d883941bd6221ba66008dce87ec5296f77
@@ -7339,7 +7339,7 @@ entries:
     version: 0.1.0
   - apiVersion: v1
     appVersion: 0.0.0
-    created: "2020-10-07T17:39:18.682913405Z"
+    created: "2019-07-25T20:00:15Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 15018d851f94aabdcd452be9179090c2ae4be7744be7b66190b32e14ae7e2c34


### PR DESCRIPTION
###### Description

Fix creation date for helm charts using [script](https://gist.github.com/kkujawa-sumo/b196d4106201c23d740ed2f051c989df), [report](https://gist.github.com/kkujawa-sumo/58d697ba69f74331e865daeb06eb4ede) generated by script

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
