### PR TITLE
update regex varnish remotewirte

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -2549,6 +2549,79 @@ kube-prometheus-stack:
               regex: (?:rabbitmq_(exchange_messages_publish_(in_rate|in|out_rate|out)|node_(disk_free_limit|disk_free|mem_(limit|used)|uptime|fd_used|mnesia_(disk_tx_count|ram_tx_count)|gc_num_rate)|overview_(clustering_listerners|connections|exchanges|consumers|queues|messages_(delivered|published|unacked))|queue_(consumers|memory|slave_nodes|messages_(publish_rate|deliver_rate|memory|max_time|unack))))
               sourceLabels: [__name__]
 
+        ## Rabbitmq Telegraf Metrics
+        ## List of Metrics are on following github page:
+        ## https://github.com/influxdata/telegraf/tree/master/plugins/inputs/varnish
+        ## Metrics follow following format:
+        ## varnish_backend_busy
+        ## varnish_backend_conn
+        ## varnish_backend_fail
+        ## varnish_backend_recycle
+        ## varnish_backend_req
+        ## varnish_backend_retry
+        ## varnish_backend_reuse
+        ## varnish_backend_unhealthy
+        ## varnish_bans
+        ## varnish_bans_completed
+        ## varnish_bans_deleted
+        ## varnish_bans_dups
+        ## varnish_bans_lurker_contention
+        ## varnish_bans_lurker_obj_killed
+        ## varnish_bans_lurker_tested
+        ## varnish_bans_lurker_tests_tested
+        ## varnish_bans_obj
+        ## varnish_bans_obj_killed
+        ## varnish_bans_persisted_bytes
+        ## varnish_bans_persisted_fragmentation
+        ## varnish_boot_*_*_bodybytes
+        ## varnish_boot_*_*_hdrbytes
+        ## varnish_boot_*_bereq_bodybytes
+        ## varnish_boot_*_bereq_hdrbytes
+        ## varnish_cache_hit
+        ## varnish_cache_hit_grace
+        ## varnish_cache_hitpass
+        ## varnish_cache_miss
+        ## varnish_client_req
+        ## varnish_client_req_400
+        ## varnish_client_req_417
+        ## varnish_client_resp_500
+        ## varnish_n_backend
+        ## varnish_n_expired
+        ## varnish_n_lru_nuked
+        ## varnish_n_vcl_avail
+        ## varnish_pools
+        ## varnish_s0_g_bytes
+        ## varnish_s0_g_space
+        ## varnish_s_fetch
+        ## varnish_s_pipe_in
+        ## varnish_s_pipe_out
+        ## varnish_s_req_bodybytes
+        ## varnish_s_req_hdrbytes
+        ## varnish_s_resp_bodybytes
+        ## varnish_s_resp_hdrbytes
+        ## varnish_s_sess
+        ## varnish_sess_closed
+        ## varnish_sess_closed_err
+        ## varnish_sess_conn
+        ## varnish_sess_drop
+        ## varnish_sess_dropped
+        ## varnish_sess_fail
+        ## varnish_sess_queued
+        ## varnish_thread_queue_len
+        ## varnish_threads
+        ## varnish_threads_created
+        ## varnish_threads_destroyed
+        ## varnish_threads_failed
+        ## varnish_threads_limited
+        ## varnish_uptime
+        ## varnish_vmods
+        - url: http://$(FLUENTD_METRICS_SVC).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.applications.varnish
+          remoteTimeout: 5s
+          writeRelabelConfigs:
+            - action: keep
+              regex: (?:varnish_(backend_(busy|conn|fail|recycle|req|retry|reuse|unhealthy)|bans_(completed|deleted|dups|lurker_(contention|obj_killed|tests_tested|tested|)|obj_killed|obj|persisted_(bytes|fragmentation))|bans|boot_.*_.*_(bodybytes|hdrbytes)|cache_(hit_grace|hitpass|miss|hit)|client_(req_400|req_417|req|resp_500)|n_(backend|expired|lru_nuked|vcl_avail)|pools|s0_g_(bytes|space)|s_(fetch|pipe_(in|out)|req_(bodybytes|hdrbytes)|resp_(bodybytes|hdrbytes)|sess)|sess_(closed_err|closed|conn|drop|dropped|fail|queued)|thread_queue_len|threads_(created|destroyed|failed|limited)|threads|uptime|vmods))
+              sourceLabels: [__name__]
+
 ## Configure optional OpenTelemetry Collector in Agent mode
 otelagent:
   enabled: false


### PR DESCRIPTION
###### Description

Added Remote/Write Configs for Varnish metrics:
List of Metrics are on following page:

https://github.com/influxdata/telegraf/tree/master/plugins/inputs/varnish

Metrics follow following formart
``` bash 
        ## varnish_backend_busy
        ## varnish_backend_conn
        ## varnish_backend_fail
        ## varnish_backend_recycle
        ## varnish_backend_req
        ## varnish_backend_retry
        ## varnish_backend_reuse
        ## varnish_backend_unhealthy
        ## varnish_bans
        ## varnish_bans_completed
        ## varnish_bans_deleted
        ## varnish_bans_dups
        ## varnish_bans_lurker_contention
        ## varnish_bans_lurker_obj_killed
        ## varnish_bans_lurker_tested
        ## varnish_bans_lurker_tests_tested
        ## varnish_bans_obj
        ## varnish_bans_obj_killed
        ## varnish_bans_persisted_bytes
        ## varnish_bans_persisted_fragmentation
        ## varnish_boot_*_*_bodybytes
        ## varnish_boot_*_*_hdrbytes
        ## varnish_boot_*_bereq_bodybytes
        ## varnish_boot_*_bereq_hdrbytes
        ## varnish_cache_hit
        ## varnish_cache_hit_grace
        ## varnish_cache_hitpass
        ## varnish_cache_miss
        ## varnish_client_req
        ## varnish_client_req_400
        ## varnish_client_req_417
        ## varnish_client_resp_500
        ## varnish_n_backend
        ## varnish_n_expired
        ## varnish_n_lru_nuked
        ## varnish_n_vcl_avail
        ## varnish_pools
        ## varnish_s0_g_bytes
        ## varnish_s0_g_space
        ## varnish_s_fetch
        ## varnish_s_pipe_in
        ## varnish_s_pipe_out
        ## varnish_s_req_bodybytes
        ## varnish_s_req_hdrbytes
        ## varnish_s_resp_bodybytes
        ## varnish_s_resp_hdrbytes
        ## varnish_s_sess
        ## varnish_sess_closed
        ## varnish_sess_closed_err
        ## varnish_sess_conn
        ## varnish_sess_drop
        ## varnish_sess_dropped
        ## varnish_sess_fail
        ## varnish_sess_queued
        ## varnish_thread_queue_len
        ## varnish_threads
        ## varnish_threads_created
        ## varnish_threads_destroyed
        ## varnish_threads_failed
        ## varnish_threads_limited
        ## varnish_uptime
        ## varnish_vmods
  ```
---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
