### PR TITLE
fix: remove host metadata coming with metrics from Telegraf receiver

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -2540,6 +2540,8 @@ otelcol:
               - key: k8s.pod.name
                 from_attribute: pod
                 action: upsert
+              - key: host
+                action: delete
           ## Configuration for Memory Limiter Processor
           ## The memory_limiter processor is used to prevent out of memory situations on the collector.
           ## ref: https://github.com/SumoLogic/opentelemetry-collector/tree/main/processor/memorylimiter


### PR DESCRIPTION
###### Description

Metrics coming from Fleuntd does not have `host` metadata.

Example metrics coming from Telegraf receiver:
```
Metric #0
Descriptor:
     -> Name: node_namespace_pod:kube_pod_info:
     -> Description: 
     -> Unit: 
     -> DataType: Gauge
NumberDataPoints #0
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2021-09-07 11:07:05.914 +0000 UTC
Value: 1.000000
ResourceMetrics #74
Resource labels:
     -> host: STRING(collection-sumologic-otelcol-metrics-1)
     -> namespace: STRING(kube-system)
     -> node: STRING(sumologic-kubernetes-collection)
     -> pod: STRING(hostpath-provisioner-75fdc8fccd-c8xzs)
     -> prometheus: STRING(sumologic1/collection-kube-prometheus-prometheus)
     -> prometheus_replica: STRING(prometheus-collection-kube-prometheus-prometheus-0)
``` 
---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
