### PR TITLE
Update v2 migration script - quote empty values

### DIFF
--- a/tests/upgrade_v2_script/static/fluentd_whole_config.input.yaml
+++ b/tests/upgrade_v2_script/static/fluentd_whole_config.input.yaml
@@ -1,0 +1,534 @@
+fluentd:
+  image:
+    repository: public.ecr.aws/sumologic/kubernetes-fluentd
+    tag: 1.11.5-sumo-0
+    pullPolicy: IfNotPresent
+
+  ## Specifies whether a PodSecurityPolicy should be created
+  podSecurityPolicy:
+    create: false
+  additionalPlugins: []
+
+  ## Sets the fluentd log level. The default log level, if not specified, is info.
+  ## Sumo will only ingest the error log level and some specific warnings, the info logs can be seen in kubectl logs.
+  ## ref: https://docs.fluentd.org/deployment/logging
+  logLevel: "info"
+  ## to ingest all fluentd logs, turn the logLevelFilter to false
+  logLevelFilter: true
+
+  ## Verify SumoLogic HTTPS certificates
+  verifySsl: true
+  ## Proxy URI for sumologic output plugin
+  proxyUri: ""
+
+  ## Enable and set compression encoding for fluentd output plugin
+  compression:
+    enabled: true
+    encoding: gzip
+
+  securityContext:
+    ## The group ID of all processes in the statefulset containers. By default this needs to be fluent(999).
+    fsGroup: 999
+
+  ## Add custom labels to all fluentd sts pods(logs, metrics, events)
+  podLabels: {}
+
+  ## Add custom annotations to all fluentd sts pods(logs, metrics, events)
+  podAnnotations: {}
+
+  ## Persist data to a persistent volume; When enabled, fluentd uses the file buffer instead of memory buffer.
+  persistence:
+    ## After setting the value to true, run the helm upgrade command with the --force flag.
+    enabled: true
+
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, Azure & OpenStack)
+    ##
+    # storageClass: "-"
+    # annotations: {}
+    accessMode: ReadWriteOnce
+    size: 10Gi
+
+  buffer:
+    ## Option to specify the Fluentd buffer as file/memory.
+    ## If fluentd.persistence.enabled is true, this will be ignored.
+    type: "memory"
+
+    ## How frequently to push logs to SumoLogic
+    ## ref: https://github.com/SumoLogic/fluentd-kubernetes-sumologic#options
+    flushInterval: "5s"
+    ## Increase number of http threads to Sumo. May be required in heavy logging/high DPM clusters
+    numThreads: 8
+    chunkLimitSize: "1m"
+    queueChunkLimitSize: 128
+    totalLimitSize: "128m"
+    retryMaxInterval: "10m"
+    retryForever: true
+    compress: gzip
+
+    ## File paths to buffer to, if Fluentd buffer type is specified as file above.
+    ## Each sumologic output plugin buffers to its own unique file.
+    filePaths:
+      logs:
+        containers: /fluentd/buffer/logs.containers
+        kubelet: /fluentd/buffer/logs.kubelet
+        systemd: /fluentd/buffer/logs.systemd
+        default: /fluentd/buffer/logs.default
+      metrics:
+        apiserver: /fluentd/buffer/metrics.apiserver
+        kubelet: /fluentd/buffer/metrics.kubelet
+        container: /fluentd/buffer/metrics.container
+        controller: /fluentd/buffer/metrics.controller
+        scheduler: /fluentd/buffer/metrics.scheduler
+        state: /fluentd/buffer/metrics.state
+        node: /fluentd/buffer/metrics.node
+        control-plane: /fluentd/buffer/metrics.control_plane
+        default: /fluentd/buffer/metrics.default
+      events: /fluentd/buffer/events
+      traces: /fluentd/buffer/traces
+
+    ## Additional config for buffer settings
+    extraConf: |-
+
+  ## configuration of fluentd monitoring metrics
+  ## input -> fluentd_input_status_num_records_total (~5% DPM increase for empty cluster)
+  ## output -> fluentd_output_status_num_records_total (~25% DPM increase for empty cluster)
+  monitoring:
+    input: false
+    output: false
+
+  metadata:
+    ## Option to control the enabling of metadata filter plugin cache_size.
+    ## ref: https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter#configuration
+    cacheSize: "10000"
+    ## Option to control the enabling of metadata filter plugin cache_ttl (in seconds).
+    ## ref: https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter#configuration
+    cacheTtl: "7200"
+    ## Option to control the interval at which metadata cache is asynchronously refreshed (in seconds).
+    cacheRefresh: "3600"
+    ## Option to control the variation in seconds by which the cacheRefresh option is changed for each pod separately.
+    ## For example, if cache refresh is 1 hour and variation is 15 minutes, then actual cache refresh interval
+    ## will be a random value between 45 minutes and 1 hour 15 minutes, different for each pod. This helps spread
+    ## the load on API server that the cache refresh induces. Setting this to 0 disables cache refresh variation.
+    cacheRefreshVariation: "900"
+    ## Option to give plugin specific log level
+    pluginLogLevel: "error"
+    ## Option to specify K8s API versions
+    coreApiVersions:
+      - v1
+    ## Option to specify K8s API groups
+    apiGroups:
+      - apps/v1
+      - extensions/v1beta1
+
+  logs:
+    enabled: true
+    statefulset:
+      nodeSelector: {}
+      tolerations: {}
+      affinity: {}
+      ## Acceptable values for podAntiAffinity:
+      ## soft: specifies preferences that the scheduler will try to enforce but will not guarantee (Default)
+      ## hard: specifies rules that must be met for a pod to be scheduled onto a node
+      podAntiAffinity: "soft"
+      replicaCount: 3
+      resources:
+        limits:
+          memory: 1Gi
+          cpu: 1000m
+        requests:
+          memory: 768Mi
+          cpu: 500m
+      ## Option to define priorityClassName to assign a priority class to pods.
+      priorityClassName:
+
+      ## Add custom labels only to logs fluentd sts pods
+      podLabels: {}
+      ## Add custom annotations only to logs fluentd sts pods
+      podAnnotations: {}
+
+    ## Option to turn autoscaling on for fluentd and specify params for HPA.
+    ## Autoscaling needs metrics-server to access cpu metrics.
+    autoscaling:
+      enabled: false
+      minReplicas: 3
+      maxReplicas: 10
+      targetCPUUtilizationPercentage: 50
+      # targetMemoryUtilizationPercentage: 50
+
+    ## Option to specify PodDisrutionBudgets
+    ## You can specify only one of maxUnavailable and minAvailable in a single PodDisruptionBudget
+    podDisruptionBudget:
+      minAvailable: 2
+    ## To use maxUnavailable, set minAvailable to null and uncomment the below:
+    #   maxUnavailable: 1
+
+    rawConfig: |-
+      @include common.conf
+      @include logs.conf
+
+    ## Configuration for the forward input plugin that receives logs from FluentBit
+    ## ref: https://docs.fluentd.org/input/forward
+    input:
+      ## Use to specify additional config, including transport or security options.
+      forwardExtraConf: |-
+
+    ## Configuration for sumologic output plugin
+    ## ref: https://github.com/SumoLogic/fluentd-output-sumologic
+    ## ref: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/main/deploy/helm/sumologic/conf/logs/logs.output.conf
+    output:
+      ## Format to post logs into Sumo: fields, json, json_merge, or text.
+      ## NOTE: for logs metadata, fields is required.
+      logFormat: fields
+      ## Option to control adding timestamp to logs.
+      addTimestamp: true
+      ## Field name when add_timestamp is on.
+      timestampKey: "timestamp"
+      ## Option to give plugin specific log level
+      pluginLogLevel: "error"
+      ## Additional config parameters for sumologic output plugin
+      extraConf: |-
+
+    ## Additional config for custom log pipelines
+    ## ref: TODO: documentation for custom logs pipelines
+    extraLogs: |-
+
+    ## Container log configuration
+    containers:
+      ## To override the entire contents of logs.source.containers.conf file. Leave empty for the default pipeline
+      overrideRawConfig: |-
+
+      outputConf: |-
+        @include logs.output.conf
+
+      ## Override output section for container logs. Leave empty for the default output section
+      overrideOutputConf: |-
+
+      ## Set the _sourceName metadata field in Sumo Logic.
+      sourceName: "%{namespace}.%{pod}.%{container}"
+      ## Set the _sourceCategory metadata field in Sumo Logic.
+      sourceCategory: "%{namespace}/%{pod_name}"
+      ## Set the prefix, for _sourceCategory metadata.
+      sourceCategoryPrefix: "kubernetes/"
+      ## Used to replace - with another character.
+      sourceCategoryReplaceDash: "/"
+
+      ## A regular expression for containers.
+      ## Matching containers will be excluded from Sumo. The logs will still be sent to FluentD.
+      excludeContainerRegex: ""
+      ## A regular expression for hosts.
+      ## Matching hosts will be excluded from Sumo. The logs will still be sent to FluentD.
+      excludeHostRegex: ""
+      ## A regular expression for namespaces.
+      ## Matching namespaces will be excluded from Sumo. The logs will still be sent to FluentD.
+      excludeNamespaceRegex: ""
+      ## A regular expression for pods.
+      ## Matching pods will be excluded from Sumo. The logs will still be sent to FluentD.
+      excludePodRegex: ""
+
+      ## ref: https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter#configuration
+      k8sMetadataFilter:
+        ## Option to control the enabling of metadata filter plugin watch.
+        watch: "true"
+        ## path to CA file for Kubernetes server certificate validation
+        caFile: ""
+        ## Validate SSL certificates
+        verifySsl: true
+        ## Path to a client cert file to authenticate to the API server
+        clientCert: ""
+        ## Path to a client key file to authenticate to the API server
+        clientKey: ""
+        ## Path to a file containing the bearer token to use for authentication
+        bearerTokenFile: ""
+
+      ## To use additional filter plugins
+      extraFilterPluginConf: |-
+
+      ## To enable stiching multiline logs in fluentd when fluent-bit Multiline feature is On
+      multiline:
+        enabled: true
+
+    ## Kubelet log configuration
+    kubelet:
+      enabled: true
+      outputConf: |-
+        @include logs.output.conf
+
+      ## Override output section for kubelet logs. Leave empty for the default output section.
+      overrideOutputConf: |-
+
+      ## Set the _sourceName metadata field in Sumo Logic.
+      sourceName: "k8s_kubelet"
+      ## Set the _sourceCategory metadata field in Sumo Logic.
+      sourceCategory: "kubelet"
+      ## Set the prefix, for _sourceCategory metadata.
+      sourceCategoryPrefix: "kubernetes/"
+      ## Used to replace - with another character.
+      sourceCategoryReplaceDash: "/"
+
+      ## A regular expression for facility.
+      ## Matching facility will be excluded from Sumo. The logs will still be sent to FluentD.
+      excludeFacilityRegex: ""
+      ## A regular expression for hosts.
+      ## Matching hosts will be excluded from Sumo. The logs will still be sent to FluentD.
+      excludeHostRegex: ""
+      ## A regular expression for priority.
+      ## Matching priority will be excluded from Sumo. The logs will still be sent to FluentD.
+      excludePriorityRegex: ""
+      ## A regular expression for unit.
+      ## Matching unit will be excluded from Sumo. The logs will still be sent to FluentD.
+      excludeUnitRegex: ""
+
+    ## Systemd log configuration
+    systemd:
+      enabled: true
+      outputConf: |-
+        @include logs.output.conf
+
+      ## Override output section for systemd logs. Leave empty for the default output section.
+      overrideOutputConf: |-
+
+      ## Set the _sourceName metadata field in Sumo Logic.
+      sourceName: "k8s_systemd"
+      ## Set the _sourceCategory metadata field in Sumo Logic.
+      sourceCategory: "system"
+      ## Set the prefix, for _sourceCategory metadata.
+      sourceCategoryPrefix: "kubernetes/"
+      ## Used to replace - with another character.
+      sourceCategoryReplaceDash: "/"
+
+      ## A regular expression for facility.
+      ## Matching facility will be excluded from Sumo. The logs will still be sent to FluentD.
+      excludeFacilityRegex: ""
+      ## A regular expression for hosts.
+      ## Matching hosts will be excluded from Sumo. The logs will still be sent to FluentD.
+      excludeHostRegex: ""
+      ## A regular expression for priority.
+      ## Matching priority will be excluded from Sumo. The logs will still be sent to FluentD.
+      excludePriorityRegex: ""
+      ## A regular expression for unit.
+      ## Matching unit will be excluded from Sumo. The logs will still be sent to FluentD.
+      excludeUnitRegex: ""
+
+    ## Default log configuration (catch-all)
+    default:
+      outputConf: |-
+        @include logs.output.conf
+
+      ## Override output section for untagged logs. Leave empty for the default output section.
+      overrideOutputConf: |-
+
+      ## Set the _sourceName metadata field in Sumo Logic.
+      sourceName: "k8s_default"
+      ## Set the _sourceCategory metadata field in Sumo Logic.
+      sourceCategory: "default"
+      ## Set the prefix, for _sourceCategory metadata.
+      sourceCategoryPrefix: "kubernetes/"
+      ## Used to replace - with another character.
+      sourceCategoryReplaceDash: "/"
+
+      ## A regular expression for facility.
+      ## Matching facility will be excluded from Sumo. The logs will still be sent to FluentD.
+      excludeFacilityRegex: ""
+      ## A regular expression for hosts.
+      ## Matching hosts will be excluded from Sumo. The logs will still be sent to FluentD.
+      excludeHostRegex: ""
+      ## A regular expression for priority.
+      ## Matching priority will be excluded from Sumo. The logs will still be sent to FluentD.
+      excludePriorityRegex: ""
+      ## A regular expression for unit.
+      ## Matching unit will be excluded from Sumo. The logs will still be sent to FluentD.
+      excludeUnitRegex: ""
+
+    ## Extra Environment Values - allows yaml definitions
+    # extraEnvVars:
+    #   - name: VALUE_FROM_SECRET
+    #     valueFrom:
+    #       secretKeyRef:
+    #         name: secret_name
+    #         key: secret_key
+
+    # extraVolumes:
+    #   - name: es-certs
+    #     secret:
+    #       defaultMode: 420
+    #       secretName: es-certs
+    # extraVolumeMounts:
+    #   - name: es-certs
+    #     mountPath: /certs
+    #     readOnly: true
+
+  metrics:
+    enabled: true
+    statefulset:
+      nodeSelector: {}
+      tolerations: {}
+      affinity: {}
+      ## Acceptable values for podAntiAffinity:
+      ## soft: specifies preferences that the scheduler will try to enforce but will not guarantee (Default)
+      ## hard: specifies rules that must be met for a pod to be scheduled onto a node
+      podAntiAffinity: "soft"
+      replicaCount: 3
+      resources:
+        limits:
+          memory: 1Gi
+          cpu: 1000m
+        requests:
+          memory: 768Mi
+          cpu: 500m
+      ## Option to define priorityClassName to assign a priority class to pods.
+      priorityClassName:
+
+      ## Add custom labels only to metrics fluentd sts pods
+      podLabels: {}
+      ## Add custom annotations only to metrics fluentd sts pods
+      podAnnotations: {}
+
+    ## Option to turn autoscaling on for fluentd and specify params for HPA.
+    ## Autoscaling needs metrics-server to access cpu metrics.
+    autoscaling:
+      enabled: false
+      minReplicas: 3
+      maxReplicas: 10
+      targetCPUUtilizationPercentage: 50
+      # targetMemoryUtilizationPercentage: 50
+
+    ## Option to specify PodDisrutionBudgets
+    ## You can specify only one of maxUnavailable and minAvailable in a single PodDisruptionBudget
+    podDisruptionBudget:
+      minAvailable: 2
+
+    rawConfig: |-
+      @include common.conf
+      @include metrics.conf
+
+    ## Configuration for sumologic output plugin
+    ## ref: https://github.com/SumoLogic/fluentd-output-sumologic
+    ## ref: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/main/deploy/helm/sumologic/conf/metrics/metrics.output.conf
+    outputConf: |-
+      @include metrics.output.conf
+
+    ## Override output section for metrics. Leave empty for the default output section
+    overrideOutputConf: |-
+
+    ## To use additional filter plugins
+    extraFilterPluginConf: |-
+
+    ## To use additional output plugins
+    extraOutputPluginConf: |-
+
+    ## Extra Environment Values - allows yaml definitions
+    # extraEnvVars:
+    #   - name: VALUE_FROM_SECRET
+    #     valueFrom:
+    #       secretKeyRef:
+    #         name: secret_name
+    #         key: secret_key
+
+    # extraVolumes:
+    #   - name: es-certs
+    #     secret:
+    #       defaultMode: 420
+    #       secretName: es-certs
+    # extraVolumeMounts:
+    #   - name: es-certs
+    #     mountPath: /certs
+    #     readOnly: true
+
+    ## Output configuration
+    ## tag: tag for fluentd match
+    ## id: sumologic output @id
+    ## endpoint: [optional] [output key by default] It should match the sumologic.collector.sources.metrics[].endpoint
+    ## drop: [optional] [false by default] Change it to true to drop traffic for specific output
+    ## weight: [optional [0 by default] Order of fluentd output (lower means higher priority)
+    ## The weight has meaning in case of fluentd matches
+    output:
+      apiserver:
+        tag: prometheus.metrics.apiserver**
+        id: sumologic.endpoint.metrics.apiserver
+        weight: 90
+      kubelet:
+        tag: prometheus.metrics.kubelet**
+        id: sumologic.endpoint.metrics.kubelet
+        weight: 90
+      container:
+        tag: prometheus.metrics.container**
+        id: sumologic.endpoint.metrics.container
+        source: kubelet
+        weight: 90
+      controller:
+        tag: prometheus.metrics.controller-manager**
+        id: sumologic.endpoint.metrics.kube.controller.manager
+        weight: 90
+      scheduler:
+        tag: prometheus.metrics.scheduler**
+        id: sumologic.endpoint.metrics.kube.scheduler
+        weight: 90
+      state:
+        tag: prometheus.metrics.state**
+        id: sumologic.endpoint.metrics.kube.state
+        weight: 90
+      node:
+        tag: prometheus.metrics.node**
+        id: sumologic.endpoint.metrics.node.exporter
+        weight: 90
+      control-plane:
+        tag: prometheus.metrics.control-plane**
+        id: sumologic.endpoint.metrics.control.plane
+        weight: 90
+      default:
+        tag: prometheus.metrics**
+        id: sumologic.endpoint.metrics
+        weight: 100
+
+  events:
+    ## If enabled, collect K8s events
+    enabled: true
+
+    statefulset:
+      nodeSelector: {}
+      tolerations: {}
+      resources:
+        limits:
+          memory: 512Mi
+          cpu: 200m
+        requests:
+          memory: 256Mi
+          cpu: 100m
+      ## Option to define priorityClassName to assign a priority class to pods.
+      priorityClassName:
+
+      ## Add custom labels only to events fluentd sts pods
+      podLabels: {}
+      ## Add custom annotations only to events fluentd sts pods
+      podAnnotations: {}
+
+    ## Source category for the Events source. Default: "{clusterName}/events"
+    sourceCategory: ""
+    ## Override Kubernetes resource types you want to get events for from different Kubernetes
+    ## API versions. The key represents the name of the resource type and the value represents
+    ## the API version.
+    # watchResourceEventsOverrides:
+    #   pods: "v1"
+    #   events: "events.k8s.io/v1beta1"
+
+    ## Extra Environment Values - allows yaml definitions
+    # extraEnvVars:
+    #   - name: VALUE_FROM_SECRET
+    #     valueFrom:
+    #       secretKeyRef:
+    #         name: secret_name
+    #         key: secret_key
+
+    # extraVolumes:
+    #   - name: es-certs
+    #     secret:
+    #       defaultMode: 420
+    #       secretName: es-certs
+    # extraVolumeMounts:
+    #   - name: es-certs
+    #     mountPath: /certs
+    #     readOnly: true

--- a/tests/upgrade_v2_script/static/fluentd_whole_config.log
+++ b/tests/upgrade_v2_script/static/fluentd_whole_config.log
@@ -1,0 +1,8 @@
+[INFO]    Mapping fluentd.image.repository into:
+[INFO]    Mapping fluentd.image.tag into:
+[INFO]    Mapping fluentd.image.pullPolicy into:
+
+[INFO]    Migrating prometheus remote write urls
+
+Thank you for upgrading to v2.0.0 of the Sumo Logic Kubernetes Collection Helm chart.
+A new yaml file has been generated for you. Please check the current directory for new_values.yaml.

--- a/tests/upgrade_v2_script/static/fluentd_whole_config.output.yaml
+++ b/tests/upgrade_v2_script/static/fluentd_whole_config.output.yaml
@@ -1,0 +1,242 @@
+fluentd:
+  podSecurityPolicy:
+    create: false
+  additionalPlugins: []
+  logLevel: info
+  logLevelFilter: true
+  verifySsl: true
+  proxyUri: ""
+  compression:
+    enabled: true
+    encoding: gzip
+  securityContext:
+    fsGroup: 999
+  podLabels: {}
+  podAnnotations: {}
+  persistence:
+    enabled: true
+    accessMode: ReadWriteOnce
+    size: 10Gi
+  buffer:
+    type: memory
+    flushInterval: 5s
+    numThreads: 8
+    chunkLimitSize: 1m
+    queueChunkLimitSize: 128
+    totalLimitSize: 128m
+    retryMaxInterval: 10m
+    retryForever: true
+    compress: gzip
+    filePaths:
+      logs:
+        containers: /fluentd/buffer/logs.containers
+        kubelet: /fluentd/buffer/logs.kubelet
+        systemd: /fluentd/buffer/logs.systemd
+        default: /fluentd/buffer/logs.default
+      metrics:
+        apiserver: /fluentd/buffer/metrics.apiserver
+        kubelet: /fluentd/buffer/metrics.kubelet
+        container: /fluentd/buffer/metrics.container
+        controller: /fluentd/buffer/metrics.controller
+        scheduler: /fluentd/buffer/metrics.scheduler
+        state: /fluentd/buffer/metrics.state
+        node: /fluentd/buffer/metrics.node
+        control-plane: /fluentd/buffer/metrics.control_plane
+        default: /fluentd/buffer/metrics.default
+      events: /fluentd/buffer/events
+      traces: /fluentd/buffer/traces
+    extraConf: ""
+  monitoring:
+    input: false
+    output: false
+  metadata:
+    cacheSize: 10000
+    cacheTtl: 7200
+    cacheRefresh: 3600
+    cacheRefreshVariation: 900
+    pluginLogLevel: error
+    coreApiVersions:
+      - v1
+    apiGroups:
+      - apps/v1
+      - extensions/v1beta1
+  logs:
+    enabled: true
+    statefulset:
+      nodeSelector: {}
+      tolerations: {}
+      affinity: {}
+      podAntiAffinity: soft
+      replicaCount: 3
+      resources:
+        limits:
+          memory: 1Gi
+          cpu: 1000m
+        requests:
+          memory: 768Mi
+          cpu: 500m
+      priorityClassName: ""
+      podLabels: {}
+      podAnnotations: {}
+    autoscaling:
+      enabled: false
+      minReplicas: 3
+      maxReplicas: 10
+      targetCPUUtilizationPercentage: 50
+    podDisruptionBudget:
+      minAvailable: 2
+    rawConfig: |-
+      @include common.conf
+      @include logs.conf
+    input:
+      forwardExtraConf: ""
+    output:
+      logFormat: fields
+      addTimestamp: true
+      timestampKey: timestamp
+      pluginLogLevel: error
+      extraConf: ""
+    extraLogs: ""
+    containers:
+      overrideRawConfig: ""
+      outputConf: '@include logs.output.conf'
+      overrideOutputConf: ""
+      sourceName: '%{namespace}.%{pod}.%{container}'
+      sourceCategory: '%{namespace}/%{pod_name}'
+      sourceCategoryPrefix: kubernetes/
+      sourceCategoryReplaceDash: /
+      excludeContainerRegex: ""
+      excludeHostRegex: ""
+      excludeNamespaceRegex: ""
+      excludePodRegex: ""
+      k8sMetadataFilter:
+        watch: true
+        caFile: ""
+        verifySsl: true
+        clientCert: ""
+        clientKey: ""
+        bearerTokenFile: ""
+      extraFilterPluginConf: ""
+      multiline:
+        enabled: true
+    kubelet:
+      enabled: true
+      outputConf: '@include logs.output.conf'
+      overrideOutputConf: ""
+      sourceName: k8s_kubelet
+      sourceCategory: kubelet
+      sourceCategoryPrefix: kubernetes/
+      sourceCategoryReplaceDash: /
+      excludeFacilityRegex: ""
+      excludeHostRegex: ""
+      excludePriorityRegex: ""
+      excludeUnitRegex: ""
+    systemd:
+      enabled: true
+      outputConf: '@include logs.output.conf'
+      overrideOutputConf: ""
+      sourceName: k8s_systemd
+      sourceCategory: system
+      sourceCategoryPrefix: kubernetes/
+      sourceCategoryReplaceDash: /
+      excludeFacilityRegex: ""
+      excludeHostRegex: ""
+      excludePriorityRegex: ""
+      excludeUnitRegex: ""
+    default:
+      outputConf: '@include logs.output.conf'
+      overrideOutputConf: ""
+      sourceName: k8s_default
+      sourceCategory: default
+      sourceCategoryPrefix: kubernetes/
+      sourceCategoryReplaceDash: /
+      excludeFacilityRegex: ""
+      excludeHostRegex: ""
+      excludePriorityRegex: ""
+      excludeUnitRegex: ""
+  metrics:
+    enabled: true
+    statefulset:
+      nodeSelector: {}
+      tolerations: {}
+      affinity: {}
+      podAntiAffinity: soft
+      replicaCount: 3
+      resources:
+        limits:
+          memory: 1Gi
+          cpu: 1000m
+        requests:
+          memory: 768Mi
+          cpu: 500m
+      priorityClassName: ""
+      podLabels: {}
+      podAnnotations: {}
+    autoscaling:
+      enabled: false
+      minReplicas: 3
+      maxReplicas: 10
+      targetCPUUtilizationPercentage: 50
+    podDisruptionBudget:
+      minAvailable: 2
+    rawConfig: |-
+      @include common.conf
+      @include metrics.conf
+    outputConf: '@include metrics.output.conf'
+    overrideOutputConf: ""
+    extraFilterPluginConf: ""
+    extraOutputPluginConf: ""
+    output:
+      apiserver:
+        tag: prometheus.metrics.apiserver**
+        id: sumologic.endpoint.metrics.apiserver
+        weight: 90
+      kubelet:
+        tag: prometheus.metrics.kubelet**
+        id: sumologic.endpoint.metrics.kubelet
+        weight: 90
+      container:
+        tag: prometheus.metrics.container**
+        id: sumologic.endpoint.metrics.container
+        source: kubelet
+        weight: 90
+      controller:
+        tag: prometheus.metrics.controller-manager**
+        id: sumologic.endpoint.metrics.kube.controller.manager
+        weight: 90
+      scheduler:
+        tag: prometheus.metrics.scheduler**
+        id: sumologic.endpoint.metrics.kube.scheduler
+        weight: 90
+      state:
+        tag: prometheus.metrics.state**
+        id: sumologic.endpoint.metrics.kube.state
+        weight: 90
+      node:
+        tag: prometheus.metrics.node**
+        id: sumologic.endpoint.metrics.node.exporter
+        weight: 90
+      control-plane:
+        tag: prometheus.metrics.control-plane**
+        id: sumologic.endpoint.metrics.control.plane
+        weight: 90
+      default:
+        tag: prometheus.metrics**
+        id: sumologic.endpoint.metrics
+        weight: 100
+  events:
+    enabled: true
+    statefulset:
+      nodeSelector: {}
+      tolerations: {}
+      resources:
+        limits:
+          memory: 512Mi
+          cpu: 200m
+        requests:
+          memory: 256Mi
+          cpu: 100m
+      priorityClassName: ""
+      podLabels: {}
+      podAnnotations: {}
+    sourceCategory: ""

--- a/tests/upgrade_v2_script/static/prometheus_whole_config.output.yaml
+++ b/tests/upgrade_v2_script/static/prometheus_whole_config.output.yaml
@@ -10,29 +10,29 @@ kube-prometheus-stack:
   commonLabels: {}
   kubeApiServer:
     serviceMonitor:
-      interval:
+      interval: ""
   kubelet:
     serviceMonitor:
-      interval:
+      interval: ""
       resource: false
   kubeControllerManager:
     serviceMonitor:
-      interval:
+      interval: ""
   coreDns:
     serviceMonitor:
-      interval:
+      interval: ""
   kubeEtcd:
     serviceMonitor:
-      interval:
+      interval: ""
   kubeScheduler:
     serviceMonitor:
-      interval:
+      interval: ""
   kubeStateMetrics:
     serviceMonitor:
-      interval:
+      interval: ""
   nodeExporter:
     serviceMonitor:
-      interval:
+      interval: ""
   alertmanager:
     enabled: false
   grafana:


### PR DESCRIPTION
###### Description

When using `yq` to write empty values (the ones with only `|-` or without values at all) it writes no values at all causing some helm templates to fail to render:

```
Error: template: sumologic/templates/statefulset.yaml:19:28: executing "sumologic/templates/statefulset.yaml" at <include (print $.Template.BasePath "/configmap.yaml") .>: error calling include: template: sumologic/templates/configmap.yaml:15:5: executing "sumologic/templates/configmap.yaml" at <tpl (.Files.Glob "conf/*.conf").AsConfig .>: error calling tpl: error during tpl function execution for "buffer.output.conf: |-\n  compress {{ .Values.fluentd.buffer.compress | quote }}\n  flush_interval {{ .Values.fluentd.buffer.flushInterval | quote }}\n  flush_thread_count {{ .Values.fluentd.buffer.numThreads | quote }}\n  chunk_limit_size {{ .Values.fluentd.buffer.chunkLimitSize | quote }}\n  total_limit_size {{ .Values.fluentd.buffer.totalLimitSize | quote }}\n  queued_chunks_limit_size {{ .Values.fluentd.buffer.queueChunkLimitSize | quote }}\n  overflow_action drop_oldest_chunk\n  retry_max_interval {{ .Values.fluentd.buffer.retryMaxInterval | quote }}\n  retry_forever {{ .Values.fluentd.buffer.retryForever | quote }}\n  {{- .Values.fluentd.buffer.extraConf | nindent 2 }}\ncommon.conf: |-\n  # Prevent fluentd from handling records containing its own logs.\n  <match fluentd.**>\n    @type null\n  </match>\n  # expose the Fluentd metrics to Prometheus\n  <source>\n    @type prometheus\n    metrics_path /metrics\n    port 24231\n  </source>\n  <source>\n    @type prometheus_output_monitor\n  </source>\n  <source>\n    @type http\n    port 9880\n    bind 0.0.0.0\n  </source>\n  {{- if .Values.fluentd.logLevel }}\n  <system>\n    log_level {{ .Values.fluentd.logLevel }}\n  </system>\n  {{- end }}": template: sumologic/templates/statefulset.yaml:11:49: executing "sumologic/templates/statefulset.yaml" at <2>: invalid value; expected string
```

hence this PR adds explicit quoting of those empty values.

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
