### PR TITLE
Bump receiver-mock image in vagrant to kubernetes-tools:2.1.0

### DIFF
--- a/vagrant/k8s/receiver-mock.yaml
+++ b/vagrant/k8s/receiver-mock.yaml
@@ -30,7 +30,7 @@ spec:
         - ports:
             - containerPort: 3000
             - containerPort: 3001
-          image: sumologic/kubernetes-tools:2.0.0
+          image: sumologic/kubernetes-tools:2.1.0
           name: receiver-mock
           args:
             - receiver-mock


### PR DESCRIPTION
###### Description

Bump receiver-mock image in vagrant to kubernetes-tools:2.1.0

https://github.com/SumoLogic/sumologic-kubernetes-tools/releases/tag/v2.1.0

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
