### PR TITLE
chore: remove support for EOL K8s platform versions

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -82,15 +82,15 @@ The diagram below illustrates the components of the Kubernetes collection soluti
 
 The following table displays the tested Kubernetes and Helm versions.
 
-| Name          | Version                                  |
-|---------------|------------------------------------------|
-| K8s with EKS  | 1.17<br/>1.18<br/>1.19<br/>1.20<br/>1.21 |
-| K8s with Kops | 1.18<br/>1.19<br/>1.20<br/>1.21          |
-| K8s with GKE  | 1.19<br/>1.20                            |
-| K8s with AKS  | 1.19<br/>1.20<br/>1.21                   |
-| OpenShift     | 4.6<br/>4.7                              |
-| Helm          | 3.5.4 (Linux)                            |
-| kubectl       | 1.16.0                                   |
+| Name          | Version                         |
+|---------------|---------------------------------|
+| K8s with EKS  | 1.18<br/>1.19<br/>1.20<br/>1.21 |
+| K8s with Kops | 1.18<br/>1.19<br/>1.20<br/>1.21 |
+| K8s with GKE  | 1.20                            |
+| K8s with AKS  | 1.19<br/>1.20<br/>1.21          |
+| OpenShift     | 4.6<br/>4.7                     |
+| Helm          | 3.5.4 (Linux)                   |
+| kubectl       | 1.16.0                          |
 
 The following matrix displays the tested package versions for our Helm chart.
 


### PR DESCRIPTION
###### Description

1.17 on EKS and 1.18 on GKE don't allow new clusters to be created; 1.19 on GKE shouldn't either according to GCP's schedule. As we can't test on these platforms, we can't officially support them.

See https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar and https://cloud.google.com/kubernetes-engine/docs/release-schedule#schedule_for_static_no-channel_versions.

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
