### PR TITLE
Add release job for kubernetes-setup image

### DIFF
--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -9,6 +9,37 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
 
 jobs:
+  setup-image:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Extract tag
+        id: extract_tag
+        run: echo "::set-output name=tag::$(echo ${GITHUB_REF#refs/tags/v})"
+      - name: Print tag
+        run: echo "Running release build for ${{ steps.extract_tag.outputs.tag }}"
+      - name: Build kubernetes-setup
+        run: make build BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
+        working-directory: deploy/docker/setup/
+      # We need to install awscli v1 via pip because it contains a version
+      # that supports ecr-public while github actions environment on Ubuntu 20.04
+      # contains aws v2.1.4 which doesn't know about it yet.
+      # (support for ecr-public landed in v2.1.6)
+      # ref: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
+      - name: install awscli
+        run: |
+          pip install awscli
+          echo "/home/runner/.local/bin" >> $GITHUB_PATH
+      - name: Login to AWS public ECR
+        working-directory: deploy/docker/setup/
+        run: make login
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PUBLIC_ECR_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PUBLIC_ECR_SECRET_ACCESS_KEY }}
+      - name: Push kubernetes-setup image
+        working-directory: deploy/docker/setup/
+        run: make push BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
+
   build:
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
###### Description

This will allowing automatic `kubernetes-image` build and push procedure whenever a proper semver tag is pushed to repository.

Image tags are being trimmed of `v` prefix.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
