### PR TITLE
make updateStrategy configurable for fluent-bit

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -885,6 +885,11 @@ fluent-bit:
         path: /var/lib/fluent-bit
         type: DirectoryOrCreate
       name: tail-db
+  
+  updateStrategy: {}
+    # type: RollingUpdate
+    # rollingUpdate:
+    #   maxUnavailable: 1
 
   ## https://docs.fluentbit.io/manual/administration/configuring-fluent-bit
   config:


### PR DESCRIPTION
###### Description

make updateStrategy configurable for fluent-bit sub-chart

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
