### PR TITLE
fix: change link to VirtualBox

### DIFF
--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -4,7 +4,7 @@
 
 Please install the following:
 
-- [VirtualBox](https://www.virtualbox.org/)
+- [VirtualBox](https://www.oracle.com/virtualization/technologies/vm/downloads/virtualbox-downloads.html)
 - [Vagrant](https://www.vagrantup.com/)
 - [vagrant-disksize](https://github.com/sprotheroe/vagrant-disksize) plugin
 


### PR DESCRIPTION
###### Description

https://www.virtualbox.org/ is now down

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
