### PR TITLE
[Backport] Fix information about falco on GKE

### DIFF
--- a/deploy/docs/Troubleshoot_Collection.md
+++ b/deploy/docs/Troubleshoot_Collection.md
@@ -23,7 +23,8 @@
   - [Error: could not find tiller](#error-could-not-find-tiller)
   - [Errors in helm installation](#errors-in-helm-installation)
   - [Rancher](#rancher)
-  - [Falco](#falco)
+  - [Falco and Google Kubernetes Engine (GKE)](#falco-and-google-kubernetes-engine-gke)
+  - [Falco and OpenShift](#falco-and-openshift)
 
 <!-- /TOC -->
 
@@ -366,7 +367,7 @@ If you have the Rancher prometheus operator setup running, they will have to use
 
 ### Falco and Google Kubernetes Engine (GKE)
 
-`Google Kubernetes Engine (GKE)` uses Container-Optimized OS (COS) as the default operating system for its worker node pools. COS is a security-enhanced operating system that limits access to certain parts of the underlying OS. Because of this security constraint, Falco cannot insert its kernel module to process events for system calls. However, COS provides the ability to use extended Berkeley Packet Filter (eBPF) to supply the stream of system calls to the Falco engine. eBPF is currently only supported on GKE and COS. For more information see [Installing Falco](https://falco.org/docs/installation/).
+`Google Kubernetes Engine (GKE)` uses Container-Optimized OS (COS) as the default operating system for its worker node pools. COS is a security-enhanced operating system that limits access to certain parts of the underlying OS. Because of this security constraint, Falco cannot insert its kernel module to process events for system calls. However, COS provides the ability to use extended Berkeley Packet Filter (eBPF) to supply the stream of system calls to the Falco engine. eBPF is currently only supported on GKE and COS. For more information see [Falco documentation](https://falco.org/docs/getting-started/third-party/#gke).
 
 To install on `GKE`, use the provided override file to customize your configuration and uncomment the following lines in the `values.yaml` file referenced below:
 
@@ -375,7 +376,7 @@ To install on `GKE`, use the provided override file to customize your configurat
   #  enabled: true
 ```
 
-### Falco
+### Falco and OpenShift
 
 Falco does not provide modules for all kernels.
 When Falco module is not available for particular kernel, Falco tries to build it.

--- a/deploy/helm/falco-overrides.yaml
+++ b/deploy/helm/falco-overrides.yaml
@@ -25,6 +25,9 @@ extraInitContainers:
 #     - mountPath: /host/etc
 #       name: etc-fs
 #       readOnly: true
+# Enable eBPF support for Falco instead of falco-probe kernel module.
+# Set to true for GKE, for details see:
+# https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/release-v1.3/deploy/docs/Troubleshoot_Collection.md#falco-and-google-kubernetes-engine-gke
 #ebpf:
 #  enabled: true
 falco:

--- a/deploy/helm/sumologic/README.md
+++ b/deploy/helm/sumologic/README.md
@@ -201,7 +201,7 @@ Parameter | Description | Default
 `falco.enabled` | Flag to control deploying Falco Helm sub-chart. | `false`
 `falco.addKernelDevel` | Flag to control installation of `kernel-devel` on nodes using MachineConfig, required to build falco modules (only for OpenShift with Machine Config operator) | `false`
 `falco.extraInitContainers` | InitContainers for Falco pod |  `[]`
-`falco.ebpf.enabled` | Enable eBPF support for Falco instead of falco-probe kernel module. Set to false for GKE. | `true`
+`falco.ebpf.enabled` | Enable eBPF support for Falco instead of falco-probe kernel module. Set to true for GKE. | `false`
 `falco.falco.jsonOutput` | Output events in json. | `true`
 `telegraf-operator.enabled` | Flag to control deploying Telegraf Operator Helm sub-chart. | `false`
 `telegraf-operator.replicaCount` | Replica count for Telegraf Operator pods. | 1

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1587,6 +1587,9 @@ falco:
     #     - mountPath: /host/etc
     #       name: etc-fs
     #       readOnly: true
+  # Enable eBPF support for Falco instead of falco-probe kernel module.
+  # Set to true for GKE, for details see:
+  # https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/release-v1.3/deploy/docs/Troubleshoot_Collection.md#falco-and-google-kubernetes-engine-gke
   #ebpf:
   #  enabled: true
   falco:


### PR DESCRIPTION
###### Description

Manual backport of #1360 into release-v1.3

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
