### PR TITLE
docs: remove deprecated --export flag from 'kubectl get' call

### DIFF
--- a/deploy/docs/existingPrometheusDoc.md
+++ b/deploy/docs/existingPrometheusDoc.md
@@ -127,7 +127,7 @@ kube-prometheus-stack is in `<destination-namespace>`, run the below command:
 
 ```bash
 kubectl get configmap sumologic-configmap \
---namespace=<source-namespace> --export -o yaml | \
+--namespace=<source-namespace> -o yaml | \
 kubectl apply --namespace=<destination-namespace> -f -
 ```
 


### PR DESCRIPTION
###### Description

`--export` is now deprecated [ref#1](https://github.com/kubernetes/kubernetes/pull/73787) so don't use it.

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
