### PR TITLE
Fix #1453, remove build-setup from Makefile and README

### DIFF
--- a/vagrant/Makefile
+++ b/vagrant/Makefile
@@ -18,19 +18,6 @@ namespace = sumologic
 test:
 	$(MAKE) -C ${root_dir} test
 
-build-setup:
-	cd ${root_dir} && $(MAKE) -C ${root_dir}deploy/docker/setup build
-	${mkfile_path} \
-		tag-and-push-local-setup
-
-tag-and-push-local-setup:
-	$(eval timestamp := $(shell date +%s))
-	docker tag kubernetes-setup:latest localhost:32000/kubernetes-setup:local-${timestamp}
-	docker push localhost:32000/kubernetes-setup:local-${timestamp}
-	touch ${local_values_file}
-	yq w -i ${local_values_file} sumologic.setup.job.image.repository localhost:32000/kubernetes-setup
-	yq w -i ${local_values_file} sumologic.setup.job.image.tag local-${timestamp}
-
 generate-local-config:
 	${vagrant_scripts_dir}/generate-local-config.sh
 

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -32,20 +32,6 @@ vagrant ssh
 
 NOTICE: The directory with sumo-kubernetes-collection repository on the host is synced with `/sumologic/` directory on the virtual machine.
 
-## Build setup job
-
-On the virtual machine, to build the setup job Docker image please use `build-setup` target:
-
-```bash
-sumo-make build-setup
-```
-
-or
-
-```bash
-/sumologic/vagrant/Makefile build-setup
-```
-
 ## Collector
 
 To install or upgrade collector please type:


### PR DESCRIPTION
###### Description

Fix #1453
Backport to 2.0 in https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1367

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
