### PR TITLE
Bump fluent-bit to 1.6.10

### DIFF
--- a/deploy/helm/fluent-bit-overrides.yaml
+++ b/deploy/helm/fluent-bit-overrides.yaml
@@ -2,7 +2,7 @@
 image:
   fluent_bit:
     repository: public.ecr.aws/sumologic/fluent-bit
-    tag: 1.6.0
+    tag: 1.6.10
 ## Resource limits for fluent-bit
 resources: {}
 # limits:

--- a/deploy/helm/sumologic/Chart.lock
+++ b/deploy/helm/sumologic/Chart.lock
@@ -1,0 +1,18 @@
+dependencies:
+- name: fluent-bit
+  repository: https://fluent.github.io/helm-charts
+  version: 0.7.13
+- name: kube-prometheus-stack
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 12.3.0
+- name: falco
+  repository: https://falcosecurity.github.io/charts
+  version: 1.5.7
+- name: metrics-server
+  repository: https://charts.bitnami.com/bitnami
+  version: 5.0.2
+- name: telegraf-operator
+  repository: https://helm.influxdata.com/
+  version: 1.1.5
+digest: sha256:8434ad5edecfa173c9fa856987ca044c2d2bec45ac465332d1c135c004b2e46b
+generated: "2021-01-25T10:03:10.173435248Z"

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -706,7 +706,7 @@ fluent-bit:
   image:
     fluent_bit:
       repository: public.ecr.aws/sumologic/fluent-bit
-      tag: 1.6.0
+      tag: 1.6.10
   ## Resource limits for fluent-bit
   resources: {}
     # limits:


### PR DESCRIPTION
###### Description

Bump fluent-bit to newest version (1.6.10)

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
