### PR TITLE
Fix CI not pushing helm charts

### DIFF
--- a/ci/_build_functions.sh
+++ b/ci/_build_functions.sh
@@ -125,7 +125,7 @@ function is_checkout_on_tag() {
 
 function fetch_current_branch() {
   # No need to fetch when we can already do 'git describe ...'
-  git describe --tags >/dev/null && exit 0
+  git describe --tags >/dev/null && return
 
   # No need to fetch full history with:
   # git fetch --tags --unshallow


### PR DESCRIPTION
###### Description

Fix CI not pushing helm charts

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
