### PR TITLE
Allow backport job to run on PR coming from forks

### DIFF
--- a/.github/workflows/backport_bot.yaml
+++ b/.github/workflows/backport_bot.yaml
@@ -1,6 +1,6 @@
 name: Backport
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
       - labeled


### PR DESCRIPTION
###### Description

Allow backport job to run on PR coming from forks. This can be achieved by changing `pull_request` to [`pull_request_target`](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target).

Related blog post: https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/

--- 

Example of a failed backport job due to a missing secret:
> Error: Input required and not supplied: app_id

https://github.com/SumoLogic/sumologic-kubernetes-collection/actions/runs/835990115
