### PR TITLE
Backport CODEOWNERS from the main branch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Learn about CODEOWNERS file format:
+#  https://help.github.com/en/articles/about-code-owners
+
+* @SumoLogic/k8s-collection-team @astencel-sumo @frankreno @kkujawa-sumo @perk-sumo @pmalek-sumo @sumo-drosiek

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 script: bash ci/build.sh
 branches:
   only:
-  - master
+  - main
   - /^release-v\d+\.\d+$/
   - /^v\d+\.\d+\.\d+$/
   - /^v\d+\.\d+\.\d+-(alpha|beta|rc)\.\d+$/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/SumoLogic/sumologic-kubernetes-collection.svg?branch=master)](https://travis-ci.org/SumoLogic/sumologic-kubernetes-collection) [![Docker Pulls](https://img.shields.io/docker/pulls/sumologic/kubernetes-fluentd.svg)](https://hub.docker.com/r/sumologic/kubernetes-fluentd) 
+[![Build Status](https://travis-ci.org/SumoLogic/sumologic-kubernetes-collection.svg?branch=main)](https://travis-ci.org/SumoLogic/sumologic-kubernetes-collection) [![Docker Pulls](https://img.shields.io/docker/pulls/sumologic/kubernetes-fluentd.svg)](https://hub.docker.com/r/sumologic/kubernetes-fluentd)
 
 # sumologic-kubernetes-collection
 

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -73,10 +73,10 @@ shellcheck ci/build.sh || true
 # Exclude branches that start with "revert-" to allow reverts
 if [ -n "$GITHUB_TOKEN" ] && [ "$TRAVIS_EVENT_TYPE" == "pull_request" ] && [[ ! "$TRAVIS_PULL_REQUEST_BRANCH" =~ ^revert- ]]; then
   # Check most recent commit author. If non-Travis, check for changes made to generated files
-  recent_author=$(git log origin-repo/master..HEAD --format="%an" | grep -m1 "")
+  recent_author=$(git log origin-repo/main..HEAD --format="%an" | grep -m1 "")
   if echo "$recent_author" | grep -v -q -i "travis"; then
     # NOTE(ryan, 2019-08-30): Append "|| true" to command to ignore non-zero exit code
-    changes=$(git log origin-repo/master..HEAD --name-only --format="" --author="$recent_author" | grep -i "fluentd-sumologic.yaml.tmpl\|fluent-bit-overrides.yaml\|prometheus-overrides.yaml\|falco-overrides.yaml") || true
+    changes=$(git log origin-repo/main..HEAD --name-only --format="" --author="$recent_author" | grep -i "fluentd-sumologic.yaml.tmpl\|fluent-bit-overrides.yaml\|prometheus-overrides.yaml\|falco-overrides.yaml") || true
     if [ -n "$changes" ]; then
       echo "Aborting due to manual changes detected in the following generated files: $changes"
       exit 1
@@ -246,7 +246,7 @@ if [ -n "$DOCKER_PASSWORD" ] && [ -n "$TRAVIS_TAG" ]; then
   push_docker_image "$VERSION"
   push_helm_chart "$VERSION"
 
-elif [ -n "$DOCKER_PASSWORD" ] && [[ "$TRAVIS_BRANCH" == "master" || "$TRAVIS_BRANCH" =~ ^release-v[0-9]+\.[0-9]+$ ]] && [ "$TRAVIS_EVENT_TYPE" == "push" ]; then
+elif [ -n "$DOCKER_PASSWORD" ] && [[ "$TRAVIS_BRANCH" == "main" || "$TRAVIS_BRANCH" =~ ^release-v[0-9]+\.[0-9]+$ ]] && [ "$TRAVIS_EVENT_TYPE" == "push" ]; then
   dev_build_tag=$(git describe --tags --always)
   dev_build_tag=${dev_build_tag#v}
   push_docker_image "$dev_build_tag"

--- a/deploy/docs/v1_conf_examples.md
+++ b/deploy/docs/v1_conf_examples.md
@@ -90,7 +90,7 @@ Reference documentation: [Fluentd Filter Plugin](https://docs.fluentd.org/filter
 ## Override Fluentd Output plugin to forward data to Sumo as well as S3
 The example below shows how you can override the entire output section for the container logs pipeline.
 
-You can look at the Default output section [here](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/master/deploy/helm/sumologic/conf/logs/logs.source.containers.conf#L51)
+You can look at the Default output section [here](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/main/deploy/helm/sumologic/conf/logs/logs.source.containers.conf#L51)
 
 ```yaml
 fluentd:

--- a/deploy/docs/v1_migration_doc.md
+++ b/deploy/docs/v1_migration_doc.md
@@ -199,9 +199,9 @@ sed 's/cluster kubernetes/cluster <CLUSTER_NAME>/g'  >> fluentd-sumologic.yaml
 </filter>
 ```
 ##### 2.2 Deploy Prometheus
-- Follow steps mentioned [here](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/master/deploy/docs/Non_Helm_Installation.md#deploy-prometheus) to deploy Prometheus.
+- Follow steps mentioned [here](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/main/deploy/docs/Non_Helm_Installation.md#deploy-prometheus) to deploy Prometheus.
 ##### 2.3: Deploy Fluent Bit
-- Follow steps mentioned [here](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/master/deploy/docs/Non_Helm_Installation.md#deploy-fluentbit) to deploy Fluent Bit.
+- Follow steps mentioned [here](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/main/deploy/docs/Non_Helm_Installation.md#deploy-fluentbit) to deploy Fluent Bit.
 
 ## Kubernetes App dashboard update
 After successful migration please make sure to [reinstall your Kubernetes App](https://help.sumologic.com/07Sumo-Logic-Apps/10Containers_and_Orchestration/Kubernetes/Install_the_Kubernetes_App_and_view_the_Dashboards) to the latest version.

--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -6,7 +6,7 @@ description: A Helm chart for collecting Kubernetes logs, metrics and events int
 keywords:
   - monitoring
   - logging
-icon: https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/master/images/sumo_logic_logo.png
+icon: https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/main/images/sumo_logic_logo.png
 home: https://github.com/SumoLogic/sumologic-kubernetes-collection
 sources:
   - https://github.com/SumoLogic/sumologic-kubernetes-collection

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -338,7 +338,7 @@ fluentd:
 
     ## Configuration for sumologic output plugin
     ## ref: https://github.com/SumoLogic/fluentd-output-sumologic
-    ## ref: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/master/deploy/helm/sumologic/conf/logs/logs.output.conf
+    ## ref: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/main/deploy/helm/sumologic/conf/logs/logs.output.conf
     output:
       ## Format to post logs into Sumo: fields, json, json_merge, or text.
       ## NOTE: for logs metadata, fields is required.
@@ -566,7 +566,7 @@ fluentd:
 
     ## Configuration for sumologic output plugin
     ## ref: https://github.com/SumoLogic/fluentd-output-sumologic
-    ## ref: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/master/deploy/helm/sumologic/conf/metrics/metrics.output.conf
+    ## ref: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/main/deploy/helm/sumologic/conf/metrics/metrics.output.conf
     outputConf: |-
       @include metrics.output.conf
 


### PR DESCRIPTION
It's a backport of the following commits:
96c4ace6f224993c57d8ab3605759d2dabee7ac9
fb7376675ef2cb6c83140edaaeef904fd9169b8c
19a931712c417fb475a4cb8e8793c8ccf0f3ca15

###### Description

Fill in your description here.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
