### PR TITLE
Add artifacthub-repo.yaml with owners

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,11 @@
+owners:
+  - name: astencel-sumo
+    email: astencel@sumologic.com
+  - name: kkujawa-sumo
+    email: kkujawa@sumologic.com
+  - name: perk-sumo
+    email: mstozek@sumologic.com
+  - name: pmalek-sumo
+    email: pmalek@sumologic.com
+  - name: sumo-drosiek
+    email: drosiek@sumologic.com


### PR DESCRIPTION
###### Description

Added artifacthub-repo.yaml required to [claim ownership](https://github.com/artifacthub/hub/blob/master/docs/repositories.md#ownership-claim).

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
