### PR TITLE
[Backport release-v2.0] Use the ECR repository for dependencies: Fluent Bit, Telegraf and Falco

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -768,6 +768,7 @@ metrics-server:
 ## ref: https://github.com/fluent/helm-charts/blob/master/charts/fluent-bit/values.yaml
 fluent-bit:
   image:
+    repository: public.ecr.aws/sumologic/fluent-bit
     pullPolicy: IfNotPresent
     # If specified, use these secrets to access the image
     # pullSecrets:
@@ -2196,6 +2197,8 @@ otelcol:
 ## ref: https://github.com/influxdata/helm-charts/blob/master/charts/telegraf-operator/values.yaml
 telegraf-operator:
   enabled: false
+  image:
+    sidecarImage: public.ecr.aws/sumologic/telegraf:1.14.4
   replicaCount: 1
   classes:
     secretName: "telegraf-operator-classes"
@@ -2214,6 +2217,9 @@ telegraf-operator:
 ## https://github.com/falcosecurity/charts/tree/master/falco
 falco:
   enabled: false
+  image:
+    registry: public.ecr.aws
+    repository: sumologic/falco
 
   ## Add kernel-devel package through MachineConfig, required to enable building of missing falco modules (only for OpenShift)
   addKernelDevel: true

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -2031,12 +2031,12 @@ otelcol:
     #     mountPath: /certs
     #     readOnly: true
 
-  # To enable collecting all logs, set to false
+  ## To enable collecting all logs, set to false
   logLevelFilter: true
-  # Metrics from Collector
+  ## Metrics from Collector
   metrics:
     enabled: true
-  # Collector configuration
+  ## Collector configuration
   config:
     receivers:
       jaeger:
@@ -2214,11 +2214,12 @@ telegraf-operator:
 ## https://github.com/falcosecurity/charts/tree/master/falco
 falco:
   enabled: false
-  # Add kernel-devel package through MachineConfig, required to enable building of missing falco modules (only for OpenShift)
+
+  ## Add kernel-devel package through MachineConfig, required to enable building of missing falco modules (only for OpenShift)
   addKernelDevel: true
-  # Add initContainers to Falco pod
+  ## Add initContainers to Falco pod
   extraInitContainers:
-    # Add initContainer to wait until kernel-devel is installed on host
+    ## Add initContainer to wait until kernel-devel is installed on host
     - name: init-falco
       image: busybox
       command:
@@ -2236,9 +2237,9 @@ falco:
         - mountPath: /host/etc
           name: etc-fs
           readOnly: true
-  # Enable eBPF support for Falco instead of falco-probe kernel module.
-  # Set to true for GKE, for details see:
-  # https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/release-v2.0/deploy/docs/Troubleshoot_Collection.md#falco-and-google-kubernetes-engine-gke
+  ## Enable eBPF support for Falco instead of falco-probe kernel module.
+  ## Set to true for GKE, for details see:
+  ## https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/release-v2.0/deploy/docs/Troubleshoot_Collection.md#falco-and-google-kubernetes-engine-gke
   # ebpf:
   #   enabled: true
   falco:
@@ -2246,12 +2247,12 @@ falco:
   # image:
   #   pullSecrets: []
   customRules:
-    # Mark the following as known k8s api callers:
-    # * fluentd and its plugins from sumologic/kubernetes-fluentd image
-    # * prometheus
-    # * prometheus operator
-    # * telegraf operator
-    # * grafana sidecar
+    ## Mark the following as known k8s api callers:
+    ## * fluentd and its plugins from sumologic/kubernetes-fluentd image
+    ## * prometheus
+    ## * prometheus operator
+    ## * telegraf operator
+    ## * grafana sidecar
     rules_user_known_k8s_api_callers.yaml: |-
       - macro: user_known_contact_k8s_api_server_activities
         condition: >
@@ -2265,8 +2266,8 @@ falco:
         condition: >
           (container.image.repository = "falcosecurity/falco") or
           (container.image.repository = "quay.io/prometheus/node-exporter")
-    # NOTE: kube-proxy not exact matching because of regional ecr e.g.
-    # 602401143452.dkr.ecr.us-west-1.amazonaws.com/eks/kube-proxy
+    ## NOTE: kube-proxy not exact matching because of regional ecr e.g.
+    ## 602401143452.dkr.ecr.us-west-1.amazonaws.com/eks/kube-proxy
     rules_user_privileged_containers.yaml: |-
       - macro: user_privileged_containers
         condition: >


### PR DESCRIPTION
Backport db1e9f89bd2153e043409e1e465784880898f4f9 and b02fc8d3cdb55a34b9ed6c70928ef0352b96f7dd from https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1442
