### PR TITLE
docs: add mysql multiline logs example and instruction how to change scrape interval for metrics

### DIFF
--- a/deploy/docs/Best_Practices.md
+++ b/deploy/docs/Best_Practices.md
@@ -18,6 +18,7 @@
 - [Configure Ignore_Older Config for Fluentbit](#configure-ignore_older-config-for-fluentbit)
 - [Disable logs, metrics, or falco](#disable-logs-metrics-or-falco)
 - [Load Balancing Prometheus traffic between Fluentds](#load-balancing-prometheus-traffic-between-fluentds)
+- [Changing scrape interval for Prometheus](#changing-scrape-interval-for-prometheus)
 
 ## Multiline Log Support
 
@@ -549,3 +550,16 @@ kube-prometheus-stack:
 
 **NOTE** We observed that changing this value increases metrics loss during prometheus resharding,
 but the traffic is much better balanced between Fluentds and Prometheus is more stable in terms of memory.
+
+## Changing scrape interval for Prometheus
+
+Default scrapeInterval for collection is `30s`. This is the recommended value which ensures that all of Sumo Logic dashboards
+are filled up with proper data.
+
+To change it, you can use following configuration:
+
+```yaml
+kube-prometheus-stack:  # For values.yaml
+  prometheus:
+    prometheusSpec:
+      scrapeInterval: '1m'

--- a/deploy/docs/Best_Practices.md
+++ b/deploy/docs/Best_Practices.md
@@ -1,6 +1,7 @@
 # Advanced Configuration / Best Practices
 
 - [Multiline Log Support](#multiline-log-support)
+  - [MySQL slow logs example](#mysql-slow-logs-example)
 - [Collecting Log Lines Over 16KB (with multiline support)](#collecting-log-lines-over-16kb-with-multiline-support)
   - [Multiline Support](#multiline-support)
 - [Fluentd Autoscaling](#fluentd-autoscaling)
@@ -60,6 +61,22 @@ the rest of the lines will be matched against `Parser_N`.
 ```bash
 Parser_Firstline multi_line
 Parser_1 optional_parser
+```
+
+### MySQL slow logs example
+
+For example to detect mulitlines for `slow logs` correctly,
+ensure that `Fluent Bit` reads `slow log` files and update your configuration
+with following snippet:
+
+```
+fluent-bit:
+  config:
+    customParsers: |
+      [PARSER]
+          Name        multi_line
+          Format      regex
+          Regex       (?<log>^{"log":"(\d{4}-\d{1,2}-\d{1,2}.\d{2}:\d{2}:\d{2}.*|#\sTime:\s+.*))
 ```
 
 ## Collecting Log Lines Over 16KB (with multiline support)


### PR DESCRIPTION
###### Description

docs: add mysql multiline example and indtruction how to change scrape interval for metrics

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
