### PR TITLE
Switch back to docker_mode

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -815,17 +815,17 @@ fluent-bit:
           HTTP_Port    2020
     inputs: |
       [INPUT]
-          Name             tail
-          Path             /var/log/containers/*.log
-          Multiline        On
-          Parser_Firstline multi_line
-          Tag              containers.*
-          Refresh_Interval 1
-          Rotate_Wait      60
-          Mem_Buf_Limit    5MB
-          Skip_Long_Lines  On
-          DB               /tail-db/tail-containers-state-sumo.db
-          DB.Sync          Normal
+          Name                tail
+          Path                /var/log/containers/*.log
+          Docker_Mode         On
+          Docker_Mode_Parser  multi_line
+          Tag                 containers.*
+          Refresh_Interval    1
+          Rotate_Wait         60
+          Mem_Buf_Limit       5MB
+          Skip_Long_Lines     On
+          DB                  /tail-db/tail-containers-state-sumo.db
+          DB.Sync             Normal
       [INPUT]
           Name            systemd
           Tag             host.*


### PR DESCRIPTION
When migrating to the new fluent-bit chart, I removed docker_mode support.  This adds it back in.