### PR TITLE
fix(helm/metrics/otc): remove unnecessary metadata

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -2533,16 +2533,13 @@ otelcol:
         sumologic:
           metric_format: prometheus
           endpoint: ${SUMO_ENDPOINT_DEFAULT_METRICS_SOURCE}
-          source_host: '%{host}'
           metadata_attributes:
             - k8s.*
             - pod_.*
             - namespace_.*
 
             - Deployment
-            - Namespace
             - container
-            - host
             - node
             - pod
       processors:


### PR DESCRIPTION
Namespace duplicates namespace metadata
host duplicates node metadata
_sourceHost is not available in metrics created by Fluentd