### PR TITLE
Fix link to Fluentd output configuration

### DIFF
--- a/deploy/docs/v1_conf_examples.md
+++ b/deploy/docs/v1_conf_examples.md
@@ -105,7 +105,7 @@ Reference documentation: [Fluentd Filter Plugin](https://docs.fluentd.org/filter
 
 The example below shows how you can override the entire output section for the container logs pipeline.
 
-You can look at the Default output section [here](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/main/deploy/helm/sumologic/conf/logs/logs.source.containers.conf#L51)
+You can look at the Default output section [here](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/dc0ee4b26eddaf5eabbb2f5478421ea020d055fb/deploy/helm/sumologic/conf/logs/logs.source.containers.conf#L75)
 
 ```yaml
 fluentd:


### PR DESCRIPTION
###### Description

Link to `logs.source.containers.conf#L51` was introduced in https://github.com/SumoLogic/sumologic-kubernetes-collection/commit/e96ace9e02ff6bb797aee575f6c4f143b0f32465# on that day `logs.source.containers.conf` had form from this commit: https://github.com/SumoLogic/sumologic-kubernetes-collection/commit/3e50bc0b1abc4419098f5378ae665f9142924a7a# 

Currently content from `logs.source.containers.conf#L51` is available in `logs.source.containers.conf#L75`.

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
