### PR TITLE
Fix configuration for otc metrics pipeline

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -2590,12 +2590,6 @@ otelcol:
                 - replicaSetName
                 - serviceName
                 - statefulSetName
-              annotations:
-                - tag_name: "pod_annotations_%s"
-                  key: "*"
-              namespace_labels:
-                - tag_name: "namespace_labels_%s"
-                  key: "*"
               labels:
                 - tag_name: "pod_labels_%s"
                   key: "*"

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -2582,7 +2582,6 @@ otelcol:
                 - clusterName
                 - daemonSetName
                 - deploymentName
-                - hostName
                 - namespace
                 - nodeName
                 - podId


### PR DESCRIPTION
###### Description

Fix configuration for otc metrics pipeline:
- remove configuration for adding host metadata
   host metadata is not available for metrics coming from Fluentd
- remove configuration for namespace labels and pod annotations added as metadata
   namespace labels and pod annotations cannot be added in Fluentd metrics pipeline
---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
