### PR TITLE
Bump setup image to 3.0.0

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -91,7 +91,7 @@ sumologic:
     job:
       image:
         repository: public.ecr.aws/sumologic/kubernetes-setup
-        tag: 2.0.1
+        tag: 3.0.0
         pullPolicy: IfNotPresent
       resources:
         limits:


### PR DESCRIPTION
###### Description

This will use https://github.com/SumoLogic/sumologic-kubernetes-setup/releases/tag/v3.0.0 which is based on terraform 0.13.

The image contains the same version of terraform as 2.0.1 used to but it aligns with semver versioning i.e. bumping terraform from 0.12 to 0.13 is a braking change to users and should hence be a major bump not a patch version bump.