### PR TITLE
Add v2 migration logic for prometheus retention

### DIFF
--- a/tests/upgrade_v2_script/static/prometheus_operator_valid.input.yaml
+++ b/tests/upgrade_v2_script/static/prometheus_operator_valid.input.yaml
@@ -12,7 +12,7 @@ prometheus-operator:
   prometheus:
     prometheusSpec:
       scrapeInterval: 30s
-      retention: 1d
+      retention: 7d
       podMetadata:
         labels: {}
         annotations: {}

--- a/tests/upgrade_v2_script/static/prometheus_operator_valid.log
+++ b/tests/upgrade_v2_script/static/prometheus_operator_valid.log
@@ -1,5 +1,6 @@
 [INFO]    Mapping prometheus-operator.prometheusOperator.tlsProxy.enabled into kube-prometheus-stack.prometheusOperator.tls.enabled
 
+[INFO]    Changing prometheus retention period from 7d to 1d
 [INFO]    Adding 'additionalPrometheusRulesMap.pre-1.14-node-rules' to kube-prometheus-stack chart configuration
 [INFO]    Removing prometheus kubeTargetVersionOverride='1.13.0-0'
 [INFO]    Migrating prometheus-config-reloader container to config-reloader in prometheusSpec


### PR DESCRIPTION
###### Description

Add v2 migration logic for prometheus retention (`prometheus-operator.prometheus.prometheusSpec.retention`)

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
