### PR TITLE
Upgrade Fluentd image to 1.12.0-sumo-2.1

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -196,7 +196,7 @@ sumologic:
 fluentd:
   image:
     repository: public.ecr.aws/sumologic/kubernetes-fluentd
-    tag: 1.12.0-sumo-2
+    tag: 1.12.0-sumo-2.1
     pullPolicy: IfNotPresent
 
   ## Specifies whether a PodSecurityPolicy should be created


### PR DESCRIPTION
###### Description

It's a backport of https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1510 with FluentD version https://github.com/SumoLogic/sumologic-kubernetes-fluentd/releases/tag/v1.12.0-sumo-2.1

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
