### PR TITLE
fix(otelcol): set log level using service.telemetry.logs in otelcol's config not app flags

### DIFF
--- a/deploy/helm/sumologic/templates/logs/otelcol/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/logs/otelcol/statefulset.yaml
@@ -106,7 +106,6 @@ spec:
         image: {{ .Values.otelcol.statefulset.image.repository }}:{{ .Values.otelcol.statefulset.image.tag }}
         imagePullPolicy: {{ .Values.otelcol.statefulset.image.pullPolicy }}
         args:
-          - --log-level={{ .Values.otelcol.metadata.logs.logLevel }}
           - --config=/etc/otel/config.yaml
           {{- if eq .Values.otelcol.metrics.enabled false }}
           - --metrics-level=none

--- a/deploy/helm/sumologic/templates/metrics/otelcol/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics/otelcol/statefulset.yaml
@@ -106,7 +106,6 @@ spec:
         image: {{ .Values.otelcol.statefulset.image.repository }}:{{ .Values.otelcol.statefulset.image.tag }}
         imagePullPolicy: {{ .Values.otelcol.statefulset.image.pullPolicy }}
         args:
-          - --log-level={{ .Values.otelcol.metadata.metrics.logLevel }}
           - --config=/etc/otel/config.yaml
           {{- if eq .Values.otelcol.metrics.enabled false }}
           - --metrics-level=none

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -3218,6 +3218,9 @@ otelcol:
           source:
             collector: '{{ .Values.sumologic.collectorName | default .Values.sumologic.clusterName | quote }}'
         service:
+          telemetry:
+            logs:
+              level: '{{ .Values.otelcol.metadata.metrics.logLevel }}'
           extensions:
             - health_check
           pipelines:
@@ -3475,6 +3478,9 @@ otelcol:
               _SYSTEMD_UNIT: '{{ .Values.fluentd.logs.kubelet.excludeUnitRegex | quote }}'
 
         service:
+          telemetry:
+            logs:
+              level: '{{ .Values.otelcol.metadata.logs.logLevel }}'
           extensions:
             - health_check
             # - sumologic

--- a/tests/metadata_logs_otc/static/basic.output.yaml
+++ b/tests/metadata_logs_otc/static/basic.output.yaml
@@ -260,3 +260,6 @@ data:
           - batch
           receivers:
           - fluentforward
+      telemetry:
+        logs:
+          level: info

--- a/tests/metadata_logs_otc/static/templates.output.yaml
+++ b/tests/metadata_logs_otc/static/templates.output.yaml
@@ -260,3 +260,6 @@ data:
           - batch
           receivers:
           - fluentforward
+      telemetry:
+        logs:
+          level: info

--- a/tests/metadata_logs_otc_statefulset/static/basic.output.yaml
+++ b/tests/metadata_logs_otc_statefulset/static/basic.output.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f0366e61637c44c3ef0274b75dedbf0c8c8f8644ab2f2999a5184fd0d0ffb580
+        checksum/config: 7c14330d39a9e374d2e4643e950d59912856c03fa2be48049a5e70a0d16fbaaa
         someAnnotation: someValue
       labels:
         app: RELEASE-NAME-sumologic-otelcol-logs
@@ -68,7 +68,6 @@ spec:
         image: public.ecr.aws/sumologic/sumologic-otel-collector:0.0.37-beta.0
         imagePullPolicy: IfNotPresent
         args:
-          - --log-level=info
           - --config=/etc/otel/config.yaml
         resources:
           limits:

--- a/tests/metadata_metrics_otc_statefulset/static/basic.output.yaml
+++ b/tests/metadata_metrics_otc_statefulset/static/basic.output.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a07dfb64aa3e81f8159f73a37f5081dc25a29cea3214ac82566ffc1ef646eb09
+        checksum/config: 913a542a5141112b182e9490691e05ebd1d760a08b9a5d2f1cd491b3b4b06549
         someAnnotation: someValue
       labels:
         app: RELEASE-NAME-sumologic-otelcol-metrics
@@ -68,7 +68,6 @@ spec:
         image: public.ecr.aws/sumologic/sumologic-otel-collector:0.0.37-beta.0
         imagePullPolicy: IfNotPresent
         args:
-          - --log-level=info
           - --config=/etc/otel/config.yaml
         resources:
           limits:


### PR DESCRIPTION
This has been changed in https://github.com/open-telemetry/opentelemetry-collector/pull/4011/files and this PR addresses the deprecation notice when using flags:

```
2021-10-15T17:22:27.755+0200 warn    telemetrylogs/logger.go:121     `log-level` command line option has been deprecated. Use `service::telemetry::logs` in config instead!
```