### PR TITLE
Use sumologic alias for ECR

### DIFF
--- a/deploy/helm/falco-overrides.yaml
+++ b/deploy/helm/falco-overrides.yaml
@@ -1,7 +1,7 @@
 # This file is auto-generated.
 image:
   registry: public.ecr.aws
-  repository: u5z5f8z6/falco
+  repository: sumologic/falco
 #ebpf:
 #  enabled: true
 falco:

--- a/deploy/helm/fluent-bit-overrides.yaml
+++ b/deploy/helm/fluent-bit-overrides.yaml
@@ -1,7 +1,7 @@
 # This file is auto-generated.
 image:
   fluent_bit:
-    repository: public.ecr.aws/u5z5f8z6/fluent-bit
+    repository: public.ecr.aws/sumologic/fluent-bit
     tag: 1.6.0
 ## Resource limits for fluent-bit
 resources: {}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -2,7 +2,7 @@
 ## All the comments start with two or more # characters
 
 image:
-  repository: public.ecr.aws/u5z5f8z6/kubernetes-fluentd
+  repository: public.ecr.aws/sumologic/kubernetes-fluentd
   tag: 1.3.4-rc.0
   pullPolicy: IfNotPresent
 
@@ -704,7 +704,7 @@ metrics-server:
 fluent-bit:
   image:
     fluent_bit:
-      repository: public.ecr.aws/u5z5f8z6/fluent-bit
+      repository: public.ecr.aws/sumologic/fluent-bit
       tag: 1.6.0
   ## Resource limits for fluent-bit
   resources: {}
@@ -1562,7 +1562,7 @@ falco:
   enabled: false
   image:
     registry: public.ecr.aws
-    repository: u5z5f8z6/falco
+    repository: sumologic/falco
   #ebpf:
   #  enabled: true
   falco:
@@ -1591,7 +1591,7 @@ otelcol:
     ## Memory Ballast size should be max 1/3 to 1/2 of memory.
     memBallastSizeMib: "683"
     image:
-      name: "public.ecr.aws/u5z5f8z6/opentelemetry-collector"
+      name: "public.ecr.aws/sumologic/opentelemetry-collector"
       tag: "0.12.0"
       pullPolicy: IfNotPresent
   # To enable collecting all logs, set to false
@@ -1732,7 +1732,7 @@ otelcol:
 telegraf-operator:
   enabled: false
   image:
-    sidecarImage: public.ecr.aws/u5z5f8z6/telegraf:1.14.4
+    sidecarImage: public.ecr.aws/sumologic/telegraf:1.14.4
   replicaCount: 1
   classes:
     secretName: "telegraf-operator-classes"

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -834,7 +834,7 @@ spec:
         
       containers:
       - name: fluentd-events
-        image: public.ecr.aws/u5z5f8z6/kubernetes-fluentd:1.3.4-rc.0
+        image: public.ecr.aws/sumologic/kubernetes-fluentd:1.3.4-rc.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -917,7 +917,7 @@ spec:
         
       containers:
       - name: fluentd
-        image: public.ecr.aws/u5z5f8z6/kubernetes-fluentd:1.3.4-rc.0
+        image: public.ecr.aws/sumologic/kubernetes-fluentd:1.3.4-rc.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -1042,7 +1042,7 @@ spec:
         
       containers:
       - name: fluentd
-        image: public.ecr.aws/u5z5f8z6/kubernetes-fluentd:1.3.4-rc.0
+        image: public.ecr.aws/sumologic/kubernetes-fluentd:1.3.4-rc.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/deploy/kubernetes/setup-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/setup-sumologic.yaml.tmpl
@@ -266,7 +266,7 @@ spec:
           defaultMode: 0777
       containers:
       - name: setup
-        image: public.ecr.aws/u5z5f8z6/kubernetes-fluentd:1.3.4-rc.0
+        image: public.ecr.aws/sumologic/kubernetes-fluentd:1.3.4-rc.0
         imagePullPolicy: IfNotPresent
         command: ["/etc/terraform/setup.sh"]
         resources:


### PR DESCRIPTION
###### Description

Backporting https://github.com/SumoLogic/sumologic-kubernetes-collection/commit/94161a5e31a759768765258c663870bee45cdc36 to `release-v1.3`

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
