### PR TITLE
Add explicit list of active maintainers to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Learn about CODEOWNERS file format:
 #  https://help.github.com/en/articles/about-code-owners
 
-* @SumoLogic/k8s-collection-team
+* @SumoLogic/k8s-collection-team @astencel-sumo @frankreno @kkujawa-sumo @perk-sumo @pmalek-sumo @sumo-drosiek


### PR DESCRIPTION
###### Description

Add explicit list of active maintainers to CODEOWNERS

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
