### PR TITLE
Bump fluentd image to v1.11.5

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluent/fluentd:v1.11.3-debian-1.0 AS builder
+FROM fluent/fluentd:v1.11.5-debian-1.0 AS builder
 
 # Use root account to use apt
 USER root
@@ -66,7 +66,7 @@ RUN gem install \
         --local fluent-plugin-events
 
 # Start with fresh image
-FROM fluent/fluentd:v1.11.3-debian-1.0
+FROM fluent/fluentd:v1.11.5-debian-1.0
 
 USER root
 


### PR DESCRIPTION
###### Description

Bump fluentd image to v1.11.5

Changelog: https://github.com/fluent/fluentd/blob/master/CHANGELOG.md#release-v1115---20201106

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
