### PR TITLE
Check API errors when getting fields quota in setup job

### DIFF
--- a/deploy/helm/sumologic/conf/setup/setup.sh
+++ b/deploy/helm/sumologic/conf/setup/setup.sh
@@ -22,18 +22,33 @@ export HTTP_PROXY=${HTTP_PROXY:=""}
 export HTTPS_PROXY=${HTTPS_PROXY:=""}
 export NO_PROXY=${NO_PROXY:=""}
 
-function remaining_fields() {
-    local RESPONSE="$(curl -XGET -s \
+function get_remaining_fields() {
+    local RESPONSE
+    readonly RESPONSE="$(curl -XGET -s \
         -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
         "${SUMOLOGIC_BASE_URL}"v1/fields/quota)"
 
-    echo "${RESPONSE}" | jq '.remaining'
+    echo "${RESPONSE}"
 }
 
 # Check if we'd have at least 10 fields remaining after additional fields
 # would be created for the collection
 function should_create_fields() {
-    local REMAINING=$(remaining_fields)
+    local RESPONSE
+    readonly RESPONSE=$(get_remaining_fields)
+
+    if ! jq -e <<< "${RESPONSE}" ; then
+        printf "Failed requesting fields API:\n%s\n" "${RESPONSE}"
+        return 1
+    fi
+
+    if ! jq -e '.remaining' <<< "${RESPONSE}" ; then
+        printf "Failed requesting fields API:\n%s\n" "${RESPONSE}"
+        return 1
+    fi
+
+    local REMAINING
+    readonly REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
     if [[ $(( REMAINING - {{ len .Values.sumologic.logs.fields }} )) -ge 10 ]] ; then
         return 0
     else

--- a/tests/terraform/static/all_fields.output.yaml
+++ b/tests/terraform/static/all_fields.output.yaml
@@ -306,18 +306,33 @@ data:
     export HTTPS_PROXY=${HTTPS_PROXY:=""}
     export NO_PROXY=${NO_PROXY:=""}
   
-    function remaining_fields() {
-        local RESPONSE="$(curl -XGET -s \
+    function get_remaining_fields() {
+        local RESPONSE
+        readonly RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields/quota)"
   
-        echo "${RESPONSE}" | jq '.remaining'
+        echo "${RESPONSE}"
     }
   
     # Check if we'd have at least 10 fields remaining after additional fields
     # would be created for the collection
     function should_create_fields() {
-        local REMAINING=$(remaining_fields)
+        local RESPONSE
+        readonly RESPONSE=$(get_remaining_fields)
+  
+        if ! jq -e <<< "${RESPONSE}" ; then
+            printf "Failed requesting fields API:\n%s\n" "${RESPONSE}"
+            return 1
+        fi
+  
+        if ! jq -e '.remaining' <<< "${RESPONSE}" ; then
+            printf "Failed requesting fields API:\n%s\n" "${RESPONSE}"
+            return 1
+        fi
+  
+        local REMAINING
+        readonly REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
         if [[ $(( REMAINING - 8 )) -ge 10 ]] ; then
             return 0
         else

--- a/tests/terraform/static/collector_fields.output.yaml
+++ b/tests/terraform/static/collector_fields.output.yaml
@@ -261,18 +261,33 @@ data:
     export HTTPS_PROXY=${HTTPS_PROXY:=""}
     export NO_PROXY=${NO_PROXY:=""}
   
-    function remaining_fields() {
-        local RESPONSE="$(curl -XGET -s \
+    function get_remaining_fields() {
+        local RESPONSE
+        readonly RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields/quota)"
   
-        echo "${RESPONSE}" | jq '.remaining'
+        echo "${RESPONSE}"
     }
   
     # Check if we'd have at least 10 fields remaining after additional fields
     # would be created for the collection
     function should_create_fields() {
-        local REMAINING=$(remaining_fields)
+        local RESPONSE
+        readonly RESPONSE=$(get_remaining_fields)
+  
+        if ! jq -e <<< "${RESPONSE}" ; then
+            printf "Failed requesting fields API:\n%s\n" "${RESPONSE}"
+            return 1
+        fi
+  
+        if ! jq -e '.remaining' <<< "${RESPONSE}" ; then
+            printf "Failed requesting fields API:\n%s\n" "${RESPONSE}"
+            return 1
+        fi
+  
+        local REMAINING
+        readonly REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
         if [[ $(( REMAINING - 8 )) -ge 10 ]] ; then
             return 0
         else

--- a/tests/terraform/static/conditional_sources.output.yaml
+++ b/tests/terraform/static/conditional_sources.output.yaml
@@ -188,18 +188,33 @@ data:
     export HTTPS_PROXY=${HTTPS_PROXY:=""}
     export NO_PROXY=${NO_PROXY:=""}
   
-    function remaining_fields() {
-        local RESPONSE="$(curl -XGET -s \
+    function get_remaining_fields() {
+        local RESPONSE
+        readonly RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields/quota)"
   
-        echo "${RESPONSE}" | jq '.remaining'
+        echo "${RESPONSE}"
     }
   
     # Check if we'd have at least 10 fields remaining after additional fields
     # would be created for the collection
     function should_create_fields() {
-        local REMAINING=$(remaining_fields)
+        local RESPONSE
+        readonly RESPONSE=$(get_remaining_fields)
+  
+        if ! jq -e <<< "${RESPONSE}" ; then
+            printf "Failed requesting fields API:\n%s\n" "${RESPONSE}"
+            return 1
+        fi
+  
+        if ! jq -e '.remaining' <<< "${RESPONSE}" ; then
+            printf "Failed requesting fields API:\n%s\n" "${RESPONSE}"
+            return 1
+        fi
+  
+        local REMAINING
+        readonly REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
         if [[ $(( REMAINING - 8 )) -ge 10 ]] ; then
             return 0
         else

--- a/tests/terraform/static/custom.output.yaml
+++ b/tests/terraform/static/custom.output.yaml
@@ -188,18 +188,33 @@ data:
     export HTTPS_PROXY=${HTTPS_PROXY:=""}
     export NO_PROXY=${NO_PROXY:=""}
   
-    function remaining_fields() {
-        local RESPONSE="$(curl -XGET -s \
+    function get_remaining_fields() {
+        local RESPONSE
+        readonly RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields/quota)"
   
-        echo "${RESPONSE}" | jq '.remaining'
+        echo "${RESPONSE}"
     }
   
     # Check if we'd have at least 10 fields remaining after additional fields
     # would be created for the collection
     function should_create_fields() {
-        local REMAINING=$(remaining_fields)
+        local RESPONSE
+        readonly RESPONSE=$(get_remaining_fields)
+  
+        if ! jq -e <<< "${RESPONSE}" ; then
+            printf "Failed requesting fields API:\n%s\n" "${RESPONSE}"
+            return 1
+        fi
+  
+        if ! jq -e '.remaining' <<< "${RESPONSE}" ; then
+            printf "Failed requesting fields API:\n%s\n" "${RESPONSE}"
+            return 1
+        fi
+  
+        local REMAINING
+        readonly REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
         if [[ $(( REMAINING - 8 )) -ge 10 ]] ; then
             return 0
         else

--- a/tests/terraform/static/default.output.yaml
+++ b/tests/terraform/static/default.output.yaml
@@ -259,18 +259,33 @@ data:
     export HTTPS_PROXY=${HTTPS_PROXY:=""}
     export NO_PROXY=${NO_PROXY:=""}
   
-    function remaining_fields() {
-        local RESPONSE="$(curl -XGET -s \
+    function get_remaining_fields() {
+        local RESPONSE
+        readonly RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields/quota)"
   
-        echo "${RESPONSE}" | jq '.remaining'
+        echo "${RESPONSE}"
     }
   
     # Check if we'd have at least 10 fields remaining after additional fields
     # would be created for the collection
     function should_create_fields() {
-        local REMAINING=$(remaining_fields)
+        local RESPONSE
+        readonly RESPONSE=$(get_remaining_fields)
+  
+        if ! jq -e <<< "${RESPONSE}" ; then
+            printf "Failed requesting fields API:\n%s\n" "${RESPONSE}"
+            return 1
+        fi
+  
+        if ! jq -e '.remaining' <<< "${RESPONSE}" ; then
+            printf "Failed requesting fields API:\n%s\n" "${RESPONSE}"
+            return 1
+        fi
+  
+        local REMAINING
+        readonly REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
         if [[ $(( REMAINING - 8 )) -ge 10 ]] ; then
             return 0
         else

--- a/tests/terraform/static/disable_default_metrics.output.yaml
+++ b/tests/terraform/static/disable_default_metrics.output.yaml
@@ -252,18 +252,33 @@ data:
     export HTTPS_PROXY=${HTTPS_PROXY:=""}
     export NO_PROXY=${NO_PROXY:=""}
   
-    function remaining_fields() {
-        local RESPONSE="$(curl -XGET -s \
+    function get_remaining_fields() {
+        local RESPONSE
+        readonly RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields/quota)"
   
-        echo "${RESPONSE}" | jq '.remaining'
+        echo "${RESPONSE}"
     }
   
     # Check if we'd have at least 10 fields remaining after additional fields
     # would be created for the collection
     function should_create_fields() {
-        local REMAINING=$(remaining_fields)
+        local RESPONSE
+        readonly RESPONSE=$(get_remaining_fields)
+  
+        if ! jq -e <<< "${RESPONSE}" ; then
+            printf "Failed requesting fields API:\n%s\n" "${RESPONSE}"
+            return 1
+        fi
+  
+        if ! jq -e '.remaining' <<< "${RESPONSE}" ; then
+            printf "Failed requesting fields API:\n%s\n" "${RESPONSE}"
+            return 1
+        fi
+  
+        local REMAINING
+        readonly REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
         if [[ $(( REMAINING - 8 )) -ge 10 ]] ; then
             return 0
         else

--- a/tests/terraform/static/strip_extrapolation.output.yaml
+++ b/tests/terraform/static/strip_extrapolation.output.yaml
@@ -260,18 +260,33 @@ data:
     export HTTPS_PROXY=${HTTPS_PROXY:=""}
     export NO_PROXY=${NO_PROXY:=""}
   
-    function remaining_fields() {
-        local RESPONSE="$(curl -XGET -s \
+    function get_remaining_fields() {
+        local RESPONSE
+        readonly RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields/quota)"
   
-        echo "${RESPONSE}" | jq '.remaining'
+        echo "${RESPONSE}"
     }
   
     # Check if we'd have at least 10 fields remaining after additional fields
     # would be created for the collection
     function should_create_fields() {
-        local REMAINING=$(remaining_fields)
+        local RESPONSE
+        readonly RESPONSE=$(get_remaining_fields)
+  
+        if ! jq -e <<< "${RESPONSE}" ; then
+            printf "Failed requesting fields API:\n%s\n" "${RESPONSE}"
+            return 1
+        fi
+  
+        if ! jq -e '.remaining' <<< "${RESPONSE}" ; then
+            printf "Failed requesting fields API:\n%s\n" "${RESPONSE}"
+            return 1
+        fi
+  
+        local REMAINING
+        readonly REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
         if [[ $(( REMAINING - 8 )) -ge 10 ]] ; then
             return 0
         else

--- a/tests/terraform/static/traces.output.yaml
+++ b/tests/terraform/static/traces.output.yaml
@@ -196,18 +196,33 @@ data:
     export HTTPS_PROXY=${HTTPS_PROXY:=""}
     export NO_PROXY=${NO_PROXY:=""}
   
-    function remaining_fields() {
-        local RESPONSE="$(curl -XGET -s \
+    function get_remaining_fields() {
+        local RESPONSE
+        readonly RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields/quota)"
   
-        echo "${RESPONSE}" | jq '.remaining'
+        echo "${RESPONSE}"
     }
   
     # Check if we'd have at least 10 fields remaining after additional fields
     # would be created for the collection
     function should_create_fields() {
-        local REMAINING=$(remaining_fields)
+        local RESPONSE
+        readonly RESPONSE=$(get_remaining_fields)
+  
+        if ! jq -e <<< "${RESPONSE}" ; then
+            printf "Failed requesting fields API:\n%s\n" "${RESPONSE}"
+            return 1
+        fi
+  
+        if ! jq -e '.remaining' <<< "${RESPONSE}" ; then
+            printf "Failed requesting fields API:\n%s\n" "${RESPONSE}"
+            return 1
+        fi
+  
+        local REMAINING
+        readonly REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
         if [[ $(( REMAINING - 8 )) -ge 10 ]] ; then
             return 0
         else


### PR DESCRIPTION
###### Description

Whenever a user encounters an error that is received from Sumo Logic API it's somehow lost.

This PR addresses that by explicitly checking for expected `.remaining` key in the returned JSON and it explicitly logs the received JSON whenever an error occurs.

Fixes: #1523