### PR TITLE
Clean makefile and update vagrant due to new ruby package

### DIFF
--- a/vagrant/Makefile
+++ b/vagrant/Makefile
@@ -16,10 +16,10 @@ name = collection
 namespace = sumologic
 
 test:
-	${root_dir}ci/tests.sh
+	$(MAKE) -C ${root_dir} test
 
 build:
-	cd ${root_dir} && DOCKER_USE_CACHE=true ${root_dir}ci/build.sh
+	cd ${root_dir} && DOCKER_USE_CACHE=true $(MAKE) -C ${root_dir} build
 	${mkfile_path} \
 		tag-and-push-local
 
@@ -42,7 +42,6 @@ upgrade:
 		remove-tmp \
 		apply-namespace \
 		apply-receiver-mock \
-		create-secrets \
 		grafana-dashboards \
 		helm-dependencies \
 		helm-upgrade \
@@ -130,14 +129,6 @@ expose-grafana:
 grafana-dashboards:
 	kubectl delete configmap -n "${namespace}" sumologic-dashboards || true
 	kubectl create configmap -n "${namespace}" sumologic-dashboards --from-file="${dashboards_path}"
-
-# Create secrets with microk8s certs
-create-secrets:
-	kubectl delete secret -n "${namespace}" microk8s-certs || true
-	kubectl create secret -n "${namespace}" generic microk8s-certs \
-		--from-file=/var/snap/microk8s/current/certs/server.key \
-		--from-file=/var/snap/microk8s/current/certs/server.crt \
-		--from-file=/var/snap/microk8s/current/certs/ca.crt
 
 # patch context to use sumologic namespace as default
 patch-context:
@@ -255,9 +246,3 @@ test-receiver-mock-metrics:
 
 shellcheck:
 	$(MAKE) -C ${root_dir} shellcheck
-
-test:
-	$(MAKE) -C ${root_dir} test
-
-build:
-	$(MAKE) -C ${root_dir} build

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -77,7 +77,7 @@ done
 # install requirements for ci/build.sh
 snap install ruby --channel=2.6/stable --classic
 gem install bundler
-apt install -y gcc g++ libsnappy-dev
+apt install -y gcc g++ libsnappy-dev libicu-dev zlib1g-dev cmake pkg-config libssl-dev
 
 SHELLCHECK_VERSION=v0.7.1
 curl -Lo- "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | tar -xJf -


### PR DESCRIPTION
###### Description

Clean makefile and update vagrant due to new ruby package

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
