### PR TITLE
Add changes required for OpenShift support

### DIFF
--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -23,6 +23,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- template "sumologic.fullname" . }}
 {{- end -}}
 
+{{- define "sumologic.labels.app.setup.securitycontextconstraints" -}}
+{{- template "sumologic.fullname" . }}-setup-scc
+{{- end -}}
+
 {{- define "sumologic.labels.app.roles.clusterrole" -}}
 {{- template "sumologic.fullname" . }}
 {{- end -}}
@@ -295,6 +299,10 @@ helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 
 {{- define "sumologic.metadata.name.setup" -}}
 {{ template "sumologic.fullname" . }}-setup
+{{- end -}}
+
+{{- define "sumologic.metadata.name.setup.securitycontextconstraints" -}}
+{{- template "sumologic.metadata.name.setup" . }}-scc
 {{- end -}}
 
 {{- define "sumologic.metadata.name.setup.job" -}}

--- a/deploy/helm/sumologic/templates/setup/setup-job.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-job.yaml
@@ -67,4 +67,6 @@ spec:
         - name: NO_PROXY
           value: {{ .Values.sumologic.noProxy }}
         {{ end }}
+      securityContext:
+        runAsUser: 999
 {{- end }}

--- a/deploy/helm/sumologic/templates/setup/setup-scc.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-scc.yaml
@@ -3,11 +3,12 @@ apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
   annotations:
+{{ include "sumologic.annotations.app.setup.helmsh" "0" | indent 4 }}
     kubernetes.io/description: |
       This provides the minimum requirements Sumo Logic Kubernetes Collection to run in Openshift.
-  name: {{ template "sumologic.metadata.name.securitycontextconstraints" . }}
+  name: {{ template "sumologic.metadata.name.setup.securitycontextconstraints" . }}
   labels:
-    app: {{ template "sumologic.labels.app.securitycontextconstraints" . }}
+    app: {{ template "sumologic.labels.app.setup.securitycontextconstraints" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -15,7 +16,7 @@ allowHostDirVolumePlugin: true
 allowHostIPC: false
 allowHostNetwork: true
 allowHostPID: true
-allowHostPorts: true
+allowHostPorts: false
 allowPrivilegeEscalation: true
 allowPrivilegedContainer: true
 allowedCapabilities: []
@@ -23,7 +24,7 @@ allowedUnsafeSysctls: []
 defaultAddCapabilities: []
 fsGroup:
   type: RunAsAny
-groups: 
+groups:
 - system:serviceaccounts:{{ .Release.Namespace }}
 priority: 0
 readOnlyRootFilesystem: false
@@ -43,5 +44,4 @@ volumes:
 - emptyDir
 - secret
 - configMap
-- persistentVolumeClaim
 {{- end }}

--- a/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/fluentd-sumologic.yaml.tmpl
@@ -1105,3 +1105,4 @@ spec:
 ---
 # Source: sumologic/templates/scc.yaml
 
+

--- a/deploy/kubernetes/setup-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/setup-sumologic.yaml.tmpl
@@ -294,4 +294,10 @@ spec:
         - name: NO_PROXY
           value: kubernetes.default.svc
         
+      securityContext:
+        runAsUser: 999
+
+---
+# Source: sumologic/templates/setup/setup-scc.yaml
+
 


### PR DESCRIPTION
###### Description

Added changes required for OpenShift support

###### Testing performed

```
helm upgrade  collection deploy/helm/sumologic -f deploy/helm/sumologic/values.yaml,vagrant/values.yaml --set sumologic.scc.create=true --set fluent-bit.securityContext.privileged=true
```
Used files:
[deploy/helm/sumologic/values.yaml](https://gist.github.com/kkujawa-sumo/de7517931c4e90d333f1fb8fe9eb11e6)
[vagrant/values.yaml](https://gist.github.com/kkujawa-sumo/fde38282ba2b755c288afaa83c6e7652)

Tested on VM with OpenShift 3.11 from https://github.com/hector-vido/okd-3.11 with following [Vagrantfile](https://gist.github.com/kkujawa-sumo/14e51861cce40707f5b4ba29a8c8da75)

Checked that metrics and logs are comming to receiver-mock.
Checked that following metrics are available:
- etcd_helper_cache_hit_count
- etcd_helper_cache_miss_count
- node_cpu_seconds_total
- fluentbit_build_info
- apiserver_request_latencies_bucket


