### PR TITLE
Use 40 SHA chars in dev helm chart versions

### DIFF
--- a/ci/push-helm-chart.sh
+++ b/ci/push-helm-chart.sh
@@ -5,7 +5,7 @@ readonly ROOT_DIR="$(dirname "$(dirname "${0}")")"
 source "${ROOT_DIR}"/ci/_build_functions.sh
 
 fetch_current_branch
-VERSION="$(git describe --tags)"
+VERSION="$(git describe --tags --abbrev=40)"
 readonly VERSION="${VERSION#v}"
 
 pushd "${ROOT_DIR}" || exit 1


### PR DESCRIPTION
###### Description

Because of ambiguous versions being produced (most likely caused by calling `git describe` on a repo with only one branch checked out on Github Actions [link](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/20922c23e213249cbd7466360b1b1e1f40124af5/ci/_build_functions.sh#L60-L75) versus the same command being called on a full repo locally) let's use a longer version for our dev helm charts, i.e. 40 SHA characters.

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
