### PR TITLE
Fix secret cleanup

### DIFF
--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -212,6 +212,18 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- template "sumologic.labels.app.cleanup" . }}
 {{- end -}}
 
+{{- define "sumologic.labels.app.cleanup.roles.clusterrole" -}}
+{{- template "sumologic.labels.app.cleanup" . }}
+{{- end -}}
+
+{{- define "sumologic.labels.app.cleanup.roles.clusterrolebinding" -}}
+{{- template "sumologic.labels.app.cleanup" . }}
+{{- end -}}
+
+{{- define "sumologic.labels.app.cleanup.roles.serviceaccount" -}}
+{{- template "sumologic.labels.app.cleanup" . }}
+{{- end -}}
+
 {{/*
 Generate cleanup job helm.sh annotations. It takes weight as parameter.
 
@@ -405,6 +417,18 @@ helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 {{- end -}}
 
 {{- define "sumologic.metadata.name.cleanup.configmap" -}}
+{{ template "sumologic.metadata.name.cleanup" . }}
+{{- end -}}
+
+{{- define "sumologic.metadata.name.cleanup.roles.clusterrole" -}}
+{{ template "sumologic.metadata.name.cleanup" . }}
+{{- end -}}
+
+{{- define "sumologic.metadata.name.cleanup.roles.clusterrolebinding" -}}
+{{ template "sumologic.metadata.name.cleanup" . }}
+{{- end -}}
+
+{{- define "sumologic.metadata.name.cleanup.roles.serviceaccount" -}}
 {{ template "sumologic.metadata.name.cleanup" . }}
 {{- end -}}
 

--- a/deploy/helm/sumologic/templates/cleanup/cleanup-clusterrole.yaml
+++ b/deploy/helm/sumologic/templates/cleanup/cleanup-clusterrole.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.sumologic.cleanupEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name:  {{ template "sumologic.metadata.name.cleanup.roles.clusterrole" . }}
+  annotations:
+{{ include "sumologic.annotations.app.cleanup.helmsh" "1" | indent 4 }}
+  labels:
+    app: {{ template "sumologic.labels.app.cleanup.roles.clusterrole" . }}
+    {{- include "sumologic.labels.common" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs: ["get", "list", "describe", "delete"]
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs: ["get", "list", "describe"]
+{{- end }}

--- a/deploy/helm/sumologic/templates/cleanup/cleanup-clusterrolebinding.yaml
+++ b/deploy/helm/sumologic/templates/cleanup/cleanup-clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.sumologic.cleanupEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name:  {{ template "sumologic.metadata.name.cleanup.roles.clusterrolebinding" . }}
+  annotations:
+{{ include "sumologic.annotations.app.cleanup.helmsh" "2" | indent 4 }}
+  labels:
+    app: {{ template "sumologic.labels.app.cleanup.roles.clusterrolebinding" . }}
+    {{- include "sumologic.labels.common" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "sumologic.metadata.name.cleanup.roles.clusterrole" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "sumologic.metadata.name.cleanup.roles.serviceaccount" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/deploy/helm/sumologic/templates/cleanup/cleanup-job.yaml
+++ b/deploy/helm/sumologic/templates/cleanup/cleanup-job.yaml
@@ -4,7 +4,7 @@ kind: Job
 metadata:
   name: {{ template "sumologic.metadata.name.cleanup" . }}
   annotations:
-{{ include "sumologic.annotations.app.cleanup.helmsh" "0" | indent 4 }}
+{{ include "sumologic.annotations.app.cleanup.helmsh" "3" | indent 4 }}
   labels:
     app: {{ template "sumologic.metadata.name.cleanup" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
@@ -21,7 +21,7 @@ spec:
 {{- end }}
     spec:
       restartPolicy: OnFailure
-      serviceAccountName: {{ template "sumologic.metadata.name.roles.serviceaccount" . }}
+      serviceAccountName: {{ template "sumologic.metadata.name.cleanup.roles.serviceaccount" . }}
       volumes:
       - name: configmap
         configMap:

--- a/deploy/helm/sumologic/templates/cleanup/cleanup-serviceaccount.yaml
+++ b/deploy/helm/sumologic/templates/cleanup/cleanup-serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.sumologic.cleanupEnabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name:  {{ template "sumologic.metadata.name.cleanup.roles.serviceaccount" . }}
+  annotations:
+{{ include "sumologic.annotations.app.cleanup.helmsh" "0" | indent 4 }}
+  labels:
+    app: {{ template "sumologic.labels.app.cleanup.roles.serviceaccount" . }}
+    {{- include "sumologic.labels.common" . | nindent 4 }}
+{{- end }}


### PR DESCRIPTION
###### Description

* Add separate `ServiceAccount`, `ClusterRole` and `ClusterRoleBinding` for cleanup job
* Change cleanup job helm hook weight from `0` to `3` so that the RBAC resources (listed above) are created before the job runs

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
