### PR TITLE
feat(otc-metrics): add '_origin' metadata to metrics to keep the same format as for metrics from Fluentd

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -2616,6 +2616,9 @@ otelcol:
                 action: upsert
               - key: service
                 action: delete
+              - key: _origin  # add "_origin" metadata to metrics to keep the same format as for metrics from Fluentd
+                value: kubernetes
+                action: upsert
           ## Configuration for Memory Limiter Processor
           ## The memory_limiter processor is used to prevent out of memory situations on the collector.
           ## ref: https://github.com/SumoLogic/opentelemetry-collector/tree/main/processor/memorylimiter


### PR DESCRIPTION
add '_origin' metadata to metrics to keep the same format as for metrics from Fluentd

in Prometheus '_origin' metadata is not available

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
