### PR TITLE
Update OTC to v0.38.1-sumo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   - Move insecure parameter to separate configuration variable
   - Fix OTLP/HTTP metadata tagging
-  - Update [Cascading Filter processor](https://github.com/SumoLogic/opentelemetry-collector-contrib/tree/v0.38.1-sumo/processor/cascadingfilterprocessor#cascading-filter-processor) to a new version which adds new features such filtering by number of errors and switches to a new,
-    [easier to use config format](https://help.sumologic.com/Traces/Getting_Started_with_Transaction_Tracing/What_if_I_don't_want_to_send_all_the_tracing_data_to_Sumo_Logic%3F)
+  - Update [Cascading Filter processor][v0.38.1-cfp] to a new version which adds new features such filtering
+    by number of errors and switches to a new, [easier to use config format][v0.38.1-cfp-help]
   - Change the default number of traces for Cascading Filter to 200000
 
+[v0.38.1-cfp]: https://github.com/SumoLogic/opentelemetry-collector-contrib/tree/v0.38.1-sumo/processor/cascadingfilterprocessor#cascading-filter-processor
+[v0.38.1-cfp-help]: https://help.sumologic.com/Traces/Getting_Started_with_Transaction_Tracing/What_if_I_don't_want_to_send_all_the_tracing_data_to_Sumo_Logic%3F
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.2.0...main
 [#1895]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1895
 [#1893]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1893

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
 - feat: add affinity to fluentd events statefulset [#1895][#1895]
-- fix: fix Fluentd to support Kubernetes 1.22 [#1892][#1892]
 - feat(helm): add PodDisruptionBudget api version helm chart helpers [#1865][#1865]
+
+### Changed
+
+- fix: fix Fluentd to support Kubernetes 1.22 [#1892][#1892]
+- Update OpenTelemetry Collector version to v0.38.1-sumo [#1893][#1893]
+
+  - Move insecure parameter to separate configuration variable
+  - Fix OTLP/HTTP metadata tagging
+  - Update [Cascading Filter processor](https://github.com/SumoLogic/opentelemetry-collector-contrib/tree/v0.38.1-sumo/processor/cascadingfilterprocessor#cascading-filter-processor) to a new version which adds new features such filtering by number of errors and switches to a new,
+    [easier to use config format](https://help.sumologic.com/Traces/Getting_Started_with_Transaction_Tracing/What_if_I_don't_want_to_send_all_the_tracing_data_to_Sumo_Logic%3F)
+  - Change the default number of traces for Cascading Filter to 200000
 
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.2.0...main
 [#1895]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1895
+[#1893]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1893
 [#1892]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1892
 [#1865]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1865
 

--- a/deploy/helm/sumologic/templates/traces/otel-agent/daemonset.yaml
+++ b/deploy/helm/sumologic/templates/traces/otel-agent/daemonset.yaml
@@ -58,7 +58,6 @@ spec:
         command:
           - "/otelcontribcol"
           - "--config=/conf/traces.otelagent.conf.yaml"
-          - {{ printf "--mem-ballast-size-mib=%s" .Values.otelagent.daemonset.memBallastSizeMib }}
         env:
         - name: GOGC
           value: "80"

--- a/deploy/helm/sumologic/templates/traces/otelcol/deployment.yaml
+++ b/deploy/helm/sumologic/templates/traces/otelcol/deployment.yaml
@@ -61,7 +61,6 @@ spec:
           {{- if eq .Values.otelcol.metrics.enabled false }}
           - --metrics-level=none
           {{- end }}
-          - {{ printf "--mem-ballast-size-mib=%s" .Values.otelcol.deployment.memBallastSizeMib }}
         env:
         - name: GOGC
           value: "80"

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -3208,31 +3208,8 @@ otelcol:
 
       ## Smart cascading filtering rules with preset limits.
       cascading_filter:
-        ## (default = 30s): Wait time since the first span of a trace arrived before making
-        ## a filtering decision
-        decision_wait: 30s
-        ## (default = 50000): Maximum number of traces kept in memory
-        num_traces: 90000
-        ## (default = 0): Expected number of new traces (helps in allocating data structures)
-        expected_new_traces_per_sec: 100
-        ## (default = 0): defines the global limit of maximum number of spans per second
-        ## that are going to be emitted
-        spans_per_second: 1660
-        ## (default = 0.2): Ratio of spans that are always probabilistically filtered
-        ## (hence might be used for metrics calculation).
-        probabilistic_filtering_ratio: 0.2
-        ## (no default): Policies used to make a sampling decision
-        policies:
-          - name: extended-duration
-            ## Spans_per_second: max number of emitted spans per second by this policy.
-            spans_per_second: 500
-            properties:
-              ## Selects the span if the duration is greater or equal the given
-              ## value (use s or ms as the suffix to indicate unit).
-              min_duration: 5s
-          - name: everything-else
-            ## This selects all traces, up the to the global limit
-            spans_per_second: -1
+        ## Max number of traces for which decisions are kept in memory
+        num_traces: 200000
 
       ## The batch processor accepts spans and places them into batches grouped by node and resource
       batch:
@@ -3264,7 +3241,7 @@ otelcol:
       pipelines:
         traces:
           receivers: [jaeger, opencensus, otlp, zipkin]
-          processors: [memory_limiter, k8s_tagger, source, resource, batch]
+          processors: [memory_limiter, k8s_tagger, source, resource, cascading_filter, batch]
           ## To enable zipkin exporter comment out following line
           exporters: [otlphttp]
           ## and uncomment next one

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -2978,7 +2978,7 @@ otelagent:
     podAnnotations: {}
     image:
       repository: "public.ecr.aws/sumologic/opentelemetry-collector"
-      tag: "0.38.0-sumo"
+      tag: "0.38.1-sumo"
       pullPolicy: IfNotPresent
 
     ## Extra Environment Values - allows yaml definitions
@@ -3054,7 +3054,9 @@ otelagent:
     exporters:
       otlp:
         endpoint: "exporters.otlp.endpoint.replace:4317"
-        insecure: true
+        tls:
+          ## This disables TLS when communicating with the gateway (within the same cluster)
+          insecure: true
     service:
       extensions: [health_check, memory_ballast]
       pipelines:
@@ -3085,7 +3087,7 @@ otelcol:
     podAnnotations: {}
     image:
       repository: "public.ecr.aws/sumologic/opentelemetry-collector"
-      tag: "0.38.0-sumo"
+      tag: "0.38.1-sumo"
       pullPolicy: IfNotPresent
 
     ## Extra Environment Values - allows yaml definitions

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -2976,11 +2976,9 @@ otelagent:
     podLabels: {}
     ## Add custom annotations only to otelagent daemonset.
     podAnnotations: {}
-    ## Memory Ballast size should be max 1/3 to 1/2 of memory.
-    memBallastSizeMib: "250"
     image:
       repository: "public.ecr.aws/sumologic/opentelemetry-collector"
-      tag: "0.22.0-sumo"
+      tag: "0.38.0-sumo"
       pullPolicy: IfNotPresent
 
     ## Extra Environment Values - allows yaml definitions
@@ -3050,12 +3048,15 @@ otelagent:
         timeout: 5s
     extensions:
       health_check: {}
+      memory_ballast:
+        ## Memory Ballast size should be max 1/3 to 1/2 of memory.
+        size_mib: 250
     exporters:
       otlp:
         endpoint: "exporters.otlp.endpoint.replace:4317"
         insecure: true
     service:
-      extensions: [health_check]
+      extensions: [health_check, memory_ballast]
       pipelines:
         traces:
           receivers: [jaeger, opencensus, otlp, zipkin]
@@ -3082,11 +3083,9 @@ otelcol:
     podLabels: {}
     ## Add custom annotations only to otelcol deployment.
     podAnnotations: {}
-    ## Memory Ballast size should be max 1/3 to 1/2 of memory.
-    memBallastSizeMib: "683"
     image:
       repository: "public.ecr.aws/sumologic/opentelemetry-collector"
-      tag: "0.22.0-sumo"
+      tag: "0.38.0-sumo"
       pullPolicy: IfNotPresent
 
     ## Extra Environment Values - allows yaml definitions
@@ -3245,6 +3244,9 @@ otelcol:
         timeout: 5s
     extensions:
       health_check: {}
+      memory_ballast:
+        ## Memory Ballast size should be max 1/3 to 1/2 of memory.
+        size_mib: 683
     exporters:
       zipkin:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_TRACES_SOURCE}
@@ -3258,7 +3260,7 @@ otelcol:
         traces_endpoint: ${SUMO_ENDPOINT_DEFAULT_TRACES_SOURCE}
         compression: gzip
     service:
-      extensions: [health_check]
+      extensions: [health_check, memory_ballast]
       pipelines:
         traces:
           receivers: [jaeger, opencensus, otlp, zipkin]

--- a/tests/tracing/static/collection-monitoring-false.output.yaml
+++ b/tests/tracing/static/collection-monitoring-false.output.yaml
@@ -19,24 +19,15 @@ data:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_TRACES_SOURCE}
     extensions:
       health_check: {}
+      memory_ballast:
+        size_mib: 683
     processors:
       batch:
         send_batch_max_size: 512
         send_batch_size: 256
         timeout: 5s
       cascading_filter:
-        decision_wait: 30s
-        expected_new_traces_per_sec: 100
-        num_traces: 90000
-        policies:
-        - name: extended-duration
-          properties:
-            min_duration: 5s
-          spans_per_second: 500
-        - name: everything-else
-          spans_per_second: -1
-        probabilistic_filtering_ratio: 0.2
-        spans_per_second: 1660
+        num_traces: 200000
       k8s_tagger:
         extract:
           annotations:
@@ -113,6 +104,7 @@ data:
     service:
       extensions:
       - health_check
+      - memory_ballast
       pipelines:
         traces:
           exporters:
@@ -122,6 +114,7 @@ data:
           - k8s_tagger
           - source
           - resource
+          - cascading_filter
           - batch
           receivers:
           - jaeger

--- a/tests/tracing/static/simple.output.yaml
+++ b/tests/tracing/static/simple.output.yaml
@@ -19,24 +19,15 @@ data:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_TRACES_SOURCE}
     extensions:
       health_check: {}
+      memory_ballast:
+        size_mib: 683
     processors:
       batch:
         send_batch_max_size: 512
         send_batch_size: 256
         timeout: 5s
       cascading_filter:
-        decision_wait: 30s
-        expected_new_traces_per_sec: 100
-        num_traces: 90000
-        policies:
-        - name: extended-duration
-          properties:
-            min_duration: 5s
-          spans_per_second: 500
-        - name: everything-else
-          spans_per_second: -1
-        probabilistic_filtering_ratio: 0.2
-        spans_per_second: 1660
+        num_traces: 200000
       k8s_tagger:
         extract:
           annotations:
@@ -113,6 +104,7 @@ data:
     service:
       extensions:
       - health_check
+      - memory_ballast
       pipelines:
         traces:
           exporters:
@@ -122,6 +114,7 @@ data:
           - k8s_tagger
           - source
           - resource
+          - cascading_filter
           - batch
           receivers:
           - jaeger


### PR DESCRIPTION
###### Description

- Update OpenTelemetry Collector version to v0.38.1-sumo

  - Move insecure parameter to separate configuration variable
  - Fix OTLP/HTTP metadata tagging
  - Update [Cascading Filter processor][v0.38.1-cfp] to a new version which adds new features such filtering
    by number of errors and switches to a new, [easier to use config format][v0.38.1-cfp-help]
  - Change the default number of traces for Cascading Filter to 200000
---

###### Testing performed

- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in

[v0.38.1-cfp]: https://github.com/SumoLogic/opentelemetry-collector-contrib/tree/v0.38.1-sumo/processor/cascadingfilterprocessor#cascading-filter-processor
[v0.38.1-cfp-help]: https://help.sumologic.com/Traces/Getting_Started_with_Transaction_Tracing/What_if_I_don't_want_to_send_all_the_tracing_data_to_Sumo_Logic%3F
