### PR TITLE
Remove .travis.yml from gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-lang: ruby
-services: docker
-before_install:
-  - rm -f ./Gemfile.lock
-  - gem install bundler
-script: bash ci/build.sh


### PR DESCRIPTION
###### Description

.travis.yml seems to be no longer needed, please see [this conversation](https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1093#issuecomment-727885480). It causes failed build result, see [example](https://travis-ci.com/github/SumoLogic/sumologic-kubernetes-collection/builds/201716813).

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
