### PR TITLE
Refine requirements for sumologic-terraform-provider to ~> 2.8.0

### DIFF
--- a/deploy/helm/sumologic/conf/setup/main.tf
+++ b/deploy/helm/sumologic/conf/setup/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     sumologic = {
       source  = "sumologic/sumologic"
-      version = "~> 2.6"
+      version = "~> 2.8.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/tests/terraform/static/all_fields.output.yaml
+++ b/tests/terraform/static/all_fields.output.yaml
@@ -137,7 +137,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.6"
+          version = "~> 2.8.0"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/terraform/static/collector_fields.output.yaml
+++ b/tests/terraform/static/collector_fields.output.yaml
@@ -136,7 +136,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.6"
+          version = "~> 2.8.0"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/terraform/static/conditional_sources.output.yaml
+++ b/tests/terraform/static/conditional_sources.output.yaml
@@ -126,7 +126,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.6"
+          version = "~> 2.8.0"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/terraform/static/custom.output.yaml
+++ b/tests/terraform/static/custom.output.yaml
@@ -126,7 +126,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.6"
+          version = "~> 2.8.0"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/terraform/static/default.output.yaml
+++ b/tests/terraform/static/default.output.yaml
@@ -136,7 +136,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.6"
+          version = "~> 2.8.0"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/terraform/static/disable_default_metrics.output.yaml
+++ b/tests/terraform/static/disable_default_metrics.output.yaml
@@ -135,7 +135,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.6"
+          version = "~> 2.8.0"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/terraform/static/strip_extrapolation.output.yaml
+++ b/tests/terraform/static/strip_extrapolation.output.yaml
@@ -136,7 +136,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.6"
+          version = "~> 2.8.0"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/terraform/static/traces.output.yaml
+++ b/tests/terraform/static/traces.output.yaml
@@ -127,7 +127,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.6"
+          version = "~> 2.8.0"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"


### PR DESCRIPTION
###### Description

Previous requirement of `~> 2.6` as per [terraform doc](https://www.terraform.io/docs/language/expressions/version-constraints.html#version-constraint-syntax) allows rightmost segment to increment. Let's refine the requirement to `~> 2.8.0
` so that we only get patch version releases.
