### PR TITLE
feat: ingest stacktraces from fluentd

### DIFF
--- a/deploy/helm/sumologic/conf/logs/fluentd/logs.source.containers.conf
+++ b/deploy/helm/sumologic/conf/logs/fluentd/logs.source.containers.conf
@@ -26,11 +26,14 @@
   # only match fluentd logs based on fluentd container log file name.
   # by default, this is <filter **collection-sumologic-fluentd**>
   {{ printf "<filter **%s**>" (include "sumologic.metadata.name.fluentd" .) }}
-    # only ingest fluentd logs of levels: {error, fatal} and warning messages if buffer is full
+    # only ingest:
+    #   - stacktraces (containing /usr/local)
+    #   - fluentd logs of levels: {error, fatal}: `\[error\]|\[fatal\]`
+    #   - warning messages if buffer is full `drop_oldest_chunk|retry succeeded`
     @type grep
     <regexp>
       key log
-      pattern /\[error\]|\[fatal\]|drop_oldest_chunk|retry succeeded/
+      pattern /\/usr\/local|\[error\]|\[fatal\]|drop_oldest_chunk|retry succeeded/
     </regexp>
   </filter>
 {{- end }}


### PR DESCRIPTION
###### Description

Ingest stacktraces from fluentd (even for [warn]), so we can see them in sumologic 

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
