### PR TITLE
Use 40 SHA chars in dev helm chart versions on release-1.3 branch

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -5,7 +5,7 @@ readonly ROOT_DIR="$(dirname "$(dirname "${0}")")"
 source "${ROOT_DIR}"/ci/_build_functions.sh
 
 fetch_current_branch
-VERSION="$(git describe --tags)"
+VERSION="$(git describe --tags --abbrev=40)"
 readonly VERSION="${VERSION#v}"
 
 : "${DOCKER_TAG:=sumologic/kubernetes-fluentd}"

--- a/ci/push.sh
+++ b/ci/push.sh
@@ -5,7 +5,7 @@ readonly ROOT_DIR="$(dirname "$(dirname "${0}")")"
 source "${ROOT_DIR}"/ci/_build_functions.sh
 
 fetch_current_branch
-VERSION="$(git describe --tags)"
+VERSION="$(git describe --tags --abbrev=40)"
 readonly VERSION="${VERSION#v}"
 : "${DOCKER_TAG:=sumologic/kubernetes-fluentd}"
 : "${DOCKER_USERNAME:=sumodocker}"

--- a/ci/tests.sh
+++ b/ci/tests.sh
@@ -9,7 +9,7 @@ source "${ROOT_DIR}"/ci/_test_functions.sh
 source "${ROOT_DIR}"/ci/_build_functions.sh
 
 fetch_current_branch
-VERSION="$(git describe --tags)"
+VERSION="$(git describe --tags --abbrev=40)"
 readonly VERSION="${VERSION#v}"
 
 pushd "${ROOT_DIR}" || exit 1


### PR DESCRIPTION
###### Description

Manual backport of https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1374

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
