### PR TITLE
fix(helm/otelcol/metrics): revert host attribute

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -2921,8 +2921,6 @@ otelcol:
                 action: upsert
               - key: pod  # remove pod to avoid duplication when attribute translation is enabled
                 action: delete
-              - key: host
-                action: delete
               - key: prometheus_service
                 from_attribute: service
                 action: upsert


### PR DESCRIPTION
host attribute is being used by telegraf
and application dashboards

Signed-off-by: Dominik Rosiek <drosiek@sumologic.com>