### PR TITLE
Fix additionalLabels in collection-fluent-bit

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1333,7 +1333,7 @@ kube-prometheus-stack:
             sumologic.com/scrape: "true"
       - name: collection-fluent-bit
         additionalLabels:
-          app: collection-fluent-bit
+          sumologic.com/app: collection-fluent-bit
         endpoints:
           - port: http
             path: /api/v1/metrics/prometheus


### PR DESCRIPTION
In https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/690 the prometheus additionalLabels were updated to use `sumologic.com/app` instead of `app`. The entry for `collection-fluent-bit` was missed, causing the helm chart to fail when using the built in prometheus stack due to duplicate labels.

This change should fix that so the built in prometheus stack works with collection-fluent-bit.

###### Description

Fill in your description here.

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
