### PR TITLE
fix(otelcol): use source metdata set by sourceprocessor

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -2773,16 +2773,18 @@ otelcol:
             log_format: json
             endpoint: ${SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE}
             ## ToDo: Move sources to sourceprocessor
-            source_name: "%{k8s.namespace.name}.%{k8s.pod.name}.%{k8s.container.name}"
-            source_category: "%{k8s.namespace.name}/%{k8s.pod.pod_name}"
-            source_host: '%{k8s.pod.hostname}'
+            source_name: "%{_sourceName}"
+            source_category: "%{_sourceCategory}"
+            source_host: "%{_sourceHost}"
             sending_queue:
               enabled: true
             metadata_attributes:
+              - _sourceCategory
+              - _sourceHost
+              - _sourceName
               - k8s.*
               - pod_.*
               - namespace_.*
-
               - Deployment
               - Namespace
               - container


### PR DESCRIPTION
Rely on source metadata set by source processor and don't construct it in the exporter.