### PR TITLE
Add configuration for VS Code's Markdownlint extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # VS Code ignores
 .vscode/*
+!.vscode/extensions.json
 
 # Helm chart dependencies
 deploy/helm/sumologic/charts

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,9 @@
+/**
+ * Note: This configuration is used by VS Code's Markdownlint extension and is only included for convenience.
+ * The original and primary Markdownlint configuration as used in CI is .markdownlint/style.rb.
+ */
+{
+    "default": true,
+    "MD004": { "style": "dash" },
+    "MD013": { "line_length": 120, "code_blocks": false, "tables": false }
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "davidanson.vscode-markdownlint",
+    ]
+}


### PR DESCRIPTION
Note: This configuration is used by VS Code's Markdownlint extension and is only included for convenience.
The original and primary Markdownlint configuration as used in CI is `.markdownlint/style.rb`.