### PR TITLE
Remove duplicated collector source category from configuration

### DIFF
--- a/deploy/docs/Terraform.md
+++ b/deploy/docs/Terraform.md
@@ -60,9 +60,6 @@ sumologic:
         example-source: # source reference name
           name: # name of the source (visible on the sumologic platform)
           config-name: # name which be used in secret to store the url. This is backward-compatibility option
-          category: # this is backward compatibility property. It's deprecated and it's going to be removed in version 2.0
-                    # Sets source category to "${var.cluster_name}/${local.default_events_source}" if true
-                    # To overwrite category, please use `sumologic.collector.sources[].properties.category`
           properties: # Additional Terraform properties like fields or content_type
                       # ref: https://www.terraform.io/docs/providers/sumologic/r/collector.html
 ```

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -755,9 +755,6 @@ Example usage:
 resource "sumologic_http_source" "{{ .Name }}" {
     name         = local.{{ .Name }}
     collector_id = sumologic_collector.collector.id
-    {{- if $source.category }}
-    category     = {{ if $ctx.fluentd.events.sourceCategory }}{{ $ctx.fluentd.events.sourceCategory | quote }}{{- else}}{{ "\"${var.cluster_name}/${local.default_events_source}\"" }}{{- end}}
-    {{- end }}
     {{- if $source.properties }}
     {{- range $fkey, $fvalue := $source.properties }}
     {{- include "terraform.generate-object" (dict "Name" $fkey "Value" $fvalue "KeyLength" (include "terraform.max-key-length" $source.properties) "Indent" 2) -}}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -167,7 +167,8 @@ sumologic:
         default:
           name: events
           config-name: endpoint-events
-          category: true
+          properties:
+            category: "${var.cluster_name}/${local.default_events_source}"
       traces:
         default:
           name: traces

--- a/tests/terraform/static/all_fields.output.yaml
+++ b/tests/terraform/static/all_fields.output.yaml
@@ -166,7 +166,7 @@ data:
     resource "sumologic_http_source" "default_events_source" {
         name         = local.default_events_source
         collector_id = sumologic_collector.collector.id
-        category     = "${var.cluster_name}/${local.default_events_source}"
+        category = "${var.cluster_name}/${local.default_events_source}"
     }
     
     resource "sumologic_http_source" "default_logs_source" {

--- a/tests/terraform/static/collector_fields.output.yaml
+++ b/tests/terraform/static/collector_fields.output.yaml
@@ -167,7 +167,7 @@ data:
     resource "sumologic_http_source" "default_events_source" {
         name         = local.default_events_source
         collector_id = sumologic_collector.collector.id
-        category     = "${var.cluster_name}/${local.default_events_source}"
+        category = "${var.cluster_name}/${local.default_events_source}"
     }
     
     resource "sumologic_http_source" "default_logs_source" {

--- a/tests/terraform/static/default.output.yaml
+++ b/tests/terraform/static/default.output.yaml
@@ -165,7 +165,7 @@ data:
     resource "sumologic_http_source" "default_events_source" {
         name         = local.default_events_source
         collector_id = sumologic_collector.collector.id
-        category     = "${var.cluster_name}/${local.default_events_source}"
+        category = "${var.cluster_name}/${local.default_events_source}"
     }
     
     resource "sumologic_http_source" "default_logs_source" {

--- a/tests/terraform/static/disable_default_metrics.output.yaml
+++ b/tests/terraform/static/disable_default_metrics.output.yaml
@@ -164,7 +164,7 @@ data:
     resource "sumologic_http_source" "default_events_source" {
         name         = local.default_events_source
         collector_id = sumologic_collector.collector.id
-        category     = "${var.cluster_name}/${local.default_events_source}"
+        category = "${var.cluster_name}/${local.default_events_source}"
     }
     
     resource "sumologic_http_source" "default_logs_source" {

--- a/tests/terraform/static/strip_extrapolation.output.yaml
+++ b/tests/terraform/static/strip_extrapolation.output.yaml
@@ -166,7 +166,7 @@ data:
     resource "sumologic_http_source" "default_events_source" {
         name         = local.default_events_source
         collector_id = sumologic_collector.collector.id
-        category     = "${var.cluster_name}/${local.default_events_source}"
+        category = "${var.cluster_name}/${local.default_events_source}"
     }
     
     resource "sumologic_http_source" "default_logs_source" {


### PR DESCRIPTION
###### Description

Remove duplicated collector source category from configuration

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
