### PR TITLE
Fix links to Prometheus and FluenBit deploy instuctions

### DIFF
--- a/deploy/docs/v1_migration_doc.md
+++ b/deploy/docs/v1_migration_doc.md
@@ -281,11 +281,11 @@ Follow the below steps to deploy new resources.
 
 ##### 2.2 Deploy Prometheus
 
-- Follow steps mentioned [here](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/main/deploy/docs/Non_Helm_Installation.md#deploy-prometheus) to deploy Prometheus.
+- Follow steps mentioned [here](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/release-v1.0/deploy/docs/Non_Helm_Installation.md#deploy-prometheus) to deploy Prometheus.
 
 ##### 2.3: Deploy Fluent Bit
 
-- Follow steps mentioned [here](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/main/deploy/docs/Non_Helm_Installation.md#deploy-fluentbit) to deploy Fluent Bit.
+- Follow steps mentioned [here](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/release-v1.0/deploy/docs/Non_Helm_Installation.md#deploy-fluentbit) to deploy Fluent Bit.
 
 ## Kubernetes App dashboard update
 


### PR DESCRIPTION
###### Description

Non_Helm_Installation.md was modified in #686 and sections "Deploy FluentBit" and "Deploy Prometheus" were removed. The last Non_Helm_Installation.md with "Deploy FluentBit" and "Deploy Prometheus" sections is available on release-v1.0 branch.

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
