### PR TITLE
chore: Upgrade Fluentd from v1.12.1-sumo-2 to v1.12.2-sumo-0

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -199,7 +199,7 @@ sumologic:
 fluentd:
   image:
     repository: public.ecr.aws/sumologic/kubernetes-fluentd
-    tag: 1.12.1-sumo-2
+    tag: 1.12.2-sumo-0
     pullPolicy: IfNotPresent
 
   ## Specifies whether a PodSecurityPolicy should be created


### PR DESCRIPTION
Changes:
- chore: Upgrade Fluentd from 1.12.1 to 1.12.2
- feat(kubernetes_sumologic): Set default per-container annotation prefix to "sumologic.com/"
- fix(enhance_k8s_metadata): Fix duplicated service names in metrics metadata

https://github.com/SumoLogic/sumologic-kubernetes-fluentd/releases/tag/v1.12.2-sumo-0