### PR TITLE
Add if conditions to fluentd configuration templates

### DIFF
--- a/deploy/helm/sumologic/conf/buffer.output.conf
+++ b/deploy/helm/sumologic/conf/buffer.output.conf
@@ -7,4 +7,6 @@ queued_chunks_limit_size {{ .Values.fluentd.buffer.queueChunkLimitSize | quote }
 overflow_action drop_oldest_chunk
 retry_max_interval {{ .Values.fluentd.buffer.retryMaxInterval | quote }}
 retry_forever {{ .Values.fluentd.buffer.retryForever | quote }}
+{{- if .Values.fluentd.buffer.extraConf }}
 {{- .Values.fluentd.buffer.extraConf | nindent 2 }}
+{{- end }}

--- a/deploy/helm/sumologic/conf/logs/logs.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.conf
@@ -6,5 +6,7 @@
 </source>
 @include logs.source.containers.conf
 @include logs.source.systemd.conf
+{{- if .Values.fluentd.logs.extraLogs }}
 {{- .Values.fluentd.logs.extraLogs | nindent 2 }}
+{{- end }}
 @include logs.source.default.conf

--- a/deploy/helm/sumologic/conf/logs/logs.output.conf
+++ b/deploy/helm/sumologic/conf/logs/logs.output.conf
@@ -8,4 +8,6 @@ timestamp_key {{ .Values.fluentd.logs.output.timestampKey | quote }}
 proxy_uri {{ .Values.fluentd.proxyUri | quote }}
 compress {{ .Values.fluentd.compression.enabled | quote }}
 compress_encoding {{ .Values.fluentd.compression.encoding | quote }}
+{{- if .Values.fluentd.logs.output.extraConf }}
 {{- .Values.fluentd.logs.output.extraConf | nindent 2 }}
+{{- end }}


### PR DESCRIPTION
###### Description

In case user overwrites default values in the following manner (i.e. without specifying a value for keys surround with conditions in this PR)

```yaml
fluentd:
  buffer:
    extraConf:
...
```

`helm` commands might render errors similar to:

```
Error: template: sumologic/templates/statefulset.yaml:19:28: executing "sumologic/templates/statefulset.yaml" at <include (print $.Template.BasePath "/configmap.yaml") .>: error calling include: template: sumologic/templates/configmap.yaml:15:5: executing "sumologic/templates/configmap.yaml" at <tpl (.Files.Glob "conf/*.conf").AsConfig .>: error calling tpl: error during tpl function execution for "buffer.output.conf: |-\n  compress {{ .Values.fluentd.buffer.compress | quote }}\n  flush_interval {{ .Values.fluentd.buffer.flushInterval | quote }}\n  flush_thread_count {{ .Values.fluentd.buffer.numThreads | quote }}\n  chunk_limit_size {{ .Values.fluentd.buffer.chunkLimitSize | quote }}\n  total_limit_size {{ .Values.fluentd.buffer.totalLimitSize | quote }}\n  queued_chunks_limit_size {{ .Values.fluentd.buffer.queueChunkLimitSize | quote }}\n  overflow_action drop_oldest_chunk\n  retry_max_interval {{ .Values.fluentd.buffer.retryMaxInterval | quote }}\n  retry_forever {{ .Values.fluentd.buffer.retryForever | quote }}\n  {{- .Values.fluentd.buffer.extraConf | nindent 2 }}\ncommon.conf: |-\n  # Prevent fluentd from handling records containing its own logs.\n  <match fluentd.**>\n    @type null\n  </match>\n  # expose the Fluentd metrics to Prometheus\n  <source>\n    @type prometheus\n    metrics_path /metrics\n    port 24231\n  </source>\n  <source>\n    @type prometheus_output_monitor\n  </source>\n  <source>\n    @type http\n    port 9880\n    bind 0.0.0.0\n  </source>\n  {{- if .Values.fluentd.logLevel }}\n  <system>\n    log_level {{ .Values.fluentd.logLevel }}\n  </system>\n  {{- end }}": template: sumologic/templates/statefulset.yaml:11:49: executing "sumologic/templates/statefulset.yaml" at <2>: invalid value; expected string
```

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
