### PR TITLE
Only import sources when collector exists

### DIFF
--- a/deploy/helm/sumologic/conf/setup/setup.sh
+++ b/deploy/helm/sumologic/conf/setup/setup.sh
@@ -60,8 +60,8 @@ fi
 readonly COLLECTOR_NAME="{{ template "terraform.collector.name" . }}"
 
 # Sumo Logic Collector and HTTP sources
-terraform import sumologic_collector.collector "${COLLECTOR_NAME}"
-
+# Only import sources when collector exists.
+if terraform import sumologic_collector.collector "${COLLECTOR_NAME}"; then
 {{- $ctx := .Values -}}
 {{- range $type, $sources := .Values.sumologic.sources }}
 {{- if eq (include "terraform.sources.component_enabled" (dict "Context" $ctx "Type" $type)) "true" }}
@@ -72,6 +72,7 @@ terraform import sumologic_http_source.{{ template "terraform.sources.name" (dic
 {{- end }}
 {{- end }}
 {{- end }}
+fi
 
 # Kubernetes Secret
 terraform import kubernetes_secret.sumologic_collection_secret {{ template "terraform.secret.fullname" . }}

--- a/tests/terraform/static/all_fields.output.yaml
+++ b/tests/terraform/static/all_fields.output.yaml
@@ -332,7 +332,8 @@ data:
     readonly COLLECTOR_NAME="kubernetes"
   
     # Sumo Logic Collector and HTTP sources
-    terraform import sumologic_collector.collector "${COLLECTOR_NAME}"
+    # Only import sources when collector exists.
+    if terraform import sumologic_collector.collector "${COLLECTOR_NAME}"; then
     terraform import sumologic_http_source.default_events_source "${COLLECTOR_NAME}/events"
     terraform import sumologic_http_source.default_logs_source "${COLLECTOR_NAME}/logs"
     terraform import sumologic_http_source.apiserver_metrics_source "${COLLECTOR_NAME}/apiserver-metrics"
@@ -344,6 +345,7 @@ data:
     terraform import sumologic_http_source.scheduler_metrics_source "${COLLECTOR_NAME}/kube-scheduler-metrics"
     terraform import sumologic_http_source.state_metrics_source "${COLLECTOR_NAME}/kube-state-metrics"
     terraform import sumologic_http_source.test_source_metrics_source "${COLLECTOR_NAME}/(Test source)"
+    fi
   
     # Kubernetes Secret
     terraform import kubernetes_secret.sumologic_collection_secret sumologic/sumologic

--- a/tests/terraform/static/collector_fields.output.yaml
+++ b/tests/terraform/static/collector_fields.output.yaml
@@ -287,7 +287,8 @@ data:
     readonly COLLECTOR_NAME="kubernetes"
   
     # Sumo Logic Collector and HTTP sources
-    terraform import sumologic_collector.collector "${COLLECTOR_NAME}"
+    # Only import sources when collector exists.
+    if terraform import sumologic_collector.collector "${COLLECTOR_NAME}"; then
     terraform import sumologic_http_source.default_events_source "${COLLECTOR_NAME}/events"
     terraform import sumologic_http_source.default_logs_source "${COLLECTOR_NAME}/logs"
     terraform import sumologic_http_source.apiserver_metrics_source "${COLLECTOR_NAME}/apiserver-metrics"
@@ -298,6 +299,7 @@ data:
     terraform import sumologic_http_source.node_metrics_source "${COLLECTOR_NAME}/node-exporter-metrics"
     terraform import sumologic_http_source.scheduler_metrics_source "${COLLECTOR_NAME}/kube-scheduler-metrics"
     terraform import sumologic_http_source.state_metrics_source "${COLLECTOR_NAME}/kube-state-metrics"
+    fi
   
     # Kubernetes Secret
     terraform import kubernetes_secret.sumologic_collection_secret sumologic/sumologic

--- a/tests/terraform/static/conditional_sources.output.yaml
+++ b/tests/terraform/static/conditional_sources.output.yaml
@@ -214,7 +214,9 @@ data:
     readonly COLLECTOR_NAME="kubernetes"
   
     # Sumo Logic Collector and HTTP sources
-    terraform import sumologic_collector.collector "${COLLECTOR_NAME}"
+    # Only import sources when collector exists.
+    if terraform import sumologic_collector.collector "${COLLECTOR_NAME}"; then
+    fi
   
     # Kubernetes Secret
     terraform import kubernetes_secret.sumologic_collection_secret sumologic/sumologic

--- a/tests/terraform/static/custom.output.yaml
+++ b/tests/terraform/static/custom.output.yaml
@@ -214,7 +214,9 @@ data:
     readonly COLLECTOR_NAME="kubernetes"
   
     # Sumo Logic Collector and HTTP sources
-    terraform import sumologic_collector.collector "${COLLECTOR_NAME}"
+    # Only import sources when collector exists.
+    if terraform import sumologic_collector.collector "${COLLECTOR_NAME}"; then
+    fi
   
     # Kubernetes Secret
     terraform import kubernetes_secret.sumologic_collection_secret sumologic/sumologic

--- a/tests/terraform/static/default.output.yaml
+++ b/tests/terraform/static/default.output.yaml
@@ -285,7 +285,8 @@ data:
     readonly COLLECTOR_NAME="kubernetes"
   
     # Sumo Logic Collector and HTTP sources
-    terraform import sumologic_collector.collector "${COLLECTOR_NAME}"
+    # Only import sources when collector exists.
+    if terraform import sumologic_collector.collector "${COLLECTOR_NAME}"; then
     terraform import sumologic_http_source.default_events_source "${COLLECTOR_NAME}/events"
     terraform import sumologic_http_source.default_logs_source "${COLLECTOR_NAME}/logs"
     terraform import sumologic_http_source.apiserver_metrics_source "${COLLECTOR_NAME}/apiserver-metrics"
@@ -296,6 +297,7 @@ data:
     terraform import sumologic_http_source.node_metrics_source "${COLLECTOR_NAME}/node-exporter-metrics"
     terraform import sumologic_http_source.scheduler_metrics_source "${COLLECTOR_NAME}/kube-scheduler-metrics"
     terraform import sumologic_http_source.state_metrics_source "${COLLECTOR_NAME}/kube-state-metrics"
+    fi
   
     # Kubernetes Secret
     terraform import kubernetes_secret.sumologic_collection_secret sumologic/sumologic

--- a/tests/terraform/static/disable_default_metrics.output.yaml
+++ b/tests/terraform/static/disable_default_metrics.output.yaml
@@ -278,7 +278,8 @@ data:
     readonly COLLECTOR_NAME="kubernetes"
   
     # Sumo Logic Collector and HTTP sources
-    terraform import sumologic_collector.collector "${COLLECTOR_NAME}"
+    # Only import sources when collector exists.
+    if terraform import sumologic_collector.collector "${COLLECTOR_NAME}"; then
     terraform import sumologic_http_source.default_events_source "${COLLECTOR_NAME}/events"
     terraform import sumologic_http_source.default_logs_source "${COLLECTOR_NAME}/logs"
     terraform import sumologic_http_source.apiserver_metrics_source "${COLLECTOR_NAME}/apiserver-metrics"
@@ -288,6 +289,7 @@ data:
     terraform import sumologic_http_source.node_metrics_source "${COLLECTOR_NAME}/node-exporter-metrics"
     terraform import sumologic_http_source.scheduler_metrics_source "${COLLECTOR_NAME}/kube-scheduler-metrics"
     terraform import sumologic_http_source.state_metrics_source "${COLLECTOR_NAME}/kube-state-metrics"
+    fi
   
     # Kubernetes Secret
     terraform import kubernetes_secret.sumologic_collection_secret sumologic/sumologic

--- a/tests/terraform/static/strip_extrapolation.output.yaml
+++ b/tests/terraform/static/strip_extrapolation.output.yaml
@@ -286,7 +286,8 @@ data:
     readonly COLLECTOR_NAME="kubernetes"
   
     # Sumo Logic Collector and HTTP sources
-    terraform import sumologic_collector.collector "${COLLECTOR_NAME}"
+    # Only import sources when collector exists.
+    if terraform import sumologic_collector.collector "${COLLECTOR_NAME}"; then
     terraform import sumologic_http_source.default_events_source "${COLLECTOR_NAME}/events"
     terraform import sumologic_http_source.default_logs_source "${COLLECTOR_NAME}/logs"
     terraform import sumologic_http_source.apiserver_metrics_source "${COLLECTOR_NAME}/apiserver-metrics"
@@ -297,6 +298,7 @@ data:
     terraform import sumologic_http_source.node_metrics_source "${COLLECTOR_NAME}/node-exporter-metrics"
     terraform import sumologic_http_source.scheduler_metrics_source "${COLLECTOR_NAME}/kube-scheduler-metrics"
     terraform import sumologic_http_source.state_metrics_source "${COLLECTOR_NAME}/kube-state-metrics"
+    fi
   
     # Kubernetes Secret
     terraform import kubernetes_secret.sumologic_collection_secret sumologic/sumologic

--- a/tests/terraform/static/traces.output.yaml
+++ b/tests/terraform/static/traces.output.yaml
@@ -222,8 +222,10 @@ data:
     readonly COLLECTOR_NAME="kubernetes"
   
     # Sumo Logic Collector and HTTP sources
-    terraform import sumologic_collector.collector "${COLLECTOR_NAME}"
+    # Only import sources when collector exists.
+    if terraform import sumologic_collector.collector "${COLLECTOR_NAME}"; then
     terraform import sumologic_http_source.default_traces_source "${COLLECTOR_NAME}/traces"
+    fi
   
     # Kubernetes Secret
     terraform import kubernetes_secret.sumologic_collection_secret sumologic/sumologic


### PR DESCRIPTION
###### Description

Only import sources when collector exists.
This should cut down the time needed for setup job to complete.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
