### PR TITLE
Migrate prometheus-config-reloader only when overwritten in values.yaml

### DIFF
--- a/deploy/helm/sumologic/upgrade-2.0.0.sh
+++ b/deploy/helm/sumologic/upgrade-2.0.0.sh
@@ -152,17 +152,19 @@ function migrate_prometheus_operator_to_kube_prometheus_stack() {
     return
   fi
 
-  info "Migrating prometheus-config-reloader container to config-reloader in prometheusSpec"
-  yq m -i --arrays append \
-    "${TEMP_FILE}" \
-    <(
-      yq p <(
-        yq w <(
-          yq r "${TEMP_FILE}" -- 'prometheus-operator.prometheus.prometheusSpec.containers.(name==prometheus-config-reloader)' \
-          ) name config-reloader \
-        ) 'prometheus-operator.prometheus.prometheusSpec.containers[+]'
-      )
-  yq d -i "${TEMP_FILE}" "prometheus-operator.prometheus.prometheusSpec.containers.(name==prometheus-config-reloader)"
+  if [[ -n "$(yq r "${TEMP_FILE}" 'prometheus-operator.prometheus.prometheusSpec.containers.(name==prometheus-config-reloader)')" ]]; then
+    info "Migrating prometheus-config-reloader container to config-reloader in prometheusSpec"
+    yq m -i --arrays append \
+      "${TEMP_FILE}" \
+      <(
+        yq p <(
+          yq w <(
+            yq r "${TEMP_FILE}" -- 'prometheus-operator.prometheus.prometheusSpec.containers.(name==prometheus-config-reloader)' \
+            ) name config-reloader \
+          ) 'prometheus-operator.prometheus.prometheusSpec.containers[+]'
+        )
+    yq d -i "${TEMP_FILE}" "prometheus-operator.prometheus.prometheusSpec.containers.(name==prometheus-config-reloader)"
+  fi
 
   info "Migrating from prometheus-operator to kube-prometheus-stack"
   yq m -i \

--- a/tests/upgrade_v2_script/static/prometheus_remote_write_regexes.log
+++ b/tests/upgrade_v2_script/static/prometheus_remote_write_regexes.log
@@ -1,5 +1,4 @@
 
-[INFO]    Migrating prometheus-config-reloader container to config-reloader in prometheusSpec
 [INFO]    Migrating from prometheus-operator to kube-prometheus-stack
 [INFO]    Migrating prometheus remote write urls
 [INFO]    Updating prometheus regex in rewrite rule for url: http://$(FLUENTD_METRICS_SVC).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.operator.rule...

--- a/tests/upgrade_v2_script/static/prometheus_remote_write_regexes.output.yaml
+++ b/tests/upgrade_v2_script/static/prometheus_remote_write_regexes.output.yaml
@@ -127,5 +127,3 @@ kube-prometheus-stack:
             - action: keep
               regex: 'coredns;(?:coredns_cache_(size|entries|(hits|misses)_total)|coredns_dns_request_duration_seconds_(count|sum)|coredns_(dns_request|dns_response_rcode|forward_request)_count_total|coredns_(forward_requests|dns_requests|dns_responses)_total|process_(cpu_seconds_total|open_fds|resident_memory_bytes))'
               sourceLabels: [job, __name__]
-      containers:
-        - name: config-reloader

--- a/tests/upgrade_v2_script/static/prometheus_remote_write_regexes_changed_values.log
+++ b/tests/upgrade_v2_script/static/prometheus_remote_write_regexes_changed_values.log
@@ -1,5 +1,4 @@
 
-[INFO]    Migrating prometheus-config-reloader container to config-reloader in prometheusSpec
 [INFO]    Migrating from prometheus-operator to kube-prometheus-stack
 [INFO]    Migrating prometheus remote write urls
 [INFO]    Updating prometheus regex in rewrite rule for url: http://$(FLUENTD_METRICS_SVC).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.operator.rule but it has a different value than expected

--- a/tests/upgrade_v2_script/static/prometheus_remote_write_regexes_changed_values.output.yaml
+++ b/tests/upgrade_v2_script/static/prometheus_remote_write_regexes_changed_values.output.yaml
@@ -12,5 +12,3 @@ kube-prometheus-stack:
             - action: keep
               regex: 'coredns;(?:coredns_cache_(size|entries|(hits|misses)_total)|coredns_dns_request_duration_seconds_(count|sum)|coredns_(dns_request|dns_response_rcode|forward_request)_count_total|coredns_(forward_requests|dns_requests|dns_responses)_total|process_(cpu_seconds_total|open_fds|resident_memory_bytes))'
               sourceLabels: [job, __name__]
-      containers:
-        - name: config-reloader

--- a/tests/upgrade_v2_script/static/prometheus_remote_write_timeout.log
+++ b/tests/upgrade_v2_script/static/prometheus_remote_write_timeout.log
@@ -1,5 +1,4 @@
 
-[INFO]    Migrating prometheus-config-reloader container to config-reloader in prometheusSpec
 [INFO]    Migrating from prometheus-operator to kube-prometheus-stack
 
 [INFO]    kube-prometheus-stack.prometheus.prometheusSpec.remoteWrite.[*].remoteTimeout is set

--- a/tests/upgrade_v2_script/static/prometheus_remote_write_timeout.output.yaml
+++ b/tests/upgrade_v2_script/static/prometheus_remote_write_timeout.output.yaml
@@ -137,5 +137,3 @@ kube-prometheus-stack:
             - action: keep
               regex: 'coredns;(?:coredns_cache_(size|entries|(hits|misses)_total)|coredns_dns_request_duration_seconds_(count|sum)|coredns_(dns_request|dns_response_rcode|forward_request)_count_total|coredns_(forward_requests|dns_requests|dns_responses)_total|process_(cpu_seconds_total|open_fds|resident_memory_bytes))'
               sourceLabels: [job, __name__]
-      containers:
-        - name: config-reloader

--- a/tests/upgrade_v2_script/static/prometheus_service_monitors.log
+++ b/tests/upgrade_v2_script/static/prometheus_service_monitors.log
@@ -3,7 +3,6 @@
 [INFO]    Adding 'additionalPrometheusRulesMap.pre-1.14-node-rules' to kube-prometheus-stack chart configuration
 [INFO]    Removing prometheus kubeTargetVersionOverride='1.13.0-0'
 [INFO]    Adding 'sumologic.com/scrape: "true"' scrape labels to prometheus service monitors
-[INFO]    Migrating prometheus-config-reloader container to config-reloader in prometheusSpec
 [INFO]    Migrating from prometheus-operator to kube-prometheus-stack
 [INFO]    Migrating prometheus remote write urls
 [INFO]    deleting prometheus-operator

--- a/tests/upgrade_v2_script/static/prometheus_service_monitors.output.yaml
+++ b/tests/upgrade_v2_script/static/prometheus_service_monitors.output.yaml
@@ -83,9 +83,6 @@ kube-prometheus-stack:
           matchLabels:
             sumologic.com/app: otelcol
             sumologic.com/scrape: "true"
-    prometheusSpec:
-      containers:
-        - name: config-reloader
   additionalPrometheusRulesMap:
     pre-1.14-node-rules:
       groups:


### PR DESCRIPTION
###### Description

Migrate `prometheus-config-reloader` only when overwritten in values.yaml

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
