### PR TITLE
update terraform to 0.13.7

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -46,7 +46,7 @@ RUN gem install \
         fluent-plugin-prometheus:1.6.1
 
 # Install Terraform
-ENV TERRAFORM_VERSION 0.12.26
+ENV TERRAFORM_VERSION 0.13.7
 RUN mkdir /tmp/terraform \
  && curl https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip -o /tmp/terraform/terraform.zip \
  && cd /tmp/terraform \

--- a/deploy/helm/sumologic/conf/setup/main.tf
+++ b/deploy/helm/sumologic/conf/setup/main.tf
@@ -1,6 +1,12 @@
 terraform {
   required_providers {
-    sumologic  = "~> 2.6"
-    kubernetes = "~> 1.11.3"
+    sumologic = {
+      source  = "sumologic/sumologic"
+      version = "~> 2.6"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 1.11.3"
+    }
   }
 }

--- a/deploy/kubernetes/setup-sumologic.yaml.tmpl
+++ b/deploy/kubernetes/setup-sumologic.yaml.tmpl
@@ -30,8 +30,14 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.6"
-        kubernetes = "~> 1.11.3"
+        sumologic = {
+          source  = "sumologic/sumologic"
+          version = "~> 2.6"
+        }
+        kubernetes = {
+          source  = "hashicorp/kubernetes"
+          version = "~> 1.11.3"
+        }
       }
     }
   providers.tf: |-

--- a/tests/terraform/static/all_fields.output.yaml
+++ b/tests/terraform/static/all_fields.output.yaml
@@ -31,8 +31,14 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.6"
-        kubernetes = "~> 1.11.3"
+        sumologic = {
+          source  = "sumologic/sumologic"
+          version = "~> 2.6"
+        }
+        kubernetes = {
+          source  = "hashicorp/kubernetes"
+          version = "~> 1.11.3"
+        }
       }
     }
   providers.tf: |-

--- a/tests/terraform/static/collector_fields.output.yaml
+++ b/tests/terraform/static/collector_fields.output.yaml
@@ -30,8 +30,14 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.6"
-        kubernetes = "~> 1.11.3"
+        sumologic = {
+          source  = "sumologic/sumologic"
+          version = "~> 2.6"
+        }
+        kubernetes = {
+          source  = "hashicorp/kubernetes"
+          version = "~> 1.11.3"
+        }
       }
     }
   providers.tf: |-

--- a/tests/terraform/static/conditional_sources.output.yaml
+++ b/tests/terraform/static/conditional_sources.output.yaml
@@ -20,8 +20,14 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.6"
-        kubernetes = "~> 1.11.3"
+        sumologic = {
+          source  = "sumologic/sumologic"
+          version = "~> 2.6"
+        }
+        kubernetes = {
+          source  = "hashicorp/kubernetes"
+          version = "~> 1.11.3"
+        }
       }
     }
   providers.tf: |-

--- a/tests/terraform/static/default.output.yaml
+++ b/tests/terraform/static/default.output.yaml
@@ -30,8 +30,14 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.6"
-        kubernetes = "~> 1.11.3"
+        sumologic = {
+          source  = "sumologic/sumologic"
+          version = "~> 2.6"
+        }
+        kubernetes = {
+          source  = "hashicorp/kubernetes"
+          version = "~> 1.11.3"
+        }
       }
     }
   providers.tf: |-

--- a/tests/terraform/static/strip_extrapolation.output.yaml
+++ b/tests/terraform/static/strip_extrapolation.output.yaml
@@ -30,8 +30,14 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.6"
-        kubernetes = "~> 1.11.3"
+        sumologic = {
+          source  = "sumologic/sumologic"
+          version = "~> 2.6"
+        }
+        kubernetes = {
+          source  = "hashicorp/kubernetes"
+          version = "~> 1.11.3"
+        }
       }
     }
   providers.tf: |-

--- a/tests/terraform/static/traces.output.yaml
+++ b/tests/terraform/static/traces.output.yaml
@@ -21,8 +21,14 @@ data:
   main.tf: |
     terraform {
       required_providers {
-        sumologic  = "~> 2.6"
-        kubernetes = "~> 1.11.3"
+        sumologic = {
+          source  = "sumologic/sumologic"
+          version = "~> 2.6"
+        }
+        kubernetes = {
+          source  = "hashicorp/kubernetes"
+          version = "~> 1.11.3"
+        }
       }
     }
   providers.tf: |-


### PR DESCRIPTION
###### Description

update terraform to 0.13.7 due to following error:

```
Initializing the backend...
Initializing provider plugins...
- Checking for available provider plugins...
Error verifying GPG signature for provider "sumologic"
Terraform was unable to verify the GPG signature of the downloaded provider
files using the keys downloaded from the Terraform Registry. This may mean that
the publisher of the provider removed the key it was signed with, or that the
distributed files were changed after this version was released.
- Downloading plugin for provider "kubernetes" (hashicorp/kubernetes) 1.11.4...
Warning: registry.terraform.io: For users on Terraform 0.13 or greater, this provider has moved to SumoLogic/sumologic. Please update your source in required_providers.
Error: unable to verify signature
Error: Could not satisfy plugin requirements
Plugin reinitialization required. Please run "terraform init".
Plugins are external binaries that Terraform uses to access and manipulate
resources. The configuration provided requires plugins which can't be located,
don't satisfy the version constraints, or are otherwise incompatible.
Terraform automatically discovers provider requirements from your
configuration, including providers used in child modules. To see the
requirements and constraints from each module, run "terraform providers".
```

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
