### PR TITLE
Fix information about falco on GKE

### DIFF
--- a/deploy/docs/Troubleshoot_Collection.md
+++ b/deploy/docs/Troubleshoot_Collection.md
@@ -22,7 +22,8 @@
   - [Prometheus stuck in `Terminating` state after running `helm del collection`](#prometheus-stuck-in-terminating-state-after-running-helm-del-collection)
   - [Errors in helm installation](#errors-in-helm-installation)
   - [Rancher](#rancher)
-  - [Falco](#falco)
+  - [Falco and Google Kubernetes Engine (GKE)](#falco-and-google-kubernetes-engine-gke)
+  - [Falco and OpenShift](#falco-and-openshift)
 
 <!-- /TOC -->
 
@@ -320,7 +321,7 @@ Because of this security constraint, Falco cannot insert its kernel module to pr
 However, COS provides the ability to use extended Berkeley Packet Filter (eBPF)
 to supply the stream of system calls to the Falco engine.
 eBPF is currently only supported on GKE and COS.
-For more information see [Installing Falco](https://falco.org/docs/installation/).
+For more information see [Falco documentation](https://falco.org/docs/getting-started/third-party/#gke).
 
 To install on `GKE`, use the provided override file to customize your configuration and uncomment the following lines in the `values.yaml` file referenced below:
 
@@ -329,7 +330,7 @@ To install on `GKE`, use the provided override file to customize your configurat
   #  enabled: true
 ```
 
-### Falco
+### Falco and OpenShift
 
 Falco does not provide modules for all kernels.
 When Falco module is not available for particular kernel, Falco tries to build it.

--- a/deploy/helm/sumologic/README.md
+++ b/deploy/helm/sumologic/README.md
@@ -214,7 +214,7 @@ Parameter | Description | Default
 `falco.enabled` | Flag to control deploying Falco Helm sub-chart. | `false`
 `falco.addKernelDevel` | Flag to control installation of `kernel-devel` on nodes using MachineConfig, required to build falco modules (only for OpenShift)| `true`
 `falco.extraInitContainers` | InitContainers for Falco pod |  `[{'name': 'init-falco', 'image': 'busybox', 'command': ['sh', '-c', 'while [ -f /host/etc/redhat-release ] && [ -z "$(ls /host/usr/src/kernels)" ] ; do\necho "waiting for kernel headers to be installed"\nsleep 3\ndone\n'], 'volumeMounts': [{'mountPath': '/host/usr', 'name': 'usr-fs', 'readOnly': True}, {'mountPath': '/host/etc', 'name': 'etc-fs', 'readOnly': True}]}]`
-`falco.ebpf.enabled` | Enable eBPF support for Falco instead of falco-probe kernel module. Set to false for GKE. | `true`
+`falco.ebpf.enabled` | Enable eBPF support for Falco instead of falco-probe kernel module. Set to true for GKE. | `false`
 `falco.falco.jsonOutput` | Output events in json. | `true`
 `telegraf-operator.enabled` | Flag to control deploying Telegraf Operator Helm sub-chart. | `false`
 `telegraf-operator.replicaCount` | Replica count for Telegraf Operator pods. | 1

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -2215,6 +2215,9 @@ falco:
         - mountPath: /host/etc
           name: etc-fs
           readOnly: true
+  # Enable eBPF support for Falco instead of falco-probe kernel module.
+  # Set to true for GKE, for details see:
+  # https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/main/deploy/docs/Troubleshoot_Collection.md#falco-and-google-kubernetes-engine-gke
   # ebpf:
   #   enabled: true
   falco:


### PR DESCRIPTION
###### Description

- Fixed information about falco on GKE
- Changed information about default setting for falco.ebpf.enabled in chart Readme.md, in [falco 1.5.7](https://github.com/falcosecurity/charts/releases/tag/falco-1.5.7) there is following setting:
```
ebpf:
  # Enable eBPF support for Falco
  enabled: false
```

Related to https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/1356

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
