### PR TITLE
fix(otc-metrics): rename label service to prometheus_service, add delimiter set to '_'

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -2467,7 +2467,7 @@ otelcol:
   statefulset:
     image:
       repository: public.ecr.aws/sumologic/sumologic-otel-collector
-      tag: 0.0.23-beta.0
+      tag: 0.0.24-beta.0
       pullPolicy: IfNotPresent
   metadata:
     metrics:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -2546,6 +2546,11 @@ otelcol:
                 action: upsert
               - key: host
                 action: delete
+              - key: prometheus_service
+                from_attribute: service
+                action: upsert
+              - key: service
+                action: delete
           ## Configuration for Memory Limiter Processor
           ## The memory_limiter processor is used to prevent out of memory situations on the collector.
           ## ref: https://github.com/SumoLogic/opentelemetry-collector/tree/main/processor/memorylimiter
@@ -2592,6 +2597,7 @@ otelcol:
               labels:
                 - tag_name: "pod_labels_%s"
                   key: "*"
+              delimiter: "_"
             pod_association:
               - from: build_hostname
           ## Configuration for Source Processor


### PR DESCRIPTION
- rename label service to prometheus_service, add delimiter set to '_' 
service label is visible in Sumo as prometheus_service in metrics coming from Fluentd
delimiter is used when for example pod is associated with more than one service,
delimiter is going be used to join them

metadata in Sumo:
<img width="1265" alt="Screenshot 2021-09-14 at 10 17 27" src="https://user-images.githubusercontent.com/73836361/133222924-2c6c4fce-a647-415d-9e3f-09a50cabf668.png">

tested with:
```
  statefulset:
    image:
      repository: public.ecr.aws/sumologic/sumologic-otel-collector-dev
      tag: d35b54257c68170e8ce1bb1f35048871e69d7238-amd64
```
---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
