### PR TITLE
fix: fix switching between fluentd and otelcol

### DIFF
--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -345,7 +345,7 @@ helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 {{- end -}}
 
 {{- define "sumologic.metadata.name.metrics.service" -}}
-{{ template "sumologic.metadata.name.metrics" . }}
+{{ template "sumologic.metadata.name.fluentd" . }}-metrics
 {{- end -}}
 
 {{- define "sumologic.metadata.name.metrics.service-headless" -}}

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -313,7 +313,7 @@ helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 {{- end -}}
 
 {{- define "sumologic.metadata.name.logs.service" -}}
-{{ template "sumologic.metadata.name.logs" . }}
+{{ template "sumologic.metadata.name.fluentd" . }}-logs
 {{- end -}}
 
 {{- define "sumologic.metadata.name.logs.service-headless" -}}

--- a/deploy/helm/sumologic/templates/chart-configmap.yaml
+++ b/deploy/helm/sumologic/templates/chart-configmap.yaml
@@ -4,5 +4,5 @@ metadata:
   name: sumologic-configmap
 data:
   fluentdLogs: {{ template "sumologic.metadata.name.logs.service" . }}
-  fluentdMetrics: {{ template "sumologic.metadata.name.metrics" . }}
+  fluentdMetrics: {{ template "sumologic.metadata.name.metrics.service" . }}
   fluentdNamespace: {{ .Release.Namespace }}

--- a/deploy/helm/sumologic/templates/chart-configmap.yaml
+++ b/deploy/helm/sumologic/templates/chart-configmap.yaml
@@ -3,6 +3,6 @@ kind: ConfigMap
 metadata:
   name: sumologic-configmap
 data:
-  fluentdLogs: {{ template "sumologic.metadata.name.logs" . }}
+  fluentdLogs: {{ template "sumologic.metadata.name.logs.service" . }}
   fluentdMetrics: {{ template "sumologic.metadata.name.metrics" . }}
   fluentdNamespace: {{ .Release.Namespace }}


### PR DESCRIPTION
Given I'm running with Fluentd as logs and/or metrics metadata provider,
When I switch to OtelCol as logs and/or metrics metadata provider in place (with `helm upgrade` as opposed to `helm uninstall` and `helm install`),
Fluent Bit and/or Prometheus is not able to pick up the new configuration and keeps trying to send data to Fluentd service, which doesn't exist anymore.

To properly fix that, we would need to introduce a breaking change
in Fluent Bit and/or Prometheus configuration. This should be done in v3.0.

For now, let's disguise OtelCol statefulset as Fluentd by naming its service with the name of the Fluentd service, so that Fluent Bit and Prometheus can keep using the Fluentd service name, even though there's really OtelCol under the hood.
    
Fixes #1741