### PR TITLE
Make connections to k8s API server persistent

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
         curl \
         g++ \
         gcc \
+        git \
         libc-dev \
         libsnappy-dev \
         make \
@@ -20,9 +21,13 @@ RUN apt-get update \
 RUN gem install \
         concurrent-ruby:1.1.5 \
         google-protobuf:3.9.2 \
-        kubeclient:4.9.1 \
         lru_redux:1.1.0 \
-        snappy:0.0.17
+        net-http-persistent:3.1.0 \
+        snappy:0.0.17 \
+        specific_install:0.3.5
+
+# Use unreleased Kubeclient version with persistent HTTP connections.
+RUN gem specific_install https://github.com/abonas/kubeclient --ref 3267dc3fd02c49e3b19f1210ff7cb84c3b2a4478
 
 # FluentD plugins to allow customers to forward data if needed to various cloud providers
 RUN gem install \

--- a/fluent-plugin-enhance-k8s-metadata/Gemfile
+++ b/fluent-plugin-enhance-k8s-metadata/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
+gem 'kubeclient', git: 'https://github.com/abonas/kubeclient/', ref: '3267dc3fd02c49e3b19f1210ff7cb84c3b2a4478'
+
 gemspec

--- a/fluent-plugin-enhance-k8s-metadata/fluent-plugin-enhance-k8s-metadata.gemspec
+++ b/fluent-plugin-enhance-k8s-metadata/fluent-plugin-enhance-k8s-metadata.gemspec
@@ -21,8 +21,9 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.1'
   spec.add_runtime_dependency 'fluentd', ['>= 0.14.10', '< 2']
-  spec.add_runtime_dependency 'kubeclient', '4.9.1'
+  # spec.add_runtime_dependency 'kubeclient', '4.9.1' # Git version of Kubeclient specified in Gemfile
   spec.add_runtime_dependency 'lru_redux', '~> 1.1.0'
+  spec.add_runtime_dependency 'net-http-persistent', '~> 3.1'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 12.0'

--- a/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/connector.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/connector.rb
@@ -51,6 +51,7 @@ module SumoLogic
                 read: 5
               }
             )
+            client.faraday_client.adapter(:net_http_persistent)
             client.api_valid?
           end
           client

--- a/fluent-plugin-events/Gemfile
+++ b/fluent-plugin-events/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
+gem 'kubeclient', git: 'https://github.com/abonas/kubeclient/', ref: '3267dc3fd02c49e3b19f1210ff7cb84c3b2a4478'
+
 gemspec

--- a/fluent-plugin-events/fluent-plugin-events.gemspec
+++ b/fluent-plugin-events/fluent-plugin-events.gemspec
@@ -23,7 +23,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "test-unit", "~> 3.0"
   spec.add_runtime_dependency "fluentd", [">= 0.14.10", "< 2"]
-  spec.add_runtime_dependency 'kubeclient', '4.9.1'
+  # spec.add_runtime_dependency 'kubeclient', '4.9.1' # Git version of Kubeclient specified in Gemfile
+  spec.add_runtime_dependency 'net-http-persistent', '~> 3.1'
+
   spec.add_development_dependency 'webmock', '~> 3.0'
   spec.add_development_dependency 'mocha'
 end

--- a/fluent-plugin-events/lib/sumologic/kubernetes/connector.rb
+++ b/fluent-plugin-events/lib/sumologic/kubernetes/connector.rb
@@ -45,6 +45,7 @@ module SumoLogic
               ssl_options: ssl_options,
               auth_options: auth_options
             )
+            client.faraday_client.adapter(:net_http_persistent)
             client.api_valid?
           end
           client

--- a/fluent-plugin-kubernetes-metadata-filter/Gemfile
+++ b/fluent-plugin-kubernetes-metadata-filter/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+gem 'kubeclient', git: 'https://github.com/abonas/kubeclient/', ref: '3267dc3fd02c49e3b19f1210ff7cb84c3b2a4478'
+
 gem 'codeclimate-test-reporter', '<1.0.0', :group => :test, :require => nil
 gem 'rubocop', require: false
 

--- a/fluent-plugin-kubernetes-metadata-filter/fluent-plugin-kubernetes-metadata-filter.gemspec
+++ b/fluent-plugin-kubernetes-metadata-filter/fluent-plugin-kubernetes-metadata-filter.gemspec
@@ -18,7 +18,8 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'fluentd', ['>= 0.14.0', '< 1.12']
   gem.add_runtime_dependency "lru_redux"
-  gem.add_runtime_dependency "kubeclient", '< 5'
+  # gem.add_runtime_dependency "kubeclient", '< 5' # Git version of Kubeclient specified in Gemfile
+  gem.add_runtime_dependency 'net-http-persistent', '~> 3.1'
 
   gem.add_development_dependency "bundler", "~> 2.0"
   gem.add_development_dependency "rake"

--- a/fluent-plugin-kubernetes-metadata-filter/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/fluent-plugin-kubernetes-metadata-filter/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -240,6 +240,7 @@ module Fluent::Plugin
           auth_options: auth_options,
           as: :parsed_symbolized
         )
+        @client.faraday_client.adapter(:net_http_persistent)
 
         begin
           @client.api_valid?


### PR DESCRIPTION
###### Description

The Fluentd plugins we use make a good amount of HTTP connections to the Kubernetes API server for Kubernetes metadata enrichment. Until now, the HTTP connections were being closed after each HTTP request, requiring a new HTTP connection to be established on every request to API server. This was a suboptimal solution, and the root cause for SNAT port exhaustion in AKS clusters.

With this change, we are using a yet unreleased version of [Kubeclient](https://github.com/abonas/kubeclient/) library to be able to create persistent HTTP connections. The Kubeclient library (which is used by our Fluentd plugins to make requests to k8s API server) originally used [RestClient](https://github.com/rest-client/rest-client/) gem under the hood, which does not make it possible to create persistent connections. With the unreleased version of Kubeclient, the underlying HTTP library has been changed from RestClient to [Faraday](https://github.com/lostisland/faraday), which, when used with [NetHttpPersistent adapter](https://lostisland.github.io/faraday/adapters/net-http-persistent), makes connections persistent by default.

Testing in AKS showed that SNAT port usage with persistent connections is constant, no matter how many requests our plugins make to API server.

###### Testing performed

- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
