### PR TITLE
fix: change Vagrant IP address for vbox 6.1.28 compat

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,9 @@ Vagrant.configure('2') do |config|
   config.disksize.size = '50GB'
   config.vm.box_check_update = false
   config.vm.host_name = 'sumologic-kubernetes-collection'
-  config.vm.network :private_network, ip: "192.168.78.66"
+  # Vbox 6.1.28+ restricts host-only adapters to 192.168.56.0/21
+  # See: https://www.virtualbox.org/manual/ch06.html#network_hostonly
+  config.vm.network :private_network, ip: "192.168.56.2"
 
   config.vm.provider 'virtualbox' do |vb|
     vb.gui = false


### PR DESCRIPTION
###### Description

Trying to bring up Vagrant with Virtualbox 6.1.28 with the current setup results in the following error:

<img width="978" alt="Screenshot 2021-11-04 at 10 16 02" src="https://user-images.githubusercontent.com/93588780/140288316-d659630e-f08e-4f2e-818a-21bdc89b0b47.png">

As it turns out, Virtualbox 6.1.28 restricts the IP addresses permitted in host-only networks to 192.168.56.0/21. Strangely, there isn't any mention of this in the [changelog](https://www.virtualbox.org/wiki/Changelog). This restriction can be lifted via vbox config, but we don't care what our guest IP is, so changing that instead is simpler.

See: https://www.virtualbox.org/manual/ch06.html#network_hostonly for more information. The relevant passage is:

> On Linux, Mac OS X and Solaris Oracle VM VirtualBox will only allow IP addresses in 192.68.56.0/21 range to be assigned to host-only adapters. For IPv6 only link-local addresses are allowed. If other ranges are desired, they can be enabled by creating /etc/vbox/networks.conf and specifying allowed ranges there.

There's also discussion of this problem in the Vagrant forums [here](https://discuss.hashicorp.com/t/vagrant-2-2-18-osx-11-6-cannot-create-private-network/30984). And a bug report where the change is explicitly acknowledged [here](https://www.virtualbox.org/ticket/20626).

Note: Existing networks will continue to work even with Vbox 6.1.28. Not sure why, probably has to do with specifics of how Vagrant interacts with vbox.

###### Testing performed

- [X] Redeploy fluentd and fluentd-events pods
- [X] Confirm events, logs, and metrics are coming in
