### PR TITLE
docs: change type of brackets used to set kube-prometheus-stack.prometheusOperator.namespaces.additional

### DIFF
--- a/deploy/docs/Installation_with_Helm.md
+++ b/deploy/docs/Installation_with_Helm.md
@@ -170,7 +170,7 @@ helm upgrade --install my-release sumologic/sumologic \
   --set fluent-bit.securityContext.privileged=true \
   --set kube-prometheus-stack.prometheus-node-exporter.service.port=9200 \
   --set kube-prometheus-stack.prometheus-node-exporter.service.targetPort=9200 \
-  --set kube-prometheus-stack.prometheusOperator.namespaces.additional=[my-namespace]
+  --set kube-prometheus-stack.prometheusOperator.namespaces.additional={my-namespace}
 ```
 
 **Notice:** Prometheus Operator is deployed by default on OpenShift platform,

--- a/deploy/docs/Non_Helm_Installation.md
+++ b/deploy/docs/Non_Helm_Installation.md
@@ -188,7 +188,7 @@ kubectl run tools \
   --set fluent-bit.securityContext.privileged=true \
   --set kube-prometheus-stack.prometheus-node-exporter.service.port=9200 \
   --set kube-prometheus-stack.prometheus-node-exporter.service.targetPort=9200 \
-  --set kube-prometheus-stack.prometheusOperator.namespaces.additional=[my-namespace] \
+  --set kube-prometheus-stack.prometheusOperator.namespaces.additional={my-namespace} \
   | tee sumologic.yaml
 ```
 

--- a/deploy/docs/SideBySidePrometheus.md
+++ b/deploy/docs/SideBySidePrometheus.md
@@ -109,7 +109,7 @@ helm upgrade --install my-release sumologic/sumologic \
     --set sumologic.clusterName="<MY_CLUSTER_NAME>" \
     --set kube-prometheus-stack.prometheus-node-exporter.service.port=9200 \
     --set kube-prometheus-stack.prometheus-node-exporter.service.targetPort=9200 \
-    --set kube-prometheus-stack.prometheusOperator.namespaces.additional=[my-namespace] \
+    --set kube-prometheus-stack.prometheusOperator.namespaces.additional={my-namespace} \
     --set sumologic.scc.create=true \
     --set fluent-bit.securityContext.privileged=true
 ```


### PR DESCRIPTION
###### Description

ref: https://helm.sh/docs/intro/using_helm/#the-format-and-limitations-of---set

Tested with:

```
helm upgrade --install sumo-dev sumologic/sumologic \
  --namespace=sumologic --create-namespace=true \
  --set sumologic.accessId="dummy" \
  --set sumologic.accessKey="dummy" \
  --set sumologic.endpoint=http://receiver-mock.receiver-mock:3000/terraform/api/ \
  --set sumologic.clusterName="test-k8s-1" \
  --set kube-prometheus-stack.prometheus-node-exporter.service.port=9200 \
  --set kube-prometheus-stack.prometheus-node-exporter.service.targetPort=9200 \
  --set sumologic.scc.create=true \
  --set fluent-bit.securityContext.privileged=true \
  --set kube-prometheus-stack.prometheusOperator.namespaces.additional={sumologic}
```
Results:

```
$ helm get values sumo-dev -n sumologic
USER-SUPPLIED VALUES:
fluent-bit:
  securityContext:
    privileged: true
fluentd:
  persistence:
    enabled: false
kube-prometheus-stack:
  prometheus-node-exporter:
    service:
      port: 9200
      targetPort: 9200
  prometheusOperator:
    namespaces:
      additional:
      - sumologic
sumologic:
  accessId: dummy
  accessKey: dummy
  clusterName: test-k8s-1
  endpoint: http://receiver-mock.receiver-mock:3000/terraform/api/
  scc:
    create: true
```

```
$ kubectl get pods -n sumologic
NAME                                                   READY   STATUS    RESTARTS   AGE
prometheus-sumo-dev-kube-prometheus-s-prometheus-0     3/3     Running   1          33m
sumo-dev-fluent-bit-c7m6r                              1/1     Running   0          34m
sumo-dev-kube-prometheus-s-operator-7cc5d97d5b-2lq82   1/1     Running   0          34m
sumo-dev-kube-state-metrics-844d7f5b55-n52cn           1/1     Running   0          34m
sumo-dev-prometheus-node-exporter-x4864                1/1     Running   0          34m
sumo-dev-sumologic-fluentd-events-0                    1/1     Running   0          34m
sumo-dev-sumologic-fluentd-logs-0                      1/1     Running   0          34m
sumo-dev-sumologic-fluentd-logs-1                      1/1     Running   0          34m
sumo-dev-sumologic-fluentd-logs-2                      1/1     Running   0          34m
sumo-dev-sumologic-fluentd-metrics-0                   1/1     Running   0          34m
sumo-dev-sumologic-fluentd-metrics-1                   1/1     Running   0          34m
sumo-dev-sumologic-fluentd-metrics-2                   1/1     Running   0          34m
```

```
$ kubectl get pods -n sumologic sumo-dev-kube-prometheus-s-operator-7cc5d97d5b-2lq82 -o yaml
...
  containers:
  - args:
    - --kubelet-service=kube-system/sumo-dev-kube-prometheus-s-kubelet
    - --namespaces=sumologic
    - --logtostderr=true
    - --localhost=127.0.0.1
    - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.43.2
    - --config-reloader-cpu=100m
    - --config-reloader-memory=25Mi
    image: quay.io/prometheus-operator/prometheus-operator:v0.43.2
    imagePullPolicy: IfNotPresent
    name: kube-prometheus-stack
...
```

```
$ kubectl logs  -n receiver-mock receiver-mock-c794c996d-2ntxl --tail 20
1635251722 Metrics:      11851 Logs:        539; 0.003783 MB/s
1635251782 Metrics:      12275 Logs:        484; 0.002097 MB/s
1635251842 Metrics:      12270 Logs:        408; 0.001907 MB/s
1635251902 Metrics:      12282 Logs:        412; 0.002011 MB/s
1635251962 Metrics:      12532 Logs:        409; 0.001968 MB/s
1635252022 Metrics:      12571 Logs:        382; 0.001781 MB/s
1635252082 Metrics:      11814 Logs:        386; 0.001886 MB/s
1635252142 Metrics:      12581 Logs:        494; 0.003573 MB/s
1635252202 Metrics:      11603 Logs:        381; 0.001836 MB/s
1635252262 Metrics:      12228 Logs:        504; 0.002686 MB/s
1635252322 Metrics:      12236 Logs:        463; 0.002794 MB/s
1635252382 Metrics:      12275 Logs:        506; 0.002161 MB/s
1635252442 Metrics:      12276 Logs:        405; 0.001912 MB/s
1635252502 Metrics:      12278 Logs:        364; 0.001754 MB/s
1635252562 Metrics:      12266 Logs:        375; 0.001811 MB/s
1635252622 Metrics:      12208 Logs:        375; 0.001788 MB/s
1635252682 Metrics:      12169 Logs:        372; 0.001795 MB/s
1635252742 Metrics:      12241 Logs:        517; 0.004305 MB/s
1635252802 Metrics:      12619 Logs:        410; 0.001927 MB/s
1635252862 Metrics:      11866 Logs:        514; 0.002732 MB/s
```

Environment:
```
$ helm version
version.BuildInfo{Version:"v3.5.0+6.el8", GitCommit:"77fb4bd2415712e8bfebe943389c404893ad53ce", GitTreeState:"clean", GoVersion:"go1.14.12"
```

```
$ oc version
Client Version: 4.7.13
Server Version: 4.7.13
Kubernetes Version: v1.20.0+df9c838
```

```
$ kubectl version
Client Version: version.Info{Major:"1", Minor:"16", GitVersion:"v1.16.0", GitCommit:"2bd9643cee5b3b3a5ecbd3af49d09018f0773c77", GitTreeState:"clean", BuildDate:"2019-09-18T14:36:53Z", GoVersion:"go1.12.9", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.0+df9c838", GitCommit:"df9c8387b2dc2308da01706ff89982c6b7ad9c48", GitTreeState:"clean", BuildDate:"2021-05-15T22:35:16Z", GoVersion:"go1.15.7", Compiler:"gc", Platform:"linux/amd64"}
```
---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
