### PR TITLE
Update coredns metrics due to 1.7.0 release

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1645,20 +1645,24 @@ kube-prometheus-stack:
         ## control plane metrics
         ## coredns:
         ## coredns_cache_size
+        ## coredns_cache_entries
         ## coredns_cache_hits_total
         ## coredns_cache_misses_total
         ## coredns_dns_request_duration_seconds_count
         ## coredns_dns_request_duration_seconds_sum
         ## coredns_dns_request_count_total
+        ## coredns_dns_requests_total
         ## coredns_dns_response_rcode_count_total
+        ## coredns_dns_responses_total
         ## coredns_forward_request_count_total
+        ## coredns_forward_requests_total
         ## process_cpu_seconds_total
         ## process_open_fds
         ## process_resident_memory_bytes
         - url: http://$(CHART).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.control-plane.coredns
           writeRelabelConfigs:
             - action: keep
-              regex: coredns;(?:coredns_cache_(size|(hits|misses)_total)|coredns_dns_request_duration_seconds_(count|sum)|coredns_(dns_request|dns_response_rcode|forward_request)_count_total|process_(cpu_seconds_total|open_fds|resident_memory_bytes))
+              regex: coredns;(?:coredns_cache_(size|entries|(hits|misses)_total)|coredns_dns_request_duration_seconds_(count|sum)|coredns_(dns_request|dns_response_rcode|forward_request)_count_total|coredns_(forward_requests|dns_requests|dns_responses)_total|process_(cpu_seconds_total|open_fds|resident_memory_bytes))
               sourceLabels: [job, __name__]
         ## etcd server:
         ## etcd_debugging_mvcc_db_total_size_in_bytes


### PR DESCRIPTION
###### Description

Update coredns metrics due to 1.7.0 release

ref: https://coredns.io/2020/06/15/coredns-1.7.0-release/#metric-changes

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
