### PR TITLE
 fix: Fix duplicated service names in metrics metadata

### DIFF
--- a/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/service_monitor.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/service_monitor.rb
@@ -45,7 +45,7 @@ module SumoLogic
 
           result['items'].each do |endpoint|
             service = endpoint['metadata']['name']
-            get_pods_for_service(endpoint).each {|pod| new_snapshot_pods_to_services[pod] << service}
+            get_pods_for_service(endpoint).each {|pod| new_snapshot_pods_to_services[pod] << service unless new_snapshot_pods_to_services[pod].include? service}
           end
 
           log.debug "Reinitializing @pods_to_services to #{new_snapshot_pods_to_services}"

--- a/fluent-plugin-enhance-k8s-metadata/test/resources/endpoints_list.json
+++ b/fluent-plugin-enhance-k8s-metadata/test/resources/endpoints_list.json
@@ -314,6 +314,86 @@
                     ]
                 }
             ]
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Endpoints",
+            "metadata": {
+                "annotations": {
+                    "endpoints.kubernetes.io/last-change-trigger-time": "2021-04-15T11:26:57Z"
+                },
+                "creationTimestamp": "2021-04-15T11:24:58Z",
+                "name": "mysts",
+                "namespace": "sts1",
+                "resourceVersion": "1151520",
+                "selfLink": "/api/v1/namespaces/sts1/endpoints/mysts",
+                "uid": "a78c9393-dd0d-4d6d-95bf-6982707dbb82"
+            },
+            "subsets": [
+                {
+                    "addresses": [
+                        {
+                            "hostname": "mysts-0",
+                            "ip": "10.1.14.77",
+                            "nodeName": "sumo",
+                            "targetRef": {
+                                "kind": "Pod",
+                                "name": "mysts-0",
+                                "namespace": "sts1",
+                                "resourceVersion": "1151518",
+                                "uid": "7305b656-ed07-497d-abbe-506a9c092f3a"
+                            }
+                        }
+                    ],
+                    "ports": [
+                        {
+                            "name": "metrics",
+                            "port": 8123,
+                            "protocol": "TCP"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Endpoints",
+            "metadata": {
+                "annotations": {
+                    "endpoints.kubernetes.io/last-change-trigger-time": "2021-04-15T11:30:26Z"
+                },
+                "creationTimestamp": "2021-04-15T11:30:23Z",
+                "name": "mysts",
+                "namespace": "sts2",
+                "resourceVersion": "1152021",
+                "selfLink": "/api/v1/namespaces/sts2/endpoints/mysts",
+                "uid": "4b8078a7-65bd-4bc0-80f4-27a446347c69"
+            },
+            "subsets": [
+                {
+                    "addresses": [
+                        {
+                            "hostname": "mysts-0",
+                            "ip": "10.1.14.78",
+                            "nodeName": "sumo",
+                            "targetRef": {
+                                "kind": "Pod",
+                                "name": "mysts-0",
+                                "namespace": "sts2",
+                                "resourceVersion": "1152020",
+                                "uid": "2cb1717e-ea36-4360-b736-20bb2d091096"
+                            }
+                        }
+                    ],
+                    "ports": [
+                        {
+                            "name": "metrics",
+                            "port": 8123,
+                            "protocol": "TCP"
+                        }
+                    ]
+                }
+            ]
         }
     ],
     "kind": "List",

--- a/fluent-plugin-enhance-k8s-metadata/test/sumologic/kubernetes/test_service_monitor.rb
+++ b/fluent-plugin-enhance-k8s-metadata/test/sumologic/kubernetes/test_service_monitor.rb
@@ -82,7 +82,8 @@ class ServiceMonitorTest < Test::Unit::TestCase
         "tiller-deploy-69458576b-27mp8": ["tiller-deploy"],
         "fluentd-59d9c9656d-cg5m4": ["fluentd"],
         "fluentd-59d9c9656d-5pwjg": ["fluentd"],
-        "fluentd-59d9c9656d-zlhjh": ["fluentd"]
+        "fluentd-59d9c9656d-zlhjh": ["fluentd"],
+        "mysts-0": ["mysts"]
       }
       assert_expected_state(expected)
     end


### PR DESCRIPTION
This backports https://github.com/SumoLogic/sumologic-kubernetes-fluentd/pull/184 from v2 release.