### PR TITLE
Use only 10 SHA characters for dev builds instead of 40

### DIFF
--- a/ci/push-helm-chart.sh
+++ b/ci/push-helm-chart.sh
@@ -5,7 +5,7 @@ readonly ROOT_DIR="$(dirname "$(dirname "${0}")")"
 source "${ROOT_DIR}"/ci/_build_functions.sh
 
 fetch_current_branch
-VERSION="$(git describe --tags --abbrev=40)"
+VERSION="$(git describe --tags --abbrev=10)"
 readonly VERSION="${VERSION#v}"
 
 pushd "${ROOT_DIR}" || exit 1


### PR DESCRIPTION
To mitigate the following error:

```
$ helm upgrade --install collection --namespace sumologic sumologic/sumologic \
    -f /sumologic/values.perk.yaml \
    --create-namespace \
    --version 2.1.0-rc.0-3-g5482116e84c5075b589a504f61f0f204a15a61e8
Release "collection" does not exist. Installing it now.
Error: failed pre-install: warning: Hook pre-install sumologic/templates/setup/setup-serviceaccount.yaml failed: ServiceAccount "collection-sumologic-setup" is invalid: metadata.labels: Invalid value: "sumologic-2.1.0-rc.0-3-g5482116e84c5075b589a504f61f0f204a15a61e8": must be no more than 63 characters
```

use only 10 SHA characters in dev version instead of 40.