### PR TITLE
Change ServiceMonitor for fluent-bit - port and matchLabels

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1050,14 +1050,14 @@ kube-prometheus-stack:
         additionalLabels:
           app: collection-fluent-bit
         endpoints:
-          - port: metrics
+          - port: http
             path: /api/v1/metrics/prometheus
         namespaceSelector:
           matchNames:
             - $(NAMESPACE)
         selector:
           matchLabels:
-            app: fluent-bit
+            app.kubernetes.io/name: fluent-bit
       - name: collection-sumologic-otelcol
         additionalLabels:
           sumologic.com/app: otelcol


### PR DESCRIPTION
###### Description
Fixes #1187 

Changes according to current definition of fluent-bit service:
```
$ kubectl describe svc collection-fluent-bit
Name:              collection-fluent-bit
Namespace:         sumologic
Labels:            app.kubernetes.io/instance=collection
                   app.kubernetes.io/managed-by=Helm
                   app.kubernetes.io/name=fluent-bit
                   app.kubernetes.io/version=1.6.3
                   helm.sh/chart=fluent-bit-0.7.4
Annotations:       meta.helm.sh/release-name: collection
                   meta.helm.sh/release-namespace: sumologic
Selector:          app.kubernetes.io/instance=collection,app.kubernetes.io/name=fluent-bit
Type:              ClusterIP
IP:                10.152.183.87
Port:              http  2020/TCP
TargetPort:        http/TCP
Endpoints:         10.1.57.18:2020
Session Affinity:  None
Events:            <none>
```
###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
