### PR TITLE
feat(ci): add github action PR label checker

### DIFF
--- a/.github/workflows/check_pr_labels.yaml
+++ b/.github/workflows/check_pr_labels.yaml
@@ -1,0 +1,14 @@
+name: PRs Labels
+
+on:
+  pull_request_target:
+    types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jesusvasquez333/verify-pr-label-action@v1.4.0
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+          invalid-labels: 'do-not-merge/hold'


### PR DESCRIPTION
###### Description

Prevent merging when `do-not-merge/hold` label is added.

This PR uses: https://github.com/marketplace/actions/verify-pull-request-labels

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
