### PR TITLE
fix(ci): fix ci label checker - provide required pr number

### DIFF
--- a/.github/workflows/check_pr_labels.yaml
+++ b/.github/workflows/check_pr_labels.yaml
@@ -12,3 +12,4 @@ jobs:
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
           invalid-labels: 'do-not-merge/hold'
+          pull-request-number: '${{ github.event.pull_request.number }}'


### PR DESCRIPTION
###### Description

`pull-request-number: '${{ github.event.pull_request.number }}'` is required 😞 

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
