### PR TITLE
Upgrade Sumologic Kubernetes Tool version to 2.2.3

### DIFF
--- a/ci/_build_functions.sh
+++ b/ci/_build_functions.sh
@@ -12,7 +12,7 @@ function helm() {
   docker run --rm \
     -v "$(pwd):/chart" \
     -w /chart \
-    sumologic/kubernetes-tools:2.2.0 \
+    sumologic/kubernetes-tools:2.2.3 \
     helm "$@"
 }
 

--- a/deploy/docs/Kube-Prometheus.md
+++ b/deploy/docs/Kube-Prometheus.md
@@ -9,12 +9,12 @@ You can generate mixin configuration using `kubectl` or `docker`:
  kubectl run tools \
   -it --quiet --rm \
   --restart=Never -n sumologic \
-  --image sumologic/kubernetes-tools:2.2.0 \
+  --image sumologic/kubernetes-tools:2.2.3 \
   -- template-prometheus-mixin > kube-prometheus-sumo-logic-mixin.libsonnet
 
  # or using docker
  docker run -it --rm \
-  sumologic/kubernetes-tools:2.2.0 \
+  sumologic/kubernetes-tools:2.2.3 \
   template-prometheus-mixin > kube-prometheus-sumo-logic-mixin.libsonnet
 ```
 

--- a/deploy/docs/Non_Helm_Installation.md
+++ b/deploy/docs/Non_Helm_Installation.md
@@ -91,7 +91,7 @@ First you will generate the YAML to apply to your cluster.  The following comman
 kubectl run tools \
   -it --quiet --rm \
   --restart=Never \
-  --image sumologic/kubernetes-tools:2.2.0 -- \
+  --image sumologic/kubernetes-tools:2.2.3 -- \
   template \
   --name-template 'collection' \
   --set sumologic.accessId='<ACCESS_ID>' \
@@ -143,7 +143,7 @@ The following will render the YAML and install in the `my-namespace` namespace.
 kubectl run tools \
   -it --quiet --rm \
   --restart=Never \
-  --image sumologic/kubernetes-tools:2.2.0 -- \
+  --image sumologic/kubernetes-tools:2.2.3 -- \
   template \
   --namespace 'my-namespace' \
   --name-template 'collection' \
@@ -192,7 +192,7 @@ you can do the following:
 kubectl run tools \
   -it --quiet --rm \
   --restart=Never \
-  --image sumologic/kubernetes-tools:2.2.0 -- \
+  --image sumologic/kubernetes-tools:2.2.3 -- \
   template \
   --namespace 'my-namespace' \
   --name-template 'collection' \
@@ -264,7 +264,7 @@ cat sumo-values.yaml | \
   kubectl run tools \
     -i --quiet --rm \
     --restart=Never \
-    --image sumologic/kubernetes-tools:2.2.0 -- \
+    --image sumologic/kubernetes-tools:2.2.3 -- \
     template \
       --name-template 'collection' \
       | tee sumologic.yaml
@@ -285,7 +285,7 @@ You can use the same commands used to create the YAML in the first place.
 kubectl run tools \
   -it --quiet --rm \
   --restart=Never \
-  --image sumologic/kubernetes-tools:2.2.0 -- \
+  --image sumologic/kubernetes-tools:2.2.3 -- \
   template \
   --namespace 'my-namespace' \
   --name-template 'collection' \
@@ -303,7 +303,7 @@ cat sumo-values.yaml | \
      kubectl run tools \
        -i --quiet --rm \
        --restart=Never \
-       --image sumologic/kubernetes-tools:2.2.0 -- \
+       --image sumologic/kubernetes-tools:2.2.3 -- \
        template \
          --name-template 'collection' \
          | tee sumologic.yaml
@@ -318,7 +318,7 @@ cat values.yaml | \
   kubectl run tools \
     -i --quiet --rm \
     --restart=Never \
-    --image sumologic/kubernetes-tools:2.2.0 -- \
+    --image sumologic/kubernetes-tools:2.2.3 -- \
     template \
       --name-template 'collection' \
       --version=1.0.0

--- a/deploy/docs/additional_prometheus_configuration.md
+++ b/deploy/docs/additional_prometheus_configuration.md
@@ -12,12 +12,12 @@ using `docker`/`kubectl` and [sumologic-kubernetes-tools](https://github.com/sum
  kubectl run tools \
   -it --quiet --rm \
   --restart=Never -n sumologic \
-  --image sumologic/kubernetes-tools:2.2.0 \
+  --image sumologic/kubernetes-tools:2.2.3 \
   -- template-dependency kube-prometheus-stack > prometheus-overrides.yaml
 
  # or using docker
  docker run -it --rm \
-  sumologic/kubernetes-tools:2.2.0 \
+  sumologic/kubernetes-tools:2.2.3 \
   template-dependency kube-prometheus-stack > prometheus-overrides.yaml
 ```
 

--- a/deploy/docs/existingPrometheusDoc.md
+++ b/deploy/docs/existingPrometheusDoc.md
@@ -126,12 +126,12 @@ First, generate the Prometheus Operator `prometheus-overrides.yaml` by running c
  kubectl run tools \
   -it --quiet --rm \
   --restart=Never -n sumologic \
-  --image sumologic/kubernetes-tools:2.2.0 \
+  --image sumologic/kubernetes-tools:2.2.3 \
   -- template-dependency kube-prometheus-stack > prometheus-overrides.yaml
 
  # or using docker
  docker run -it --rm \
-  sumologic/kubernetes-tools:2.2.0 \
+  sumologic/kubernetes-tools:2.2.3 \
   template-dependency kube-prometheus-stack > prometheus-overrides.yaml
 ```
 

--- a/deploy/docs/standAlonePrometheus.md
+++ b/deploy/docs/standAlonePrometheus.md
@@ -89,12 +89,12 @@ First, generate the Prometheus Operator `prometheus-overrides.yaml` by running
  kubectl run tool \
   -it --quiet --rm \
   --restart=Never -n sumologic \
-  --image sumologic/kubernetes-tools:2.2.0 \
+  --image sumologic/kubernetes-tools:2.2.3 \
   -- template-dependency kube-prometheus-stack > prometheus-overrides.yaml
 
  # or using docker
  docker run -it --rm \
-  sumologic/kubernetes-tools:2.2.0 \
+  sumologic/kubernetes-tools:2.2.3 \
   template-dependency kube-prometheus-stack > prometheus-overrides.yaml
 ```
 

--- a/tests/functions.sh
+++ b/tests/functions.sh
@@ -37,7 +37,7 @@ function prepare_environment() {
   rm -rf "${repo_path}/tmpcharts"
   docker run --rm \
     -v "${repo_path}":/chart \
-    sumologic/kubernetes-tools:2.2.0 \
+    sumologic/kubernetes-tools:2.2.3 \
     helm dependency update /chart
 }
 
@@ -71,7 +71,7 @@ function generate_file {
   docker run --rm \
     -v "${TEST_SCRIPT_PATH}/../../deploy/helm/sumologic":/chart \
     -v "${TEST_STATICS_PATH}/${input_file}":/values.yaml \
-    sumologic/kubernetes-tools:2.2.0 \
+    sumologic/kubernetes-tools:2.2.3 \
     helm template /chart -f /values.yaml \
       --namespace sumologic \
       --set sumologic.accessId='accessId' \

--- a/vagrant/k8s/receiver-mock.yaml
+++ b/vagrant/k8s/receiver-mock.yaml
@@ -30,7 +30,7 @@ spec:
         - ports:
             - containerPort: 3000
             - containerPort: 3001
-          image: sumologic/kubernetes-tools:2.2.0
+          image: sumologic/kubernetes-tools:2.2.3
           name: receiver-mock
           args:
             - receiver-mock


### PR DESCRIPTION
###### Description

Use newer Kubernetes Tools to profit from fixed `template` command.

Release notes:
* [template] Wait 10s for stdin (due to kubectl delay)
* [template] Fix template command
* [template] Fix skipping first line of the values.yaml if file has been provided by stdin

The full list of changes can be found here:
https://github.com/SumoLogic/sumologic-kubernetes-tools/compare/v2.2.0...v2.2.3

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
