### PR TITLE
feat(otelcol): add node name as attribute to metrics

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -2984,6 +2984,7 @@ otelcol:
                 - clusterName
                 - daemonSetName
                 - deploymentName
+                - nodeName
                 - replicaSetName
                 - serviceName
                 - statefulSetName


### PR DESCRIPTION
To match what fluentd is sending let's attach `node` attribute by adding it to k8sprocessor config to include it in metadata enrichment.

For reference, this is an entry sent by fluentd:

```
coredns_cache_hits_total{
_origin="kubernetes"
cluster="kubernetes-pmalek-vagrant-otc-cluster-1",
container="coredns",
deployment="coredns",
endpoint="http-metrics",
instance="10.1.34.69:9153",
job="coredns",
namespace="kube-system",
node="sumologic-kubernetes-collection",
pod_labels_k8s-app="kube-dns",
pod_labels_pod-template-hash="588fd544bf",
pod="coredns-588fd544bf-xwxzc",
prometheus_replica="prometheus-collection-kube-prometheus-prometheus-0",
prometheus_service="collection-kube-prometheus-coredns",
prometheus="sumologic/collection-kube-prometheus-prometheus",
replicaset="coredns-588fd544bf",
server="dns://:53",
service="collection-kube-prometheus-coredns_kube-dns",
type="success",
} 3173.0 1632914680313
```

and this one is send from otelcol's pipeline:

```
metric => coredns_cache_hits_total{
_collector="kubernetes-pmalek-vagrant-otc-collector-1"
_origin="kubernetes"
cluster="microk8s"
container="coredns"
deployment="coredns"
endpoint="http-metrics"
host="collection-sumologic-otelcol-metrics-0"
instance="10.1.34.69:9153"
job="coredns"
namespace="kube-system"
pod_labels_k8s-app="kube-dns"
pod_labels_pod-template-hash="588fd544bf"
pod="coredns-588fd544bf-xwxzc"
prometheus_replica="prometheus-collection-kube-prometheus-prometheus-0"
prometheus_service="collection-kube-prometheus-coredns"
prometheus="sumologic/collection-kube-prometheus-prometheus"
replicaset="coredns-588fd544bf"
server="dns://:53"
service="collection-kube-prometheus-coredns_kube-dns"
type="success"
} 3182 1632915700313
```