### PR TITLE
fix(otelcol): delete source metadata from resource attributes

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -2907,6 +2907,18 @@ otelcol:
               match_type: regexp
               action: update
               new_name: $$1
+          ## NOTE: Drop these for now and and when proper configuration options
+          ## are exposed and source processor is configured then send them
+          ## as headers.
+          ## ref: https://github.com/SumoLogic/sumologic-otel-collector/issues/265
+          resource/delete_source_metadata:
+            attributes:
+              - key: _sourceCategory
+                action: delete
+              - key: _sourceHost
+                action: delete
+              - key: _sourceName
+                action: delete
           ## Configuration for Resource Processor
           ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourceprocessor
           resource:
@@ -3000,6 +3012,7 @@ otelcol:
                 - k8s_tagger
                 - source
                 - resource/remove_k8s_pod_pod_name
+                - resource/delete_source_metadata
                 - batch
               exporters:
                 - sumologic


### PR DESCRIPTION
In order to match what's being sent with fluentd let's drop the source metadata set by sourceprocessor which in some cases is not filled properly due to missing k8s metadata, e.g. (mark the `undefined` in `_sourceHost`)

```
coredns_cache_hits_total{
container="coredns"
endpoint="http-metrics"
prometheus="sumologic/collection-kube-prometheus-prometheus"
server="dns://:53"
cluster="microk8s"
instance="10.1.34.69:9153"
job="coredns"
namespace="kube-system"
pod="coredns-588fd544bf-xwxzc"
prometheus_replica="prometheus-collection-kube-prometheus-prometheus-0"
prometheus_service="collection-kube-prometheus-coredns"
type="denial"
_origin="kubernetes"
k8s.container.name="coredns"
pod_labels_k8s-app="kube-dns"
pod_labels_pod-template-hash="588fd544bf"
replicaset="coredns-588fd544bf"
deployment="coredns"
service="collection-kube-prometheus-coredns_kube-dns"
_sourceName="kube-system.coredns-588fd544bf-xwxzc.coredns"
_collector="kubernetes-pmalek-vagrant-otc-1"
_sourceHost="undefined"
_sourceCategory="kubernetes/kube/system/coredns/588fd544bf"
} 29785 163276450047 8
```

This can be addressed as part of https://github.com/SumoLogic/sumologic-otel-collector/issues/265 where we could properly set `X-Sumo-...` headers to allow users to customize these metadata attributes.