### PR TITLE
Migrate otelcol image name to otelcol image repository

### DIFF
--- a/deploy/helm/sumologic/templates/otelcol-deployment.yaml
+++ b/deploy/helm/sumologic/templates/otelcol-deployment.yaml
@@ -53,7 +53,7 @@ spec:
       {{- end }}
       containers:
       - name: otelcontrib-collector
-        image: {{ .Values.otelcol.deployment.image.name }}:{{ .Values.otelcol.deployment.image.tag }}
+        image: {{ .Values.otelcol.deployment.image.repository }}:{{ .Values.otelcol.deployment.image.tag }}
         imagePullPolicy: {{ .Values.otelcol.deployment.image.pullPolicy }}
         command:
           - "/otelcontribcol"

--- a/deploy/helm/sumologic/upgrade-2.0.0.sh
+++ b/deploy/helm/sumologic/upgrade-2.0.0.sh
@@ -13,6 +13,7 @@ readonly MIN_YQ_VERSION=3.2.1
 
 readonly KEY_MAPPINGS="
 prometheus-operator.prometheusOperator.tlsProxy.enabled:kube-prometheus-stack.prometheusOperator.tls.enabled
+otelcol.deployment.image.name:otelcol.deployment.image.repository
 "
 
 readonly KEY_VALUE_MAPPINGS="

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1655,7 +1655,7 @@ otelcol:
     ## Memory Ballast size should be max 1/3 to 1/2 of memory.
     memBallastSizeMib: "683"
     image:
-      name: "sumologic/opentelemetry-collector"
+      repository: "sumologic/opentelemetry-collector"
       tag: "0.12.0"
       pullPolicy: IfNotPresent
 

--- a/tests/upgrade_v2_script/static/otelcol_image_name.input.yaml
+++ b/tests/upgrade_v2_script/static/otelcol_image_name.input.yaml
@@ -1,0 +1,21 @@
+otelcol:
+  deployment:
+    nodeSelector: {}
+    tolerations: {}
+    replicas: 1
+    resources:
+      limits:
+        memory: 2Gi
+        cpu: 1000m
+      requests:
+        memory: 384Mi
+        cpu: 200m
+    podLabels: {}
+    podAnnotations: {}
+    memBallastSizeMib: "683"
+    image:
+      name: "sumologic/opentelemetry-collector"
+      tag: "0.12.0"
+      pullPolicy: IfNotPresent
+  metrics:
+    enabled: true

--- a/tests/upgrade_v2_script/static/otelcol_image_name.log
+++ b/tests/upgrade_v2_script/static/otelcol_image_name.log
@@ -1,0 +1,5 @@
+[INFO]    Mapping otelcol.deployment.image.name into otelcol.deployment.image.repository
+
+
+Thank you for upgrading to v2.0.0 of the Sumo Logic Kubernetes Collection Helm chart.
+A new yaml file has been generated for you. Please check the current directory for new_values.yaml.

--- a/tests/upgrade_v2_script/static/otelcol_image_name.output.yaml
+++ b/tests/upgrade_v2_script/static/otelcol_image_name.output.yaml
@@ -1,0 +1,21 @@
+otelcol:
+  deployment:
+    nodeSelector: {}
+    tolerations: {}
+    replicas: 1
+    resources:
+      limits:
+        memory: 2Gi
+        cpu: 1000m
+      requests:
+        memory: 384Mi
+        cpu: 200m
+    podLabels: {}
+    podAnnotations: {}
+    memBallastSizeMib: 683
+    image:
+      repository: sumologic/opentelemetry-collector
+      tag: 0.12.0
+      pullPolicy: IfNotPresent
+  metrics:
+    enabled: true


### PR DESCRIPTION
###### Description

Migrate `otelcol.deployment.image.name` -> `otelcol.deployment.image.repository`

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
