### PR TITLE
kube-scheduler and kube-controller-manager listen on all interfaces in vagrant

### DIFF
--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -29,6 +29,10 @@ echo "--authentication-token-webhook=true" >> /var/snap/microk8s/current/args/ku
 echo "--authorization-mode=Webhook" >> /var/snap/microk8s/current/args/kubelet
 # allow privileged
 echo "--allow-privileged=true" >> /var/snap/microk8s/current/args/kube-apiserver
+# remove address flags to listen on all interfaces
+sed -i '/address/d' kube-scheduler
+sed -i '/address/d' kub-controller-manager
+
 systemctl restart snap.microk8s.daemon-kubelet.service
 systemctl restart snap.microk8s.daemon-apiserver.service
 


### PR DESCRIPTION
###### Description

Remove address flags from kube-scheduler and kube-controller-manager launch options

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
