### PR TITLE
docs: improve documentation for installation on OpenShift

### DIFF
--- a/deploy/docs/Installation_with_Helm.md
+++ b/deploy/docs/Installation_with_Helm.md
@@ -169,12 +169,13 @@ helm upgrade --install my-release sumologic/sumologic \
   --set sumologic.scc.create=true \
   --set fluent-bit.securityContext.privileged=true \
   --set kube-prometheus-stack.prometheus-node-exporter.service.port=9200 \
-  --set kube-prometheus-stack.prometheus-node-exporter.service.targetPort=9200
+  --set kube-prometheus-stack.prometheus-node-exporter.service.targetPort=9200 \
+  --set kube-prometheus-stack.prometheusOperator.namespaces.additional=[my-namespace]
 ```
 
 **Notice:** Prometheus Operator is deployed by default on OpenShift platform,
 you may either limit scope for Prometheus Operator installed with Sumo Logic Kubernetes Collection using
-`kube-prometheus-stack.prometheusOperator.prometheusInstanceNamespaces` parameter in values.yaml or
+`kube-prometheus-stack.prometheusOperator.namespaces.additional` parameter in values.yaml or
 exclude namespaces for Prometheus Operator installed with Sumo Logic Kubernetes Collection
 using `kube-prometheus-stack.prometheusOperator.denyNamespaces` in values.yaml.
 

--- a/deploy/docs/Non_Helm_Installation.md
+++ b/deploy/docs/Non_Helm_Installation.md
@@ -188,12 +188,13 @@ kubectl run tools \
   --set fluent-bit.securityContext.privileged=true \
   --set kube-prometheus-stack.prometheus-node-exporter.service.port=9200 \
   --set kube-prometheus-stack.prometheus-node-exporter.service.targetPort=9200 \
+  --set kube-prometheus-stack.prometheusOperator.namespaces.additional=[my-namespace] \
   | tee sumologic.yaml
 ```
 
 **Notice:** Prometheus Operator is deployed by default on OpenShift platform,
 you may either limit scope for Prometheus Operator installed with Sumo Logic Kubernetes Collection using
-`kube-prometheus-stack.prometheusOperator.prometheusInstanceNamespaces` parameter in values.yaml or
+`kube-prometheus-stack.prometheusOperator.namespaces.additional` parameter in values.yaml or
 exclude namespaces for Prometheus Operator installed with Sumo Logic Kubernetes Collection
 using `kube-prometheus-stack.prometheusOperator.denyNamespaces` in values.yaml.
 

--- a/deploy/docs/SideBySidePrometheus.md
+++ b/deploy/docs/SideBySidePrometheus.md
@@ -109,7 +109,7 @@ helm upgrade --install my-release sumologic/sumologic \
     --set sumologic.clusterName="<MY_CLUSTER_NAME>" \
     --set kube-prometheus-stack.prometheus-node-exporter.service.port=9200 \
     --set kube-prometheus-stack.prometheus-node-exporter.service.targetPort=9200 \
-    --set kube-prometheus-stack.prometheusOperator.prometheusInstanceNamespaces=[my-namespace] \
+    --set kube-prometheus-stack.prometheusOperator.namespaces.additional=[my-namespace] \
     --set sumologic.scc.create=true \
     --set fluent-bit.securityContext.privileged=true
 ```


### PR DESCRIPTION
whne option `kube-prometheus-stack.prometheusOperator.prometheusInstanceNamespaces` is set
Pod for Prometheus is not create and in logs there is following error:
`level=info ts=2021-09-16T08:41:08.622312669Z caller=listwatch.go:88 component=prometheusoperator msg="namespace not found" namespace=[sumologic]`
but sumologic namespace is available

Tested version:
```
$ helm ls -A
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART           APP VERSION
my-release      sumologic       2               2021-09-16 08:28:05.740943426 +0000 UTC deployed        sumologic-2.1.5 2.1.5 
```

For reference part of configuration for namespaces in scope for Prometheus Operator from kube-prometheus-stack:
```
## Manages Prometheus and Alertmanager components
##
prometheusOperator:
  ## Namespaces to scope the interaction of the Prometheus Operator and the apiserver (allow list).
  ## This is mutually exclusive with denyNamespaces. Setting this to an empty object will disable the configuration
  ##
  namespaces: {}
    # releaseNamespace: true
    # additional:
    # - kube-system

  ## Namespaces not to scope the interaction of the Prometheus Operator (deny list).
  ##
  denyNamespaces: []

  ## Filter namespaces to look for prometheus-operator custom resources
  ##
  alertmanagerInstanceNamespaces: []
  prometheusInstanceNamespaces: []
  thanosRulerInstanceNamespaces: []
```

Testing sumologic collection on OpenShift I've found some cases for further investigation:

### CASE 1

```
$ helm upgrade --install my-release sumologic/sumologic \
>   --namespace=sumologic \
>   --set sumologic.accessId="dummy" \
>   --set sumologic.accessKey="dummy" \
>   --set sumologic.endpoint="http://receiver-mock.receiver-mock:3000/terraform/api/" \
>   --set sumologic.clusterName="test" \
>   --set sumologic.scc.create=true \
>   --set fluent-bit.securityContext.privileged=true \
>   --set kube-prometheus-stack.prometheus-node-exporter.service.port=9200 \
>   --set kube-prometheus-stack.prometheus-node-exporter.service.targetPort=9200 \
>   --set kube-prometheus-stack.prometheusOperator.namespaces.releaseNamespace=true \
>   --set kube-prometheus-stack.prometheusOperator.namespaces.additional=[default]
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /operator/config.yaml
WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /operator/config.yaml
Error: UPGRADE FAILED: template: sumologic/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml:57:22: executing "sumologic/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml" at <append $ns $namespace>: error calling append: Cannot push on type string
```

### CASE 2

```
 $ helm upgrade --install my-release sumologic/sumologic \
>   --namespace=sumologic \
>   --set sumologic.accessId="dummy" \
>   --set sumologic.accessKey="dummy" \
>   --set sumologic.endpoint="http://receiver-mock.receiver-mock:3000/terraform/api/" \
>   --set sumologic.clusterName="test" \
>   --set sumologic.scc.create=true \
>   --set fluent-bit.securityContext.privileged=true \
>   --set kube-prometheus-stack.prometheus-node-exporter.service.port=9200 \
>   --set kube-prometheus-stack.prometheus-node-exporter.service.targetPort=9200 \
>   --set kube-prometheus-stack.prometheusOperator.namespaces.releaseNamespace=true
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /operator/config.yaml
WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /operator/config.yaml
Error: UPGRADE FAILED: template: sumologic/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml:57:22: executing "sumologic/charts/kube-prometheus-stack/templates/prometheus-operator/deployment.yaml" at <append $ns $namespace>: error calling append: runtime error: invalid memory address or nil pointer dereference
```

### CASE 3

```
helm upgrade --install my-release sumologic/sumologic \
  --namespace=sumologic \
  --set sumologic.accessId="dummy" \
  --set sumologic.accessKey="dummy" \
  --set sumologic.endpoint="http://receiver-mock.receiver-mock:3000/terraform/api/" \
  --set sumologic.clusterName="test" \
  --set sumologic.scc.create=true \
  --set fluent-bit.securityContext.privileged=true \
  --set kube-prometheus-stack.prometheus-node-exporter.service.port=9200 \
  --set kube-prometheus-stack.prometheus-node-exporter.service.targetPort=9200 \
  --set kube-prometheus-stack.prometheusOperator.prometheusInstanceNamespaces=[sumologic]

$ kubectl logs -n sumologic my-release-kube-prometheus-operator-7b55cc5cd7-fbxd
level=info ts=2021-09-16T08:41:08.558090865Z caller=main.go:228 msg="Starting Prometheus Operator" version="(version=0.43.2, branch=refs/tags/v0.43.2, revision=b86ab77239f2a11ee69ad05b24122958d8b2df5b)"
level=info ts=2021-09-16T08:41:08.558146258Z caller=main.go:229 build_context="(go=go1.14.10, user=simonpasquier, date=20201109-10:55:44)"
ts=2021-09-16T08:41:08.56806791Z caller=main.go:106 msg="Starting insecure server on [::]:8080"
level=info ts=2021-09-16T08:41:08.576691827Z caller=operator.go:434 component=alertmanageroperator msg="connection established" cluster-version=v1.20.0+bafe72f
level=info ts=2021-09-16T08:41:08.576740189Z caller=operator.go:443 component=alertmanageroperator msg="CRD API endpoints ready"
level=info ts=2021-09-16T08:41:08.576745896Z caller=operator.go:300 component=thanosoperator msg="connection established" cluster-version=v1.20.0+bafe72f
level=info ts=2021-09-16T08:41:08.576766285Z caller=operator.go:419 component=prometheusoperator msg="connection established" cluster-version=v1.20.0+bafe72f
level=info ts=2021-09-16T08:41:08.576784832Z caller=operator.go:309 component=thanosoperator msg="CRD API endpoints ready"
level=info ts=2021-09-16T08:41:08.576796652Z caller=operator.go:428 component=prometheusoperator msg="CRD API endpoints ready"
I0916 08:41:08.576784       1 shared_informer.go:240] Waiting for caches to sync for alertmanager
I0916 08:41:08.576824       1 shared_informer.go:240] Waiting for caches to sync for thanos
I0916 08:41:08.576834       1 shared_informer.go:240] Waiting for caches to sync for prometheus
level=info ts=2021-09-16T08:41:08.622312669Z caller=listwatch.go:88 component=prometheusoperator msg="namespace not found" namespace=[sumologic]
```

```
$ kubectl get pods -n sumologic
NAME                                                   READY   STATUS    RESTARTS   AGE
my-release-fluent-bit-55nsk                            1/1     Running   0          49m
my-release-fluent-bit-6b75m                            1/1     Running   0          49m
my-release-fluent-bit-ck645                            1/1     Running   0          49m
my-release-fluent-bit-dkv9x                            1/1     Running   0          49m
my-release-fluent-bit-fnd47                            1/1     Running   0          49m
my-release-fluent-bit-h4rkn                            1/1     Running   0          49m
my-release-fluent-bit-l8kbx                            1/1     Running   0          49m
my-release-fluent-bit-qlhgm                            1/1     Running   0          49m
my-release-kube-prometheus-operator-7b55cc5cd7-fbxdf   1/1     Running   0          2m11s
my-release-kube-state-metrics-6455966c87-tjjvm         1/1     Running   0          49m
my-release-prometheus-node-exporter-6jt9v              1/1     Running   0          49m
my-release-prometheus-node-exporter-6v6br              1/1     Running   0          49m
my-release-prometheus-node-exporter-8prqf              1/1     Running   0          49m
my-release-prometheus-node-exporter-ccx7n              1/1     Running   0          49m
my-release-prometheus-node-exporter-dkwpx              1/1     Running   0          49m
my-release-prometheus-node-exporter-h64rm              1/1     Running   0          49m
my-release-prometheus-node-exporter-hg65m              1/1     Running   0          49m
my-release-prometheus-node-exporter-kbnbj              1/1     Running   0          49m
my-release-sumologic-fluentd-events-0                  1/1     Running   0          49m
my-release-sumologic-fluentd-logs-0                    1/1     Running   0          49m
my-release-sumologic-fluentd-logs-1                    1/1     Running   0          49m
my-release-sumologic-fluentd-logs-2                    1/1     Running   0          49m
my-release-sumologic-fluentd-metrics-0                 1/1     Running   0          49m
my-release-sumologic-fluentd-metrics-1                 1/1     Running   0          49m
my-release-sumologic-fluentd-metrics-2                 1/1     Running   0          49m
```

---

###### Testing performed

- Tested scenario:
```
$ oc get co
NAME                                       VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE
authentication                             4.7.6     True        False         False      65m
baremetal                                  4.7.6     True        False         False      84m
cloud-credential                           4.7.6     True        False         False      88m
cluster-autoscaler                         4.7.6     True        False         False      83m
config-operator                            4.7.6     True        False         False      84m
console                                    4.7.6     True        False         False      72m
csi-snapshot-controller                    4.7.6     True        False         False      84m
dns                                        4.7.6     True        False         False      83m
etcd                                       4.7.6     True        False         False      83m
image-registry                             4.7.6     True        False         False      77m
ingress                                    4.7.6     True        False         False      77m
insights                                   4.7.6     True        False         False      78m
kube-apiserver                             4.7.6     True        False         False      82m
kube-controller-manager                    4.7.6     True        False         False      83m
kube-scheduler                             4.7.6     True        False         False      82m
kube-storage-version-migrator              4.7.6     True        False         False      77m
machine-api                                4.7.6     True        False         False      79m
machine-approver                           4.7.6     True        False         False      83m
machine-config                             4.7.6     True        False         False      84m
marketplace                                4.7.6     True        False         False      83m
monitoring                                 4.7.6     True        False         False      76m
network                                    4.7.6     True        False         False      84m
node-tuning                                4.7.6     True        False         False      83m
openshift-apiserver                        4.7.6     True        False         False      79m
openshift-controller-manager               4.7.6     True        False         False      77m
openshift-samples                          4.7.6     True        False         False      78m
operator-lifecycle-manager                 4.7.6     True        False         False      83m
operator-lifecycle-manager-catalog         4.7.6     True        False         False      83m
operator-lifecycle-manager-packageserver   4.7.6     True        False         False      79m
service-ca                                 4.7.6     True        False         False      84m
storage                                    4.7.6     True        False         False      84m



helm upgrade --install my-release sumologic/sumologic \
  --namespace=sumologic \
  --set sumologic.accessId="dummy" \
  --set sumologic.accessKey="dummy" \
  --set sumologic.endpoint="http://receiver-mock.receiver-mock:3000/terraform/api/" \
  --set sumologic.clusterName="test" \
  --set sumologic.scc.create=true \
  --set fluent-bit.securityContext.privileged=true \
  --set kube-prometheus-stack.prometheus-node-exporter.service.port=9200 \
  --set kube-prometheus-stack.prometheus-node-exporter.service.targetPort=9200 \
  --set kube-prometheus-stack.prometheusOperator.namespaces.additional=[sumologic]


$ kubectl get pods -n sumologic my-release-kube-prometheus-operator-6bc678cd9d-b64q4 -o yaml
...
spec:
  containers:
  - args:
    - --kubelet-service=kube-system/my-release-kube-prometheus-kubelet
    - --namespaces=[sumologic]
    - --logtostderr=true
    - --localhost=127.0.0.1
    - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.43.2
    - --config-reloader-cpu=100m
    - --config-reloader-memory=25Mi
    image: quay.io/prometheus-operator/prometheus-operator:v0.43.2
    imagePullPolicy: IfNotPresent
    name: kube-prometheus-stack

$ kubectl get pods -n sumologic
NAME                                                   READY   STATUS    RESTARTS   AGE
my-release-fluent-bit-55nsk                            1/1     Running   0          35m
my-release-fluent-bit-6b75m                            1/1     Running   0          35m
my-release-fluent-bit-ck645                            1/1     Running   0          35m
my-release-fluent-bit-dkv9x                            1/1     Running   0          35m
my-release-fluent-bit-fnd47                            1/1     Running   0          35m
my-release-fluent-bit-h4rkn                            1/1     Running   0          35m
my-release-fluent-bit-l8kbx                            1/1     Running   0          35m
my-release-fluent-bit-qlhgm                            1/1     Running   0          35m
my-release-kube-prometheus-operator-6bc678cd9d-b64q4   1/1     Running   0          35m
my-release-kube-state-metrics-6455966c87-tjjvm         1/1     Running   0          35m
my-release-prometheus-node-exporter-6jt9v              1/1     Running   0          35m
my-release-prometheus-node-exporter-6v6br              1/1     Running   0          35m
my-release-prometheus-node-exporter-8prqf              1/1     Running   0          35m
my-release-prometheus-node-exporter-ccx7n              1/1     Running   0          35m
my-release-prometheus-node-exporter-dkwpx              1/1     Running   0          35m
my-release-prometheus-node-exporter-h64rm              1/1     Running   0          35m
my-release-prometheus-node-exporter-hg65m              1/1     Running   0          35m
my-release-prometheus-node-exporter-kbnbj              1/1     Running   0          35m
my-release-sumologic-fluentd-events-0                  1/1     Running   0          35m
my-release-sumologic-fluentd-logs-0                    1/1     Running   0          35m
my-release-sumologic-fluentd-logs-1                    1/1     Running   0          35m
my-release-sumologic-fluentd-logs-2                    1/1     Running   0          35m
my-release-sumologic-fluentd-metrics-0                 1/1     Running   0          35m
my-release-sumologic-fluentd-metrics-1                 1/1     Running   0          35m
my-release-sumologic-fluentd-metrics-2                 1/1     Running   0          35m

$ kubectl logs -n receiver-mock receiver-mock-c794c996d-lrx87 --tail 20
1631779807 Metrics:          0 Logs:       1479; 0.007484 MB/s
1631779867 Metrics:          0 Logs:       1679; 0.008127 MB/s
1631779927 Metrics:          0 Logs:       3583; 0.016734 MB/s
1631779987 Metrics:          0 Logs:       1441; 0.007172 MB/s
1631780047 Metrics:          0 Logs:       1625; 0.007986 MB/s
1631780107 Metrics:          0 Logs:       2480; 0.011715 MB/s
1631780167 Metrics:          0 Logs:       2499; 0.011814 MB/s
1631780227 Metrics:          0 Logs:       1679; 0.008487 MB/s
1631780287 Metrics:          0 Logs:       1987; 0.010229 MB/s
1631780347 Metrics:          0 Logs:       3680; 0.017329 MB/s
1631780407 Metrics:          0 Logs:       1576; 0.007444 MB/s
1631780467 Metrics:          0 Logs:       1618; 0.007628 MB/s
1631780527 Metrics:          0 Logs:       3570; 0.016676 MB/s
1631780587 Metrics:          0 Logs:       1589; 0.007747 MB/s
1631780647 Metrics:          0 Logs:       1565; 0.008427 MB/s
1631780707 Metrics:          0 Logs:       2763; 0.013073 MB/s
1631780767 Metrics:          0 Logs:       2337; 0.011028 MB/s
1631780827 Metrics:          0 Logs:       1370; 0.006626 MB/s
1631780887 Metrics:          0 Logs:       2233; 0.011835 MB/s
1631780947 Metrics:          0 Logs:       3665; 0.017000 MB/s

$ oc get co
NAME                                       VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE
authentication                             4.7.6     True        False         False      111m
baremetal                                  4.7.6     True        False         False      130m
cloud-credential                           4.7.6     True        False         False      134m
cluster-autoscaler                         4.7.6     True        False         False      128m
config-operator                            4.7.6     True        False         False      130m
console                                    4.7.6     True        False         False      117m
csi-snapshot-controller                    4.7.6     True        False         False      129m
dns                                        4.7.6     True        False         False      128m
etcd                                       4.7.6     True        False         False      128m
image-registry                             4.7.6     True        False         False      123m
ingress                                    4.7.6     True        False         False      122m
insights                                   4.7.6     True        False         False      123m
kube-apiserver                             4.7.6     True        False         False      127m
kube-controller-manager                    4.7.6     True        False         False      128m
kube-scheduler                             4.7.6     True        False         False      127m
kube-storage-version-migrator              4.7.6     True        False         False      123m
machine-api                                4.7.6     True        False         False      124m
machine-approver                           4.7.6     True        False         False      129m
machine-config                             4.7.6     True        False         False      129m
marketplace                                4.7.6     True        False         False      128m
monitoring                                 4.7.6     True        False         False      121m
network                                    4.7.6     True        False         False      129m
node-tuning                                4.7.6     True        False         False      129m
openshift-apiserver                        4.7.6     True        False         False      124m
openshift-controller-manager               4.7.6     True        False         False      122m
openshift-samples                          4.7.6     True        False         False      124m
operator-lifecycle-manager                 4.7.6     True        False         False      129m
operator-lifecycle-manager-catalog         4.7.6     True        False         False      129m
operator-lifecycle-manager-packageserver   4.7.6     True        False         False      124m
service-ca                                 4.7.6     True        False         False      130m
storage                                    4.7.6     True        False         False      129m
```
