### PR TITLE
Upgrade Fluentd to 1.12.0-sumo-1

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -196,7 +196,7 @@ sumologic:
 fluentd:
   image:
     repository: public.ecr.aws/sumologic/kubernetes-fluentd
-    tag: 1.11.5-sumo-0
+    tag: 1.12.0-sumo-1
     pullPolicy: IfNotPresent
 
   ## Specifies whether a PodSecurityPolicy should be created


### PR DESCRIPTION
Changes from 1.11.5-sumo-0:
- Upgrade Fluentd to 1.12.0
- Make connections to k8s API server persistent
- Use numeric user ID in Fluentd Dockerfile

See https://github.com/SumoLogic/sumologic-kubernetes-fluentd/compare/v1.11.5-sumo-0...v1.12.0-sumo-1
for all commits.