### PR TITLE
docs(helm): add uninstall step for the kubelet Service

### DIFF
--- a/deploy/docs/Installation_with_Helm.md
+++ b/deploy/docs/Installation_with_Helm.md
@@ -306,3 +306,24 @@ kubectl delete secret sumologic
 ```
 
 and the associated hosted collector can be deleted in the Sumo Logic UI.
+
+### Removing the kubelet Service
+
+The Helm chart uses the Prometheus Operator to manage Prometheus instances.
+This operator creates a Service for scraping metrics exposed by the kubelet (subject to configuration in the
+`kube-prometheus-stack.prometheusOperator.kubeletService` key in `values.yaml`), which isn't removed by the chart
+uninstall process.
+This Service is largely harmless, but can cause issues if a different release of the chart is installed, resulting in
+duplicated metrics from the kubelet.
+See [this issue](https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/1101) and the corresponding
+[upstream issue](https://github.com/prometheus-community/helm-charts/issues/1523) for a more detailed explanation.
+
+To remove this service after uninstalling the chart, run:
+
+```bash
+kubectl delete svc <release_name>-kube-prometheus-kubelet -n kube-system
+```
+
+Please keep in mind that if you've changed any configuration values related to this service (they reside under the
+`kube-prometheus-stack.prometheusOperator.kubeletService` key in `values.yaml`), you should substitute those values in
+the command provided above.


### PR DESCRIPTION
###### Description
prometheus-operator creates a kubelet Service when started, but the kube-prometheus-stack doesn't remove it on uninstall. This can cause problems with duplicated metric if multiple releases with different names are installed in the cluster. Pending a fix upstream, document the steps necessary to remove the Service when uninstalling the Helm release.

This partially addresses #1101 

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
