### PR TITLE
fix: fix fluent-bit's imageSecrets comment

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -822,12 +822,12 @@ metrics-server:
 ## Configure fluent-bit
 ## ref: https://github.com/fluent/helm-charts/blob/master/charts/fluent-bit/values.yaml
 fluent-bit:
+  ## If specified, use these secrets to access the image
+  # imagePullSecrets:
+  #   - name: "image-pull-secret"
   image:
     repository: public.ecr.aws/sumologic/fluent-bit
     pullPolicy: IfNotPresent
-    # If specified, use these secrets to access the image
-    # pullSecrets:
-    #   - name: "image-pull-secret"
 
   ## Resource limits for fluent-bit
   resources: {}


### PR DESCRIPTION
###### Description

fix fluent-bit's imageSecrets comment to align what's actually expected in fluent-bit's chart: https://github.com/fluent/helm-charts/blob/fluent-bit-0.12.1/charts/fluent-bit/values.yaml#L20

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
