### PR TITLE
Prepare v2.1.6

### DIFF
--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sumologic
-version: 2.1.6-rc.0
-appVersion: 2.1.6-rc.0
+version: 2.1.6
+appVersion: 2.1.6
 description: A Helm chart for collecting Kubernetes logs, metrics, traces and events into Sumo Logic.
 type: application
 keywords:


### PR DESCRIPTION
Notable changes since https://github.com/SumoLogic/sumologic-kubernetes-collection/releases/tag/v2.1.5

```
- Fixing regex for Istio logs, splitting istio logs (#1781)
- docs: improve documentation for installation on OpenShift
- chore: bump telegraf operator subchart to 1.2.0 (#1723)
- feat(helm): add sumologic.serviceAccount.annotations so custom annotation cen be added #1716
```