### PR TITLE
Fix match fluent.** deprecation warning

### DIFF
--- a/deploy/helm/sumologic/conf/common.conf
+++ b/deploy/helm/sumologic/conf/common.conf
@@ -1,7 +1,13 @@
-# Prevent fluentd from handling records containing its own logs.
-<match fluentd.**>
-  @type null
+# Prevent fluentd from handling records containing its own logs and health checks.
+<match fluentd.pod.healthcheck>
+  @type relabel
+  @label @FLUENT_LOG
 </match>
+<label @FLUENT_LOG>
+  <match **>
+    @type null
+  </match>
+</label>
 # expose the Fluentd metrics to Prometheus
 <source>
   @type prometheus


### PR DESCRIPTION
Fixes #1185

It also catches `fluentd.pod.healthcheck`s which are sent in kubernetes as liveness and readiness probes

https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/529c984c572d7ccc98a89b3c4aedc60db94feceb/deploy/helm/sumologic/templates/statefulset.yaml#L123-L135

Reference in FluentD docs: https://docs.fluentd.org/deployment/logging#capture-fluentd-logs