### PR TITLE
fix(otelcol): fix match_type in filterprocessor's config for logs pipeline

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -2989,7 +2989,7 @@ otelcol:
           filter/exclude_kubelet:
             logs:
               exclude:
-                match_type: service
+                match_type: strict
                 record_attributes:
                   - key: _SYSTEMD_UNIT
                     value: kubelet.service
@@ -3016,7 +3016,7 @@ otelcol:
           filter/include_kubelet:
             logs:
               include:
-                match_type: service
+                match_type: strict
                 record_attributes:
                   - key: _SYSTEMD_UNIT
                     value: kubelet.service


### PR DESCRIPTION
It seems that `filterprocessor` doesn't validate the `match_type` used in its config.

I've created an issue for that: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5382

In the meantime let's just correct it in our `values.yaml`