### PR TITLE
Pin setup image to alpine:3.12

### DIFF
--- a/deploy/docker/setup/Dockerfile
+++ b/deploy/docker/setup/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM alpine:3.12
 
 ENV TERRAFORM_VERSION 0.12.25-r0
 


### PR DESCRIPTION
###### Description

After [release of alpine 3.13](https://alpinelinux.org/posts/Alpine-3.13.0-released.html) terraform has been bumped in their repositories to `0.14.4-r0` from`0.12.25-r0` what we rely on in setup image 
https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/f01a31af115730b0901757ac8a458b85b9edcd73/deploy/docker/setup/Dockerfile#L3
 hence pin the version of alpine to `3.12` instead of `3`.

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
