### PR TITLE
Fix expose-prometheus target in Makefile

### DIFF
--- a/vagrant/Makefile
+++ b/vagrant/Makefile
@@ -119,7 +119,7 @@ remove-service-monitors:
 
 ## k8s commands
 expose-prometheus:
-	kubectl port-forward -n "${namespace}" service/collection-prometheus-oper-prometheus --address=0.0.0.0 9090
+	kubectl port-forward -n "${namespace}" service/collection-kube-prometheus-prometheus --address=0.0.0.0 9090
 
 expose-grafana:
 	echo "Grafana credentials\n  login:    admin\n  password: prom-operator"


### PR DESCRIPTION
###### Description

Fixes following error:
```
$sumo-make expose-prometheus
kubectl port-forward -n "sumologic" service/collection-prometheus-oper-prometheus --address=0.0.0.0 9090
Error from server (NotFound): services "collection-prometheus-oper-prometheus" not found
make: *** [/sumologic/vagrant/Makefile:122: expose-prometheus] Error 1
```
###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
