### PR TITLE
ci: fix push helm chart missing remote

### DIFF
--- a/ci/_build_functions.sh
+++ b/ci/_build_functions.sh
@@ -24,6 +24,7 @@ function push_helm_chart() {
   local version="$1"
   local chart_dir="$2"
   local sync_dir="./tmp-helm-sync"
+  local remote="origin"
 
   echo "Pushing new Helm Chart release ${version}"
 


### PR DESCRIPTION
Previous PR https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1853 seems to have forgotten to include `remote` in the script :) 

