### PR TITLE
Do not attach empty 'node' metadata

### DIFF
--- a/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
@@ -86,7 +86,7 @@ module Fluent
           service = @pods_to_services[pod_name] unless @pods_to_services.nil?
           metadata['service'] = {'service' => service.sort!.join('_')} if !(service.nil? || service.empty?)
 
-          if @data_type == 'metrics' && (record['node'].nil? || record['node'] == "")
+          if @data_type == 'metrics' && (record['node'].nil? || record['node'] == "") && !metadata['node'].nil?
             record['node'] = metadata['node']
           end
 

--- a/fluent-plugin-enhance-k8s-metadata/test/plugin/test_filter_enhance_k8s_metadata.rb
+++ b/fluent-plugin-enhance-k8s-metadata/test/plugin/test_filter_enhance_k8s_metadata.rb
@@ -56,10 +56,24 @@ class EnhanceK8sMetadataFilterTest < Test::Unit::TestCase
       driver = create_driver(conf)
 
       input_record = get_test_record[2]
-      assert_nil input_record['node']
+      assert_false input_record.key?('node')
       record = driver.filter('tag', 'time', input_record)
 
       assert_equal 'ip-172-20-62-242.us-west-1.compute.internal', record['node']
+    end
+
+    test 'do not attach node metadata to metrics when not found' do
+      conf = %{
+        kubernetes_url http://localhost:8080
+        data_type metrics
+      }
+      driver = create_driver(conf)
+
+      input_record = get_test_record[3]
+      assert_false input_record.key?('node')
+      record = driver.filter('tag', 'time', input_record)
+
+      assert_false record.key?('node')
     end
   end
 

--- a/fluent-plugin-enhance-k8s-metadata/test/resources/records.json
+++ b/fluent-plugin-enhance-k8s-metadata/test/resources/records.json
@@ -46,6 +46,10 @@
       "@metric": "http_request_size_bytes_sum",
       "@timestamp": 1550862304339,
       "@value": 1619905.0
+    },
+    {
+      "pod": "nonexistent-pod",
+      "namespace": "non-exist"
     }
   ]
 }


### PR DESCRIPTION
After attaching `node=nil` metadata to a metrics record, the other plugin `prometheus_format` fails with "undefined method `gsub' for nil:NilClass":

```console
long-collection-sumologic-fluentd-metrics-8 fluentd 2020-12-23 11:18:21 +0000 [warn]: #0 dump an error event: error_class=NoMethodError error="undefined method `gsub' for nil:NilClass" location="/usr/local/bundle/gems/fluent-plugin-prometheus-format-1.3.2/lib/fluent/plugin/filter_prometheus_format.rb:127:in `escape'" tag="prometheus.metrics.state" time=2020-12-23 11:18:14.000000000 +0000 record={"@metric"=>"kube_pod_container_resource_limits", "app"=>"collections", "container"=>"forge-metrics", "endpoint"=>"http", "instance"=>"10.3.71.116:8080", "job"=>"kube-state-metrics", "namespace"=>"long-distributed-systems", "pod"=>"forge-pod1-fd7c8b6d4-gtvdw", "prometheus"=>"long-collections/long-collection-prometheus", "prometheus_replica"=>"prometheus-long-collection-prometheus-0", "resource"=>"cpu", "unit"=>"core", "@timestamp"=>1608722294978, "@value"=>0.1, "cluster"=>"long", "prometheus_service"=>"long-prometheus-kube-state-metrics", "node"=>nil, "pod_labels"=>{"assembly"=>"forge", "assemblyVersion"=>"21.0-1606248095-4476-165371dae6bb", "chart"=>"sumo-assembly", "chartVersion"=>"1.0.1", "heritage"=>"Helm", "pod-template-hash"=>"fd7c8b6d4", "release"=>"long-forge", "sumoPod"=>"1", "sumoPodGroup"=>"ingestion", "team"=>"distributed-systems"}, "replicaset"=>"forge-pod1-fd7c8b6d4", "deployment"=>"forge-pod1"}
```