### PR TITLE
Prevent "undefined local variable or method" error from enhance_k8s_metadata Fluent plugin

### DIFF
--- a/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/reader.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/reader.rb
@@ -76,7 +76,7 @@ module SumoLogic
                 )
 
                 if owner.nil?
-                  log.warn "failed to fetch resource: #{type}, name: #{name}, ns:#{namespace} with API version #{api_version}"
+                  log.warn "failed to fetch resource: #{RESOURCE_MAPPING[owner_reference['kind']]}, name: #{owner_reference['name']}, ns:#{namespace} with API version #{owner_reference['apiVersion']}"
                   next
                 end
                 queue.push(owner)

--- a/fluent-plugin-enhance-k8s-metadata/test/helper.rb
+++ b/fluent-plugin-enhance-k8s-metadata/test/helper.rb
@@ -49,6 +49,14 @@ def stub_apis
     .to_return(body: test_resource('deploy_kube-system.json'), status: 200)
   stub_request(:get, %r{/api/v1/namespaces/non-exist/pods})
     .to_raise(Kubeclient::ResourceNotFoundError.new(404, nil, nil))
+  stub_pod_with_nonexistent_owner
+end
+
+def stub_pod_with_nonexistent_owner
+  stub_request(:get, %r{/api/v1/namespaces/sumologic/pods/pod-with-nonexistent-owner})
+    .to_return(body: test_resource('pod_with_nonexistent_owner.json'), status: 200)
+  stub_request(:get, %r{/apis/extensions/v1beta1/namespaces/sumologic/replicasets/non-existent-replicaset})
+    .to_return(status: 404)
 end
 
 def init_globals

--- a/fluent-plugin-enhance-k8s-metadata/test/resources/pod_with_nonexistent_owner.json
+++ b/fluent-plugin-enhance-k8s-metadata/test/resources/pod_with_nonexistent_owner.json
@@ -1,0 +1,23 @@
+{
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+        "labels": {
+            "pod-template-hash": "1691804714",
+            "run": "whatever"
+        },
+        "name": "whatever-5bf5d48c57-74ffa",
+        "uid": "1a1e5ad4-7818-11e9-90f1-02324f7e0d1f",
+        "ownerReferences": [
+            {
+                "apiVersion": "extensions/v1beta1",
+                "kind": "ReplicaSet",
+                "name": "non-existent-replicaset",
+                "uid": "1a1a368a-7818-11e9-90f1-02324f7e0d1f"
+            }
+        ]
+    },
+    "spec": {
+        "nodeName": "ip-172-20-62-243.us-west-1.compute.internal"
+    }
+}

--- a/fluent-plugin-enhance-k8s-metadata/test/sumologic/kubernetes/test_reader.rb
+++ b/fluent-plugin-enhance-k8s-metadata/test/sumologic/kubernetes/test_reader.rb
@@ -57,6 +57,10 @@ class ReaderTest < Test::Unit::TestCase
     assert_not_nil metadata
     assert_equal '1691804714', metadata['pod_labels']['pod_labels']['pod-template-hash']
     assert_empty metadata['owners']
-    assert log.logs.any? { |log| log.include?('failed to fetch resource') }, "'failed to fetch resource' not found in logs: #{log.logs}"
+    expected_log_message = '[warn]: failed to fetch resource: replicasets, name: non-existent-replicaset, ns:sumologic with API version extensions/v1beta1'
+    assert(
+      log.logs.any? { |log| log.include?(expected_log_message) },
+      "'#{expected_log_message}' not found in logs: #{log.logs}"
+    )
   end
 end

--- a/fluent-plugin-enhance-k8s-metadata/test/sumologic/kubernetes/test_reader.rb
+++ b/fluent-plugin-enhance-k8s-metadata/test/sumologic/kubernetes/test_reader.rb
@@ -51,4 +51,12 @@ class ReaderTest < Test::Unit::TestCase
     assert_equal 0, metadata.size
     assert log.logs.any? { |log| log.include?('404') }
   end
+
+  test 'fetch_pod_metadata for pod with non-existent owner logs warning' do
+    metadata = fetch_pod_metadata('sumologic', 'pod-with-nonexistent-owner')
+    assert_not_nil metadata
+    assert_equal '1691804714', metadata['pod_labels']['pod_labels']['pod-template-hash']
+    assert_empty metadata['owners']
+    assert log.logs.any? { |log| log.include?('failed to fetch resource') }, "'failed to fetch resource' not found in logs: #{log.logs}"
+  end
 end

--- a/fluent-plugin-enhance-k8s-metadata/test/sumologic/kubernetes/test_reader.rb
+++ b/fluent-plugin-enhance-k8s-metadata/test/sumologic/kubernetes/test_reader.rb
@@ -17,7 +17,7 @@ class ReaderTest < Test::Unit::TestCase
   end
 
   def log
-    Fluent::Test::TestLogger.new
+    @test_log ||= Fluent::Test::TestLogger.new
   end
 
   test 'fetch_resource is expected' do
@@ -49,5 +49,6 @@ class ReaderTest < Test::Unit::TestCase
     metadata = fetch_pod_metadata('non-exist', 'somepod')
     assert_not_nil metadata
     assert_equal 0, metadata.size
+    assert log.logs.any? { |log| log.include?('404') }
   end
 end


### PR DESCRIPTION
###### Description

This PR fixes the "undefined local variable or method `type'" error coming from enhance_k8s_metadata Fluent plugin.

Here's a sample error log:

```
2020-12-02 01:13:43 +0000 [error]: #0 undefined local variable or method `type' for #<Fluent::Plugin::EnhanceK8sMetadataFilter:007fc915dc9138>
```

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
