### PR TITLE
Fix upgrade v2 script image rename

### DIFF
--- a/deploy/helm/sumologic/upgrade-2.0.0.sh
+++ b/deploy/helm/sumologic/upgrade-2.0.0.sh
@@ -621,13 +621,21 @@ function get_regex() {
 
 function check_user_image() {
   # Check user's image and echo warning if the image has been changed
+  local USER_VERSION
   readonly USER_VERSION="$(yq r "${OLD_VALUES_YAML}" -- image.tag)"
+  local USER_IMAGE_REPOSITORY
+  readonly USER_IMAGE_REPOSITORY="$(yq r "${OLD_VALUES_YAML}" -- image.repository)"
   if [[ -n "${USER_VERSION}" ]]; then
     if [[ "${USER_VERSION}" =~ ^"${PREVIOUS_VERSION}"\.[[:digit:]]+$ ]]; then
       info "Migrating from image.tag '${USER_VERSION}' to sumologic.setup.job.image.tag '2.0.0'"
       yq w -i "${TEMP_FILE}" -- sumologic.setup.job.image.tag 2.0.0
+      info "Migrating from image.repository '${USER_IMAGE_REPOSITORY}' to sumologic.setup.job.image.repository 'public.ecr.aws/sumologic/kubernetes-setup'"
+      yq w -i "${TEMP_FILE}" -- sumologic.setup.job.image.repository "public.ecr.aws/sumologic/kubernetes-setup"
+
       info "Migrating from image.tag '${USER_VERSION}' to fluentd.image.tag '2.0.0'"
       yq w -i "${TEMP_FILE}" -- fluentd.image.tag 2.0.0
+      info "Migrating from image.repository '${USER_IMAGE_REPOSITORY}' to fluentd.image.repository 'public.ecr.aws/sumologic/kubernetes-fluentd'"
+      yq w -i "${TEMP_FILE}" -- fluentd.image.repository "public.ecr.aws/sumologic/kubernetes-fluentd"
     else
       warning "You are using unsupported version: ${USER_VERSION}"
       warning "Please upgrade to '${PREVIOUS_VERSION}.x' or ensure that new_values.yaml is valid"

--- a/tests/upgrade_v2_script/static/image_rename.input.yaml
+++ b/tests/upgrade_v2_script/static/image_rename.input.yaml
@@ -3,8 +3,6 @@ image:
   tag: 1.3.0
   pullPolicy: IfNotPresent
 
-nameOverride: ""
-
 sumologic:
   ### Setup
   ## If enabled, a pre-install hook will create Collector and Sources in Sumo Logic

--- a/tests/upgrade_v2_script/static/image_rename.log
+++ b/tests/upgrade_v2_script/static/image_rename.log
@@ -9,7 +9,9 @@
 [INFO]    - sumologic.setup.job.image.pullPolicy
 
 [INFO]    Migrating from image.tag '1.3.0' to sumologic.setup.job.image.tag '2.0.0'
+[INFO]    Migrating from image.repository 'sumologic/kubernetes-fluentd' to sumologic.setup.job.image.repository 'public.ecr.aws/sumologic/kubernetes-setup'
 [INFO]    Migrating from image.tag '1.3.0' to fluentd.image.tag '2.0.0'
+[INFO]    Migrating from image.repository 'sumologic/kubernetes-fluentd' to fluentd.image.repository 'public.ecr.aws/sumologic/kubernetes-fluentd'
 
 Thank you for upgrading to v2.0.0 of the Sumo Logic Kubernetes Collection Helm chart.
 A new yaml file has been generated for you. Please check the current directory for new_values.yaml.

--- a/tests/upgrade_v2_script/static/image_rename.output.yaml
+++ b/tests/upgrade_v2_script/static/image_rename.output.yaml
@@ -1,6 +1,6 @@
 fluentd:
   image:
-    repository: sumologic/kubernetes-fluentd
+    repository: public.ecr.aws/sumologic/kubernetes-fluentd
     tag: 2.0.0
     pullPolicy: IfNotPresent
   logLevel: info
@@ -12,11 +12,10 @@ sumologic:
   setup:
     job:
       image:
-        repository: sumologic/kubernetes-fluentd
+        repository: public.ecr.aws/sumologic/kubernetes-setup
         tag: 2.0.0
         pullPolicy: IfNotPresent
   setupEnabled: true
   cleanUpEnabled: false
   accessId: dummy
   accessKey: dummy
-nameOverride:


### PR DESCRIPTION
###### Description

Fix upgrade v2 script image rename and add also renaming `repository` (both for `fluentd` and for `setup` images)

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
