### PR TITLE
Allow setting securityContext per container in fluentd statefulsets

### DIFF
--- a/deploy/helm/sumologic/templates/events-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/events-statefulset.yaml
@@ -65,6 +65,10 @@ spec:
         imagePullPolicy: {{ .Values.fluentd.image.pullPolicy }}
         resources:
           {{- toYaml .Values.fluentd.events.statefulset.resources | nindent 10 }}
+        {{- if .Values.fluentd.events.statefulset.containers.fluentd.securityContext }}
+        securityContext:
+          {{- toYaml .Values.fluentd.events.statefulset.containers.fluentd.securityContext | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - name: config-volume
           mountPath: /fluentd/etc/

--- a/deploy/helm/sumologic/templates/metrics-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics-statefulset.yaml
@@ -105,6 +105,10 @@ spec:
         imagePullPolicy: {{ .Values.fluentd.image.pullPolicy }}
         resources:
           {{- toYaml .Values.fluentd.metrics.statefulset.resources | nindent 10 }}
+        {{- if .Values.fluentd.metrics.statefulset.containers.fluentd.securityContext }}
+        securityContext:
+          {{- toYaml .Values.fluentd.metrics.statefulset.containers.fluentd.securityContext | nindent 10 }}
+        {{- end }}
         ports:
         - name: prom-write
           containerPort: 9888

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -105,6 +105,10 @@ spec:
         imagePullPolicy: {{ .Values.fluentd.image.pullPolicy }}
         resources:
           {{- toYaml .Values.fluentd.logs.statefulset.resources | nindent 10 }}
+        {{- if .Values.fluentd.logs.statefulset.containers.fluentd.securityContext }}
+        securityContext:
+          {{- toYaml .Values.fluentd.logs.statefulset.containers.fluentd.securityContext | nindent 10 }}
+        {{- end }}
         ports:
         {{- if .Values.sumologic.traces.enabled }}
         - name: zipkin-write

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -346,6 +346,11 @@ fluentd:
       ## Add custom annotations only to logs fluentd sts pods
       podAnnotations: {}
 
+      ## Set securityContext for containers running in pods in logs statefulset.
+      containers:
+        fluentd:
+          securityContext: {}
+
     ## Option to turn autoscaling on for fluentd and specify params for HPA.
     ## Autoscaling needs metrics-server to access cpu metrics.
     autoscaling:
@@ -604,6 +609,11 @@ fluentd:
       ## Add custom annotations only to metrics fluentd sts pods
       podAnnotations: {}
 
+      ## Set securityContext for containers running in pods in metrics statefulset.
+      containers:
+        fluentd:
+          securityContext: {}
+
     ## Option to turn autoscaling on for fluentd and specify params for HPA.
     ## Autoscaling needs metrics-server to access cpu metrics.
     autoscaling:
@@ -722,6 +732,11 @@ fluentd:
       podLabels: {}
       ## Add custom annotations only to events fluentd sts pods
       podAnnotations: {}
+
+      ## Set securityContext for containers running in pods in events statefulset.
+      containers:
+        fluentd:
+          securityContext: {}
 
     ## Source category for the Events source. Default: "{clusterName}/events"
     sourceCategory: ""


### PR DESCRIPTION
###### Description

Allow setting `securityContext` for each fluentd container separately in logs, events and metrics statefulsets.

---

###### Testing performed

- [x] Tested in vagrant environment
