### PR TITLE
Bump kube-prometheus-stack to 12.10.4

### DIFF
--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
     repository: https://fluent.github.io/helm-charts
     condition: fluent-bit.enabled,sumologic.logs.enabled
   - name: kube-prometheus-stack
-    version: 12.9.2
+    version: 12.10.4
     repository: https://prometheus-community.github.io/helm-charts
     condition: kube-prometheus-stack.enabled,sumologic.metrics.enabled
   - name: falco


### PR DESCRIPTION
###### Description

Bump kube-prometheus-stack to 12.10.4

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
