### PR TITLE
Bump sumologic terraform provider to 2.6 and relax kubernetes provider version constraints

### DIFF
--- a/deploy/helm/sumologic/conf/setup/main.tf
+++ b/deploy/helm/sumologic/conf/setup/main.tf
@@ -1,6 +1,6 @@
 terraform {
   required_providers {
-    sumologic  = "~> 2.4"
-    kubernetes = "~> 1.13.0"
+    sumologic  = "~> 2.6"
+    kubernetes = "~> 1.13"
   }
 }

--- a/tests/terraform/static/all_fields.output.yaml
+++ b/tests/terraform/static/all_fields.output.yaml
@@ -135,8 +135,8 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.4"
-        kubernetes = "~> 1.13.0"
+        sumologic  = "~> 2.6"
+        kubernetes = "~> 1.13"
       }
     }
   providers.tf: |-

--- a/tests/terraform/static/collector_fields.output.yaml
+++ b/tests/terraform/static/collector_fields.output.yaml
@@ -134,8 +134,8 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.4"
-        kubernetes = "~> 1.13.0"
+        sumologic  = "~> 2.6"
+        kubernetes = "~> 1.13"
       }
     }
   providers.tf: |-

--- a/tests/terraform/static/conditional_sources.output.yaml
+++ b/tests/terraform/static/conditional_sources.output.yaml
@@ -124,8 +124,8 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.4"
-        kubernetes = "~> 1.13.0"
+        sumologic  = "~> 2.6"
+        kubernetes = "~> 1.13"
       }
     }
   providers.tf: |-

--- a/tests/terraform/static/custom.output.yaml
+++ b/tests/terraform/static/custom.output.yaml
@@ -124,8 +124,8 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.4"
-        kubernetes = "~> 1.13.0"
+        sumologic  = "~> 2.6"
+        kubernetes = "~> 1.13"
       }
     }
   providers.tf: |-

--- a/tests/terraform/static/default.output.yaml
+++ b/tests/terraform/static/default.output.yaml
@@ -134,8 +134,8 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.4"
-        kubernetes = "~> 1.13.0"
+        sumologic  = "~> 2.6"
+        kubernetes = "~> 1.13"
       }
     }
   providers.tf: |-

--- a/tests/terraform/static/disable_default_metrics.output.yaml
+++ b/tests/terraform/static/disable_default_metrics.output.yaml
@@ -133,8 +133,8 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.4"
-        kubernetes = "~> 1.13.0"
+        sumologic  = "~> 2.6"
+        kubernetes = "~> 1.13"
       }
     }
   providers.tf: |-

--- a/tests/terraform/static/strip_extrapolation.output.yaml
+++ b/tests/terraform/static/strip_extrapolation.output.yaml
@@ -134,8 +134,8 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.4"
-        kubernetes = "~> 1.13.0"
+        sumologic  = "~> 2.6"
+        kubernetes = "~> 1.13"
       }
     }
   providers.tf: |-

--- a/tests/terraform/static/traces.output.yaml
+++ b/tests/terraform/static/traces.output.yaml
@@ -125,8 +125,8 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.4"
-        kubernetes = "~> 1.13.0"
+        sumologic  = "~> 2.6"
+        kubernetes = "~> 1.13"
       }
     }
   providers.tf: |-


### PR DESCRIPTION
###### Description

Fill in your description here.

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
