### PR TITLE
Extend helm charts owners

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,6 +1,8 @@
 owners:
   - name: astencel-sumo
     email: astencel@sumologic.com
+  - name: frankreno
+    email: freno@sumologic.com
   - name: kkujawa-sumo
     email: kkujawa@sumologic.com
   - name: perk-sumo


### PR DESCRIPTION
###### Description

Extended helm charts owners

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
