### PR TITLE
Add support for falco on OpenShift 4.6

### DIFF
--- a/deploy/docs/Troubleshoot_Collection.md
+++ b/deploy/docs/Troubleshoot_Collection.md
@@ -22,6 +22,7 @@
   - [Prometheus stuck in `Terminating` state after running `helm del collection`](#prometheus-stuck-in-terminating-state-after-running-helm-del-collection)
   - [Errors in helm installation](#errors-in-helm-installation)
   - [Rancher](#rancher)
+  - [Falco](#falco)
 
 <!-- /TOC -->
 
@@ -327,3 +328,22 @@ To install on `GKE`, use the provided override file to customize your configurat
   #ebpf:
   #  enabled: true
 ```
+
+### Falco
+
+Falco does not provide modules for all kernels.
+When Falco module is not available for particular kernel, Falco tries to build it.
+Building a module requires `kernel-devel` package installed on nodes.
+
+For OpenShift, installation of `kernel-devel` on nodes is provided through MachineConfig used by
+[Machine Config operator](https://github.com/openshift/machine-config-operator).
+When update of machine configuration is needed machine is rebooted, please see
+[documentation](https://github.com/openshift/machine-config-operator/blob/master/docs/MachineConfigDaemon.md#coordinating-updates).
+The process of changing nodes configuration may require long time
+during which Pods scheduled on unchanged nodes are in `Init` state.
+
+Node configuration can be verified by following annotations:
+
+- `machineconfiguration.openshift.io/currentConfig`
+- `machineconfiguration.openshift.io/desiredConfig`
+- `machineconfiguration.openshift.io/state`

--- a/deploy/helm/sumologic/README.md
+++ b/deploy/helm/sumologic/README.md
@@ -212,6 +212,8 @@ Parameter | Description | Default
 `kube-prometheus-stack.prometheus-node-exporter.podAnnotations` | Additional annotations for prometheus-node-exporter pods. | `{}`
 `kube-prometheus-stack.prometheus-node-exporter.resources` | Resource limits for node exporter.  Uses sub-chart defaults. | `{}`
 `falco.enabled` | Flag to control deploying Falco Helm sub-chart. | `false`
+`falco.addKernelDevel` | Flag to control installation of `kernel-devel` on nodes using MachineConfig, required to build falco modules (only for OpenShift)| `true`
+`falco.extraInitContainers` | InitContainers for Falco pod |  `[{'name': 'init-falco', 'image': 'busybox', 'command': ['sh', '-c', 'while [ -f /host/etc/redhat-release ] && [ -z "$(ls /host/usr/src/kernels)" ] ; do\necho "waiting for kernel headers to be installed"\nsleep 3\ndone\n'], 'volumeMounts': [{'mountPath': '/host/usr', 'name': 'usr-fs', 'readOnly': True}, {'mountPath': '/host/etc', 'name': 'etc-fs', 'readOnly': True}]}]`
 `falco.ebpf.enabled` | Enable eBPF support for Falco instead of falco-probe kernel module. Set to false for GKE. | `true`
 `falco.falco.jsonOutput` | Output events in json. | `true`
 `telegraf-operator.enabled` | Flag to control deploying Telegraf Operator Helm sub-chart. | `false`

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -224,6 +224,22 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- template "sumologic.labels.app.cleanup" . }}
 {{- end -}}
 
+{{- define "sumologic.labels.app.machineconfig.worker" -}}
+{{- template "sumologic.fullname" . }}-worker-extensions
+{{- end -}}
+
+{{- define "sumologic.labels.machineconfig.worker" -}}
+machineconfiguration.openshift.io/role: worker
+{{- end -}}
+
+{{- define "sumologic.labels.app.machineconfig.master" -}}
+{{- template "sumologic.fullname" . }}-master-extensions
+{{- end -}}
+
+{{- define "sumologic.labels.machineconfig.master" -}}
+machineconfiguration.openshift.io/role: master
+{{- end -}}
+
 {{/*
 Generate cleanup job helm.sh annotations. It takes weight as parameter.
 

--- a/deploy/helm/sumologic/templates/machineconfig/machineconfig-master.yaml
+++ b/deploy/helm/sumologic/templates/machineconfig/machineconfig-master.yaml
@@ -1,0 +1,15 @@
+{{- if and (eq .Values.sumologic.scc.create true) (.Capabilities.APIVersions.Has "security.openshift.io/v1")}}
+{{- if and (eq .Values.falco.enabled true) (eq .Values.falco.addKernelDevel true) }}
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    app: {{ template "sumologic.labels.app.machineconfig.master" . }}
+    {{- include "sumologic.labels.machineconfig.master" . | nindent 4 }}
+    {{- include "sumologic.labels.common" . | nindent 4 }}
+  name: {{ template "sumologic.labels.app.machineconfig.master" . }}
+spec:
+  extensions:
+    - kernel-devel
+{{- end }}
+{{- end }}

--- a/deploy/helm/sumologic/templates/machineconfig/machineconfig-worker.yaml
+++ b/deploy/helm/sumologic/templates/machineconfig/machineconfig-worker.yaml
@@ -1,0 +1,15 @@
+{{- if and (eq .Values.sumologic.scc.create true) (.Capabilities.APIVersions.Has "security.openshift.io/v1")}}
+{{- if and (eq .Values.falco.enabled true) (eq .Values.falco.addKernelDevel true) }}
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    app: {{ template "sumologic.labels.app.machineconfig.worker" . }}
+    {{- include "sumologic.labels.machineconfig.worker" . | nindent 4 }}
+    {{- include "sumologic.labels.common" . | nindent 4 }}
+  name: {{ template "sumologic.labels.app.machineconfig.worker" . }}
+spec:
+  extensions:
+    - kernel-devel
+{{- end }}
+{{- end}}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -2193,6 +2193,28 @@ telegraf-operator:
 ## https://github.com/falcosecurity/charts/tree/master/falco
 falco:
   enabled: false
+  # Add kernel-devel package through MachineConfig, required to enable building of missing falco modules (only for OpenShift)
+  addKernelDevel: true
+  # Add initContainers to Falco pod
+  extraInitContainers:
+    # Add initContainer to wait until kernel-devel is installed on host
+    - name: init-falco
+      image: busybox
+      command:
+        - 'sh'
+        - '-c'
+        - |
+          while [ -f /host/etc/redhat-release ] && [ -z "$(ls /host/usr/src/kernels)" ] ; do
+          echo "waiting for kernel headers to be installed"
+          sleep 3
+          done
+      volumeMounts:
+        - mountPath: /host/usr
+          name: usr-fs
+          readOnly: true
+        - mountPath: /host/etc
+          name: etc-fs
+          readOnly: true
   # ebpf:
   #   enabled: true
   falco:


### PR DESCRIPTION
###### Description
- Add `MachineConfig` to instal on nodes `kernel-devel`. Related to https://github.com/falcosecurity/falco/issues/1505 - missing `kernel-devel` on Red Hat Enterprise Linux CoreOS 46.82.202012151054-0 (Ootpa)

- Add init container to avoid of having falco pods in` CrashLoopBackOff` when nodes are waiting for being configured. Configuration of machines takes longer period of the time. Nodes are restarted to apply changes in configuration, see [workflow for changing machine configuration](https://github.com/openshift/machine-config-operator/blob/master/docs/MachineConfigDaemon.md).


Tested with:

```
helm upgrade --install collection -n sumologic -f deploy/helm/sumologic/values.yaml \
--set kube-prometheus-stack.prometheusOperator.enabled=false \
--set sumologic.accessId="dummy" \
--set sumologic.accessKey="dummy" \
--set sumologic.endpoint="http://receiver-mock.receiver-mock:3000/terraform/api/" \
--set sumologic.clusterName="clusterkasi" \
--set kube-prometheus-stack.prometheusOperator.enabled=false \
--set kube-prometheus-stack.prometheus-node-exporter.service.port=9200 \
--set kube-prometheus-stack.prometheus-node-exporter.service.targetPort=9200 \
--set sumologic.scc.create=true \
--set fluent-bit.securityContext.privileged=true \
--set falco.enabled=true \
deploy/helm/sumologic/
```

Tested migration from 2.0 using:
```
helm upgrade --install collection sumologic/sumologic  -n sumologic \
--set kube-prometheus-stack.prometheusOperator.enabled=false \
--set sumologic.accessId="dummy" \
--set sumologic.accessKey="dummy" \
--set sumologic.endpoint="http://receiver-mock.receiver-mock:3000/terraform/api/" \
--set sumologic.clusterName="clusterkasi" \
--set kube-prometheus-stack.prometheusOperator.enabled=false \
--set kube-prometheus-stack.prometheus-node-exporter.service.port=9200 \
--set kube-prometheus-stack.prometheus-node-exporter.service.targetPort=9200 \
--set sumologic.scc.create=true \
--set fluent-bit.securityContext.privileged=true \
--set falco.enabled=true \
--version=v2.0.0
```

```
helm upgrade --install collection -n sumologic -f deploy/helm/sumologic/values.yaml \
--set kube-prometheus-stack.prometheusOperator.enabled=false \
--set sumologic.accessId="dummy" \
--set sumologic.accessKey="dummy" \
--set sumologic.endpoint="http://receiver-mock.receiver-mock:3000/terraform/api/" \
--set sumologic.clusterName="clusterkasi" \
--set kube-prometheus-stack.prometheusOperator.enabled=false \
--set kube-prometheus-stack.prometheus-node-exporter.service.port=9200 \
--set kube-prometheus-stack.prometheus-node-exporter.service.targetPort=9200 \
--set sumologic.scc.create=true \
--set fluent-bit.securityContext.privileged=true \
--set falco.enabled=true \
deploy/helm/sumologic/
```

Tested on vagrant using `sumo-make upgrade`

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
