### PR TITLE
Add missing node:node_memory_bytes_available:sum prometheus recording rule

### DIFF
--- a/deploy/helm/sumologic/upgrade-2.0.0.sh
+++ b/deploy/helm/sumologic/upgrade-2.0.0.sh
@@ -358,6 +358,17 @@ function add_prometheus_pre_1_14_recording_rules() {
 	              sum(node_memory_MemTotal_bytes{job="node-exporter"})
 	            record: ':node_memory_utilisation:'
 	          - expr: |-
+	              sum by (node) (
+	                (
+	                  node_memory_MemFree_bytes{job="node-exporter"} +
+	                  node_memory_Cached_bytes{job="node-exporter"} +
+	                  node_memory_Buffers_bytes{job="node-exporter"}
+	                )
+	                * on (namespace, pod) group_left(node)
+	                  node_namespace_pod:kube_pod_info:
+	              )
+	            record: node:node_memory_bytes_available:sum
+	          - expr: |-
 	              (node:node_memory_bytes_total:sum - node:node_memory_bytes_available:sum)
 	              /
 	              node:node_memory_bytes_total:sum

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -960,6 +960,17 @@ kube-prometheus-stack:
                 sum(node_memory_MemTotal_bytes{job="node-exporter"})
               record: ':node_memory_utilisation:'
             - expr: |-
+                sum by (node) (
+                  (
+                    node_memory_MemFree_bytes{job="node-exporter"} +
+                    node_memory_Cached_bytes{job="node-exporter"} +
+                    node_memory_Buffers_bytes{job="node-exporter"}
+                  )
+                  * on (namespace, pod) group_left(node)
+                    node_namespace_pod:kube_pod_info:
+                )
+              record: node:node_memory_bytes_available:sum
+            - expr: |-
                 (node:node_memory_bytes_total:sum - node:node_memory_bytes_available:sum)
                 /
                 node:node_memory_bytes_total:sum

--- a/tests/upgrade_v2_script/static/prometheus_operator_valid.output.yaml
+++ b/tests/upgrade_v2_script/static/prometheus_operator_valid.output.yaml
@@ -69,6 +69,17 @@ kube-prometheus-stack:
                 sum(node_memory_MemTotal_bytes{job="node-exporter"})
               record: ':node_memory_utilisation:'
             - expr: |-
+                sum by (node) (
+                  (
+                    node_memory_MemFree_bytes{job="node-exporter"} +
+                    node_memory_Cached_bytes{job="node-exporter"} +
+                    node_memory_Buffers_bytes{job="node-exporter"}
+                  )
+                  * on (namespace, pod) group_left(node)
+                    node_namespace_pod:kube_pod_info:
+                )
+              record: node:node_memory_bytes_available:sum
+            - expr: |-
                 (node:node_memory_bytes_total:sum - node:node_memory_bytes_available:sum)
                 /
                 node:node_memory_bytes_total:sum

--- a/tests/upgrade_v2_script/static/prometheus_service_monitors.output.yaml
+++ b/tests/upgrade_v2_script/static/prometheus_service_monitors.output.yaml
@@ -107,6 +107,17 @@ kube-prometheus-stack:
                 sum(node_memory_MemTotal_bytes{job="node-exporter"})
               record: ':node_memory_utilisation:'
             - expr: |-
+                sum by (node) (
+                  (
+                    node_memory_MemFree_bytes{job="node-exporter"} +
+                    node_memory_Cached_bytes{job="node-exporter"} +
+                    node_memory_Buffers_bytes{job="node-exporter"}
+                  )
+                  * on (namespace, pod) group_left(node)
+                    node_namespace_pod:kube_pod_info:
+                )
+              record: node:node_memory_bytes_available:sum
+            - expr: |-
                 (node:node_memory_bytes_total:sum - node:node_memory_bytes_available:sum)
                 /
                 node:node_memory_bytes_total:sum

--- a/tests/upgrade_v2_script/static/prometheus_whole_config.output.yaml
+++ b/tests/upgrade_v2_script/static/prometheus_whole_config.output.yaml
@@ -366,6 +366,17 @@ kube-prometheus-stack:
                 sum(node_memory_MemTotal_bytes{job="node-exporter"})
               record: ':node_memory_utilisation:'
             - expr: |-
+                sum by (node) (
+                  (
+                    node_memory_MemFree_bytes{job="node-exporter"} +
+                    node_memory_Cached_bytes{job="node-exporter"} +
+                    node_memory_Buffers_bytes{job="node-exporter"}
+                  )
+                  * on (namespace, pod) group_left(node)
+                    node_namespace_pod:kube_pod_info:
+                )
+              record: node:node_memory_bytes_available:sum
+            - expr: |-
                 (node:node_memory_bytes_total:sum - node:node_memory_bytes_available:sum)
                 /
                 node:node_memory_bytes_total:sum


### PR DESCRIPTION
###### Description

Fix missing `node:node_memory_bytes_available:sum` prometheus recording rule and thus unblock metrics like e.g. 

* `node:node_memory_utilisation:ratio`
* `node:node_memory_utilisation_2:`
* `node:cluster_memory_utilisation:ratio`

That depend on it.

Definition was taken from: https://github.com/helm/charts/blob/7e45e678e39b88590fe877f159516f85f3fd3f38/stable/prometheus-operator/templates/prometheus/rules/node.rules.yaml#L77-L83

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
