### PR TITLE
Prepare v2.0.3-rc.0

### DIFF
--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sumologic
-version: 2.0.2
-appVersion: 2.0.2
+version: 2.0.3-rc.0
+appVersion: 2.0.3-rc.0
 description: A Helm chart for collecting Kubernetes logs, metrics, traces and events into Sumo Logic.
 type: application
 keywords:


### PR DESCRIPTION
List of commits since `v2.0.2`:

* 15d55392 Prepare v2.0.3-rc.0
* 4e3a8a3a fix: v2 migration script - info on new default value for fluent-bit.image.pullPolicy key instead of just adding it
* d50a3281 fix: v2 migration script - migrate fluent-bit.image.fluent_bit key instead of deleting it
* 0a1c9a50 fix: use the ECR repository for dependencies: Fluent Bit, Telegraf and Falco
* c13df764 doc: fix comments in values.yaml - use double hash at the beginning of a line
* 71c135ae Update additional_prometheus_configuration.md
* f01184ef Allow setting securityContext per container in fluentd statefulsets