### PR TITLE
[Backport release-v2.0] The v2 migration script fix - migrate Fluent Bit image key instead of deleting it

### DIFF
--- a/deploy/helm/sumologic/upgrade-2.0.0.sh
+++ b/deploy/helm/sumologic/upgrade-2.0.0.sh
@@ -650,8 +650,12 @@ function migrate_fluent_bit() {
     yq w -i "${TEMP_FILE}" 'fluent-bit.env.(name==CHART).name' FLUENTD_LOGS_SVC
   fi
 
-  if [[ -n "$(yq r "${TEMP_FILE}" -- 'fluent-bit.image.fluent_bit')" ]]; then
-    yq w -i "${TEMP_FILE}" 'fluent-bit.image.pullPolicy' IfNotPresent
+  local default_image_pull_policy="IfNotPresent"
+  local image_pull_policy
+  readonly image_pull_policy="$(yq r "${TEMP_FILE}" -- 'fluent-bit.image.pullPolicy')"
+  if [[ -n ${image_pull_policy} ]] && [[ ${image_pull_policy} != "${default_image_pull_policy}" ]]; then
+    info "Leaving the fluent-bit.image.pullPolicy set to '${image_pull_policy}'"
+    info "Please note that in v2.0 the fluent-bit.image.pullPolicy is set to '${default_image_pull_policy}' by default"
   fi
 
   local default_image_tag="1.6.10"
@@ -660,7 +664,7 @@ function migrate_fluent_bit() {
   if [[ -n ${image_tag} ]] && [[ ${image_tag} != "${default_image_tag}" ]]; then
     info "Leaving the fluent-bit.image.tag set to '${image_tag}'"
     info "Please note that in v2.0 the fluent-bit.image.tag is set to '${default_image_tag}' by default"
-   fi
+  fi
 
   if [[ -n "$(yq r "${TEMP_FILE}" -- 'fluent-bit.service.flush')" ]]; then
     yq w -i "${TEMP_FILE}" 'fluent-bit.service.labels."sumologic.com/scrape"' --style double true

--- a/deploy/helm/sumologic/upgrade-2.0.0.sh
+++ b/deploy/helm/sumologic/upgrade-2.0.0.sh
@@ -15,6 +15,8 @@ readonly MAX_YQ_VERSION=4.0.0
 readonly KEY_MAPPINGS="
 prometheus-operator.prometheusOperator.tlsProxy.enabled:kube-prometheus-stack.prometheusOperator.tls.enabled
 otelcol.deployment.image.name:otelcol.deployment.image.repository
+fluent-bit.image.fluent_bit.repository:fluent-bit.image.repository
+fluent-bit.image.fluent_bit.tag:fluent-bit.image.tag
 "
 
 readonly KEY_VALUE_MAPPINGS="
@@ -31,7 +33,6 @@ prometheus-operator
 fluent-bit.metrics
 fluent-bit.trackOffsets
 fluent-bit.service.flush
-fluent-bit.image.fluent_bit
 fluent-bit.backend
 fluent-bit.input
 fluent-bit.parsers
@@ -652,6 +653,14 @@ function migrate_fluent_bit() {
   if [[ -n "$(yq r "${TEMP_FILE}" -- 'fluent-bit.image.fluent_bit')" ]]; then
     yq w -i "${TEMP_FILE}" 'fluent-bit.image.pullPolicy' IfNotPresent
   fi
+
+  local default_image_tag="1.6.10"
+  local image_tag
+  readonly image_tag="$(yq r "${TEMP_FILE}" -- 'fluent-bit.image.tag')"
+  if [[ -n ${image_tag} ]] && [[ ${image_tag} != "${default_image_tag}" ]]; then
+    info "Leaving the fluent-bit.image.tag set to '${image_tag}'"
+    info "Please note that in v2.0 the fluent-bit.image.tag is set to '${default_image_tag}' by default"
+   fi
 
   if [[ -n "$(yq r "${TEMP_FILE}" -- 'fluent-bit.service.flush')" ]]; then
     yq w -i "${TEMP_FILE}" 'fluent-bit.service.labels."sumologic.com/scrape"' --style double true

--- a/tests/upgrade_v2_script/static/fluent_bit.input.yaml
+++ b/tests/upgrade_v2_script/static/fluent_bit.input.yaml
@@ -39,6 +39,7 @@ fluent-bit:
     fluent_bit:
       repository: public.ecr.aws/sumologic/fluent-bit
       tag: 1.6.10
+    pullPolicy: Always
   service:
     flush: 5
   metrics:

--- a/tests/upgrade_v2_script/static/fluent_bit.input.yaml
+++ b/tests/upgrade_v2_script/static/fluent_bit.input.yaml
@@ -38,7 +38,7 @@ fluent-bit:
   image:
     fluent_bit:
       repository: public.ecr.aws/sumologic/fluent-bit
-      tag: 1.6.0
+      tag: 1.6.10
   service:
     flush: 5
   metrics:

--- a/tests/upgrade_v2_script/static/fluent_bit.log
+++ b/tests/upgrade_v2_script/static/fluent_bit.log
@@ -2,6 +2,8 @@
 [INFO]    Mapping fluent-bit.image.fluent_bit.tag into fluent-bit.image.tag
 
 [INFO]    Migrating prometheus remote write urls
+[INFO]    Leaving the fluent-bit.image.pullPolicy set to 'Always'
+[INFO]    Please note that in v2.0 the fluent-bit.image.pullPolicy is set to 'IfNotPresent' by default
 [INFO]    Migrating "fluent-bit.backend.forward.host" from "${CHART}.${NAMESPACE}.svc.cluster.local." to "${FLUENTD_LOGS_SVC}.${NAMESPACE}.svc.cluster.local."
 [WARNING] You have an unexpected section in your fluent-bit configuration that we're not migrating automatically. It shouldn't be necessary in 2.0 but please consider whether you need to migrate this manually. Line: @INCLUDE fluent-bit-service.conf
 [INFO]    Migrating fluent-bit's input config from Multiline to Docker_Mode

--- a/tests/upgrade_v2_script/static/fluent_bit.log
+++ b/tests/upgrade_v2_script/static/fluent_bit.log
@@ -1,3 +1,5 @@
+[INFO]    Mapping fluent-bit.image.fluent_bit.repository into fluent-bit.image.repository
+[INFO]    Mapping fluent-bit.image.fluent_bit.tag into fluent-bit.image.tag
 
 [INFO]    Migrating prometheus remote write urls
 [INFO]    Migrating "fluent-bit.backend.forward.host" from "${CHART}.${NAMESPACE}.svc.cluster.local." to "${FLUENTD_LOGS_SVC}.${NAMESPACE}.svc.cluster.local."

--- a/tests/upgrade_v2_script/static/fluent_bit.output.yaml
+++ b/tests/upgrade_v2_script/static/fluent_bit.output.yaml
@@ -36,7 +36,8 @@ fluent-bit:
     - effect: NoSchedule
       operator: Exists
   image:
-    pullPolicy: IfNotPresent
+    repository: public.ecr.aws/sumologic/fluent-bit
+    tag: 1.6.10
   service:
     labels:
       sumologic.com/scrape: "true"

--- a/tests/upgrade_v2_script/static/fluent_bit.output.yaml
+++ b/tests/upgrade_v2_script/static/fluent_bit.output.yaml
@@ -38,6 +38,7 @@ fluent-bit:
   image:
     repository: public.ecr.aws/sumologic/fluent-bit
     tag: 1.6.10
+    pullPolicy: Always
   service:
     labels:
       sumologic.com/scrape: "true"

--- a/tests/upgrade_v2_script/static/fluent_bit_image.input.yaml
+++ b/tests/upgrade_v2_script/static/fluent_bit_image.input.yaml
@@ -1,0 +1,6 @@
+fluent-bit:
+  image:
+    fluent_bit:
+      repository: public.ecr.aws/sumologic/fluent-bit
+      tag: 1.6.0
+    pullPolicy: Always

--- a/tests/upgrade_v2_script/static/fluent_bit_image.log
+++ b/tests/upgrade_v2_script/static/fluent_bit_image.log
@@ -1,0 +1,11 @@
+[INFO]    Mapping fluent-bit.image.fluent_bit.repository into fluent-bit.image.repository
+[INFO]    Mapping fluent-bit.image.fluent_bit.tag into fluent-bit.image.tag
+
+[INFO]    Migrating prometheus remote write urls
+[INFO]    Leaving the fluent-bit.image.pullPolicy set to 'Always'
+[INFO]    Please note that in v2.0 the fluent-bit.image.pullPolicy is set to 'IfNotPresent' by default
+[INFO]    Leaving the fluent-bit.image.tag set to '1.6.0'
+[INFO]    Please note that in v2.0 the fluent-bit.image.tag is set to '1.6.10' by default
+
+Thank you for upgrading to v2.0.0 of the Sumo Logic Kubernetes Collection Helm chart.
+A new yaml file has been generated for you. Please check the current directory for new_values.yaml.

--- a/tests/upgrade_v2_script/static/fluent_bit_image.output.yaml
+++ b/tests/upgrade_v2_script/static/fluent_bit_image.output.yaml
@@ -1,0 +1,5 @@
+fluent-bit:
+  image:
+    repository: public.ecr.aws/sumologic/fluent-bit
+    tag: 1.6.0
+    pullPolicy: Always

--- a/tests/upgrade_v2_script/static/fluent_bit_no_image.input.yaml
+++ b/tests/upgrade_v2_script/static/fluent_bit_no_image.input.yaml
@@ -1,0 +1,39 @@
+fluent-bit:
+  podLabels: {}
+  podAnnotations: {}
+  env:
+    - name: CHART
+      valueFrom:
+        configMapKeyRef:
+          name: sumologic-configmap
+          key: fluentdLogs
+    - name: NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+  extraVolumes:
+    - name: project2-db
+      emptyDir: {}
+    - name: project-db
+      emptyDir: {}
+    - name: project2-alerts
+      hostPath:
+        path: /var/project2/logs/alerts/alerts.json
+        type: File
+    - name: company-db
+      emptyDir: {}
+  extraVolumeMounts:
+    - name: project2-db
+      mountPath: /fluent-bit/project2
+    - name: project-db
+      mountPath: /fluent-bit/project
+    - name: project2-alerts
+      mountPath: /var/project2/logs/alerts/alerts.json
+      readOnly: true
+    - name: company-db
+      mountPath: /fluent-bit/company
+  tolerations:
+    - effect: NoSchedule
+      operator: Exists
+  service:
+    flush: 5

--- a/tests/upgrade_v2_script/static/fluent_bit_no_image.log
+++ b/tests/upgrade_v2_script/static/fluent_bit_no_image.log
@@ -1,0 +1,5 @@
+
+[INFO]    Migrating prometheus remote write urls
+
+Thank you for upgrading to v2.0.0 of the Sumo Logic Kubernetes Collection Helm chart.
+A new yaml file has been generated for you. Please check the current directory for new_values.yaml.

--- a/tests/upgrade_v2_script/static/fluent_bit_no_image.output.yaml
+++ b/tests/upgrade_v2_script/static/fluent_bit_no_image.output.yaml
@@ -1,0 +1,40 @@
+fluent-bit:
+  podLabels: {}
+  podAnnotations: {}
+  env:
+    - name: FLUENTD_LOGS_SVC
+      valueFrom:
+        configMapKeyRef:
+          name: sumologic-configmap
+          key: fluentdLogs
+    - name: NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+  extraVolumes:
+    - name: project2-db
+      emptyDir: {}
+    - name: project-db
+      emptyDir: {}
+    - name: project2-alerts
+      hostPath:
+        path: /var/project2/logs/alerts/alerts.json
+        type: File
+    - name: company-db
+      emptyDir: {}
+  extraVolumeMounts:
+    - name: project2-db
+      mountPath: /fluent-bit/project2
+    - name: project-db
+      mountPath: /fluent-bit/project
+    - name: project2-alerts
+      mountPath: /var/project2/logs/alerts/alerts.json
+      readOnly: true
+    - name: company-db
+      mountPath: /fluent-bit/company
+  tolerations:
+    - effect: NoSchedule
+      operator: Exists
+  service:
+    labels:
+      sumologic.com/scrape: "true"


### PR DESCRIPTION
Backport b8d9c62349f4b125305218cc1cc714301145cd73 and 577e2a8d5331e8a0af047639e83ee24f3f3b6564 from https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1444