### PR TITLE
Exclude `replicas` from Fluentd statefulsets when autoscaled

### DIFF
--- a/deploy/helm/sumologic/templates/metrics-statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics-statefulset.yaml
@@ -12,7 +12,9 @@ spec:
       app: {{ template "sumologic.labels.app.metrics.pod" . }}
   serviceName: {{ template "sumologic.metadata.name.metrics.service-headless" . }}
   podManagementPolicy: "Parallel"
+{{- if not .Values.fluentd.metrics.autoscaling.enabled }}
   replicas: {{ .Values.fluentd.metrics.statefulset.replicaCount }}
+{{- end }}
   template:
     metadata:
       annotations:

--- a/deploy/helm/sumologic/templates/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/statefulset.yaml
@@ -12,7 +12,9 @@ spec:
       app: {{ template "sumologic.labels.app.logs.pod" . }}
   serviceName: {{ template "sumologic.metadata.name.logs.service-headless" . }}
   podManagementPolicy: "Parallel"
+{{- if not .Values.fluentd.logs.autoscaling.enabled }}
   replicas: {{ .Values.fluentd.logs.statefulset.replicaCount }}
+{{- end }}
   template:
     metadata:
       annotations:


### PR DESCRIPTION
It is not needed and can cause trouble with GitOps tools.