### PR TITLE
chore(deps): bump falco subchart to 1.16.2

### DIFF
--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
     repository: https://prometheus-community.github.io/helm-charts
     condition: kube-prometheus-stack.enabled,sumologic.metrics.enabled
   - name: falco
-    version: 1.11.1
+    version: 1.16.2
     repository: https://falcosecurity.github.io/charts
     condition: falco.enabled
   - name: metrics-server


### PR DESCRIPTION
Changelog: https://github.com/falcosecurity/charts/blob/master/falco/CHANGELOG.md#v1162

This bumps the base falco image from `0.27.0` to `0.30.0` (already copied manually to https://gallery.ecr.aws/sumologic/falco)