### PR TITLE
chore: bump kube-prometheus-stack to 12.10.0

### DIFF
--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
     repository: https://fluent.github.io/helm-charts
     condition: fluent-bit.enabled,sumologic.logs.enabled
   - name: kube-prometheus-stack
-    version: 12.3.0
+    version: 12.10.0
     repository: https://prometheus-community.github.io/helm-charts
     condition: kube-prometheus-stack.enabled,sumologic.metrics.enabled
   - name: falco


### PR DESCRIPTION
###### Description

In order to avoid seeing deprecation warnings:

```
W0511 14:48:20.326099  73417 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding
W0511 14:48:51.928880  73417 warnings.go:70] admissionregistration.k8s.io/v1beta1 MutatingWebhookConfiguration is deprecated in v1.16+, unavailable in v1.22+; use admissionregistration.k8s.io/v1 MutatingWebhookConfiguration
```

let's bump `kube-prometheus-stack` subchart to `12.10.0` which in turn bumps from `5.8.*` [link](https://github.com/prometheus-community/helm-charts/blob/kube-prometheus-stack-12.3.0/charts/kube-prometheus-stack/Chart.yaml#L47) to `6.1.*` [link](https://github.com/prometheus-community/helm-charts/blob/kube-prometheus-stack-12.10.0/charts/kube-prometheus-stack/Chart.yaml#L47) 

It also bumps prometheus-operator from `0.43.2` to `0.44.0` [link](https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.44.0) but I don't see any major changes that would cause problems.

---

Fixes #1720