### PR TITLE
Add forwarding kubelet_running containers and pods metrics

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1283,7 +1283,9 @@ kube-prometheus-stack:
         ## kubelet_runtime_operations_duration_seconds_count
         ## kubelet_runtime_operations_duration_seconds_sum
         ## kubelet_running_container_count
+        ## kubelet_running_containers
         ## kubelet_running_pod_count
+        ## kubelet_running_pods
         ## kubelet_docker_operations_latency_microseconds
         ## kubelet_docker_operations_latency_microseconds_count
         ## kubelet_docker_operations_latency_microseconds_sum
@@ -1293,7 +1295,7 @@ kube-prometheus-stack:
         - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.kubelet
           writeRelabelConfigs:
             - action: keep
-              regex: kubelet;(?:kubelet_docker_operations_errors(?:|_total)|kubelet_(?:docker|runtime)_operations_duration_seconds_(?:count|sum)|kubelet_running_(?:container|pod)_count|kubelet_(:?docker|runtime)_operations_latency_microseconds(?:|_count|_sum))
+              regex: kubelet;(?:kubelet_docker_operations_errors(?:|_total)|kubelet_(?:docker|runtime)_operations_duration_seconds_(?:count|sum)|kubelet_running_(?:container|pod)(?:_count|s)|kubelet_(:?docker|runtime)_operations_latency_microseconds(?:|_count|_sum))
               sourceLabels: [job, __name__]
         ## cadvisor container metrics
         ## container_cpu_usage_seconds_total


### PR DESCRIPTION
In k8s 1.19 `kubelet_running_container_count` and `kubelet_running_pod_count` has been renamed.

https://github.com/kubernetes/kubernetes/blob/b3fc8888631a43c21df159c395e560adf967be1f/CHANGELOG/CHANGELOG-1.19.md

```
Kubelet: following metrics have been renamed: kubelet_running_container_count --> kubelet_running_containers kubelet_running_pod_count --> kubelet_running_pods (#92407, @RainbowMango) [SIG API Machinery, Cluster Lifecycle, Instrumentation and Node]
```