### PR TITLE
Add steps required for fluent-bit to upgrade

### DIFF
--- a/deploy/docs/v2_migration_doc.md
+++ b/deploy/docs/v2_migration_doc.md
@@ -79,7 +79,33 @@ the exact steps for migration.
 - `sumologic.setup.fields` become `sumologic.collector.fields` as Fields are
   set on a Collector
 
+- `spec.selector` in Fluent Bit Helm Chart was modified from:
+
+  ```yaml
+  spec:
+  selector:
+    matchLabels:
+      app: fluent-bit
+      release: <RELEASE-NAME>
+  ```
+
+  to
+
+  ```yaml
+  spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: fluent-bit
+      app.kubernetes.io/instance: <RELEASE-NAME>
+  ```
+
 ## How to upgrade
+
+### Requirements
+
+- helm3
+- yq in version: `3.4.0` <= `x` < `4.0.0`
+- bash 4.0 or higher
 
 **Note: The below steps are using Helm 3. Helm 2 is not supported.**
 
@@ -136,7 +162,104 @@ kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheu
 kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/release-0.43/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
 ```
 
-### 3. Run upgrade script
+### 3. Prepare Fluent Bit instance
+
+As `spec.selector` in Fluent Bit Helm chart was modified, it is required to manually recreate or delete existing DaemonSet
+with old version of `spec.selector` before upgrade.
+
+One of the following two strategies can be used:
+
+- #### Recreating Fluent Bit DaemonSet
+
+  Recreating Fluent Bit DaemonSet with new `spec.selector` may cause that applications' logs and Fluent Bit metrics
+  will not be available in the time of recreation. It usually shouldn't take more than several seconds.
+
+  To recreate the Fluent Bit DaemonSet with new `spec.selector` one can run the following command:
+
+  ```bash
+  kubectl get daemonset --namespace <NAMESPACE-NAME> --selector "app=fluent-bit,release=<RELEASE-NAME>" --output yaml | \
+  yq w - "items[*].spec.selector.matchLabels[app.kubernetes.io/name]" "fluent-bit" | \
+  yq w - "items[*].spec.selector.matchLabels[app.kubernetes.io/instance]" "<RELEASE-NAME>" | \
+  yq w - "items[*].spec.template.metadata.labels[app.kubernetes.io/name]" "fluent-bit" | \
+  yq w - "items[*].spec.template.metadata.labels[app.kubernetes.io/instance]" "<RELEASE-NAME>" | \
+  yq d - "items[*].spec.selector.matchLabels[app]" | \
+  yq d - "items[*].spec.selector.matchLabels[release]" | \
+  kubectl apply --namespace <NAMESPACE-NAME>  --force --filename -
+  ```
+
+- #### Preparing temporary instance of Fluent Bit
+
+  Create temporary instance of Fluent Bit and delete DaemonSet with old version of `spec.selector`.
+  This will cause application' logs to be duplicated until temporary instance of Fluent Bit is deleted
+  after the upgrade is complete. As temporary instance of Fluent Bit creates additional Pods
+  which are selected by the same Fluent Bit Service you may observe changes in Fluent Bit metrics.
+
+  Copy of database, in which Fluent Bit keeps track of monitored files and offsets, is used by temporary instance of Fluent Bit
+  (Fluent Bit database is copied in initContainer).
+  Temporary instance of Fluent Bit will start reading logs with offsets saved in database.
+
+  To create a temporary copy of Fluent Bit DaemonSet:
+
+  ```bash
+  INIT_CONTAINER=$(cat <<-"EOF"
+    name: init-tmp-fluent-bit
+    image: busybox:latest
+    command: ['sh', '-c', 'mkdir -p /tail-db/tmp; cp /tail-db/*.db /tail-db/tmp']
+    volumeMounts:
+      - mountPath: /tail-db
+        name: tail-db
+  EOF
+  ) && \
+  TMP_VOLUME=$(cat <<-"EOF"
+      hostPath:
+          path: /var/lib/fluent-bit/tmp
+          type: DirectoryOrCreate
+      name: tmp-tail-db
+  EOF
+  ) && \
+  kubectl get daemonset --namespace <NAMESPACE-NAME> --selector "app=fluent-bit,release=<RELEASE-NAME>" --output yaml | \
+  yq w - "items[*].metadata.name" "tmp-fluent-bit" | \
+  yq w - "items[*].metadata.labels[heritage]" "tmp" | \
+  yq w - "items[*].spec.template.metadata.labels[app.kubernetes.io/name]" "fluent-bit" | \
+  yq w - "items[*].spec.template.metadata.labels[app.kubernetes.io/instance]" "<RELEASE-NAME>" | \
+  yq w - "items[*].spec.template.spec.initContainers[+]" --from <(echo "${INIT_CONTAINER}") | \
+  yq w - "items[*].spec.template.spec.volumes[+]" --from <(echo "${TMP_VOLUME}") | \
+  yq w - "items[*].spec.template.spec.containers[*].volumeMounts[*].(.==tail-db)" "tmp-tail-db" | \
+  kubectl create --filename -
+  ```
+
+  Please make sure that Pods related to new DaemonSet are running:
+
+  ```bash
+  kubectl get pod --namespace <NAMESPACE-NAME> --selector "app=fluent-bit,release=<RELEASE-NAME>,app.kubernetes.io/name=fluent-bit,app.kubernetes.io/instance=<RELEASE-NAME>"
+  ```
+
+  Please check that the latest logs are duplicated in Sumo.
+
+  To delete Fluent Bit DaemonSet with old version of `spec.selector`:
+
+  ```bash
+  kubectl delete daemonset --namespace <NAMESPACE-NAME> --selector "app=fluent-bit,heritage=Helm,release=<RELEASE-NAME>"
+  ```
+
+  **Notice:** When collection upgrade creates new DaemonSet for Fluent Bit,
+  logs will be duplicated.
+  In order to stop data duplication it is required to remove the temporary copy
+  of Fluent Bit DaemonSet after the upgrade has finished.
+
+  After collection upgrade is done, in order to remove the temporary Fluent Bit
+  DaemonSet run the following commands:
+
+   ```bash
+  kubectl wait --for=condition=ready pod \
+    --namespace <NAMESPACE-NAME> \
+    --selector "app.kubernetes.io/name=fluent-bit,app.kubernetes.io/instance=<RELEASE-NAME>,app!=fluent-bit,release!=<RELEASE-NAME>" && \
+  kubectl delete daemonset \
+    --namespace <NAMESPACE-NAME> \
+    --selector "app=fluent-bit,release=<RELEASE-NAME>,heritage=tmp"
+  ```
+
+### 4. Run upgrade script
 
 For Helm users, the only breaking changes are the renamed config parameters.
 For users who use a `values.yaml` file, we provide a script that users can run


### PR DESCRIPTION
# Description:

Add steps required for fluent-bit to upgrade collection.

# Notice:
- fluent-bit uses sqlite, [see](https://docs.fluentbit.io/manual/pipeline/inputs/tail)
- sqlite db can be copied to make a backup of data, [see](https://sqlite.org/tempfiles.html), which is used in initContainer for temporary instance of fluent-bit
- `kubectl apply -f (--force)` causes that fluent-bit receives SIGTERM signal


# Tested scenarios

Content of files which where used in tests in attached at the end.

## strategy 1
weak point: fluent-bit metrics not available twice 
```
kubectl get daemonset -l "app=fluent-bit,release=my-release" -o yaml | \
yq w - "items[*].spec.selector.matchLabels[app.kubernetes.io/name]" "fluent-bit" | \
yq w - "items[*].spec.selector.matchLabels[app.kubernetes.io/instance]" "my-release" | \
yq w - "items[*].spec.template.metadata.labels[app.kubernetes.io/name]" "fluent-bit" | \
yq w - "items[*].spec.template.metadata.labels[app.kubernetes.io/instance]" "my-release" | \
yq d - "items[*].spec.selector.matchLabels[app]" | \
yq d - "items[*].spec.selector.matchLabels[release]" | \
kubectl apply --force -f -
```

```
./apply.sh
helm get values my-release  > current_values.yaml

curl -LJO https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/main/deploy/helm/sumologic/upgrade-2.0.0.sh
chmod +x upgrade-2.0.0.sh && ./upgrade-2.0.0.sh current_values.yaml
```

```
helm upgrade my-release sumologic-dev/sumologic --version=2.0.0-dev.0-150-g7b64cc1 -f new_values.yaml --set fluentd.persistence.enabled=false
```

## strategy 2

```bash
$ helm repo add sumologic https://sumologic.github.io/sumologic-kubernetes-collection
$ helm repo add sumologic-dev https://sumologic.github.io/sumologic-kubernetes-collection/dev
$ helm repo update
```

```bash
$ helm upgrade --install my-release sumologic/sumologic \
  --version 1.3.2 \
  -f /sumologic/vagrant/values-sumo.yaml
```

Deploy test Pod
```bash
$ kubectl apply -f pod.yaml
```

See that form test Pod logs are available in Sumo, example query: `(test-log) AND _sourceName="default.counter.count"`

Prepare fluent-bit

```bash
INIT_CONTAINER=$(cat <<-"EOF"
  name: init-tmp-fluent-bit
  image: busybox:latest
  command: ['sh', '-c', 'mkdir -p /tail-db/tmp; cp /tail-db/*.db /tail-db/tmp']
  volumeMounts:
    - mountPath: /tail-db
      name: tail-db
EOF
) && \
TMP_VOLUME=$(cat <<-"EOF"
    hostPath:
        path: /var/lib/fluent-bit/tmp
        type: DirectoryOrCreate
    name: tmp-tail-db
EOF
) && \
kubectl get daemonset -l "app=fluent-bit,release=my-release" -o yaml | \
yq w - "items[*].metadata.name" "tmp-fluent-bit" | \
yq w - "items[*].metadata.labels[heritage]" "tmp" | \
yq w - "items[*].spec.template.metadata.labels[app.kubernetes.io/name]" "fluent-bit" | \
yq w - "items[*].spec.template.metadata.labels[app.kubernetes.io/instance]" "my-release" | \
yq w - "items[*].spec.template.spec.initContainers[+]" --from <(echo "${INIT_CONTAINER}") | \
yq w - "items[*].spec.template.spec.volumes[+]" --from <(echo "${TMP_VOLUME}") | \
yq w - "items[*].spec.template.spec.containers[*].volumeMounts[*].(.==tail-db)" "tmp-tail-db" | \
kubectl create -f -
```

Make sure that pods for new daemonset are running:

```bash
$kubectl get pod -l "app=fluent-bit,release=my-release,app.kubernetes.io/name=fluent-bit,app.kubernetes.io/instance=my-release"
```

Check that logs from fluent-bit are duplicated in sumo `(test-log) AND _sourceName="default.counter.count"`
Make sure that temporary instance has not started reading logs from the beginning but it reads logs with offset (reads logs from several minutes before).

```bash
$ kubectl delete daemonset -l "app=fluent-bit,heritage=Helm,release=my-release"
```

Check that logs are now not duplicated.

Steps to run upgrade script:
```bash
$ ./apply.sh
```

```bash
$ helm get values my-release  > current_values.yaml
```

```bash
$ curl -LJO https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/main/deploy/helm/sumologic/upgrade-2.0.0.sh
$ chmod +x upgrade-2.0.0.sh && ./upgrade-2.0.0.sh current_values.yaml
```

```bash
$ helm upgrade my-release sumologic-dev/sumologic --version=2.0.0-dev.0-150-g7b64cc1 -f new_values.yaml --set fluentd.persistence.enabled=false
```

see that application logs from fluent-bit are again duplicated in sumo, example query:`(test-log) AND _sourceName="default.counter.count"`

```bash
$ kubectl delete daemonset -l "app=fluent-bit,heritage=tmp,release=my-release"
```

see that logs  from fluent-bit are not duplicated in sumo and there is one fluent-bit daemonset

*Files*:

values-sumo.yaml:

```bash
kube-prometheus-stack:
  prometheus:
    prometheusSpec:
      externalLabels:
        cluster: microk8s
      resources:
        limits:
          cpu: 4000m
          memory: 12Gi
        requests:
          cpu: 500m
          memory: 512Mi

sumologic:
  accessId: ***
  accessKey: ***
  endpoint: ***
  cleanUpEnabled: false
```

apply.sh:
```bash 
#!/bin/bash

kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/release-0.43/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/release-0.43/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/release-0.43/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/release-0.43/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/release-0.43/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/release-0.43/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/release-0.43/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/release-0.43/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
```

pod.yaml:

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: counter
spec:
  containers:
  - name: count
    image: busybox
    args: [/bin/sh, -c,
            'i=0; while true; do echo "$i: $(date) test-log"; i=$((i+1)); sleep 1; done']
```

