### PR TITLE
Bump falco dependency to 1.5.7

### DIFF
--- a/deploy/helm/sumologic/requirements.yaml
+++ b/deploy/helm/sumologic/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
     alias: prometheus-operator
     condition: prometheus-operator.enabled,sumologic.metrics.enabled
   - name: falco
-    version: 1.4.0
+    version: 1.5.7
     repository: https://falcosecurity.github.io/charts
     condition: falco.enabled
   - name: metrics-server


### PR DESCRIPTION
###### Description

This fixes an issue where older versions of falco (`0.25.0`) try to download modules from https://dl.bintray.com/falcosecurity/driver instead of https://download.falco.org/?prefix=driver/

Default behaviour (controlled by `DRIVERS_REPO` env variable) has been changed in  https://github.com/falcosecurity/falco/pull/1460

Additionally `falco:0.26.2` has been pushed to https://gallery.ecr.aws/sumologic/falco

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
