### PR TITLE
Add targets to test logs and metrics from receiver-mock

### DIFF
--- a/vagrant/Makefile
+++ b/vagrant/Makefile
@@ -246,3 +246,9 @@ application-metrics-jolokia-agent-run:
 
 application-metrics-jolokia-agent-clean:
 	kubectl delete ns demo-jolokia-agent
+
+test-receiver-mock-logs:
+	kubectl logs $(shell kubectl get pod -l app=receiver-mock -o jsonpath='{.items[0].metadata.name}'  -n receiver-mock) -n receiver-mock
+
+test-receiver-mock-metrics:
+	kubectl exec $(shell kubectl get pod -l app=receiver-mock -o jsonpath="{.items[0].metadata.name}"  -n receiver-mock) -it -n receiver-mock -- curl http://localhost:3000/metrics

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -87,12 +87,24 @@ In order to quickly test whether sumo-kubernetes-collection works, one can use `
 
 To check receiver-mock logs please use:
 
+```bash
+sumo-make test-receiver-mock-logs
 ```
-kubectl logs $(kubectl get pod -l app=receiver-mock -o jsonpath="{.items[0].metadata.name}"  -n receiver-mock) -n receiver-mock
+
+or
+
+```bash
+/sumologic/vagrant/Makefile test-receiver-mock-logs
 ```
 
 To check metrics exposed by receiver-mock please use:
 
+```bash
+sumo-make test-receiver-mock-metrics
 ```
-kubectl exec $(kubectl get pod -l app=receiver-mock -o jsonpath="{.items[0].metadata.name}"  -n receiver-mock) -it -n receiver-mock -- curl http://localhost:3000/metrics
+
+or
+
+```bash
+/sumologic/vagrant/Makefile test-receiver-mock-metrics
 ```


### PR DESCRIPTION
###### Description

Add targets to test logs and metrics from receiver-mock (requested in [PR#1084](https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1084#discussion_r522136049))

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
