### PR TITLE
Bump fluentd from 1.12.0-sumo-0-rc.0 to 1.12.0-sumo-1-rc.0

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -196,7 +196,7 @@ sumologic:
 fluentd:
   image:
     repository: public.ecr.aws/sumologic/kubernetes-fluentd
-    tag: 1.12.0-sumo-0-rc.0
+    tag: 1.12.0-sumo-1-rc.0
     pullPolicy: IfNotPresent
 
   ## Specifies whether a PodSecurityPolicy should be created


### PR DESCRIPTION
Changelog: https://github.com/SumoLogic/sumologic-kubernetes-fluentd/releases/tag/v1.12.0-sumo-1-rc.0

- Make connections to k8s API server persistent (https://github.com/SumoLogic/sumologic-kubernetes-fluentd/pull/111)
- Bump net-http-persistent from 3.1.0 to 4.0.1 (https://github.com/SumoLogic/sumologic-kubernetes-fluentd/pull/117)