### PR TITLE
docs: Update documentation about authenticating with container registries

### DIFF
--- a/deploy/docs/Working_with_container_registries.md
+++ b/deploy/docs/Working_with_container_registries.md
@@ -3,41 +3,62 @@
 ## Authenticating with container registry
 
 Sumo Logic container images used for collection are currently hosted on
-[Docker Hub](https://hub.docker.com/) which
-[requires authentication to provide a higher quota for image pulls][docker-rate-limit].
+[Amazon Public ECR][aws-public-ecr-docs] which requires authentication to provide
+a higher quota for image pulls.
+To find a comprehensive information on this please refer to
+[Amazon Elastic Container Registry pricing][aws-ecr-pricing].
 
-In order to authenticate with the container registry hosted on
-[Docker Hub](https://hub.docker.com/) when using helm installation you can use
-`sumologic.pullSecrets` to pass Kubernetes secret names that contain
-the required credentials.
+In order to authenticate with AWS Public ECR (to prevent hitting unauthenticated
+pulls quota) when using helm installation one can use `sumologic.pullSecrets`
+to pass Kubernetes secret names that contain the required credentials.
 
-Creating aforementioned secret is beyond the scope of this document.
-Extensive documentation on this subject can be found at
-[Creating a Secret with a Docker config at kubernetes.io][k8s-docker-secret].
+Secret with registry credentials can be created using the following commands:
 
-[docker-rate-limit]: https://www.docker.com/increase-rate-limits
+```
+kubectl create secret docker-registry ${SECRET_NAME} \
+  --docker-server=public.ecr.aws \
+  --docker-username=AWS \
+  --docker-password=$(aws ecr-public --region us-east-1 get-login-password)
+```
+
+After creating the secret one can use it in the following way:
+
+```yaml
+sumologic:
+  ...
+  pullSecrets:
+    - name: ${SECRET_NAME}
+```
+
+For more information on using Kubernetes secrets with container registries please
+refer to [Creating a Secret with a Docker config at kubernetes.io][k8s-docker-secret].
+
+[aws-public-ecr-docs]: https://aws.amazon.com/blogs/aws/amazon-ecr-public-a-new-public-container-registry/
 [k8s-docker-secret]: https://kubernetes.io/docs/concepts/containers/images/#creating-a-secret-with-a-docker-config
+[aws-ecr-pricing]: https://aws.amazon.com/ecr/pricing/
 
 ## Hosting Sumo Logic images
 
-Another approach to work around [Docker Hub](https://hub.docker.com/) limits is
-to host Sumo Logic images in one's own container registry.
+Another approach to work around Amazon Public ECR limits is to host Sumo Logic
+images in one's own container registry.
 
 Describing how to push images or how to authenticate with many different container
 registries is beyond the scope of this document but in general instructions can
 be narrowed down to:
 
 ```
-docker pull sumologic/kubernetes-fluentd:${SUMO_IMAGE_VERSION}
-docker tag sumologic/kubernetes-fluentd:${SUMO_IMAGE_VERSION} ${REGISTRY_REPO_URL}:${VERSION}
-docker push ${REGISTRY_REPO_URL}:${VERSION}
+docker pull public.ecr.aws/sumologic/kubernetes-fluentd:${SUMO_IMAGE_VERSION}
+docker tag public.ecr.aws/sumologic/kubernetes-fluentd:${SUMO_IMAGE_VERSION} ${REGISTRY_REPO_URL}:${TAG}
+docker push ${REGISTRY_REPO_URL}:${TAG}
 ```
 
-One can then use `${REGISTRY_REPO_URL}:${VERSION}` in `values.yaml` as such:
+One can then use `${REGISTRY_REPO_URL}:${TAG}` in `values.yaml` as such:
 
 ```yaml
-image:
-  repository: ${REGISTRY_REPO_URL}
-  tag: ${VERSION}
-  pullPolicy: IfNotPresent
+fluentd:
+  ...
+  image:
+    repository: ${REGISTRY_REPO_URL}
+    tag: ${TAG}
+    pullPolicy: IfNotPresent
 ```


### PR DESCRIPTION
###### Description

Since container images have been moved to AWS Public ECR let's update the docs accordingly and explain how to authenticate

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
