### PR TITLE
Bump setup image to 2.0.1

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -91,7 +91,7 @@ sumologic:
     job:
       image:
         repository: public.ecr.aws/sumologic/kubernetes-setup
-        tag: 2.0.0
+        tag: 2.0.1
         pullPolicy: IfNotPresent
       resources:
         limits:


### PR DESCRIPTION
###### Description

Bump setup image to [2.0.1](https://github.com/SumoLogic/sumologic-kubernetes-setup/releases/tag/v2.0.1)

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
