### PR TITLE
docs: document image pull secrets for all images in the chart

### DIFF
--- a/ci/markdown_links_lint.sh
+++ b/ci/markdown_links_lint.sh
@@ -21,7 +21,7 @@ for file in ${FILES}; do
     # filter out all links pointing to specific release, tag or commit
     # filter out links ended with /releases
     if "${GREP}" -HnoP '\[[^\]]*\]\([^\)]*\)' "${file}" \
-        | "${GREP}" 'sumologic-kubernetes-collection' \
+        | "${GREP}" 'github.com/sumologic-kubernetes-collection' \
         | "${GREP}" -vP '(\/(blob|tree)\/(v\d+\.|[a-f0-9]{40}\/|release\-))' \
         | "${GREP}" -vP '\/releases\)'; then
     

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -26,6 +26,7 @@ for details on our Kubernetes Solution.
   - [Advanced Configuration/Best Practices](./docs/Best_Practices.md)
   - [Advanced Configuration/Security best practices](./docs/Security_Best_Practices.md)
   - [Authenticating with container registry](./docs/Working_with_container_registries.md#authenticating-with-container-registry)
+    - [Using pull secrets with `sumologic-kubernetes-collection` helm chart](./docs/Working_with_container_registries.md#authenticating-with-container-registry)
   - [Dev Releases](./docs/Dev.md)
   - [Upgrade from v0.17 to v1.0](./docs/v1_migration_doc.md)
   - [Upgrade from v1.3 to v2.0](./docs/v2_migration_doc.md)

--- a/deploy/docs/Working_with_container_registries.md
+++ b/deploy/docs/Working_with_container_registries.md
@@ -37,6 +37,21 @@ refer to [Creating a Secret with a Docker config at kubernetes.io][k8s-docker-se
 [k8s-docker-secret]: https://kubernetes.io/docs/concepts/containers/images/#creating-a-secret-with-a-docker-config
 [aws-ecr-pricing]: https://aws.amazon.com/ecr/pricing/
 
+## Using pull secrets with `sumologic-kubernetes-collection` helm chart
+
+Full list of `values.yaml` keys for all the images that are used, can be found below:
+
+| Image                 | `value.yaml` key                                |
+|-----------------------|-------------------------------------------------|
+| setup job             | `sumologic.setup.job.pullSecrets`               |
+| fluentd               | `sumologic.pullSecrets`                         |
+| Sumo Logic OT distro  | `sumologic.pullSecrets`                         |
+| kube-prometheus-stack | `kube-prometheus-stack.global.imagePullSecrets` |
+| metrics-server        | `metrics-server.image.pullSecrets`              |
+| telegraf-operator     | `telegraf-operator.imagePullSecrets`            |
+| fluent-bit            | `fluent-bit.imagePullSecrets`                   |
+| falco                 | `falco.image.pullSecrets`                       |
+
 ## Hosting Sumo Logic images
 
 Another approach to work around Amazon Public ECR limits is to host Sumo Logic

--- a/deploy/helm/sumologic/templates/logs/otelcol/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/logs/otelcol/statefulset.yaml
@@ -101,9 +101,6 @@ spec:
       {{- if .Values.metadata.logs.statefulset.priorityClassName }}
       priorityClassName: {{ .Values.metadata.logs.statefulset.priorityClassName | quote }}
       {{- end }}
-{{- if .Values.sumologic.pullSecrets }}
-      imagePullSecrets: {{ toYaml .Values.sumologic.pullSecrets | nindent 8 }}
-{{- end }}
       containers:
       - name: otelcol
         image: {{ .Values.metadata.image.repository }}:{{ .Values.metadata.image.tag }}

--- a/deploy/helm/sumologic/templates/metrics/otelcol/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics/otelcol/statefulset.yaml
@@ -101,9 +101,6 @@ spec:
       {{- if .Values.metadata.metrics.statefulset.priorityClassName }}
       priorityClassName: {{ .Values.metadata.metrics.statefulset.priorityClassName | quote }}
       {{- end }}
-{{- if .Values.sumologic.pullSecrets }}
-      imagePullSecrets: {{ toYaml .Values.sumologic.pullSecrets | nindent 8 }}
-{{- end }}
       containers:
       - name: otelcol
         image: {{ .Values.metadata.image.repository }}:{{ .Values.metadata.image.tag }}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -3873,8 +3873,6 @@ falco:
       - /etc/falco/rules.d
       - /etc/falco/rules.available/application_rules.yaml
 
-  # image:
-  #   pullSecrets: []
   customRules:
     ## Mark the following as known k8s api callers:
     ## * fluentd and its plugins from sumologic/kubernetes-fluentd image


### PR DESCRIPTION
This PR also reverts the previous change https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1841 which was unnecessary because the pull secrets are being taken from the service account:

* service account using the pull secrets from `sumologic.pullSecrets` definition https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/9f4ed1d9295feb2484db2ae12d9331c278b98630/deploy/helm/sumologic/templates/serviceaccount.yaml#L12-L15
* binding the service account to the stateful set https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/9cc3efa5d0aba6699a3b28944fc3715084e921bf/deploy/helm/sumologic/templates/logs/otelcol/statefulset.yaml#L44