### PR TITLE
Bump otelagent version from 0.16.2-sumo to 0.19.2-sumo

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1910,7 +1910,7 @@ otelagent:
     memBallastSizeMib: "250"
     image:
       repository: "public.ecr.aws/sumologic/opentelemetry-collector"
-      tag: "0.16.2-sumo"
+      tag: "0.19.2-sumo"
       pullPolicy: IfNotPresent
 
     ## Extra Environment Values - allows yaml definitions


### PR DESCRIPTION
###### Description

Bump otelagent version from 0.16.2-sumo to 0.19.2-sumo

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
