### PR TITLE
Tweak CI for markdown-link-check and add makefile target

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -51,7 +51,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         config-file: '.markdown_link_check.json'
@@ -66,7 +66,7 @@ jobs:
 
   test:
     runs-on: ubuntu-20.04
-    needs: [markdownlint, shellcheck, yamllint, helmlint]
+    needs: [markdownlint, shellcheck, yamllint, helmlint, md-links-lint, markdown-link-check]
 
     steps:
       - uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -32,3 +32,6 @@ yamllint:
 
 markdown-links-lint:
 	./ci/markdown_links_lint.sh
+
+markdown-link-check:
+	./ci/markdown_link_check.sh

--- a/ci/markdown_link_check.sh
+++ b/ci/markdown_link_check.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+if ! markdown-link-check --help >/dev/null 2>&1 ; then
+    echo "markdown-link-check not found, please install it with 'npm install -g markdown-link-check'"
+    exit 1
+fi
+
+# Get all markdown files
+readonly FILES=$(find . -type f -name '*.md')
+
+for file in ${FILES}; do
+    markdown-link-check --progress --config .markdown_link_check.json "${file}"
+done


### PR DESCRIPTION
###### Description

* use `actions/checkout@v2` and not `actions/checkout@master`
* make markdown link checks required for tests to run
* add `markdown-link-check` makefile target to run locally

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
