### PR TITLE
Bump OTC to 0.16.2-sumo

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1888,7 +1888,7 @@ otelagent:
     memBallastSizeMib: "250"
     image:
       repository: "public.ecr.aws/sumologic/opentelemetry-collector"
-      tag: "0.16.1-sumo"
+      tag: "0.16.2-sumo"
       pullPolicy: IfNotPresent
 
     ## Extra Environment Values - allows yaml definitions
@@ -1994,7 +1994,7 @@ otelcol:
     memBallastSizeMib: "683"
     image:
       repository: "public.ecr.aws/sumologic/opentelemetry-collector"
-      tag: "0.16.1-sumo"
+      tag: "0.16.2-sumo"
       pullPolicy: IfNotPresent
 
     ## Extra Environment Values - allows yaml definitions


### PR DESCRIPTION
###### Description

Bumps OTC to `0.16.2-sumo`. It includes our extensions to filter processor. 

Manually tested and works fine