### PR TITLE
Upgrade v2 script - metrics server

### DIFF
--- a/tests/upgrade_v2_script/static/metrics_server.input.yaml
+++ b/tests/upgrade_v2_script/static/metrics_server.input.yaml
@@ -1,0 +1,9 @@
+## Configure metrics-server
+## ref: https://github.com/helm/charts/blob/master/stable/metrics-server/values.yaml
+metrics-server:
+  ## Set the enabled flag to true for enabling metrics-server.
+  ## This is required before enabling fluentd autoscaling unless you have an existing metrics-server in the cluster.
+  enabled: false
+  args:
+    - --kubelet-insecure-tls
+    - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname

--- a/tests/upgrade_v2_script/static/metrics_server.log
+++ b/tests/upgrade_v2_script/static/metrics_server.log
@@ -1,0 +1,5 @@
+
+[INFO]    Migrating metrics-server
+
+Thank you for upgrading to v2.0.0 of the Sumo Logic Kubernetes Collection Helm chart.
+A new yaml file has been generated for you. Please check the current directory for new_values.yaml.

--- a/tests/upgrade_v2_script/static/metrics_server.output.yaml
+++ b/tests/upgrade_v2_script/static/metrics_server.output.yaml
@@ -1,0 +1,5 @@
+metrics-server:
+  enabled: false
+  extraArgs:
+    kubelet-insecure-tls: true
+    kubelet-preferred-address-types: InternalIP,ExternalIP,Hostname


### PR DESCRIPTION
###### Description

Add missing `metrics-server` migration for v2 migration script.

This will cover migration between [old helm chart's `args`](https://github.com/helm/charts/blob/7e45e678e39b88590fe877f159516f85f3fd3f38/stable/metrics-server/values.yaml#L37-L39) and [bitnami's chart `extraArgs`](https://github.com/bitnami/charts/blob/2b22a217020fe3d16ef98fdcdd4a562c43f9824a/bitnami/metrics-server/values.yaml#L79-L86)

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
