### PR TITLE
Update falco subchart to 1.11.1

### DIFF
--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
     repository: https://prometheus-community.github.io/helm-charts
     condition: kube-prometheus-stack.enabled,sumologic.metrics.enabled
   - name: falco
-    version: 1.7.10
+    version: 1.11.1
     repository: https://falcosecurity.github.io/charts
     condition: falco.enabled
   - name: metrics-server


### PR DESCRIPTION
###### Description

Update falco subchart to 1.11.1

Changelog between 1.11.1 and 1.7.10 ( ref: https://github.com/falcosecurity/charts/blob/master/falco/CHANGELOG.md#v1111)

```
## v1.11.1

* Upgrade to Falco 0.28.1 (see the [Falco changelog](https://github.com/falcosecurity/falco/blob/0.28.1/CHANGELOG.md))

## v1.11.0

* Bump up version of chart for `Falcosidekick` dependency to `v3.5.0`

## v1.10.0

* Add `falcosidekick.fullfqdn` option to connect `falco` to `falcosidekick` with full FQDN
* Bump up version of chart for `Falcosidekick` dependency

## v1.9.0

* Upgrade to Falco 0.28.0 (see the [Falco changelog](https://github.com/falcosecurity/falco/blob/0.28.0/CHANGELOG.md))
* Update rulesets from Falco 0.28.0

## v1.8.1

* Bump up version of chart for `Falcosidekick` dependency

## v1.8.0

* Bump up version of chart for `Falcosidekick` dependency
```

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
