### PR TITLE
Push dev charts into dev directory

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -110,7 +110,7 @@ function push_helm_chart() {
   git fetch origin-repo
   git checkout gh-pages
 
-  helm repo index --url https://sumologic.github.io/sumologic-kubernetes-collection/ --merge "${chart_dir}"index.yaml "${sync_dir}"
+  helm repo index --url https://sumologic.github.io/sumologic-kubernetes-collection/ --merge "${chart_dir}index.yaml" "${sync_dir}"
 
   mv -f "${sync_dir}"/* .
   rmdir "${sync_dir}"

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -110,7 +110,7 @@ function push_helm_chart() {
   git fetch origin-repo
   git checkout gh-pages
 
-  helm repo index --url https://sumologic.github.io/sumologic-kubernetes-collection/ --merge "${chart_dir}index.yaml" "${sync_dir}"
+  helm repo index --url https://sumologic.github.io/sumologic-kubernetes-collection/ --merge "${chart_dir}/index.yaml" "${sync_dir}"
 
   mv -f "${sync_dir}"/* .
   rmdir "${sync_dir}"
@@ -150,7 +150,7 @@ build_docker_image "${DOCKER_TAG}" || (echo "Error during building docker image"
 
 if [ -n "${DOCKER_PASSWORD}" ] && [ -n "${TRAVIS_TAG}" ]; then
   push_docker_image "${VERSION}"
-  push_helm_chart "${VERSION}" "./"
+  push_helm_chart "${VERSION}" "."
 
 elif [ -n "${DOCKER_PASSWORD}" ] && [[ "${TRAVIS_BRANCH}" == "master" || "${TRAVIS_BRANCH}" =~ ^release-v[0-9]+\.[0-9]+$ ]] && [ "${TRAVIS_EVENT_TYPE}" == "push" ]; then
   dev_build_tag=$(git describe --tags --always)

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -110,7 +110,7 @@ function push_helm_chart() {
   git fetch origin-repo
   git checkout gh-pages
 
-  helm repo index --url https://sumologic.github.io/sumologic-kubernetes-collection/ --merge "${chart_dir}/index.yaml" "${sync_dir}"
+  helm repo index --url "https://sumologic.github.io/sumologic-kubernetes-collection${chart_dir:1}/"--merge "${chart_dir}/index.yaml" "${sync_dir}"
 
   mv -f "${sync_dir}"/* "${chart_dir}"
   rmdir "${sync_dir}"

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -112,7 +112,7 @@ function push_helm_chart() {
 
   helm repo index --url https://sumologic.github.io/sumologic-kubernetes-collection/ --merge "${chart_dir}/index.yaml" "${sync_dir}"
 
-  mv -f "${sync_dir}"/* .
+  mv -f "${sync_dir}"/* "${chart_dir}"
   rmdir "${sync_dir}"
 
   git add -A

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -94,7 +94,7 @@ function push_docker_image() {
 
 function push_helm_chart() {
   local version="$1"
-
+  local chart_dir="$2"
   local sync_dir="./tmp-helm-sync"
 
   echo "Pushing new Helm Chart release ${version}"
@@ -110,7 +110,7 @@ function push_helm_chart() {
   git fetch origin-repo
   git checkout gh-pages
 
-  helm repo index --url https://sumologic.github.io/sumologic-kubernetes-collection/ --merge ./index.yaml "${sync_dir}"
+  helm repo index --url https://sumologic.github.io/sumologic-kubernetes-collection/ --merge "${chart_dir}"index.yaml "${sync_dir}"
 
   mv -f "${sync_dir}"/* .
   rmdir "${sync_dir}"
@@ -150,13 +150,13 @@ build_docker_image "${DOCKER_TAG}" || (echo "Error during building docker image"
 
 if [ -n "${DOCKER_PASSWORD}" ] && [ -n "${TRAVIS_TAG}" ]; then
   push_docker_image "${VERSION}"
-  push_helm_chart "${VERSION}"
+  push_helm_chart "${VERSION}" "./"
 
 elif [ -n "${DOCKER_PASSWORD}" ] && [[ "${TRAVIS_BRANCH}" == "master" || "${TRAVIS_BRANCH}" =~ ^release-v[0-9]+\.[0-9]+$ ]] && [ "${TRAVIS_EVENT_TYPE}" == "push" ]; then
   dev_build_tag=$(git describe --tags --always)
   dev_build_tag=${dev_build_tag#v}
   push_docker_image "${dev_build_tag}"
-  push_helm_chart "${dev_build_tag}"
+  push_helm_chart "${dev_build_tag}" "./dev"
 
 else
   echo "Skip Docker pushing"


### PR DESCRIPTION
###### Description

There were missing these lines [line#115](https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/kkujawa-pushing-chart-to-dir?expand=1#diff-0f42fd993ce699d1eaf4007157dd696e37a4ad3f424642cf0e504cfba2faa97eR115) and [line#113](https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1122/commits/3f631c51786d349ef219a575031ab272bd49c261#diff-0f42fd993ce699d1eaf4007157dd696e37a4ad3f424642cf0e504cfba2faa97eR113) in #1117.


###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
