### PR TITLE
Allow specifying pullSecrets

### DIFF
--- a/deploy/docs/Installation_with_Helm.md
+++ b/deploy/docs/Installation_with_Helm.md
@@ -7,6 +7,7 @@ enriching them with deployment, pod, and service level metadata; and sends them 
 * [Requirements](#requirements)
 * [Prerequisite](#prerequisite)
 * [Installation Steps](#installation-steps)
+  * [Authenticating with docker registry](#authenticating-with-docker-registry)
   * [Installing the helm chart in Openshift platform](#installing-the-helm-chart-in-openshift-platform)
 * [Viewing Data In Sumo Logic](#viewing-data-in-sumo-logic)
 * [Troubleshooting Installation](#troubleshooting-installation)
@@ -98,6 +99,22 @@ If the namespace does not exist, you can add the `--create-namespace` flag.
 ```bash
 helm upgrade --install my-release sumologic/sumologic --namespace=my-namespace --set sumologic.accessId=<SUMO_ACCESS_ID> --set sumologic.accessKey=<SUMO_ACCESS_KEY>  --set sumologic.clusterName="<MY_CLUSTER_NAME>" --create-namespace
 ```
+
+### Authenticating with docker registry
+
+Sumo Logic docker images used in the collection are currently hosted on hub.docker.com which
+[requires authentication in order to provide higher quota for image pulls][docker-rate-limit].
+
+In order to authenticate with docker registry hosted at hub.docker.com one can use
+`sumologic.pullSecrets`, to pass kubernetes secret names which contain the
+required credentials.
+
+Creating aforementioned secret is beyond the scope of this document.
+Extensive documentation on this subject can be found at
+[Creating a Secret with a Docker config at kubernetes.io][k8s-docker-secret].
+
+[docker-rate-limit]: https://www.docker.com/increase-rate-limits
+[k8s-docker-secret]: https://kubernetes.io/docs/concepts/containers/images/#creating-a-secret-with-a-docker-config
 
 ### Installing the helm chart in Openshift platform
 

--- a/deploy/helm/sumologic/README.md
+++ b/deploy/helm/sumologic/README.md
@@ -28,6 +28,7 @@ Parameter | Description | Default
 `sumologic.httpProxy` | HTTP proxy URL | `Nil`
 `sumologic.httpsProxy` | HTTPS proxy URL | `Nil`
 `sumologic.noProxy` | List of comma separated hostnames which should be excluded from the proxy | `kubernetes.default.svc`
+`sumologic.pullSecrets` | Optional list of secrets that will be used for pulling images for Sumo Logic's jobs, deployments and statefulsets. | `Nil`
 `sumologic.podLabels` | Additional labels for the pods. | `{}`
 `sumologic.podAnnotations` | Additional annotations for the pods. | `{}`
 `sumologic.scc.create` | Create OpenShift's Security Context Constraint | `false`

--- a/deploy/helm/sumologic/templates/serviceaccount.yaml
+++ b/deploy/helm/sumologic/templates/serviceaccount.yaml
@@ -5,3 +5,7 @@ metadata:
   labels:
     app: {{ template "sumologic.labels.app.roles.serviceaccount" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
+{{- if .Values.sumologic.pullSecrets }}
+imagePullSecrets:
+{{ toYaml .Values.sumologic.pullSecrets | indent 2 }}
+{{- end }}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -69,7 +69,16 @@ sumologic:
 
   ## If you set it to false, it would set EXCLUDE_NAMESPACE=<release-namespace> and not add the fluentD/fluent-bit logs and Prometheus remotestorage metrics.
   collectionMonitoring: true
-  
+
+  ## Optionally specify an array of pullSecrets.
+  ## They will be added to serviceaccount that is used for Sumo Logic's jobs,
+  ## deployments and statefulsets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  # pullSecrets:
+  #   - name: myRegistryKeySecretName
+
   ## Add custom labels to the following sumologic resources(fluentd sts, setup job, otelcol deployment)
   podLabels: {}
 


### PR DESCRIPTION
###### Description

This PR adds possibility to specify `pullSecrets` in order to authenticate with docker registry.
This can be done in order to e.g. overcome [hub.docker.com rate limiting](https://www.docker.com/increase-rate-limits)

Creating this secret is beyond the scope of our manuals and readme and user can refer to [Creating a Secret with a Docker config at kubernetes.io](https://kubernetes.io/docs/concepts/containers/images/#creating-a-secret-with-a-docker-config).

In order to use this secret for our dependencies, one can use the following customization in `values.yaml`:

* kube-prometheus-stack https://github.com/prometheus-community/helm-charts/blob/72a59c7bd3ff092cfd1bd2e654feaa62618a2b6f/charts/kube-prometheus-stack/values.yaml#L105-L109
* fluent-bit https://github.com/helm/charts/blob/master/stable/fluent-bit/values.yaml#L5-L12
* metrics-server https://github.com/bitnami/charts/blob/master/bitnami/metrics-server/values.yaml#L22-L27
* telegraf-operator https://github.com/influxdata/helm-charts/blob/master/charts/telegraf-operator/values.yaml#L23
* falco https://github.com/falcosecurity/charts/blob/master/falco/values.yaml#L3-L8

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
