### PR TITLE
feat(otelcol): add metrics port for otelcol and set empty prefix in otelcol's flags

### DIFF
--- a/deploy/helm/sumologic/templates/logs/common/service.yaml
+++ b/deploy/helm/sumologic/templates/logs/common/service.yaml
@@ -28,4 +28,8 @@ spec:
     port: 24231
     targetPort: 24231
     protocol: TCP
+  - name: otelcol-metrics
+    port: 8888
+    targetPort: 8888
+    protocol: TCP
 {{- end }}

--- a/deploy/helm/sumologic/templates/logs/otelcol/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/logs/otelcol/statefulset.yaml
@@ -110,6 +110,8 @@ spec:
           - --config=/etc/otel/config.yaml
           {{- if eq .Values.otelcol.metrics.enabled false }}
           - --metrics-level=none
+          {{- else }}
+          - --metrics-prefix=
           {{- end }}
         resources:
           {{- toYaml .Values.logs.metadata.statefulset.resources | nindent 10 }}

--- a/deploy/helm/sumologic/templates/metrics/common/service.yaml
+++ b/deploy/helm/sumologic/templates/metrics/common/service.yaml
@@ -22,4 +22,8 @@ spec:
     port: 24231
     targetPort: 24231
     protocol: TCP
+  - name: otelcol-metrics
+    port: 8888
+    targetPort: 8888
+    protocol: TCP
 {{- end }}

--- a/deploy/helm/sumologic/templates/metrics/otelcol/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics/otelcol/statefulset.yaml
@@ -110,6 +110,8 @@ spec:
           - --config=/etc/otel/config.yaml
           {{- if eq .Values.otelcol.metrics.enabled false }}
           - --metrics-level=none
+          {{- else }}
+          - --metrics-prefix=
           {{- end }}
         resources:
           {{- toYaml .Values.metrics.metadata.statefulset.resources | nindent 10 }}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1424,11 +1424,35 @@ kube-prometheus-stack:
           matchLabels:
             sumologic.com/app: fluentd-logs
             sumologic.com/scrape: "true"
+      - name: collection-sumologic-otelcol-logs
+        additionalLabels:
+          sumologic.com/app: otelcol-logs
+        endpoints:
+          - port: otelcol-metrics
+        namespaceSelector:
+          matchNames:
+            - $(NAMESPACE)
+        selector:
+          matchLabels:
+            sumologic.com/app: fluentd-logs
+            sumologic.com/scrape: "true"
       - name: collection-sumologic-fluentd-metrics
         additionalLabels:
           sumologic.com/app: fluentd-metrics
         endpoints:
           - port: metrics
+        namespaceSelector:
+          matchNames:
+            - $(NAMESPACE)
+        selector:
+          matchLabels:
+            sumologic.com/app: fluentd-metrics
+            sumologic.com/scrape: "true"
+      - name: collection-sumologic-otelcol-metrics
+        additionalLabels:
+          sumologic.com/app: otelcol-metrics
+        endpoints:
+          - port: otelcol-metrics
         namespaceSelector:
           matchNames:
             - $(NAMESPACE)


### PR DESCRIPTION
~~For now let's piggy back on the values (ports `24231`) used in the services: [for logs](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/e1f8406d818aa6036450279ced0b809e9807c525/deploy/helm/sumologic/templates/logs/common/service.yaml#L27-L30) and [for metrics](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/48492ff1779fc070eb9acda92b0fb8790ef073e6/deploy/helm/sumologic/templates/metrics/common/service.yaml#L21-L24)~~

This PRs adds `otelcol-metrics` port (`8888`) to scrape metrics from otelcol instances.

At the same time let's remove the default metrics prefix (`otelcol`) from exposed metrics.

Example of what metrics are exposed as of now:

```
# HELP exporter_queue_size Current size of the retry queue (in batches)
# TYPE exporter_queue_size gauge
exporter_queue_size{exporter="sumologic",service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201"} 0
# HELP exporter_send_failed_metric_points Number of metric points in failed attempts to send to destination.
# TYPE exporter_send_failed_metric_points counter
exporter_send_failed_metric_points{exporter="sumologic",service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201"} 0
# HELP exporter_sent_metric_points Number of metric points successfully sent to destination.
# TYPE exporter_sent_metric_points counter
exporter_sent_metric_points{exporter="sumologic",service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201"} 81604
# HELP otelsvc_k8s_other_added Number of other add events received
# TYPE otelsvc_k8s_other_added counter
otelsvc_k8s_other_added{service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201"} 58
# HELP otelsvc_k8s_other_updated Number of other update events received
# TYPE otelsvc_k8s_other_updated counter
otelsvc_k8s_other_updated{service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201"} 184
# HELP otelsvc_k8s_pod_added Number of pod add events received
# TYPE otelsvc_k8s_pod_added counter
otelsvc_k8s_pod_added{service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201"} 14
# HELP otelsvc_k8s_pod_table_size Size of table containing pod info
# TYPE otelsvc_k8s_pod_table_size gauge
otelsvc_k8s_pod_table_size{service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201"} 42
# HELP otelsvc_k8s_pod_updated Number of pod update events received
# TYPE otelsvc_k8s_pod_updated counter
otelsvc_k8s_pod_updated{service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201"} 46
# HELP process_cpu_seconds Total CPU user and system time in seconds
# TYPE process_cpu_seconds gauge
process_cpu_seconds{service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201"} 22.6
# HELP process_memory_rss Total physical memory (resident set size)
# TYPE process_memory_rss gauge
process_memory_rss{service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201"} 1.22396672e+08
# HELP process_runtime_heap_alloc_bytes Bytes of allocated heap objects (see 'go doc runtime.MemStats.HeapAlloc')
# TYPE process_runtime_heap_alloc_bytes gauge
process_runtime_heap_alloc_bytes{service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201"} 3.6777136e+07
# HELP process_runtime_total_alloc_bytes Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalAlloc')
# TYPE process_runtime_total_alloc_bytes gauge
process_runtime_total_alloc_bytes{service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201"} 2.952140096e+09
# HELP process_runtime_total_sys_memory_bytes Total bytes of memory obtained from the OS (see 'go doc runtime.MemStats.Sys')
# TYPE process_runtime_total_sys_memory_bytes gauge
process_runtime_total_sys_memory_bytes{service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201"} 6.9026824e+07
# HELP process_uptime Uptime of the process
# TYPE process_uptime counter
process_uptime{service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201"} 905.0225189039996
# HELP processor_accepted_metric_points Number of metric points successfully pushed into the next component in the pipeline.
# TYPE processor_accepted_metric_points counter
processor_accepted_metric_points{processor="memory_limiter",service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201"} 81620
# HELP processor_batch_batch_send_size Number of units in the batch
# TYPE processor_batch_batch_send_size histogram
processor_batch_batch_send_size_bucket{processor="batch",service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201",le="10"} 0
processor_batch_batch_send_size_bucket{processor="batch",service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201",le="25"} 0
processor_batch_batch_send_size_bucket{processor="batch",service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201",le="50"} 0
processor_batch_batch_send_size_bucket{processor="batch",service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201",le="75"} 0
processor_batch_batch_send_size_bucket{processor="batch",service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201",le="100"} 0
processor_batch_batch_send_size_bucket{processor="batch",service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201",le="250"} 0
processor_batch_batch_send_size_bucket{processor="batch",service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201",le="500"} 0
processor_batch_batch_send_size_bucket{processor="batch",service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201",le="750"} 0
processor_batch_batch_send_size_bucket{processor="batch",service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201",le="1000"} 0
processor_batch_batch_send_size_bucket{processor="batch",service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201",le="2000"} 0
processor_batch_batch_send_size_bucket{processor="batch",service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201",le="3000"} 26
processor_batch_batch_send_size_bucket{processor="batch",service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201",le="4000"} 29
processor_batch_batch_send_size_bucket{processor="batch",service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201",le="5000"} 30
processor_batch_batch_send_size_bucket{processor="batch",service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201",le="6000"} 30
processor_batch_batch_send_size_bucket{processor="batch",service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201",le="7000"} 30
processor_batch_batch_send_size_bucket{processor="batch",service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201",le="8000"} 30
processor_batch_batch_send_size_bucket{processor="batch",service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201",le="9000"} 30
processor_batch_batch_send_size_bucket{processor="batch",service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201",le="10000"} 30
processor_batch_batch_send_size_bucket{processor="batch",service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201",le="20000"} 30
processor_batch_batch_send_size_bucket{processor="batch",service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201",le="30000"} 30
processor_batch_batch_send_size_bucket{processor="batch",service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201",le="50000"} 30
processor_batch_batch_send_size_bucket{processor="batch",service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201",le="100000"} 30
processor_batch_batch_send_size_bucket{processor="batch",service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201",le="+Inf"} 30
processor_batch_batch_send_size_sum{processor="batch",service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201"} 81604.00000000001
processor_batch_batch_send_size_count{processor="batch",service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201"} 30
# HELP processor_batch_batch_size_trigger_send Number of times the batch was sent due to a size trigger
# TYPE processor_batch_batch_size_trigger_send counter
processor_batch_batch_size_trigger_send{processor="batch",service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201"} 1
# HELP processor_batch_timeout_trigger_send Number of times the batch was sent due to a timeout trigger
# TYPE processor_batch_timeout_trigger_send counter
processor_batch_timeout_trigger_send{processor="batch",service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201"} 29
# HELP processor_dropped_metric_points Number of metric points that were dropped.
# TYPE processor_dropped_metric_points counter
processor_dropped_metric_points{processor="memory_limiter",service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201"} 0
# HELP processor_refused_metric_points Number of metric points that were rejected by the next component in the pipeline.
# TYPE processor_refused_metric_points counter
processor_refused_metric_points{processor="memory_limiter",service_instance_id="ecedcfd8-3c05-40e4-aca7-a383e9340201"} 0
```