### PR TITLE
Enable otlphttp exporter in tracing collection

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -2184,13 +2184,18 @@ otelcol:
       ## being much more verbose and including (sampled) spans content
       # logging:
       #   loglevel: debug
+      otlphttp:
+        endpoint: ${SUMO_ENDPOINT_DEFAULT_TRACES_SOURCE}
     service:
       extensions: [health_check]
       pipelines:
         traces:
           receivers: [jaeger, opencensus, otlp, zipkin]
           processors: [memory_limiter, k8s_tagger, source, resource, batch]
+          ## To enable otlphttp exporter comment out following line
           exporters: [zipkin]
+          ## and uncomment next one
+          # exporters: [otlphttp]
 
 ## Configure telegraf-operator
 ## This is an experimental configuration and shouldn't be used in production environment

--- a/tests/tracing/static/collection-monitoring-false.output.yaml
+++ b/tests/tracing/static/collection-monitoring-false.output.yaml
@@ -13,6 +13,8 @@ data:
   traces.otelcol.conf.yaml: |
     
     exporters:
+      otlphttp:
+        endpoint: ${SUMO_ENDPOINT_DEFAULT_TRACES_SOURCE}
       zipkin:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_TRACES_SOURCE}
     extensions:

--- a/tests/tracing/static/simple.output.yaml
+++ b/tests/tracing/static/simple.output.yaml
@@ -13,6 +13,8 @@ data:
   traces.otelcol.conf.yaml: |
     
     exporters:
+      otlphttp:
+        endpoint: ${SUMO_ENDPOINT_DEFAULT_TRACES_SOURCE}
       zipkin:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_TRACES_SOURCE}
     extensions:


### PR DESCRIPTION

###### Description

Enable otlphttp exporter in tracing collection

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
