### PR TITLE
Explicitly log that setup.sh is missing when using custom setup scripts

### DIFF
--- a/deploy/helm/sumologic/conf/setup/custom.sh
+++ b/deploy/helm/sumologic/conf/setup/custom.sh
@@ -36,5 +36,11 @@ for dir in $(ls -1 /customer-scripts | grep _ | grep -oE '^.*?_' | sed 's/_//g' 
   for file in $(ls -1 "/customer-scripts/${dir}_"* | grep -oE '_.*' | sed 's/_//g'); do
     cp "/customer-scripts/${dir}_${file}" "${target}/${file}"
   done
+
+  if [[ ! -f setup.sh ]]; then
+    echo "You're missing setup.sh script in custom scripts directory: '${dir}'"
+    continue
+  fi
+
   cd "${target}" && bash setup.sh
 done

--- a/tests/terraform/static/all_fields.output.yaml
+++ b/tests/terraform/static/all_fields.output.yaml
@@ -53,6 +53,12 @@ data:
       for file in $(ls -1 "/customer-scripts/${dir}_"* | grep -oE '_.*' | sed 's/_//g'); do
         cp "/customer-scripts/${dir}_${file}" "${target}/${file}"
       done
+  
+      if [[ ! -f setup.sh ]]; then
+        echo "You're missing setup.sh script in custom scripts directory: '${dir}'"
+        continue
+      fi
+  
       cd "${target}" && bash setup.sh
     done
   fields.tf: |

--- a/tests/terraform/static/collector_fields.output.yaml
+++ b/tests/terraform/static/collector_fields.output.yaml
@@ -53,6 +53,12 @@ data:
       for file in $(ls -1 "/customer-scripts/${dir}_"* | grep -oE '_.*' | sed 's/_//g'); do
         cp "/customer-scripts/${dir}_${file}" "${target}/${file}"
       done
+  
+      if [[ ! -f setup.sh ]]; then
+        echo "You're missing setup.sh script in custom scripts directory: '${dir}'"
+        continue
+      fi
+  
       cd "${target}" && bash setup.sh
     done
   fields.tf: |

--- a/tests/terraform/static/conditional_sources.output.yaml
+++ b/tests/terraform/static/conditional_sources.output.yaml
@@ -53,6 +53,12 @@ data:
       for file in $(ls -1 "/customer-scripts/${dir}_"* | grep -oE '_.*' | sed 's/_//g'); do
         cp "/customer-scripts/${dir}_${file}" "${target}/${file}"
       done
+  
+      if [[ ! -f setup.sh ]]; then
+        echo "You're missing setup.sh script in custom scripts directory: '${dir}'"
+        continue
+      fi
+  
       cd "${target}" && bash setup.sh
     done
   fields.tf: |

--- a/tests/terraform/static/custom.output.yaml
+++ b/tests/terraform/static/custom.output.yaml
@@ -53,6 +53,12 @@ data:
       for file in $(ls -1 "/customer-scripts/${dir}_"* | grep -oE '_.*' | sed 's/_//g'); do
         cp "/customer-scripts/${dir}_${file}" "${target}/${file}"
       done
+  
+      if [[ ! -f setup.sh ]]; then
+        echo "You're missing setup.sh script in custom scripts directory: '${dir}'"
+        continue
+      fi
+  
       cd "${target}" && bash setup.sh
     done
   fields.tf: |

--- a/tests/terraform/static/default.output.yaml
+++ b/tests/terraform/static/default.output.yaml
@@ -53,6 +53,12 @@ data:
       for file in $(ls -1 "/customer-scripts/${dir}_"* | grep -oE '_.*' | sed 's/_//g'); do
         cp "/customer-scripts/${dir}_${file}" "${target}/${file}"
       done
+  
+      if [[ ! -f setup.sh ]]; then
+        echo "You're missing setup.sh script in custom scripts directory: '${dir}'"
+        continue
+      fi
+  
       cd "${target}" && bash setup.sh
     done
   fields.tf: |

--- a/tests/terraform/static/disable_default_metrics.output.yaml
+++ b/tests/terraform/static/disable_default_metrics.output.yaml
@@ -53,6 +53,12 @@ data:
       for file in $(ls -1 "/customer-scripts/${dir}_"* | grep -oE '_.*' | sed 's/_//g'); do
         cp "/customer-scripts/${dir}_${file}" "${target}/${file}"
       done
+  
+      if [[ ! -f setup.sh ]]; then
+        echo "You're missing setup.sh script in custom scripts directory: '${dir}'"
+        continue
+      fi
+  
       cd "${target}" && bash setup.sh
     done
   fields.tf: |

--- a/tests/terraform/static/strip_extrapolation.output.yaml
+++ b/tests/terraform/static/strip_extrapolation.output.yaml
@@ -53,6 +53,12 @@ data:
       for file in $(ls -1 "/customer-scripts/${dir}_"* | grep -oE '_.*' | sed 's/_//g'); do
         cp "/customer-scripts/${dir}_${file}" "${target}/${file}"
       done
+  
+      if [[ ! -f setup.sh ]]; then
+        echo "You're missing setup.sh script in custom scripts directory: '${dir}'"
+        continue
+      fi
+  
       cd "${target}" && bash setup.sh
     done
   fields.tf: |

--- a/tests/terraform/static/traces.output.yaml
+++ b/tests/terraform/static/traces.output.yaml
@@ -53,6 +53,12 @@ data:
       for file in $(ls -1 "/customer-scripts/${dir}_"* | grep -oE '_.*' | sed 's/_//g'); do
         cp "/customer-scripts/${dir}_${file}" "${target}/${file}"
       done
+  
+      if [[ ! -f setup.sh ]]; then
+        echo "You're missing setup.sh script in custom scripts directory: '${dir}'"
+        continue
+      fi
+  
       cd "${target}" && bash setup.sh
     done
   fields.tf: |


### PR DESCRIPTION
###### Description

Fill in your description here.

###### Testing performed

- [ ] ci/build.sh
- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
