### PR TITLE
Make pdb definitions and usage consistent

### DIFF
--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -312,6 +312,10 @@ helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 {{ template "sumologic.metadata.name.logs" . }}
 {{- end -}}
 
+{{- define "sumologic.metadata.name.logs.pdb" -}}
+{{ template "sumologic.metadata.name.logs.statefulset" . }}-pdb
+{{- end -}}
+
 {{- define "sumologic.metadata.name.logs.hpa" -}}
 {{- template "sumologic.metadata.name.logs" . }}
 {{- end -}}

--- a/deploy/helm/sumologic/templates/logs-pdb.yaml
+++ b/deploy/helm/sumologic/templates/logs-pdb.yaml
@@ -1,11 +1,13 @@
+{{- if and .Values.sumologic.logs.enabled .Values.fluentd.logs.enabled -}}
 {{- if .Values.fluentd.logs.podDisruptionBudget -}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ template "sumologic.metadata.name.logs.statefulset" . }}-pdb
+  name: {{ template "sumologic.metadata.name.logs.pdb" . }}
 spec:
   selector:
     matchLabels:
       app: {{ template "sumologic.labels.app.logs.statefulset" . }}
 {{ toYaml .Values.fluentd.logs.podDisruptionBudget | indent 2 }}
+{{- end -}}
 {{- end -}}

--- a/deploy/helm/sumologic/templates/metrics-pdb.yaml
+++ b/deploy/helm/sumologic/templates/metrics-pdb.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.sumologic.metrics.enabled true) (eq .Values.fluentd.metrics.enabled true) -}}
+{{- if and .Values.sumologic.metrics.enabled .Values.fluentd.metrics.enabled -}}
 {{- if .Values.fluentd.metrics.podDisruptionBudget -}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget


### PR DESCRIPTION
###### Description

Up until now logs pdb was created unconditionally. Change this so that it depends on `.Values.sumologic.logs.enabled` and `.Values.fluentd.logs.enabled`.

While at it, add `sumologic.metadata.name.logs.pdb` template to be consistent with metrics pdb.

---

###### Testing performed

- [x] Redeploy fluentds in vagrant env
