### PR TITLE
Bump metrics-server to 5.5.0

### DIFF
--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
     repository: https://falcosecurity.github.io/charts
     condition: falco.enabled
   - name: metrics-server
-    version: 5.0.2
+    version: 5.5.0
     repository: https://charts.bitnami.com/bitnami
     condition: metrics-server.enabled
   - name: telegraf-operator


### PR DESCRIPTION
###### Description

Bump metrics-server from 5.0.2 [bitnami/metrics-server/Chart.yaml](https://github.com/bitnami/charts/blob/a473ab8047931eafb8cc3850de943ed4efffa47a/bitnami/metrics-server/Chart.yaml) to 5.5.0 [bitnami/metrics-server/Chart.yaml](https://github.com/bitnami/charts/blob/41be44c267b104762815b6963bae864fdc0b91d0/bitnami/metrics-server/Chart.yaml)

This is to address the following warning during installation:

```
W0304 17:00:52.357213   96795 warnings.go:67] rbac.authorization.k8s.io/v1beta1 RoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 RoleBinding
```

which comes from

https://github.com/bitnami/charts/blob/a473ab8047931eafb8cc3850de943ed4efffa47a/bitnami/metrics-server/templates/role-binding.yaml#L2

and which in 5.5.0 uses `rbac.authorization.k8s.io/v1` https://github.com/bitnami/charts/blob/41be44c267b104762815b6963bae864fdc0b91d0/bitnami/metrics-server/templates/role-binding.yaml#L2 with the same appVersion of 0.4.1