### PR TITLE
Change backport bot token

### DIFF
--- a/.github/workflows/backport_bot.yaml
+++ b/.github/workflows/backport_bot.yaml
@@ -13,4 +13,4 @@ jobs:
       - name: Backport
         uses: tibdex/backport@v1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.BACKPORT_BOT_PAT }}


### PR DESCRIPTION
###### Description

Change from `GITHUB_TOKEN` to a personal access token because of [this](https://github.com/tibdex/autosquash/blob/17fa441faea2c28da8c0dbad1156c7709e93b96d/.github/workflows/autosquash.yml#L27-L33)

> The built-in secrets.GITHUB_TOKEN cannot yet be used because of this limitation:
> https://github.community/t5/GitHub-Actions/Triggering-a-new-workflow-from-another-workflow/td-p/31676
> In the meantime, use a token granting write access on the repo:
> - a GitHub App token
>   See https://github.com/marketplace/actions/github-app-token.
> - a personal access token
>   See https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line.
