### PR TITLE
chore: bump k8s version in vagrant to 1.21

### DIFF
--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -9,7 +9,7 @@ apt-get --yes install apt-transport-https jq
 
 echo "export EDITOR=vim" >> /home/vagrant/.bashrc
 
-snap install microk8s --classic --channel=1.18/stable
+snap install microk8s --classic --channel=1.21/stable
 microk8s.status --wait-ready
 ufw allow in on cbr0
 ufw allow out on cbr0


### PR DESCRIPTION
Given 1.18 is already unsupported bump the version to 1.21