### PR TITLE
fix(ci): don't run PRs labels check on pull_request events to prevent failures on PR from forks

### DIFF
--- a/.github/workflows/check_pr_labels.yaml
+++ b/.github/workflows/check_pr_labels.yaml
@@ -3,8 +3,6 @@ name: PRs labels check
 on:
   pull_request_target:
     types: [opened, reopened, ready_for_review, labeled, unlabeled, synchronize]
-  pull_request:
-    types: [opened, reopened, ready_for_review, labeled, unlabeled, synchronize]
 
 jobs:
   label:


### PR DESCRIPTION
The gist of this is to avoid failures on PRs from forks like this: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1747/checks?check_run_id=3616995450