### PR TITLE
fix(otelcol): fix systemd logs' source name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - otelcol: add systemd logs pipeline (#1767)
 
   - This change introduces logs metadata enrichment with Sumo Open Telemetry
-    distro for systemd logs.
+    distro for systemd logs (when `sumologic.logs.metadata.provider` is set to
+    `otelcol`)
 
-    One notable change in behavior with respect to `fluentd` is that
-    `.Values.fluentd.logs.systemd.sourceName` is respected and
-    will set `_sourceName` of processed logs while fluentd would set this field
-    to the corresponding systemd serice's name e.g. `docker` for `docker.service`.
+    One notable change comparing the new behavior to `fluentd` metadat enrichment
+    is that setting source name in `sourceprocessor` configuration is respected
+    i.e.  whatever is set in
+    `otelcol.metadata.logs.config.processors.source/systemd:.source_name` will be
+    set as source name for systemd logs.
+
+    The old behavior is being retained i.e. extracting the source name from
+    `fluent.tag` using `attributes/extract_systemd_source_name_from_fluent_tag`
+    processor. For instance, for `fluent.tag=host.docker.service`, source name
+    will be set to `docker`.
+
+    In order to set the source name to something else please change
+    `otelcol.metadata.logs.config.processors.source/systemd:.source_name`
+    configuration value.
 
 ## [v2.1.5][v2_1_5] - 2021-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     One notable change comparing the new behavior to `fluentd` metadata enrichment
     is that setting source name in `sourceprocessor` configuration is respected
     i.e.  whatever is set in
-    `otelcol.metadata.logs.config.processors.source/systemd:.source_name` will be
+    `otelcol.metadata.logs.config.processors.source/systemd.source_name` will be
     set as source name for systemd logs.
 
     The old behavior is being retained i.e. extracting the source name from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     distro for systemd logs (when `sumologic.logs.metadata.provider` is set to
     `otelcol`)
 
-    One notable change comparing the new behavior to `fluentd` metadat enrichment
+    One notable change comparing the new behavior to `fluentd` metadata enrichment
     is that setting source name in `sourceprocessor` configuration is respected
     i.e.  whatever is set in
     `otelcol.metadata.logs.config.processors.source/systemd:.source_name` will be

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -3019,6 +3019,11 @@ otelcol:
                 record_attributes:
                   - key: fluent.tag
                     value: host\..+
+          attributes/extract_systemd_source_name_from_fluent_tag:
+            actions:
+              - action: extract
+                key: fluent.tag
+                pattern: ^host\.(?P<_sourceName>[a-zA-z0-9]+)\..+$
           filter/include_systemd:
             logs:
               include:
@@ -3039,9 +3044,10 @@ otelcol:
               - _HOSTNAME
               - SYSLOG_FACILITY
               - PRIORITY
+              - _sourceName
           source/systemd:
             collector: '{{ .Values.sumologic.collectorName | default .Values.sumologic.clusterName | quote }}'
-            source_name: '{{ .Values.fluentd.logs.systemd.sourceName | quote }}'
+            source_name: '%{_sourceName}'
             source_category: '{{ .Values.fluentd.logs.systemd.sourceCategory | quote }}'
             source_category_prefix: '{{ .Values.fluentd.logs.systemd.sourceCategoryPrefix | quote }}'
             source_category_replace_dash: '{{ .Values.fluentd.logs.systemd.sourceCategoryReplaceDash | quote }}'
@@ -3060,7 +3066,6 @@ otelcol:
                 record_attributes:
                   - key: _SYSTEMD_UNIT
                     value: kubelet.service
-
           source/kubelet:
             collector: '{{ .Values.sumologic.collectorName | default .Values.sumologic.clusterName | quote }}'
             source_name: '{{ .Values.fluentd.logs.kubelet.sourceName | quote }}'

--- a/vagrant/values.yaml
+++ b/vagrant/values.yaml
@@ -154,6 +154,7 @@ otelcol:
   metadata:
     logs:
       config:
+        exporters:
         processors:
           # Filter out receiver-mock logs to prevent snowball effect
           filter/exclude_fluent_tag_receiver_mock_container:
@@ -166,6 +167,13 @@ otelcol:
           filter/exclude_systemd_snap_kubelite:
             logs:
               exclude:
+                match_type: strict
+                record_attributes:
+                  - key: _SYSTEMD_UNIT
+                    value: snap.microk8s.daemon-kubelite.service
+          filter/include_systemd_snap_kubelite:
+            logs:
+              include:
                 match_type: strict
                 record_attributes:
                   - key: _SYSTEMD_UNIT
@@ -186,10 +194,10 @@ otelcol:
                 - filter/exclude_fluent_tag_receiver_mock_container
 
                 - attributes/containers
-                - attributes/remove_fluent_tag
                 - groupbyattrs/containers
                 - k8s_tagger
                 - source/containers
+                - attributes/remove_fluent_tag
                 - batch
               exporters:
                 - sumologic/containers
@@ -203,11 +211,29 @@ otelcol:
                 # Vagrant specific
                 - filter/exclude_fluent_tag_receiver_mock_container
 
-                - attributes/remove_fluent_tag
                 - filter/include_systemd
                 - filter/exclude_systemd_snap_kubelite
+                - attributes/extract_systemd_source_name_from_fluent_tag
                 - groupbyattrs/systemd
                 - source/systemd
+                - attributes/remove_fluent_tag
+                - batch
+              exporters:
+                - sumologic/systemd
+            logs/kubelet:
+              receivers:
+                - fluentforward
+              processors:
+                - memory_limiter
+                - filter/include_fluent_tag_host
+
+                # Vagrant specific
+                - filter/exclude_fluent_tag_receiver_mock_container
+
+                - filter/include_systemd_snap_kubelite
+                - groupbyattrs/systemd
+                - source/kubelet
+                - attributes/remove_fluent_tag
                 - batch
               exporters:
                 - sumologic/systemd


### PR DESCRIPTION
In oder to keep the metadata enrichment behavior from fluentd which is to extract the second element from `fluent.tag` https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/d87aab8d99d63c3ff364c72b85aa9cd2cba4855f/deploy/helm/sumologic/conf/logs/fluentd/logs.source.systemd.conf#L78 let's do the same in otelcol's config and set that as source name for systemd logs.

Additionally document the change in Changelog;.