### PR TITLE
linux only containers should target linux workers

### DIFF
--- a/deploy/helm/sumologic/templates/cleanup/job.yaml
+++ b/deploy/helm/sumologic/templates/cleanup/job.yaml
@@ -38,6 +38,8 @@ spec:
             mountPath: /configmap
           - name: cleanup
             mountPath: /etc/terraform
+      nodeSelector:
+        kubernetes.io/os: linux
       containers:
         - name: cleanup
           image: {{ .Values.sumologic.setup.job.image.repository }}:{{ .Values.sumologic.setup.job.image.tag }}

--- a/deploy/helm/sumologic/templates/events/fluentd/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/events/fluentd/statefulset.yaml
@@ -59,6 +59,8 @@ spec:
       {{- if .Values.fluentd.events.statefulset.priorityClassName }}
       priorityClassName: {{ .Values.fluentd.events.statefulset.priorityClassName | quote }}
       {{- end }}
+      nodeSelector:
+        kubernetes.io/os: linux
       containers:
       - name: fluentd-events
         image: {{ .Values.fluentd.image.repository }}:{{ .Values.fluentd.image.tag }}

--- a/deploy/helm/sumologic/templates/logs/fluentd/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/logs/fluentd/statefulset.yaml
@@ -101,6 +101,8 @@ spec:
       {{- if .Values.fluentd.logs.statefulset.priorityClassName }}
       priorityClassName: {{ .Values.fluentd.logs.statefulset.priorityClassName | quote }}
       {{- end }}
+      nodeSelector:
+        kubernetes.io/os: linux
       containers:
       - name: fluentd
         image: {{ .Values.fluentd.image.repository }}:{{ .Values.fluentd.image.tag }}

--- a/deploy/helm/sumologic/templates/metrics/fluentd/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics/fluentd/statefulset.yaml
@@ -101,6 +101,8 @@ spec:
       {{- if .Values.fluentd.metrics.statefulset.priorityClassName }}
       priorityClassName: {{ .Values.fluentd.metrics.statefulset.priorityClassName | quote }}
       {{- end }}
+      nodeSelector:
+        kubernetes.io/os: linux
       containers:
       - name: fluentd
         image: {{ .Values.fluentd.image.repository }}:{{ .Values.fluentd.image.tag }}

--- a/deploy/helm/sumologic/templates/setup/job.yaml
+++ b/deploy/helm/sumologic/templates/setup/job.yaml
@@ -41,6 +41,8 @@ spec:
         configMap:
           name: {{ template "sumologic.metadata.name.setup.configmap-custom" . }}
           defaultMode: 0777
+      nodeSelector:
+        kubernetes.io/os: linux
       containers:
       - name: setup
         image: {{ .Values.sumologic.setup.job.image.repository }}:{{ .Values.sumologic.setup.job.image.tag }}

--- a/deploy/helm/sumologic/templates/traces/otel-agent/daemonset.yaml
+++ b/deploy/helm/sumologic/templates/traces/otel-agent/daemonset.yaml
@@ -51,6 +51,8 @@ spec:
       {{- if .Values.otelagent.daemonset.priorityClassName }}
       priorityClassName: {{ .Values.otelagent.daemonset.priorityClassName | quote }}
       {{- end }}
+      nodeSelector:
+        kubernetes.io/os: linux
       containers:
       - name: otelcontrib-agent
         image: {{ .Values.otelagent.daemonset.image.repository }}:{{ .Values.otelagent.daemonset.image.tag }}

--- a/deploy/helm/sumologic/templates/traces/otelcol/deployment.yaml
+++ b/deploy/helm/sumologic/templates/traces/otelcol/deployment.yaml
@@ -51,6 +51,8 @@ spec:
       {{- if .Values.otelcol.deployment.priorityClassName }}
       priorityClassName: {{ .Values.otelcol.deployment.priorityClassName | quote }}
       {{- end }}
+      nodeSelector:
+        kubernetes.io/os: linux
       containers:
       - name: otelcontrib-collector
         image: {{ .Values.otelcol.deployment.image.repository }}:{{ .Values.otelcol.deployment.image.tag }}


### PR DESCRIPTION
###### Description

We have a few kubernetes on windows clusters that we want to pull some logs in from, but many (all?) of these containers are linux only.

This sets a nodeSelector to target linux workers via kubernetes.io/os

---

###### Testing performed

- [X] Redeploy fluentd and fluentd-events pods
- [X] Confirm events, logs, and metrics are coming in
