### PR TITLE
vagrant: add script to get kubeconfig for vagrant cluster

### DIFF
--- a/vagrant/scripts/get-kubeconfig.sh
+++ b/vagrant/scripts/get-kubeconfig.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script replaces kubeconfig with configuration for vagrant cluster
+
+clean_up() {
+	rm "${SSH_CONFIG_PATH}" || true
+	rm "${CONFIG_PATH}" || true
+	rmdir "${TEMP_DIR}" || true
+	popd || true
+}
+
+err_report() {
+    echo "Script error on line $1"
+	clean_up
+    exit 1
+}
+trap 'err_report $LINENO' ERR
+
+readonly DIR="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
+readonly ROOT_DIR="${DIR}/../../"
+readonly TEMP_DIR="$(mktemp -d)"
+readonly SSH_CONFIG_PATH="${TEMP_DIR}/ssh-connect.conf"
+readonly VAGRANT_IP="192.168.78.66"
+readonly CONFIG_PATH="${TEMP_DIR}/config"
+readonly KUBECONFIG_PATH=~/.kube/config
+
+pushd "${ROOT_DIR}" > /dev/null
+vagrant ssh-config > "${SSH_CONFIG_PATH}"
+ssh -o StrictHostKeyChecking=no -F "${SSH_CONFIG_PATH}" default 'kubectl config view --raw' | \
+	sed "s/127.0.0.1/${VAGRANT_IP}/g" > "${CONFIG_PATH}"
+
+mv "${KUBECONFIG_PATH}" "${KUBECONFIG_PATH}.bkp.$(date +%s)"
+cp "${CONFIG_PATH}" "${KUBECONFIG_PATH}"
+
+clean_up


### PR DESCRIPTION
###### Description

vagrant: add script to get kubeconfig for vagrant cluster

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
