### PR TITLE
v2 migration script

### DIFF
--- a/deploy/helm/sumologic/upgrade-2.0.0.sh
+++ b/deploy/helm/sumologic/upgrade-2.0.0.sh
@@ -4,8 +4,6 @@ set -euo pipefail
 IFS=$'\n\t'
 
 readonly OLD_VALUES_YAML="${1:---help}"
-readonly HELM_RELEASE_NAME="${2:-collection}"
-readonly NAMESPACE="${3:-sumologic}"
 readonly PREVIOUS_VERSION=1.3
 
 readonly TEMP_FILE=upgrade-2.0.0-temp-file

--- a/deploy/helm/sumologic/upgrade-2.0.0.sh
+++ b/deploy/helm/sumologic/upgrade-2.0.0.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+readonly OLD_VALUES_YAML="${1:---help}"
+readonly HELM_RELEASE_NAME="${2:-collection}"
+readonly NAMESPACE="${3:-sumologic}"
+readonly PREVIOUS_VERSION=1.3
+
+readonly TEMP_FILE=upgrade-2.0.0-temp-file
+
+readonly MIN_BASH_VERSION=4.0
+readonly MIN_YQ_VERSION=3.2.1
+
+readonly KEY_MAPPINGS="
+prometheus-operator.prometheusOperator.tlsProxy.enabled:kube-prometheus-stack.prometheusOperator.tls.enabled
+"
+
+readonly KEY_VALUE_MAPPINGS="
+prometheus-operator.prometheus.prometheusSpec.containers.[0].name:prometheus-config-reloader:config-reloader
+"
+
+readonly KEYS_TO_DELETE="
+prometheus-operator
+"
+
+# https://slides.com/perk/how-to-train-your-bash#/41
+readonly LOG_FILE="/tmp/$(basename "$0").log"
+info()    { echo -e "[INFO]    $*" | tee -a "${LOG_FILE}" >&2 ; }
+warning() { echo -e "[WARNING] $*" | tee -a "${LOG_FILE}" >&2 ; }
+error()   { echo -e "[ERROR]   $*" | tee -a "${LOG_FILE}" >&2 ; }
+fatal()   { echo -e "[FATAL]   $*" | tee -a "${LOG_FILE}" >&2 ; exit 1 ; }
+
+function print_help_and_exit() {
+  local MAN
+  set +e
+  read -r -d '' MAN <<EOF
+Thank you for upgrading to v2.0.0 of the Sumo Logic Kubernetes Collection Helm chart.
+As part of this major release, the format of the values.yaml file has changed.
+
+This script will automatically take the configurations of your existing values.yaml
+and return one that is compatible with v2.0.0.
+
+Requirements:
+  yq (>= ${MIN_YQ_VERSION}) https://github.com/mikefarah/yq/releases/tag/3.2.1
+  grep
+  sed
+  bash (>= ${MIN_BASH_VERSION})
+
+Usage:
+  # for default helm release name 'collection' and namespace 'sumologic'
+  ./upgrade-2.0.0.sh /path/to/values.yaml
+
+  # for non-default helm release name and k8s namespace
+  ./upgrade-2.0.0.sh /path/to/values.yaml helm_release_name k8s_namespace
+
+Returns:
+  new_values.yaml
+
+For more details, please refer to Migration steps and Changelog here:
+#TODO fix link
+https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/release-v1.0/deploy/docs/v2_migration_doc.md
+EOF
+  set -e
+
+  echo "${MAN}"
+  exit 0
+}
+
+function check_if_print_help_and_exit() {
+  if [[ "$1" == "--help" ]]; then
+    print_help_and_exit
+  fi
+}
+
+function check_required_command() {
+  local command_to_check="$1"
+  command -v "${command_to_check}" >/dev/null 2>&1 || { error "Required command is missing: ${command_to_check}"; fatal "Please consult --help and install missing commands before continue. Aborting."; }
+}
+
+function compare_versions() {
+  local no_lower_than="${1}"
+  local app_version="${2}"
+
+  if [[ "$(printf '%s\n' "${app_version}" "${no_lower_than}" | sort -V | head -n 1)" == "${no_lower_than}" ]]; then
+    echo "pass"
+  else
+    echo "fail"
+  fi
+}
+
+function check_app_version() {
+  local app_name="${1}"
+  local no_lower_than="${2}"
+  local app_version="${3}"
+
+  if [[ -z ${app_version} ]] || [[ $(compare_versions "${no_lower_than}" "${app_version}") == "fail" ]]; then
+    error "${app_name} version: '${app_version}' is invalid - it should be no lower than ${no_lower_than}"
+    fatal "Please update your ${app_name} and retry."
+  fi
+}
+
+function check_yq_version() {
+  local yq_version
+  yq_version=$(yq --version | grep -oE '[^[:space:]]+$')
+
+  check_app_version "grep" "${MIN_YQ_VERSION}" "${yq_version}"
+}
+
+function check_bash_version() {
+  check_app_version "bash" "${MIN_BASH_VERSION}" "${BASH_VERSION}"
+}
+
+function create_temp_file() {
+  echo -n > "${TEMP_FILE}"
+}
+
+function migrate_prometheus_operator_to_kube_prometheus_stack() {
+  info "Migrating from promtheus-operator to kube-prometheus-stack"
+  yq m -i \
+    "${TEMP_FILE}" \
+    <(
+      yq p \
+      <(yq r "${TEMP_FILE}" "prometheus-operator") \
+      "kube-prometheus-stack" \
+    )
+  yq d -i "${TEMP_FILE}" "prometheus-operator"
+}
+
+function delete_migrated_unused_keys() {
+  IFS=$'\n' read -r -d ' ' -a MAPPINGS_KEYS_TO_DELETE <<< "${KEYS_TO_DELETE}"
+  readonly MAPPINGS_KEYS_TO_DELETE
+  for i in "${MAPPINGS_KEYS_TO_DELETE[@]}"; do
+    yq d -i "${TEMP_FILE}" -- "${i}"
+  done
+}
+
+function migrate_customer_keys() {
+  # Convert variables to arrays
+  set +e
+  IFS=$'\n' read -r -d ' ' -a MAPPINGS <<< "${KEY_MAPPINGS}"
+  readonly MAPPINGS
+  IFS=$'\n' read -r -d ' ' -a MAPPINGS_KEY_VALUE <<< "${KEY_VALUE_MAPPINGS}"
+  readonly MAPPINGS_KEY_VALUE
+  set -e
+
+  readonly CUSTOMER_KEYS=$(yq --printMode p r "${OLD_VALUES_YAML}" -- '**')
+
+  for key in ${CUSTOMER_KEYS}; do
+    if [[ ${MAPPINGS[*]} =~ ${key}: ]]; then
+      # whatever you want to do when arr contains value
+      for i in "${MAPPINGS[@]}"; do
+        IFS=':' read -r -a maps <<< "${i}"
+        if [[ ${maps[0]} == "${key}" ]]; then
+          info "Mapping ${key} into ${maps[1]}"
+          yq w -i "${TEMP_FILE}" -- "${maps[1]}" "$(yq r "${OLD_VALUES_YAML}" -- "${maps[0]}")"
+          yq d -i "${TEMP_FILE}" -- "${maps[0]}"
+        fi
+      done
+    else
+      yq w -i "${TEMP_FILE}" -- "${key}" "$(yq r "${OLD_VALUES_YAML}" -- "${key}")"
+    fi
+
+    for i in "${MAPPINGS_KEY_VALUE[@]}"; do
+      IFS=':' read -r -a maps <<< "${i}"
+      if [[ ${maps[0]} == "${key}" ]]; then
+        old_value=$(yq r "${OLD_VALUES_YAML}" -- "${key}")
+
+        if [[ ${maps[1]} == "${old_value}" ]]; then
+          info "Mapping ${key}'s value from ${maps[1]} into ${maps[2]} "
+          yq w -i "${TEMP_FILE}" -- "${maps[0]}" "${maps[2]}"
+        fi
+      fi
+    done
+
+  done
+  echo
+}
+
+function migrate_pre_upgrade_hook() {
+  # Keep pre-upgrade hook
+  if [[ -n "$(yq r "${TEMP_FILE}" -- sumologic.setup)" ]]; then
+    info "Updating setup hooks (sumologic.setup.*.annotations[helm.sh/hook]) to 'pre-install,pre-upgrade'"
+    yq w -i "${TEMP_FILE}" -- 'sumologic.setup.*.annotations[helm.sh/hook]' 'pre-install,pre-upgrade'
+  fi
+}
+
+function check_falco_state() {
+  # Print information about falco state
+  if [[ "$(yq r "${TEMP_FILE}" -- falco.enabled)" == 'true' ]]; then
+    info 'falco will be enabled. Change "falco.enabled" to "false" if you want to disable it (default for 2.0)'
+  else
+    info 'falco will be disabled. Change "falco.enabled" to "true" if you want to enable it'
+  fi
+}
+
+function get_regex() {
+    # Get regex from old yaml file and strip `'` and `"` from beginning/end of it
+    local write_index="${1}"
+    local relabel_index="${2}"
+    yq r "${OLD_VALUES_YAML}" -- "prometheus-operator.prometheus.prometheusSpec.remoteWrite[${write_index}].writeRelabelConfigs[${relabel_index}].regex" | sed -e "s/^'//" -e 's/^"//' -e "s/'$//" -e 's/"$//'
+}
+
+function check_user_image() {
+  # Check user's image and echo warning if the image has been changed
+  readonly USER_VERSION="$(yq r "${OLD_VALUES_YAML}" -- image.tag)"
+  if [[ -n "${USER_VERSION}" ]]; then
+    if [[ "${USER_VERSION}" =~ ^"${PREVIOUS_VERSION}"\.[[:digit:]]+$ ]]; then
+      yq w -i "${TEMP_FILE}" -- image.tag 2.0.0
+      info "Changing image.tag from '${USER_VERSION}' to '2.0.0'"
+    else
+      warning "You are using unsupported version: ${USER_VERSION}"
+      warning "Please upgrade to '${PREVIOUS_VERSION}.x' or ensure that new_values.yaml is valid"
+    fi
+  fi
+}
+
+function fix_yq() {
+  # account for yq bug that stringifies empty maps
+  sed -i.bak "s/'{}'/{}/g" "${TEMP_FILE}"
+}
+
+function rename_temp_file() {
+  mv "${TEMP_FILE}" new_values.yaml
+}
+
+function cleanup_bak_file() {
+  rm "${TEMP_FILE}.bak"
+}
+
+function echo_footer() {
+  DONE="\nThank you for upgrading to v2.0.0 of the Sumo Logic Kubernetes Collection Helm chart.\nA new yaml file has been generated for you. Please check the current directory for new_values.yaml."
+  echo -e "${DONE}"
+}
+
+check_if_print_help_and_exit "${OLD_VALUES_YAML}"
+check_bash_version
+check_required_command yq
+check_yq_version
+check_required_command grep
+check_required_command sed
+
+create_temp_file
+
+migrate_customer_keys
+
+migrate_pre_upgrade_hook
+migrate_prometheus_operator_to_kube_prometheus_stack
+
+check_falco_state
+
+check_user_image
+
+fix_yq
+rename_temp_file
+cleanup_bak_file
+
+echo_footer
+
+exit 0

--- a/deploy/helm/sumologic/upgrade-2.0.0.sh
+++ b/deploy/helm/sumologic/upgrade-2.0.0.sh
@@ -195,14 +195,6 @@ function migrate_pre_upgrade_hook() {
   fi
 }
 
-function check_falco_state() {
-  # Print information about falco state
-  if [[ "$(yq r "${TEMP_FILE}" -- falco.enabled)" == 'true' ]]; then
-    info 'falco will be enabled. Change "falco.enabled" to "false" if you want to disable it (default for 2.0)'
-  else
-    info 'falco will be disabled. Change "falco.enabled" to "true" if you want to enable it'
-  fi
-}
 
 function get_regex() {
     # Get regex from old yaml file and strip `'` and `"` from beginning/end of it
@@ -256,8 +248,6 @@ migrate_customer_keys
 
 migrate_pre_upgrade_hook
 migrate_prometheus_operator_to_kube_prometheus_stack
-
-check_falco_state
 
 check_user_image
 

--- a/tests/upgrade_v2_script/run.sh
+++ b/tests/upgrade_v2_script/run.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# Test generation:
+# export test_name=example_test; \
+# bash deploy/helm/sumologic/upgrade-2.0.0.sh \
+#   tests/upgrade_v2_script/static/${test_name}.input.yaml \
+#   1> tests/upgrade_v2_script/static/${test_name}.log 2>&1 \
+# && cp new_values.yaml tests/upgrade_v2_script/static/${test_name}.output.yaml
+
+SCRIPT_PATH="$( dirname "$(realpath "${0}")" )"
+
+# shellcheck disable=SC1090
+source "${SCRIPT_PATH}/../functions.sh"
+readonly TEST_TMP_OUT="${SCRIPT_PATH}/tmp/out.log"
+
+set_variables "${SCRIPT_PATH}"
+# reassign variables from set_variables
+TEST_SCRIPT_PATH="${TEST_SCRIPT_PATH}"
+TEST_STATICS_PATH="${TEST_STATICS_PATH}"
+TEST_INPUT_FILES="${TEST_INPUT_FILES}"
+TEST_OUT="${TEST_OUT}"
+
+prepare_tests
+
+TEST_SUCCESS=true
+for input_file in ${TEST_INPUT_FILES}; do
+  test_name="${input_file//.input.yaml/}"
+  output_file="${test_name}.output.yaml"
+  log_file="${test_name}.log"
+
+  test_start "${test_name}"
+  bash "${TEST_SCRIPT_PATH}/../../deploy/helm/sumologic/upgrade-2.0.0.sh" "${TEST_STATICS_PATH}/${input_file}" 1>"${TEST_TMP_OUT}" 2>&1
+  mv new_values.yaml "${TEST_OUT}"
+
+  test_output=$(diff "${TEST_STATICS_PATH}/${output_file}" "${TEST_OUT}")
+  test_log=$(diff "${TEST_STATICS_PATH}/${log_file}" "${TEST_TMP_OUT}")
+  rm "${TEST_TMP_OUT}" "${TEST_OUT}"
+
+  if [[ -n "${test_output}" || -n "${test_log}" ]]; then
+    if [[ -n "${test_output}" ]]; then
+      echo -e "\tOutput diff (${TEST_STATICS_PATH}/${output_file}):\n${test_output}"
+    fi
+    if [[ -n "${test_log}" ]]; then
+      echo -e "\tLog diff (${TEST_STATICS_PATH}/${log_file}):\n${test_log}"
+    fi
+    test_failed "${test_name}"
+    TEST_SUCCESS=false
+  else
+    test_passed "${test_name}"
+  fi
+done
+
+cleanup_tests
+
+if [[ "${TEST_SUCCESS}" = "true" ]]; then
+  exit 0
+else
+  exit 1
+fi

--- a/tests/upgrade_v2_script/static/prometheus_operator_valid.input.yaml
+++ b/tests/upgrade_v2_script/static/prometheus_operator_valid.input.yaml
@@ -32,6 +32,7 @@ prometheus-operator:
             cpu: 1m
             memory: 8Mi
       containers:
+        - name: thanos-sidecar
         - name: "prometheus-config-reloader"
           env:
             - name: CHART

--- a/tests/upgrade_v2_script/static/prometheus_operator_valid.input.yaml
+++ b/tests/upgrade_v2_script/static/prometheus_operator_valid.input.yaml
@@ -1,0 +1,53 @@
+prometheus-operator:
+  prometheusOperator:
+    podLabels: {}
+    podAnnotations: {}
+    resources: {}
+    admissionWebhooks:
+      enabled: false
+    tlsProxy:
+      enabled: false
+  prometheus:
+    prometheusSpec:
+      scrapeInterval: 30s
+      retention: 1d
+      podMetadata:
+        labels: {}
+        annotations: {}
+      resources:
+        limits:
+          cpu: 2000m
+          memory: 8Gi
+        requests:
+          cpu: 500m
+          memory: 1Gi
+      thanos:
+        baseImage: quay.io/thanos/thanos
+        version: v0.10.0
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 1m
+            memory: 8Mi
+      containers:
+        - name: "prometheus-config-reloader"
+          env:
+            - name: CHART
+              valueFrom:
+                configMapKeyRef:
+                  name: sumologic-configmap
+                  key: fluentdMetrics
+            - name: NAMESPACE
+              valueFrom:
+                configMapKeyRef:
+                  name: sumologic-configmap
+                  key: fluentdNamespace
+sumologic:
+  accessId: dummy
+  accessKey: dummy
+  endpoint: http://dummy.com/
+telegraf-operator:
+  enabled: true
+  replicaCount: 1

--- a/tests/upgrade_v2_script/static/prometheus_operator_valid.log
+++ b/tests/upgrade_v2_script/static/prometheus_operator_valid.log
@@ -1,0 +1,8 @@
+[INFO]    Mapping prometheus-operator.prometheusOperator.tlsProxy.enabled into kube-prometheus-stack.prometheusOperator.tls.enabled
+[INFO]    Mapping prometheus-operator.prometheus.prometheusSpec.containers.[0].name's value from prometheus-config-reloader into config-reloader 
+
+[INFO]    Migrating from promtheus-operator to kube-prometheus-stack
+[INFO]    falco will be disabled. Change "falco.enabled" to "true" if you want to enable it
+
+Thank you for upgrading to v2.0.0 of the Sumo Logic Kubernetes Collection Helm chart.
+A new yaml file has been generated for you. Please check the current directory for new_values.yaml.

--- a/tests/upgrade_v2_script/static/prometheus_operator_valid.log
+++ b/tests/upgrade_v2_script/static/prometheus_operator_valid.log
@@ -1,7 +1,7 @@
 [INFO]    Mapping prometheus-operator.prometheusOperator.tlsProxy.enabled into kube-prometheus-stack.prometheusOperator.tls.enabled
-[INFO]    Mapping prometheus-operator.prometheus.prometheusSpec.containers.[0].name's value from prometheus-config-reloader into config-reloader 
 
-[INFO]    Migrating from promtheus-operator to kube-prometheus-stack
+[INFO]    Migrating prometheus-config-reloader to config-reloader
+[INFO]    Migrating from prometheus-operator to kube-prometheus-stack
 [INFO]    falco will be disabled. Change "falco.enabled" to "true" if you want to enable it
 
 Thank you for upgrading to v2.0.0 of the Sumo Logic Kubernetes Collection Helm chart.

--- a/tests/upgrade_v2_script/static/prometheus_operator_valid.output.yaml
+++ b/tests/upgrade_v2_script/static/prometheus_operator_valid.output.yaml
@@ -32,6 +32,7 @@ kube-prometheus-stack:
             cpu: 1m
             memory: 8Mi
       containers:
+        - name: thanos-sidecar
         - name: config-reloader
           env:
             - name: CHART

--- a/tests/upgrade_v2_script/static/prometheus_operator_valid.output.yaml
+++ b/tests/upgrade_v2_script/static/prometheus_operator_valid.output.yaml
@@ -1,0 +1,53 @@
+kube-prometheus-stack:
+  prometheusOperator:
+    tls:
+      enabled: false
+    podLabels: {}
+    podAnnotations: {}
+    resources: {}
+    admissionWebhooks:
+      enabled: false
+  prometheus:
+    prometheusSpec:
+      scrapeInterval: 30s
+      retention: 1d
+      podMetadata:
+        labels: {}
+        annotations: {}
+      resources:
+        limits:
+          cpu: 2000m
+          memory: 8Gi
+        requests:
+          cpu: 500m
+          memory: 1Gi
+      thanos:
+        baseImage: quay.io/thanos/thanos
+        version: v0.10.0
+        resources:
+          limits:
+            cpu: 10m
+            memory: 32Mi
+          requests:
+            cpu: 1m
+            memory: 8Mi
+      containers:
+        - name: config-reloader
+          env:
+            - name: CHART
+              valueFrom:
+                configMapKeyRef:
+                  name: sumologic-configmap
+                  key: fluentdMetrics
+            - name: NAMESPACE
+              valueFrom:
+                configMapKeyRef:
+                  name: sumologic-configmap
+                  key: fluentdNamespace
+sumologic:
+  accessId: dummy
+  accessKey: dummy
+  endpoint: http://dummy.com/
+telegraf-operator:
+  enabled: true
+  replicaCount: 1


### PR DESCRIPTION
###### Description

Create v2 migration script:

* add migration of `prometheus-operator.prometheusOperator.tlsProxy` -> `kube-prometheus-stack.prometheusOperator.tls`
* rename `prometheus-operator` -> `kube-prometheus-stack`
* rename `prometheus-operator.prometheus.prometheusSpec.containers.(name==prometheus-config-reloader)` -> `config-reloader` as `prometheus-config-reloader` is not supported anymore in prometheus-operator `0.43` [ref](https://github.com/prometheus-operator/prometheus-operator/blob/release-0.43/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml#L1122-L1132)

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
