### PR TITLE
Adding remote write configs for ActiveMQ Metrics

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -2834,7 +2834,6 @@ kube-prometheus-stack:
         ## activemq_broker_StoreLimit
         ## activemq_broker_TempLimit
         ## activemq_broker_TotalConnectionsCount
-        ## activemq_broker_TotalConnectionsCountactivemq_broker_TotalProducerCount
         ## activemq_broker_TotalConsumerCount
         ## activemq_broker_TotalDequeueCount
         ## activemq_broker_TotalEnqueueCount


### PR DESCRIPTION
###### Description

Added Remote/Write Configs for ActiveMQ metrics:
List of Metrics are on following page:

https://github.com/influxdata/telegraf/tree/master/plugins/inputs/activemq

Metrics follow following format

``` bash 
        ## activemq_queue_*
        ## activemq_topic_*
        ## activemq_*_QueueSize
        ## activemq_broker_AverageMessageSize
        ## activemq_broker_CurrentConnectionsCount
        ## activemq_broker_MemoryLimit
        ## activemq_broker_StoreLimit
        ## activemq_broker_TempLimit
        ## activemq_broker_TotalConnectionsCount
        ## activemq_broker_TotalConnectionsCountactivemq_broker_TotalProducerCount
        ## activemq_broker_TotalConsumerCount
        ## activemq_broker_TotalDequeueCount
        ## activemq_broker_TotalEnqueueCount
        ## activemq_broker_TotalMessageCount
        ## activemq_broker_TotalProducerCount
        ## activemq_broker_UptimeMillis
        ## activemq_jvm_memory_HeapMemoryUsage_max
        ## activemq_jvm_memory_HeapMemoryUsage_used
        ## activemq_jvm_memory_NonHeapMemoryUsage_used
        ## activemq_jvm_runtime_Uptime
        ## activemq_OperatingSystem_FreePhysicalMemorySize
        ## activemq_OperatingSystem_SystemCpuLoad
        ## activemq_OperatingSystem_TotalPhysicalMemorySize
     
     ```
---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
