### PR TITLE
feature: Add a debug mode to the setup job

### DIFF
--- a/deploy/helm/sumologic/conf/setup/setup.sh
+++ b/deploy/helm/sumologic/conf/setup/setup.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+readonly DEBUG_MODE=${DEBUG_MODE:="false"}
+readonly DEBUG_MODE_ENABLED_FLAG="true"
+
+# Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
+# so that we don't have to deal with True vs true vs TRUE
+if [[ ${DEBUG_MODE,,} == ${DEBUG_MODE_ENABLED_FLAG} ]]; then
+    echo "Entering the debug mode with continuous sleep. No setup will be performed."
+    echo "Please exec into the setup container and run the setup.sh by hand or set the sumologic.setup.debug=false and reinstall."
+
+    while true; do
+        sleep 10
+        echo "$(date) Sleeping in the debug mode..."
+    done
+fi
+
 # Fix URL to remove "v1" or "v1/"
 export SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL%v1*}
 # Support proxy for Terraform

--- a/deploy/helm/sumologic/templates/setup/setup-job.yaml
+++ b/deploy/helm/sumologic/templates/setup/setup-job.yaml
@@ -71,6 +71,10 @@ spec:
           value: {{ .Values.sumologic.httpsProxy }}
         - name: NO_PROXY
           value: {{ .Values.sumologic.noProxy }}
+{{- if .Values.sumologic.setup.debug }}
+        - name: DEBUG_MODE
+          value: "true"
+{{- end }}
         {{ end }}
       securityContext:
         runAsUser: 999

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -106,6 +106,9 @@ sumologic:
       ## Add custom annotations only to setup job pod
       podAnnotations: {}
 
+    ## uncomment for the debug mode (disables the automatic run of the setup.sh script)
+    # debug: true
+
   collector:
     ## Configuration of additional collector fields
     ## https://help.sumologic.com/Manage/Fields#http-source-fields

--- a/tests/terraform/static/all_fields.output.yaml
+++ b/tests/terraform/static/all_fields.output.yaml
@@ -284,6 +284,21 @@ data:
   setup.sh: |
     #!/bin/bash
   
+    readonly DEBUG_MODE=${DEBUG_MODE:="false"}
+    readonly DEBUG_MODE_ENABLED_FLAG="true"
+  
+    # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
+    # so that we don't have to deal with True vs true vs TRUE
+    if [[ ${DEBUG_MODE,,} == ${DEBUG_MODE_ENABLED_FLAG} ]]; then
+        echo "Entering the debug mode with continuous sleep. No setup will be performed."
+        echo "Please exec into the setup container and run the setup.sh by hand or set the sumologic.setup.debug=false and reinstall."
+  
+        while true; do
+            sleep 10
+            echo "$(date) Sleeping in the debug mode..."
+        done
+    fi
+  
     # Fix URL to remove "v1" or "v1/"
     export SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL%v1*}
     # Support proxy for Terraform

--- a/tests/terraform/static/collector_fields.output.yaml
+++ b/tests/terraform/static/collector_fields.output.yaml
@@ -239,6 +239,21 @@ data:
   setup.sh: |
     #!/bin/bash
   
+    readonly DEBUG_MODE=${DEBUG_MODE:="false"}
+    readonly DEBUG_MODE_ENABLED_FLAG="true"
+  
+    # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
+    # so that we don't have to deal with True vs true vs TRUE
+    if [[ ${DEBUG_MODE,,} == ${DEBUG_MODE_ENABLED_FLAG} ]]; then
+        echo "Entering the debug mode with continuous sleep. No setup will be performed."
+        echo "Please exec into the setup container and run the setup.sh by hand or set the sumologic.setup.debug=false and reinstall."
+  
+        while true; do
+            sleep 10
+            echo "$(date) Sleeping in the debug mode..."
+        done
+    fi
+  
     # Fix URL to remove "v1" or "v1/"
     export SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL%v1*}
     # Support proxy for Terraform

--- a/tests/terraform/static/conditional_sources.output.yaml
+++ b/tests/terraform/static/conditional_sources.output.yaml
@@ -166,6 +166,21 @@ data:
   setup.sh: |
     #!/bin/bash
   
+    readonly DEBUG_MODE=${DEBUG_MODE:="false"}
+    readonly DEBUG_MODE_ENABLED_FLAG="true"
+  
+    # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
+    # so that we don't have to deal with True vs true vs TRUE
+    if [[ ${DEBUG_MODE,,} == ${DEBUG_MODE_ENABLED_FLAG} ]]; then
+        echo "Entering the debug mode with continuous sleep. No setup will be performed."
+        echo "Please exec into the setup container and run the setup.sh by hand or set the sumologic.setup.debug=false and reinstall."
+  
+        while true; do
+            sleep 10
+            echo "$(date) Sleeping in the debug mode..."
+        done
+    fi
+  
     # Fix URL to remove "v1" or "v1/"
     export SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL%v1*}
     # Support proxy for Terraform

--- a/tests/terraform/static/custom.output.yaml
+++ b/tests/terraform/static/custom.output.yaml
@@ -166,6 +166,21 @@ data:
   setup.sh: |
     #!/bin/bash
   
+    readonly DEBUG_MODE=${DEBUG_MODE:="false"}
+    readonly DEBUG_MODE_ENABLED_FLAG="true"
+  
+    # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
+    # so that we don't have to deal with True vs true vs TRUE
+    if [[ ${DEBUG_MODE,,} == ${DEBUG_MODE_ENABLED_FLAG} ]]; then
+        echo "Entering the debug mode with continuous sleep. No setup will be performed."
+        echo "Please exec into the setup container and run the setup.sh by hand or set the sumologic.setup.debug=false and reinstall."
+  
+        while true; do
+            sleep 10
+            echo "$(date) Sleeping in the debug mode..."
+        done
+    fi
+  
     # Fix URL to remove "v1" or "v1/"
     export SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL%v1*}
     # Support proxy for Terraform

--- a/tests/terraform/static/default.output.yaml
+++ b/tests/terraform/static/default.output.yaml
@@ -237,6 +237,21 @@ data:
   setup.sh: |
     #!/bin/bash
   
+    readonly DEBUG_MODE=${DEBUG_MODE:="false"}
+    readonly DEBUG_MODE_ENABLED_FLAG="true"
+  
+    # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
+    # so that we don't have to deal with True vs true vs TRUE
+    if [[ ${DEBUG_MODE,,} == ${DEBUG_MODE_ENABLED_FLAG} ]]; then
+        echo "Entering the debug mode with continuous sleep. No setup will be performed."
+        echo "Please exec into the setup container and run the setup.sh by hand or set the sumologic.setup.debug=false and reinstall."
+  
+        while true; do
+            sleep 10
+            echo "$(date) Sleeping in the debug mode..."
+        done
+    fi
+  
     # Fix URL to remove "v1" or "v1/"
     export SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL%v1*}
     # Support proxy for Terraform

--- a/tests/terraform/static/disable_default_metrics.output.yaml
+++ b/tests/terraform/static/disable_default_metrics.output.yaml
@@ -230,6 +230,21 @@ data:
   setup.sh: |
     #!/bin/bash
   
+    readonly DEBUG_MODE=${DEBUG_MODE:="false"}
+    readonly DEBUG_MODE_ENABLED_FLAG="true"
+  
+    # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
+    # so that we don't have to deal with True vs true vs TRUE
+    if [[ ${DEBUG_MODE,,} == ${DEBUG_MODE_ENABLED_FLAG} ]]; then
+        echo "Entering the debug mode with continuous sleep. No setup will be performed."
+        echo "Please exec into the setup container and run the setup.sh by hand or set the sumologic.setup.debug=false and reinstall."
+  
+        while true; do
+            sleep 10
+            echo "$(date) Sleeping in the debug mode..."
+        done
+    fi
+  
     # Fix URL to remove "v1" or "v1/"
     export SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL%v1*}
     # Support proxy for Terraform

--- a/tests/terraform/static/strip_extrapolation.output.yaml
+++ b/tests/terraform/static/strip_extrapolation.output.yaml
@@ -238,6 +238,21 @@ data:
   setup.sh: |
     #!/bin/bash
   
+    readonly DEBUG_MODE=${DEBUG_MODE:="false"}
+    readonly DEBUG_MODE_ENABLED_FLAG="true"
+  
+    # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
+    # so that we don't have to deal with True vs true vs TRUE
+    if [[ ${DEBUG_MODE,,} == ${DEBUG_MODE_ENABLED_FLAG} ]]; then
+        echo "Entering the debug mode with continuous sleep. No setup will be performed."
+        echo "Please exec into the setup container and run the setup.sh by hand or set the sumologic.setup.debug=false and reinstall."
+  
+        while true; do
+            sleep 10
+            echo "$(date) Sleeping in the debug mode..."
+        done
+    fi
+  
     # Fix URL to remove "v1" or "v1/"
     export SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL%v1*}
     # Support proxy for Terraform

--- a/tests/terraform/static/traces.output.yaml
+++ b/tests/terraform/static/traces.output.yaml
@@ -174,6 +174,21 @@ data:
   setup.sh: |
     #!/bin/bash
   
+    readonly DEBUG_MODE=${DEBUG_MODE:="false"}
+    readonly DEBUG_MODE_ENABLED_FLAG="true"
+  
+    # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
+    # so that we don't have to deal with True vs true vs TRUE
+    if [[ ${DEBUG_MODE,,} == ${DEBUG_MODE_ENABLED_FLAG} ]]; then
+        echo "Entering the debug mode with continuous sleep. No setup will be performed."
+        echo "Please exec into the setup container and run the setup.sh by hand or set the sumologic.setup.debug=false and reinstall."
+  
+        while true; do
+            sleep 10
+            echo "$(date) Sleeping in the debug mode..."
+        done
+    fi
+  
     # Fix URL to remove "v1" or "v1/"
     export SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL%v1*}
     # Support proxy for Terraform


### PR DESCRIPTION
###### Description

We need to debug the setup job sometimes.
This PR adds the possibility to make the setup sleep indefinitely so that the setup can be done manually.

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
