### PR TITLE
Downgrade fluent-bit to 1.6.10

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -68,8 +68,8 @@ The following matrix displays the tested package versions for our Helm chart.
 
 Sumo Logic Helm Chart | kube-prometheus-stack/Prometheus Operator | FluentD | Fluent Bit | Falco | Metrics Server | Telegraf Operator | Tailing Sidecar Operator
 |:-------- |:-------- |:-------- |:-------- |:-------- |:-------- |:--------  |:--------
-2.1.1 - Latest | 12.3.0 | 1.12.1 | 0.15.4 | 1.7.10 | 5.8.4 | 1.1.5 | 0.3.0
-2.1.0 | 12.3.0 | 1.12.1 | 0.15.1 | 1.7.10 | 5.8.1 | 1.1.5 | 0.3.0
+2.1.1 - Latest | 12.3.0 | 1.12.1 | 0.12.1 | 1.7.10 | 5.8.4 | 1.1.5 | 0.3.0
+2.1.0 | 12.3.0 | 1.12.1 | 0.11.0 | 1.7.10 | 5.8.1 | 1.1.5 | 0.3.0
 2.0.2 - 2.0.5 | 12.3.0 | 1.12.0 | 0.7.13 (new fluent repository) | 1.5.7 | 5.0.2 | 1.1.5 | -
 2.0.0 - 2.0.1 | 12.3.0 | 1.11.5 | 0.7.13 (new fluent repository) | 1.5.7 | 5.0.2 | 1.1.5 | -
 1.3.6 | 9.3.4 | 1.11.5 | 2.10.1 (old helm-stable repository) | 1.5.7 | 2.11.2 | 1.1.6 | -

--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -13,7 +13,7 @@ sources:
   - https://github.com/SumoLogic/sumologic-kubernetes-collection
 dependencies:
   - name: fluent-bit
-    version: 0.15.4
+    version: 0.12.1
     repository: https://fluent.github.io/helm-charts
     condition: fluent-bit.enabled,sumologic.logs.enabled
   - name: kube-prometheus-stack


### PR DESCRIPTION
###### Description

Downgrade fluent-bit and prepare v2.1.1-rc.1

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
