### PR TITLE
refactor(prometheus): unify application metrics urls

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -2077,7 +2077,7 @@ kube-prometheus-stack:
         ## mysql_perf_schema_index_io_waits_*
         ## mysql_perf_schema_read*
         ## mysql_perf_schema_write*
-        - url: http://$(FLUENTD_METRICS_SVC).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.mysql
+        - url: http://$(FLUENTD_METRICS_SVC).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.applications.mysql
           remoteTimeout: 5s
           writeRelabelConfigs:
             - action: keep
@@ -2133,7 +2133,7 @@ kube-prometheus-stack:
         ## postgresql_toast_blks_hit
         ## postgresql_tidx_blks_read
         ## postgresql_tidx_blks_hit
-        - url: http://$(FLUENTD_METRICS_SVC).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.postgresql
+        - url: http://$(FLUENTD_METRICS_SVC).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.applications.postgresql
           remoteTimeout: 5s
           writeRelabelConfigs:
             - action: keep
@@ -2176,7 +2176,7 @@ kube-prometheus-stack:
         ## apache_scboard_sending
         ## apache_scboard_starting
         ## apache_scboard_waiting
-        - url: http://$(FLUENTD_METRICS_SVC).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.apache
+        - url: http://$(FLUENTD_METRICS_SVC).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.applications.apache
           remoteTimeout: 5s
           writeRelabelConfigs:
             - action: keep


### PR DESCRIPTION
###### Description

solves #1612

BREAKING CHANGE: This can be a breaking change in case someone added own remoteWrite

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
