### PR TITLE
Fix creation date for helm charts with missing tag

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -3136,7 +3136,7 @@ entries:
     version: 1.1.0-rc.1-7-gb505e06
   - apiVersion: v1
     appVersion: 1.1.0-rc.1-5-gbe7c000
-    created: "2020-10-07T17:39:23.175424079Z"
+    created: "2020-07-30T16:58:09Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: ce4d2c2cc68c1dc45ec738068062692379bd63117478c2e4acedc02543af5a07
@@ -4581,7 +4581,7 @@ entries:
     version: 1.0.0-beta.2-4-gb6770e8
   - apiVersion: v1
     appVersion: 1.0.0-beta.2-32-g2635a3b
-    created: "2020-10-07T17:39:21.529339538Z"
+    created: "2020-04-27T17:17:53Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: bc3c7259115fbe17984d69db08f13ac9667d272eba9a12bc7161042c54f90421
@@ -4751,7 +4751,7 @@ entries:
     version: 1.0.0-beta.2-19-gd89cd87
   - apiVersion: v1
     appVersion: 1.0.0-beta.2-17-gf2e2ca4
-    created: "2020-10-07T17:39:21.358746813Z"
+    created: "2020-04-21T08:43:00Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: c93f89d72d9fcf87d0f38555af7564e6d5e0ed612b194ac1bdd47b0aaeadd853
@@ -4768,7 +4768,7 @@ entries:
     version: 1.0.0-beta.2-17-gf2e2ca4
   - apiVersion: v1
     appVersion: 1.0.0-beta.2-16-g8367beb
-    created: "2020-10-07T17:39:21.340156861Z"
+    created: "2020-04-20T16:50:36Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 80e4dec9b047762ce4f1e538ede92d850050a5307f644abd4110f7f882186960
@@ -6893,7 +6893,7 @@ entries:
     version: 0.15.22-alpha-12-g4127801
   - apiVersion: v1
     appVersion: 0.15.22-alpha
-    created: "2020-10-07T17:39:18.97030672Z"
+    created: "2020-03-06T13:29:00Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: e95ffc7ea1a42576b7f8552542b3ee5cabce1e8446ffc5d9263ba868694de200
@@ -6910,7 +6910,7 @@ entries:
     version: 0.15.22-alpha
   - apiVersion: v1
     appVersion: 0.15.20-alpha
-    created: "2020-10-07T17:39:18.918002078Z"
+    created: "2020-03-05T21:25:49Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 2b0b63a5a0edc865cfc59c1678c07708dfe50af50d5ccd8bfa3a151f4eb2986c
@@ -6927,7 +6927,7 @@ entries:
     version: 0.15.20-alpha
   - apiVersion: v1
     appVersion: 0.15.19-alpha
-    created: "2020-10-07T17:39:18.885946509Z"
+    created: "2020-03-05T00:58:04Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 99c434b2317b9d0080923dd8a65ea7659c4af0cf45344c12935ef7db91c345de
@@ -6944,7 +6944,7 @@ entries:
     version: 0.15.19-alpha
   - apiVersion: v1
     appVersion: 0.15.17-alpha
-    created: "2020-10-07T17:39:18.869557129Z"
+    created: "2020-03-04T23:23:53Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: ee9abc47b44403561670f475f1a70959eb3e132ed9f756d4df5f820a4f0cc19e
@@ -6961,7 +6961,7 @@ entries:
     version: 0.15.17-alpha
   - apiVersion: v1
     appVersion: 0.15.14-alpha
-    created: "2020-10-07T17:39:18.851625447Z"
+    created: "2020-03-03T18:51:32Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: fddbd79a45007077f88310f4378513bc43347b4dd43b21d3b610589bb9692275
@@ -6978,7 +6978,7 @@ entries:
     version: 0.15.14-alpha
   - apiVersion: v1
     appVersion: 0.15.13-alpha
-    created: "2020-10-07T17:39:18.835428245Z"
+    created: "2020-03-03T12:32:24Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 19134c0cc6c798d60490727e3abc42d0792f9f1b826420ab62b14818a23d87e4
@@ -6995,7 +6995,7 @@ entries:
     version: 0.15.13-alpha
   - apiVersion: v1
     appVersion: 0.15.12-alpha
-    created: "2020-10-07T17:39:18.817034662Z"
+    created: "2020-03-02T18:39:31Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: afa72accd320fbf84350b1250a4a67b18e1141412ab90db65debe8702ac807b1
@@ -7012,7 +7012,7 @@ entries:
     version: 0.15.12-alpha
   - apiVersion: v1
     appVersion: 0.15.9-alpha
-    created: "2020-10-07T17:39:19.073800104Z"
+    created: "2020-02-28T08:28:59Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: d40ccf6557a77e7f62a3077da19007adfda04e2c370a9f987c183250f1175237
@@ -7029,7 +7029,7 @@ entries:
     version: 0.15.9-alpha
   - apiVersion: v1
     appVersion: 0.15.8-alpha
-    created: "2020-10-07T17:39:19.057605916Z"
+    created: "2020-02-27T00:44:58Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 3d9441c59f474d5d58e61cddecece322fd3eff4da952be239807ab4fa9ae1561
@@ -7046,7 +7046,7 @@ entries:
     version: 0.15.8-alpha
   - apiVersion: v1
     appVersion: 0.15.7-alpha
-    created: "2020-10-07T17:39:19.039573887Z"
+    created: "2020-02-26T09:05:14Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: a023c2e2a5bdc0bbae6c39813dc8ca9c423de24cfddf291b21d55acc519b6238
@@ -7063,7 +7063,7 @@ entries:
     version: 0.15.7-alpha
   - apiVersion: v1
     appVersion: 0.15.6-alpha
-    created: "2020-10-07T17:39:19.021574106Z"
+    created: "2020-02-26T07:56:59Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 66f5fcbdfae1ac1cc72d6617433793deaecc43430413173e922bd96967b5014b
@@ -7080,7 +7080,7 @@ entries:
     version: 0.15.6-alpha
   - apiVersion: v1
     appVersion: 0.15.5-alpha
-    created: "2020-10-07T17:39:19.00381672Z"
+    created: "2020-02-26T07:48:40Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: d9809c40a649afe171f81fb238be96d728b52761e8851e013b00781015fa5c53
@@ -7097,7 +7097,7 @@ entries:
     version: 0.15.5-alpha
   - apiVersion: v1
     appVersion: 0.15.4-alpha
-    created: "2020-10-07T17:39:18.986116172Z"
+    created: "2020-02-24T22:11:20Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 3ba977f662c83142258d3ef8b21a69637dd250779a1c1e21c848e0fd46366d33
@@ -7114,7 +7114,7 @@ entries:
     version: 0.15.4-alpha
   - apiVersion: v1
     appVersion: 0.15.2-alpha
-    created: "2020-10-07T17:39:18.901901512Z"
+    created: "2020-02-24T19:03:18Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: de24a36b21b2c42002b26e4b70f4635f6fc040fa3f99582438db2bb951c8e683
@@ -7131,7 +7131,7 @@ entries:
     version: 0.15.2-alpha
   - apiVersion: v1
     appVersion: 0.15.1-alpha
-    created: "2020-10-07T17:39:18.800884672Z"
+    created: "2020-02-21T21:41:55Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 3d4748a1d97c36af52a713b14f6ca6e4217414f1cd0fd3f1965c176276ecb7fa
@@ -7289,7 +7289,7 @@ entries:
     version: 0.4.0
   - apiVersion: v1
     appVersion: 0.4.0
-    created: "2020-10-07T17:39:20.105069095Z"
+    created: "2019-09-10T23:36:46Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 67a13c658accc39703d13a8b2adf5259e875721f78fec20409e2146c6d2d2306
@@ -7309,7 +7309,7 @@ entries:
     version: 0.3.0
   - apiVersion: v1
     appVersion: 0.4.0
-    created: "2020-10-07T17:39:20.08223038Z"
+    created: "2019-09-06T23:06:50Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 15dc188792915ff9bfd6d6f5b011f37e92d5c9bd16cf3c5702cfc472821cea70
@@ -7319,7 +7319,7 @@ entries:
     version: 0.3.0-alpha
   - apiVersion: v1
     appVersion: 0.0.0
-    created: "2020-10-07T17:39:18.693482994Z"
+    created: "2019-08-22T18:14:32Z"
     description: A Helm chart for collecting Kubernetes logs, metrics and events into
       Sumo Logic.
     digest: 96f30bc7ac1c97247d0e0bae7ce556e5b02037cadfc184def7b7e81c6ffa66e8


### PR DESCRIPTION
###### Description

git tag does not exist for some of helm charts versions in such cases last modification date of the chart is used.

Previously used script to fix dates was updated and this pull request contains changes only for helm charts with missing git tag.

[script](https://gist.github.com/kkujawa-sumo/b196d4106201c23d740ed2f051c989df), [report](https://gist.github.com/kkujawa-sumo/58d697ba69f74331e865daeb06eb4ede) generated by script.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
