### PR TITLE
feat(helm): add PodDisruptionBudget api version helm chart helpers

### DIFF
--- a/ci/shellcheck.sh
+++ b/ci/shellcheck.sh
@@ -7,5 +7,5 @@ find . ! -path '*deploy/helm/sumologic/conf/setup/setup.sh' ! -path "*/tmp/*" -n
     while read -r file; do
         # Run tests in their own context
         echo "Checking ${file} with shellcheck"
-        shellcheck --enable all "${file}"
+        shellcheck --enable all --external-sources --exclude SC2155 "${file}"
     done

--- a/deploy/helm/sumologic/templates/_api_versions_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_api_versions_helpers.tpl
@@ -1,0 +1,16 @@
+{{/*
+Use PodDisruptionBudget apiVersion that is available on the cluster
+
+Example Usage:
+apiVersion: {{ include "apiVersion.podDisruptionBudget" . }}
+
+*/}}
+{{- define "apiVersion.podDisruptionBudget" -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
+policy/v1
+{{- else if .Capabilities.APIVersions.Has "policy/v1beta1/PodDisruptionBudget" -}}
+policy/v1beta1
+{{- else -}}
+{{- fail "\nPodDisruptionBudget not available on the cluster in neither policy/v1/v1beta1 nor in policy/v1/v1beta1 apiVersion" -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/sumologic/templates/logs/common/pdb.yaml
+++ b/deploy/helm/sumologic/templates/logs/common/pdb.yaml
@@ -1,6 +1,6 @@
 {{- if eq (include "logs.otelcol.enabled" .) "true" }}
 {{- if .Values.metadata.logs.podDisruptionBudget -}}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "apiVersion.podDisruptionBudget" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "sumologic.metadata.name.logs.pdb" . }}

--- a/deploy/helm/sumologic/templates/logs/fluentd/pdb.yaml
+++ b/deploy/helm/sumologic/templates/logs/fluentd/pdb.yaml
@@ -1,6 +1,6 @@
 {{- if eq (include "logs.fluentd.enabled" .) "true" }}
 {{- if .Values.fluentd.logs.podDisruptionBudget -}}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "apiVersion.podDisruptionBudget" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "sumologic.metadata.name.logs.pdb" . }}

--- a/deploy/helm/sumologic/templates/metrics/common/pdb.yaml
+++ b/deploy/helm/sumologic/templates/metrics/common/pdb.yaml
@@ -1,6 +1,6 @@
 {{- if eq (include "metrics.otelcol.enabled" .) "true" }}
 {{- if .Values.metadata.metrics.podDisruptionBudget -}}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "apiVersion.podDisruptionBudget" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "sumologic.metadata.name.metrics.pdb" . }}

--- a/deploy/helm/sumologic/templates/metrics/fluentd/pdb.yaml
+++ b/deploy/helm/sumologic/templates/metrics/fluentd/pdb.yaml
@@ -1,6 +1,6 @@
 {{- if eq (include "metrics.fluentd.enabled" .) "true" }}
 {{- if .Values.fluentd.metrics.podDisruptionBudget -}}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "apiVersion.podDisruptionBudget" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "sumologic.metadata.name.metrics.pdb" . }}

--- a/tests/README.md
+++ b/tests/README.md
@@ -19,6 +19,10 @@ file name, e.g. for `deploy/helm/sumologic/templates/configmap.yaml` it will be 
 TEST_TEMPLATE="templates/configmap.yaml"
 ```
 
+There's also a shared config file: `shared_config.sh` which will be sourced for
+all tests with particular tests `config.sh`s taking precedence (as they will be
+sourced later).
+
 ## Input file
 
 Input file e.g. `test_name.input.yaml` should be compatible with `values.yaml`

--- a/tests/functions.sh
+++ b/tests/functions.sh
@@ -67,12 +67,17 @@ function patch_test() {
 # Generate output file basing on the input values.yaml
 function generate_file {
   local template_name="${1}"
+  local kube_api_versions_flags=""
+  if (( ${#KUBE_API_VERSIONS[@]} )); then
+    kube_api_versions_flags=${KUBE_API_VERSIONS[@]/#/--api-versions }
+  fi
 
   docker run --rm \
     -v "${TEST_SCRIPT_PATH}/../../deploy/helm/sumologic":/chart \
     -v "${TEST_STATICS_PATH}/${input_file}":/values.yaml \
     sumologic/kubernetes-tools:2.4.1 \
     helm template /chart -f /values.yaml \
+      ${kube_api_versions_flags} \
       --namespace sumologic \
       --set sumologic.accessId='accessId' \
       --set sumologic.accessKey='accessKey' \

--- a/tests/functions.sh
+++ b/tests/functions.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2154,SC2086
 
 
 TEST_TEMPLATE="${TEST_TEMPLATE:-}"
@@ -68,11 +69,12 @@ function patch_test() {
 function generate_file {
   local template_name="${1}"
   local kube_api_versions_flags=""
-  if (( ${#KUBE_API_VERSIONS[@]} )); then
-    kube_api_versions_flags=${KUBE_API_VERSIONS[@]/#/--api-versions }
+  # shellcheck disable=SC2154
+  if (( ${#KUBE_API_VERSIONS[*]} )); then
+    kube_api_versions_flags=${KUBE_API_VERSIONS[*]/#/--api-versions }
   fi
 
-  docker run --rm \
+  if ! docker run --rm \
     -v "${TEST_SCRIPT_PATH}/../../deploy/helm/sumologic":/chart \
     -v "${TEST_STATICS_PATH}/${input_file}":/values.yaml \
     sumologic/kubernetes-tools:2.4.1 \
@@ -81,7 +83,12 @@ function generate_file {
       --namespace sumologic \
       --set sumologic.accessId='accessId' \
       --set sumologic.accessKey='accessKey' \
-      -s "${template_name}" 2>/dev/null 1> "${TEST_OUT}"
+      -s "${template_name}" 1> "${TEST_OUT}" ; then
+    echo "Error with template ${template_name} in ${TEST_STATICS_PATH}/${input_file}"
+    return 1
+  fi
+
+  return 0
 }
 
 # Run test
@@ -95,7 +102,10 @@ function perform_test {
   patch_test "${TEST_STATICS_PATH}/${output_file}" "${TEST_TMP_PATH}/${output_file}"
 
   test_start "${test_name}"
-  generate_file "${template_name}"
+  if ! generate_file "${template_name}"; then 
+    test_failed "${test_name}"
+    return
+  fi
 
   test_output=$(diff -c "${TEST_TMP_PATH}/${output_file}" "${TEST_OUT}" | cat -te)
   rm "${TEST_OUT}"

--- a/tests/metadata_logs_otc/config.sh
+++ b/tests/metadata_logs_otc/config.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
 export TEST_TEMPLATE="templates/logs/otelcol/configmap.yaml"
+export KUBE_API_VERSIONS=("policy/v1/PodDisruptionBudget")

--- a/tests/metadata_logs_otc/config.sh
+++ b/tests/metadata_logs_otc/config.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
 export TEST_TEMPLATE="templates/logs/otelcol/configmap.yaml"
-export KUBE_API_VERSIONS=("policy/v1/PodDisruptionBudget")

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -12,21 +12,31 @@ if ! docker info >/dev/null 2>&1 ; then
 fi
 
 # shellcheck disable=SC1090
+# shellcheck source=tests/functions.sh
 source "${SCRIPT_PATH}/functions.sh"
 
 export TEST_SUCCESS=true
 
-prepare_environment "${SCRIPT_PATH}/../deploy/helm/sumologic"
+# prepare_environment "${SCRIPT_PATH}/../deploy/helm/sumologic"
+
+if [[ -f "${SCRIPT_PATH}/shared_config.sh" ]] ; then
+  echo "Sourcing ${SCRIPT_PATH}/shared_config.sh for all tests envs"
+  # shellcheck source=tests/shared_config.sh
+  source "${SCRIPT_PATH}/shared_config.sh"
+fi
 
 for config_file in ${CONFIG_FILES}; do
-  test_dir="$( dirname "$(realpath "${config_file}")" )"
-  echo "Performing tests for $(basename "${test_dir}")"
-  # shellcheck disable=SC1090
-  source "${config_file}"
-  set_variables "${test_dir}"
-  prepare_tests
-  perform_tests
-  cleanup_tests
+  # add a subshell to not inherit previous tests' envs
+  (
+    test_dir="$( dirname "$(realpath "${config_file}")" )"
+    echo "Performing tests for $(basename "${test_dir}")"
+    # shellcheck disable=SC1090
+    source "${config_file}"
+    set_variables "${test_dir}"
+    prepare_tests
+    perform_tests
+    cleanup_tests
+  )
 done
 
 if [[ "${TEST_SUCCESS}" = "true" ]]; then

--- a/tests/shared_config.sh
+++ b/tests/shared_config.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+export KUBE_API_VERSIONS=("policy/v1/PodDisruptionBudget")

--- a/tests/upgrade_script/run.sh
+++ b/tests/upgrade_script/run.sh
@@ -10,15 +10,11 @@
 SCRIPT_PATH="$( dirname "$(realpath "${0}")" )"
 
 # shellcheck disable=SC1090
+# shellcheck source=tests/functions.sh
 source "${SCRIPT_PATH}/../functions.sh"
 readonly TEST_TMP_OUT="${SCRIPT_PATH}/tmp/out.log"
 
 set_variables "${SCRIPT_PATH}"
-# reassign variables from set_variables
-TEST_SCRIPT_PATH="${TEST_SCRIPT_PATH}"
-TEST_STATICS_PATH="${TEST_STATICS_PATH}"
-TEST_INPUT_FILES="${TEST_INPUT_FILES}"
-TEST_OUT="${TEST_OUT}"
 
 prepare_tests
 

--- a/tests/upgrade_v2_script/run.sh
+++ b/tests/upgrade_v2_script/run.sh
@@ -10,15 +10,11 @@
 SCRIPT_PATH="$( dirname "$(realpath "${0}")" )"
 
 # shellcheck disable=SC1090
+# shellcheck source=tests/functions.sh
 source "${SCRIPT_PATH}/../functions.sh"
 readonly TEST_TMP_OUT="${SCRIPT_PATH}/tmp/out.log"
 
 set_variables "${SCRIPT_PATH}"
-# reassign variables from set_variables
-TEST_SCRIPT_PATH="${TEST_SCRIPT_PATH}"
-TEST_STATICS_PATH="${TEST_STATICS_PATH}"
-TEST_INPUT_FILES="${TEST_INPUT_FILES}"
-TEST_OUT="${TEST_OUT}"
 
 prepare_tests
 


### PR DESCRIPTION
The idea behind this change is to support newer version of `PodDisruptionBudget` (`policy/v1beta1/PodDisruptionBudget` vs `policy/v1/PodDisruptionBudget`)
and to get rid of deprecation warnings when installing our chart:

```
$ helm upgrade --install collection sumologic/sumologic
Release "collection" does not exist. Installing it now.
...
W1118 17:09:13.651675 2835438 warnings.go:70] policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
W1118 17:09:13.654276 2835438 warnings.go:70] policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
...
W1118 17:09:14.026749 2835438 warnings.go:70] policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
W1118 17:09:14.028299 2835438 warnings.go:70] policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
NAME: collection
LAST DEPLOYED: Thu Nov 18 17:09:12 2021
NAMESPACE: sumologic
STATUS: deployed
REVISION: 1
NOTES:
Thank you for installing sumologic.
