### PR TITLE
ci: publish tag versions to the dev repository

### DIFF
--- a/ci/push-helm-chart.sh
+++ b/ci/push-helm-chart.sh
@@ -1,22 +1,27 @@
 #!/usr/bin/env bash
 
-readonly ROOT_DIR="$(dirname "$(dirname "${0}")")"
-# shellcheck disable=SC1090
+ROOT_DIR="$(dirname "$(dirname "${0}")")"
+readonly ROOT_DIR="${ROOT_DIR}"
+
+# shellcheck disable=SC1090,SC1091
 source "${ROOT_DIR}"/ci/_build_functions.sh
 
 fetch_current_branch
-VERSION="$(git describe --tags --abbrev=10)"
-readonly VERSION="${VERSION#v}"
+RELEASE_VERSION="$(git describe --tags --abbrev=10)"
+readonly RELEASE_VERSION="${RELEASE_VERSION#v}"
+DEV_VERSION="$(git describe --tags --long)"
+readonly DEV_VERSION="${DEV_VERSION#v}"
 
 pushd "${ROOT_DIR}" || exit 1
-echo "Starting to push helm chart in: $(pwd) with version tag: ${VERSION}"
 
 set_up_github
 
+echo "Pushing helm chart in: $(pwd) with version tag: ${DEV_VERSION} to the dev catalog"
+push_helm_chart "${DEV_VERSION}" "./dev"
+
 if is_checkout_on_tag; then
-  push_helm_chart "${VERSION}" "."
-else
-  push_helm_chart "${VERSION}" "./dev"
+  echo "Pushing helm chart in: $(pwd) with version tag: ${RELEASE_VERSION} to the release catalog"
+  push_helm_chart "${RELEASE_VERSION}" "."
 fi
 
 popd || exit 1


### PR DESCRIPTION
###### Description

Publish versions for git tags to the dev repository. This causes a bit of duplication, as the same commit can be published to the dev repository with two different versions, but it ensures that it's always possible to derive the dev version from just the repository state, irrespective of whether a tag is present or not.

Fixed some shellcheck warnings while at it as well.

This also helps fix an issue in our e2e tests. See [this](https://jira.kumoroku.com/jira/browse/SUMO-155789) internal issue.

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
