### PR TITLE
Bundle terraform providers in kubernetes-fluentd image

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -128,11 +128,13 @@ function build_docker_image() {
 
   echo "Building docker image with ${tag}:local in $(pwd)..."
   pushd ./deploy/docker || exit 1
+  cp ../helm/sumologic/conf/setup/main.tf . || exit 1
   no_cache="--no-cache"
   if [[ "${DOCKER_USE_CACHE}" == "true" ]]; then
     no_cache=""
   fi
   docker build . -f ./Dockerfile -t "${tag}:local" ${no_cache:+"--no-cache"}
+  rm main.tf
   rm -f ./gems/*.gem
   popd || exit 1
 

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -41,15 +41,19 @@ RUN gem install \
         fluent-plugin-rewrite-tag-filter:2.2.0 \
         fluent-plugin-prometheus:1.6.1
 
-# Install Terraform
-ENV TERRAFORM_VERSION 0.12.26
+# Install Terraform ...
+ENV TERRAFORM_VERSION 0.12.29
 RUN mkdir /tmp/terraform \
  && curl https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip -o /tmp/terraform/terraform.zip \
  && cd /tmp/terraform \
  && unzip terraform.zip \
  && mv terraform /bin/terraform \
- && chmod +x /bin/terraform \
- && rm -rf /tmp/terraform
+ && chmod +x /bin/terraform
+
+# ... and providers
+COPY main.tf /tmp/terraform
+RUN cd /tmp/terraform \
+ && terraform init
 
 # FluentD plugins from this repository
 COPY gems/fluent-plugin*.gem ./
@@ -74,7 +78,7 @@ RUN apt-get update \
 
 # Create directory for Terraform configuration
 RUN mkdir -p /terraform /scripts \
- && chown -R fluent /terraform /scripts
+ && chown -R fluent:fluent /terraform /scripts
 
 COPY --from=builder /bin/terraform /bin/terraform
 COPY --from=builder /usr/local/bundle /usr/local/bundle
@@ -85,3 +89,6 @@ COPY ./entrypoint.sh /bin/
 RUN chown fluent /usr/local/bundle/*
 
 USER fluent
+
+COPY --from=builder --chown=fluent:fluent \
+    /tmp/terraform/.terraform /terraform/.terraform

--- a/deploy/helm/sumologic/conf/cleanup/cleanup.sh
+++ b/deploy/helm/sumologic/conf/cleanup/cleanup.sh
@@ -7,7 +7,8 @@ export HTTP_PROXY=${HTTP_PROXY:=""}
 export HTTPS_PROXY=${HTTPS_PROXY:=""}
 export NO_PROXY=${NO_PROXY:=""}
 
-cd /cleanup/ || exit 1
+cp /etc/terraform/*.tf /terraform/
+cd /terraform || exit 1
 
 terraform init
 

--- a/deploy/helm/sumologic/conf/setup/main.tf
+++ b/deploy/helm/sumologic/conf/setup/main.tf
@@ -1,6 +1,6 @@
 terraform {
   required_providers {
-    sumologic  = "~> 2.4.0"
+    sumologic  = "~> 2.4"
     kubernetes = "~> 1.13.0"
   }
 }

--- a/deploy/helm/sumologic/conf/setup/setup.sh
+++ b/deploy/helm/sumologic/conf/setup/setup.sh
@@ -27,7 +27,7 @@ function should_create_fields() {
 }
 
 cp /etc/terraform/{locals,main,providers,resources,variables,fields}.tf /terraform/
-cd /terraform
+cd /terraform || exit 1
 
 terraform init
 

--- a/deploy/helm/sumologic/templates/cleanup/cleanup-job.yaml
+++ b/deploy/helm/sumologic/templates/cleanup/cleanup-job.yaml
@@ -32,20 +32,20 @@ spec:
       initContainers:
       - name: copy-files
         image: busybox
-        command: ['sh', '-c', 'cp /configmap/* /cleanup']
+        command: ['sh', '-c', 'cp /configmap/* /etc/terraform']
         volumeMounts:
           - name: configmap
             mountPath: /configmap
           - name: cleanup
-            mountPath: /cleanup
+            mountPath: /etc/terraform
       containers:
         - name: cleanup
-          image: "hashicorp/terraform:0.12.29"
-          imagePullPolicy: IfNotPresent
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
           - name: cleanup
-            mountPath: /cleanup
-          command: ["/cleanup/cleanup.sh"]
+            mountPath: /etc/terraform
+          command: ["/etc/terraform/cleanup.sh"]
           {{- if .Values.sumologic.envFromSecret }}
           envFrom:
           - secretRef:

--- a/tests/terraform/static/all_fields.output.yaml
+++ b/tests/terraform/static/all_fields.output.yaml
@@ -129,7 +129,7 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.4.0"
+        sumologic  = "~> 2.4"
         kubernetes = "~> 1.13.0"
       }
     }
@@ -299,7 +299,7 @@ data:
     }
   
     cp /etc/terraform/{locals,main,providers,resources,variables,fields}.tf /terraform/
-    cd /terraform
+    cd /terraform || exit 1
   
     terraform init
   

--- a/tests/terraform/static/collector_fields.output.yaml
+++ b/tests/terraform/static/collector_fields.output.yaml
@@ -128,7 +128,7 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.4.0"
+        sumologic  = "~> 2.4"
         kubernetes = "~> 1.13.0"
       }
     }
@@ -254,7 +254,7 @@ data:
     }
   
     cp /etc/terraform/{locals,main,providers,resources,variables,fields}.tf /terraform/
-    cd /terraform
+    cd /terraform || exit 1
   
     terraform init
   

--- a/tests/terraform/static/conditional_sources.output.yaml
+++ b/tests/terraform/static/conditional_sources.output.yaml
@@ -118,7 +118,7 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.4.0"
+        sumologic  = "~> 2.4"
         kubernetes = "~> 1.13.0"
       }
     }
@@ -181,7 +181,7 @@ data:
     }
   
     cp /etc/terraform/{locals,main,providers,resources,variables,fields}.tf /terraform/
-    cd /terraform
+    cd /terraform || exit 1
   
     terraform init
   

--- a/tests/terraform/static/custom.output.yaml
+++ b/tests/terraform/static/custom.output.yaml
@@ -118,7 +118,7 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.4.0"
+        sumologic  = "~> 2.4"
         kubernetes = "~> 1.13.0"
       }
     }
@@ -181,7 +181,7 @@ data:
     }
   
     cp /etc/terraform/{locals,main,providers,resources,variables,fields}.tf /terraform/
-    cd /terraform
+    cd /terraform || exit 1
   
     terraform init
   

--- a/tests/terraform/static/default.output.yaml
+++ b/tests/terraform/static/default.output.yaml
@@ -128,7 +128,7 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.4.0"
+        sumologic  = "~> 2.4"
         kubernetes = "~> 1.13.0"
       }
     }
@@ -252,7 +252,7 @@ data:
     }
   
     cp /etc/terraform/{locals,main,providers,resources,variables,fields}.tf /terraform/
-    cd /terraform
+    cd /terraform || exit 1
   
     terraform init
   

--- a/tests/terraform/static/disable_default_metrics.output.yaml
+++ b/tests/terraform/static/disable_default_metrics.output.yaml
@@ -127,7 +127,7 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.4.0"
+        sumologic  = "~> 2.4"
         kubernetes = "~> 1.13.0"
       }
     }
@@ -245,7 +245,7 @@ data:
     }
   
     cp /etc/terraform/{locals,main,providers,resources,variables,fields}.tf /terraform/
-    cd /terraform
+    cd /terraform || exit 1
   
     terraform init
   

--- a/tests/terraform/static/strip_extrapolation.output.yaml
+++ b/tests/terraform/static/strip_extrapolation.output.yaml
@@ -128,7 +128,7 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.4.0"
+        sumologic  = "~> 2.4"
         kubernetes = "~> 1.13.0"
       }
     }
@@ -253,7 +253,7 @@ data:
     }
   
     cp /etc/terraform/{locals,main,providers,resources,variables,fields}.tf /terraform/
-    cd /terraform
+    cd /terraform || exit 1
   
     terraform init
   

--- a/tests/terraform/static/traces.output.yaml
+++ b/tests/terraform/static/traces.output.yaml
@@ -119,7 +119,7 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.4.0"
+        sumologic  = "~> 2.4"
         kubernetes = "~> 1.13.0"
       }
     }
@@ -189,7 +189,7 @@ data:
     }
   
     cp /etc/terraform/{locals,main,providers,resources,variables,fields}.tf /terraform/
-    cd /terraform
+    cd /terraform || exit 1
   
     terraform init
   


### PR DESCRIPTION
###### Description

* bump terraform from `0.12.26` to `0.12.29`
* relax `sumologic` terraform provider version constraint to update up to (excluding) `3.0.0` when possible (instead of `2.5.0`)
* use the same image - `.Values.image.repository` for cleanup job (instead of `hashicorp:terraform`
* bundle terraform providers (`kubernetes` and `sumologic`) in `sumologic:kubernetes-fluentd` image (in `/terraform/.terraform`)

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
