### PR TITLE
Add clarity on installation

### DIFF
--- a/deploy/docs/Installation_with_Helm.md
+++ b/deploy/docs/Installation_with_Helm.md
@@ -71,8 +71,7 @@ This is a one time setup per Sumo Logic account.
 
 ## Installation Steps
 
-These steps require that no Prometheus exists.
-If you already have Prometheus installed select from the following options:
+> **Note**: These steps will deploy Prometheus as part of installation. If you already have Prometheus installed select from the following options:
 
 - [How to install our Chart side by side with your existing Prometheus Operator](./SideBySidePrometheus.md)
 - [How to install if you have an existing Prometheus Operator you want to update](./existingPrometheusDoc.md)


### PR DESCRIPTION
Current docs are not clear that the default install will deploy Prometheus and can lead you to the other installation models incorrectly.

