### PR TITLE
refactor(ci): use forked label checker to allow empty valid label set

### DIFF
--- a/.github/workflows/check_pr_labels.yaml
+++ b/.github/workflows/check_pr_labels.yaml
@@ -1,15 +1,17 @@
 name: PRs labels check
 
 on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, labeled, unlabeled, synchronize]
   pull_request:
-    types: [opened, labeled, unlabeled, synchronize]
+    types: [opened, reopened, ready_for_review, labeled, unlabeled, synchronize]
 
 jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: mheap/github-action-required-labels@v1
+      - uses: pmalek-sumo/verify-pr-label-action@v1.4.4
         with:
-          mode: exactly
-          count: 0
-          labels: "do-not-merge/hold"
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+          invalid-labels: 'do-not-merge/hold'
+          pull-request-number: '${{ github.event.pull_request.number }}'


### PR DESCRIPTION
###### Description

Revert to using `verify-pr-label-action` action but forked and updated so that it doesn't require a "positive" valid label set.

ref: https://github.com/pmalek-sumo/verify-pr-label-action

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
