### PR TITLE
Fixing regex for Istio logs, splitting istio logs

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1082,7 +1082,7 @@ fluent-bit:
       [PARSER]
           Name        multi_line
           Format      regex
-          Regex       (?<log>^{"log":"\d{4}-\d{1,2}-\d{1,2}.\d{2}:\d{2}:\d{2}.*)
+          Regex       (?<log>^{"log":"\[?\d{4}-\d{1,2}-\d{1,2}.\d{2}:\d{2}:\d{2}.*)
       [PARSER]
           Name         crio
           Format       regex


### PR DESCRIPTION
###### Description
Istio writes logs to Stdout. In Sumo Logic logs are coming as combined logs, like : 

`{"timestamp":1625774729582,"log":"[2021-07-08T20:05:23.034Z] \"GET /ab2g HTTP/1.1\" 400 - missing_host_header - \"-\" 0 0 0 - \"-\" \"-\" \"-\" \"-\" \"-\" - - 10.12.9.6:8080 10.128.0.49:50180 - -\n[2021-07-08T20:05:24.092Z] \"GET /ab2h HTTP/1.1\" 400 - missing_host_header - \"-\" 0 0 0 - \"-\" \"-\" \"-\" \"-\" \"-\" - - 10.12.9.6:8080 10.128.0.42:43773 - -","stream":"stdout","time":"2021-07-08T20:05:26.246470661Z"}`

Note: 

- First log line starts with **[2021-07-08T20:05:23.034Z**
- Second log line starts with **[2021-07-08T20:05:24.092Z**

However, Istio application is writing these logs at different lines; when we check log file at Istio Pod. Example of above logs splitted correctly by Istio: 
`{"log":"[2021-07-08T20:05:23.034Z] \"GET /ab2g HTTP/1.1\" 400 - missing_host_header - \"-\" 0 0 0 - \"-\" \"-\" \"-\" \"-\" \"-\" - - 10.12.9.6:8080 10.128.0.49:50180 - -\n","stream":"stdout","time":"2021-07-08T20:05:26.246400946Z"}`

`{"log":"[2021-07-08T20:05:24.092Z] \"GET /ab2h HTTP/1.1\" 400 - missing_host_header - \"-\" 0 0 0 - \"-\" \"-\" \"-\" \"-\" \"-\" - - 10.12.9.6:8080 10.128.0.42:43773 - -\n","stream":"stdout","time":"2021-07-08T20:05:26.246470661Z"}`


This fix; allows splitting the Istio logs by adding `[?` to **mult_line** regex

It has been tested with Istio environment and here as well : https://rubular.com/r/xbJ9b11Mxp3hya



Fill in your description here.

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
