### PR TITLE
Bump metrics-server to 5.0.2

### DIFF
--- a/deploy/helm/sumologic/requirements.yaml
+++ b/deploy/helm/sumologic/requirements.yaml
@@ -12,7 +12,7 @@ dependencies:
     repository: https://falcosecurity.github.io/charts
     condition: falco.enabled
   - name: metrics-server
-    version: 4.3.1
+    version: 5.0.2
     repository: https://charts.bitnami.com/bitnami
     condition: metrics-server.enabled
   - name: telegraf-operator


### PR DESCRIPTION
###### Description

Bump metrics-server to 5.0.2

`5.0.0` dropped support for helm2 hence this is another change that doesn't support helm in our collection

ref: https://github.com/bitnami/charts/tree/master/bitnami/metrics-server#to-500

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
