### PR TITLE
chore(otelcol): bump ot distro version to 0.29.0-beta.0

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -2835,7 +2835,7 @@ otelcol:
   statefulset:
     image:
       repository: public.ecr.aws/sumologic/sumologic-otel-collector
-      tag: 0.0.27-beta.0
+      tag: 0.0.29-beta.0
       pullPolicy: IfNotPresent
   metadata:
     metrics:
@@ -3023,10 +3023,6 @@ otelcol:
             sending_queue:
               enabled: true
             metadata_attributes:
-              ## Required to be used in headers
-              - _sourceCategory
-              - _sourceHost
-              - _sourceName
               ## Attributes to be send as fields
               - _collector
               - k8s.*
@@ -3056,9 +3052,6 @@ otelcol:
               enabled: true
             metadata_attributes:
               - _collector
-              - _sourceCategory
-              - _sourceHost
-              - _sourceName
 
         processors:
           ## Common processors
@@ -3163,8 +3156,8 @@ otelcol:
               - from: build_hostname
           source/containers:
             collector: '{{ .Values.sumologic.collectorName | default .Values.sumologic.clusterName | quote }}'
-            source_name: '{{ .Values.fluentd.logs.containers.sourceName | quote }}'
-            source_category: '{{ .Values.fluentd.logs.containers.sourceCategory | quote }}'
+            source_name: "%{k8s.namespace.name}.%{k8s.pod.name}.%{k8s.container.name}"
+            source_category: "%{k8s.namespace.name}/%{k8s.pod.pod_name}"
             source_category_prefix: '{{ .Values.fluentd.logs.containers.sourceCategoryPrefix | quote }}'
             source_category_replace_dash: '{{ .Values.fluentd.logs.containers.sourceCategoryReplaceDash | quote }}'
             exclude:
@@ -3175,9 +3168,7 @@ otelcol:
             annotation_prefix: "pod_annotations_"
             pod_template_hash_key: "pod_labels_pod-template-hash"
             pod_name_key: "k8s.pod.pod_name"
-            namespace_key: "k8s.namespace.name"
             pod_key: "k8s.pod.name"
-            container_key: "k8s.container.name"
             source_host_key: "k8s.pod.hostname"
 
           ## Systemd related processors


### PR DESCRIPTION
This change unfortunately requires us to "hardcode" the `source_name` and `source_category` configuration options because the options that were used until now: `.Values.fluentd.logs.containers.sourceName` and `.Values.fluentd.logs.containers.sourceCategory` have keys specified in Sumo conventions.

Those cannot be used since at the stage in the pipeline where source processor resides we are still using OT naming convention.

Change in chart stems from change in OT distro's config (specifically in sourceprocessor): https://github.com/SumoLogic/sumologic-otel-collector/pull/254