### PR TITLE
Bump fluentd image to 1.12.0

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -196,7 +196,7 @@ sumologic:
 fluentd:
   image:
     repository: public.ecr.aws/sumologic/kubernetes-fluentd
-    tag: 1.11.5-sumo-0
+    tag: 1.12.0-sumo-0-rc.0
     pullPolicy: IfNotPresent
 
   ## Specifies whether a PodSecurityPolicy should be created


### PR DESCRIPTION
###### Description

Bump fluentd image to 1.12.0

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
