### PR TITLE
[Manual backport of #1761 & #1854] Improvements in Openshift documentation

### DIFF
--- a/deploy/docs/Installation_with_Helm.md
+++ b/deploy/docs/Installation_with_Helm.md
@@ -168,12 +168,13 @@ helm upgrade --install my-release sumologic/sumologic \
   --set sumologic.scc.create=true \
   --set fluent-bit.securityContext.privileged=true \
   --set kube-prometheus-stack.prometheus-node-exporter.service.port=9200 \
-  --set kube-prometheus-stack.prometheus-node-exporter.service.targetPort=9200
+  --set kube-prometheus-stack.prometheus-node-exporter.service.targetPort=9200 \
+  --set kube-prometheus-stack.prometheusOperator.namespaces.additional={my-namespace}
 ```
 
 **Notice:** Prometheus Operator is deployed by default on OpenShift platform,
 you may either limit scope for Prometheus Operator installed with Sumo Logic Kubernetes Collection using
-`kube-prometheus-stack.prometheusOperator.prometheusInstanceNamespaces` parameter in values.yaml or
+`kube-prometheus-stack.prometheusOperator.namespaces.additional` parameter in values.yaml or
 exclude namespaces for Prometheus Operator installed with Sumo Logic Kubernetes Collection
 using `kube-prometheus-stack.prometheusOperator.denyNamespaces` in values.yaml.
 

--- a/deploy/docs/Non_Helm_Installation.md
+++ b/deploy/docs/Non_Helm_Installation.md
@@ -188,12 +188,13 @@ kubectl run tools \
   --set fluent-bit.securityContext.privileged=true \
   --set kube-prometheus-stack.prometheus-node-exporter.service.port=9200 \
   --set kube-prometheus-stack.prometheus-node-exporter.service.targetPort=9200 \
+  --set kube-prometheus-stack.prometheusOperator.namespaces.additional={my-namespace} \
   | tee sumologic.yaml
 ```
 
 **Notice:** Prometheus Operator is deployed by default on OpenShift platform,
 you may either limit scope for Prometheus Operator installed with Sumo Logic Kubernetes Collection using
-`kube-prometheus-stack.prometheusOperator.prometheusInstanceNamespaces` parameter in values.yaml or
+`kube-prometheus-stack.prometheusOperator.namespaces.additional` parameter in values.yaml or
 exclude namespaces for Prometheus Operator installed with Sumo Logic Kubernetes Collection
 using `kube-prometheus-stack.prometheusOperator.denyNamespaces` in values.yaml.
 


### PR DESCRIPTION
###### Description

 Improvements in OpenShift documentation, manual backport of #1761 & #1854

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
