### PR TITLE
Bump terraform sumologic provider in release v1.3

### DIFF
--- a/deploy/helm/sumologic/conf/setup/main.tf
+++ b/deploy/helm/sumologic/conf/setup/main.tf
@@ -1,6 +1,6 @@
 terraform {
   required_providers {
-    sumologic  = "~> 2.0.3"
+    sumologic  = "~> 2.6"
     kubernetes = "~> 1.11.3"
   }
 }

--- a/deploy/kubernetes/setup-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/setup-sumologic.yaml.tmpl
@@ -30,7 +30,7 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.0.3"
+        sumologic  = "~> 2.6"
         kubernetes = "~> 1.11.3"
       }
     }

--- a/tests/terraform/static/all_fields.output.yaml
+++ b/tests/terraform/static/all_fields.output.yaml
@@ -31,7 +31,7 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.0.3"
+        sumologic  = "~> 2.6"
         kubernetes = "~> 1.11.3"
       }
     }

--- a/tests/terraform/static/collector_fields.output.yaml
+++ b/tests/terraform/static/collector_fields.output.yaml
@@ -30,7 +30,7 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.0.3"
+        sumologic  = "~> 2.6"
         kubernetes = "~> 1.11.3"
       }
     }

--- a/tests/terraform/static/conditional_sources.output.yaml
+++ b/tests/terraform/static/conditional_sources.output.yaml
@@ -20,7 +20,7 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.0.3"
+        sumologic  = "~> 2.6"
         kubernetes = "~> 1.11.3"
       }
     }

--- a/tests/terraform/static/default.output.yaml
+++ b/tests/terraform/static/default.output.yaml
@@ -30,7 +30,7 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.0.3"
+        sumologic  = "~> 2.6"
         kubernetes = "~> 1.11.3"
       }
     }

--- a/tests/terraform/static/strip_extrapolation.output.yaml
+++ b/tests/terraform/static/strip_extrapolation.output.yaml
@@ -30,7 +30,7 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.0.3"
+        sumologic  = "~> 2.6"
         kubernetes = "~> 1.11.3"
       }
     }

--- a/tests/terraform/static/traces.output.yaml
+++ b/tests/terraform/static/traces.output.yaml
@@ -21,7 +21,7 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.0.3"
+        sumologic  = "~> 2.6"
         kubernetes = "~> 1.11.3"
       }
     }


### PR DESCRIPTION
###### Description

This should fix crashes like the one below:

```
Initializing the backend...
Initializing provider plugins...
- Checking for available provider plugins...
- Downloading plugin for provider "kubernetes" (hashicorp/kubernetes) 1.11.4...
- Downloading plugin for provider "sumologic" (terraform-providers/sumologic) 2.0.3...
Warning: registry.terraform.io: For users on Terraform 0.13 or greater, this provider has moved to SumoLogic/sumologic. Please update your source in required_providers.
Terraform has been successfully initialized!
You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.
If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
sumologic_collector.collector: Importing from ID "kubeclient-persistence"...
sumologic_collector.collector: Import prepared!
  Prepared sumologic_collector for import
sumologic_collector.collector: Refreshing state... [id=kubeclient-persistence]
Error: rpc error: code = Unavailable desc = transport is closing
panic: runtime error: invalid memory address or nil pointer dereference
2021-01-25T12:08:34.837Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xda406d]
2021-01-25T12:08:34.837Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4:
2021-01-25T12:08:34.837Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4: goroutine 42 [running]:
2021-01-25T12:08:34.837Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4: github.com/terraform-providers/terraform-provider-sumologic/sumologic.resourceSumologicCollectorRead(0xc0001b6f50, 0x102cb20, 0xc0005418b0, 0xc0001b6f50, 0x0)
2021-01-25T12:08:34.837Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4:     /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-sumologic/sumologic/resource_sumologic_collector.go:77 +0x11d
2021-01-25T12:08:34.837Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4: github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Resource).RefreshWithoutUpgrade(0xc0000fa900, 0xc0005b03c0, 0x102cb20, 0xc0005418b0, 0xc00000e398, 0x0, 0x0)
2021-01-25T12:08:34.837Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4:     /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-sumologic/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/resource.go:455 +0x119
2021-01-25T12:08:34.837Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4: github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin.(*GRPCProviderServer).ReadResource(0xc000098bf8, 0x12b6020, 0xc0005aa390, 0xc0005b01e0, 0xc000098bf8, 0xc0005aa390, 0xc00056bb30)
2021-01-25T12:08:34.837Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4:     /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-sumologic/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin/grpc_provider.go:525 +0x3d8
2021-01-25T12:08:34.837Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4: github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5._Provider_ReadResource_Handler(0xff81a0, 0xc000098bf8, 0x12b6020, 0xc0005aa390, 0xc00009b2c0, 0x0, 0x12b6020, 0xc0005aa390, 0xc0003a46e0, 0x94)
2021-01-25T12:08:34.837Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4:     /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-sumologic/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5/tfplugin5.pb.go:3153 +0x217
2021-01-25T12:08:34.837Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4: google.golang.org/grpc.(*Server).processUnaryRPC(0xc00009d680, 0x12c1f00, 0xc000001680, 0xc0000f0c00, 0xc000118f00, 0x19d8550, 0x0, 0x0, 0x0)
2021-01-25T12:08:34.837Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4:     /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-sumologic/vendor/google.golang.org/grpc/server.go:1024 +0x4f4
2021-01-25T12:08:34.837Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4: google.golang.org/grpc.(*Server).handleStream(0xc00009d680, 0x12c1f00, 0xc000001680, 0xc0000f0c00, 0x0)
2021-01-25T12:08:34.837Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4:     /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-sumologic/vendor/google.golang.org/grpc/server.go:1313 +0xd97
2021-01-25T12:08:34.837Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4: google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc0000943b0, 0xc00009d680, 0x12c1f00, 0xc000001680, 0xc0000f0c00)
2021-01-25T12:08:34.837Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4:     /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-sumologic/vendor/google.golang.org/grpc/server.go:722 +0xbb
2021-01-25T12:08:34.837Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4: created by google.golang.org/grpc.(*Server).serveStreams.func1
2021-01-25T12:08:34.837Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4:     /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-sumologic/vendor/google.golang.org/grpc/server.go:720 +0xa1
2021-01-25T12:08:34.838Z [DEBUG] plugin: plugin process exited: path=/terraform/.terraform/plugins/linux_amd64/terraform-provider-sumologic_v2.0.3_x4 pid=62 error="exit status 2"
2021/01/25 12:08:34 [ERROR] <root>: eval: *terraform.EvalRefresh, err: rpc error: code = Unavailable desc = transport is closing
2021/01/25 12:08:34 [ERROR] <root>: eval: *terraform.EvalSequence, err: rpc error: code = Unavailable desc = transport is closing
2021/01/25 12:08:34 [TRACE] [walkImport] Exiting eval tree: import sumologic_collector.collector result
2021/01/25 12:08:34 [TRACE] vertex "import sumologic_collector.collector result": visit complete
2021/01/25 12:08:34 [TRACE] vertex "sumologic_collector.collector (import id \"kubeclient-persistence\")": dynamic subgraph encountered errors
2021/01/25 12:08:34 [TRACE] vertex "sumologic_collector.collector (import id \"kubeclient-persistence\")": visit complete
2021/01/25 12:08:34 [TRACE] dag/walk: upstream of "provider.sumologic (close)" errored, so skipping
2021/01/25 12:08:34 [TRACE] dag/walk: upstream of "root" errored, so skipping
2021/01/25 12:08:34 [TRACE] statemgr.Filesystem: removing lock metadata file .terraform.tfstate.lock.info
2021/01/25 12:08:34 [TRACE] statemgr.Filesystem: unlocking terraform.tfstate using fcntl flock
2021-01-25T12:08:34.838Z [DEBUG] plugin: plugin exited
!!!!!!!!!!!!!!!!!!!!!!!!!!! TERRAFORM CRASH !!!!!!!!!!!!!!!!!!!!!!!!!!!!
Terraform crashed! This is always indicative of a bug within Terraform.
A crash log has been placed at "crash.log" relative to your current
working directory. It would be immensely helpful if you could please
report the crash with Terraform[1] so that we can fix this.
When reporting bugs, please include your terraform version. That
information is available on the first line of crash.log. You can also
get it by running 'terraform --version' on the command line.
SECURITY WARNING: the "crash.log" file that was created may contain
sensitive information that must be redacted before it is safe to share
on the issue tracker.
[1]: https://github.com/hashicorp/terraform/issues
!!!!!!!!!!!!!!!!!!!!!!!!!!! TERRAFORM CRASH !!!!!!!!!!!!!!!!!!!!!!!!!!!!
```

Because in 2.6 the error from `c.GetCollectorName()` is being checked

https://github.com/SumoLogic/terraform-provider-sumologic/blob/4d2cd42646e90de001fcf3748d437e104e0c0f4e/sumologic/resource_sumologic_collector.go#L61-L68

versus 2.0 where it's not

https://github.com/SumoLogic/terraform-provider-sumologic/blob/6bb806582780086b4c7f5098f7d768f9038c37ed/sumologic/resource_sumologic_collector.go#L76-L77

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
