### PR TITLE
fix(deps): Upgrade Fluentd from v1.12.2-sumo-0 to v1.12.2-sumo-2

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -209,7 +209,7 @@ sumologic:
 fluentd:
   image:
     repository: public.ecr.aws/sumologic/kubernetes-fluentd
-    tag: 1.12.2-sumo-0
+    tag: 1.12.2-sumo-2
     pullPolicy: IfNotPresent
 
   ## Specifies whether a PodSecurityPolicy should be created


### PR DESCRIPTION
Changes since v1.12.2-sumo-0:
- feat: Build images for ARM
- chore(deps): bump fluent/fluentd from v1.12.2-debian-1.0 to v1.12.2-debian-1.1
- chore(deps): Upgrade `rexml` gem to 3.2.5 fix CVE-2021-28965
- chore(deps): Upgrade `rdoc` gem to 6.3.1 to fix CVE-2021-31799
- chore(deps): Upgrade `addressable` gem to 2.8.0 to fix a vulnerability reported by Sysdig
- chore(deps): Upgrade `ruby` in builder image from 2.6.6 to 2.6.8
- chore(deps): Upgrade all system packages in Docker image
