### PR TITLE
Dependency upgrades for ARM support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update dependencies for ARM support [#1919][#1919]
+  - Update kube-state-metrics to 1.9.8
+  - Update kubernetes-setup to 3.1.1
+  - Update kuberenetes-tools to 2.6.0
+  - Update telegraf-operator subchart to 1.3.3
 - Bump Sumo OT distro to `0.0.42-beta.0` [#1921][#1921]
 - Remove support for EKS 1.17, GKE 1.18 and 1.19 [#1906][#1906]
 - fix: fix Fluentd to support Kubernetes 1.22 [#1892][#1892]

--- a/ci/_build_functions.sh
+++ b/ci/_build_functions.sh
@@ -12,7 +12,7 @@ function helm() {
   docker run --rm \
     -v "$(pwd):/chart" \
     -w /chart \
-    sumologic/kubernetes-tools:2.5.0 \
+    sumologic/kubernetes-tools:2.6.0 \
     helm "$@"
 }
 

--- a/deploy/docs/Kube-Prometheus.md
+++ b/deploy/docs/Kube-Prometheus.md
@@ -9,12 +9,12 @@ You can generate mixin configuration using `kubectl` or `docker`:
  kubectl run tools \
   -it --quiet --rm \
   --restart=Never -n sumologic \
-  --image sumologic/kubernetes-tools:2.2.3 \
+  --image sumologic/kubernetes-tools:2.6.0 \
   -- template-prometheus-mixin > kube-prometheus-sumo-logic-mixin.libsonnet
 
  # or using docker
  docker run -it --rm \
-  sumologic/kubernetes-tools:2.2.3 \
+  sumologic/kubernetes-tools:2.6.0 \
   template-prometheus-mixin > kube-prometheus-sumo-logic-mixin.libsonnet
 ```
 

--- a/deploy/docs/Non_Helm_Installation.md
+++ b/deploy/docs/Non_Helm_Installation.md
@@ -91,7 +91,7 @@ First you will generate the YAML to apply to your cluster.  The following comman
 kubectl run tools \
   -it --quiet --rm \
   --restart=Never \
-  --image sumologic/kubernetes-tools:2.2.3 -- \
+  --image sumologic/kubernetes-tools:2.6.0 -- \
   template \
   --name-template 'collection' \
   --set sumologic.accessId='<ACCESS_ID>' \
@@ -128,7 +128,7 @@ The following will render the YAML and install in the `my-namespace` namespace.
 kubectl run tools \
   -it --quiet --rm \
   --restart=Never \
-  --image sumologic/kubernetes-tools:2.2.3 -- \
+  --image sumologic/kubernetes-tools:2.6.0 -- \
   template \
   --namespace 'my-namespace' \
   --name-template 'collection' \
@@ -177,7 +177,7 @@ you can do the following:
 kubectl run tools \
   -it --quiet --rm \
   --restart=Never \
-  --image sumologic/kubernetes-tools:2.2.3 -- \
+  --image sumologic/kubernetes-tools:2.6.0 -- \
   template \
   --namespace 'my-namespace' \
   --name-template 'collection' \
@@ -258,7 +258,7 @@ cat sumo-values.yaml | \
   kubectl run tools \
     -i --quiet --rm \
     --restart=Never \
-    --image sumologic/kubernetes-tools:2.2.3 -- \
+    --image sumologic/kubernetes-tools:2.6.0 -- \
     template \
       --name-template 'collection' \
       | tee sumologic.yaml
@@ -279,7 +279,7 @@ You can use the same commands used to create the YAML in the first place.
 kubectl run tools \
   -it --quiet --rm \
   --restart=Never \
-  --image sumologic/kubernetes-tools:2.2.3 -- \
+  --image sumologic/kubernetes-tools:2.6.0 -- \
   template \
   --namespace 'my-namespace' \
   --name-template 'collection' \
@@ -297,7 +297,7 @@ cat sumo-values.yaml | \
      kubectl run tools \
        -i --quiet --rm \
        --restart=Never \
-       --image sumologic/kubernetes-tools:2.2.3 -- \
+       --image sumologic/kubernetes-tools:2.6.0 -- \
        template \
          --name-template 'collection' \
          | tee sumologic.yaml
@@ -312,7 +312,7 @@ cat values.yaml | \
   kubectl run tools \
     -i --quiet --rm \
     --restart=Never \
-    --image sumologic/kubernetes-tools:2.2.3 -- \
+    --image sumologic/kubernetes-tools:2.6.0 -- \
     template \
       --name-template 'collection' \
       --version=1.0.0

--- a/deploy/docs/additional_prometheus_configuration.md
+++ b/deploy/docs/additional_prometheus_configuration.md
@@ -12,12 +12,12 @@ using `docker`/`kubectl` and [sumologic-kubernetes-tools](https://github.com/sum
  kubectl run tools \
   -it --quiet --rm \
   --restart=Never -n sumologic \
-  --image sumologic/kubernetes-tools:2.2.3 \
+  --image sumologic/kubernetes-tools:2.6.0 \
   -- template-dependency kube-prometheus-stack > prometheus-overrides.yaml
 
  # or using docker
  docker run -it --rm \
-  sumologic/kubernetes-tools:2.2.3 \
+  sumologic/kubernetes-tools:2.6.0 \
   template-dependency kube-prometheus-stack > prometheus-overrides.yaml
 ```
 

--- a/deploy/docs/existingPrometheusDoc.md
+++ b/deploy/docs/existingPrometheusDoc.md
@@ -142,12 +142,12 @@ First, generate the Prometheus Operator `prometheus-overrides.yaml` by running c
  kubectl run tools \
   -it --quiet --rm \
   --restart=Never -n sumologic \
-  --image sumologic/kubernetes-tools:2.2.3 \
+  --image sumologic/kubernetes-tools:2.6.0 \
   -- template-dependency kube-prometheus-stack > prometheus-overrides.yaml
 
  # or using docker
  docker run -it --rm \
-  sumologic/kubernetes-tools:2.2.3 \
+  sumologic/kubernetes-tools:2.6.0 \
   template-dependency kube-prometheus-stack > prometheus-overrides.yaml
 ```
 

--- a/deploy/docs/standAlonePrometheus.md
+++ b/deploy/docs/standAlonePrometheus.md
@@ -101,12 +101,12 @@ First, generate the Prometheus Operator `prometheus-overrides.yaml` by running
  kubectl run tool \
   -it --quiet --rm \
   --restart=Never -n sumologic \
-  --image sumologic/kubernetes-tools:2.2.3 \
+  --image sumologic/kubernetes-tools:2.6.0 \
   -- template-dependency kube-prometheus-stack > prometheus-overrides.yaml
 
  # or using Docker
  docker run -it --rm \
-  sumologic/kubernetes-tools:2.2.3 \
+  sumologic/kubernetes-tools:2.6.0 \
   template-dependency kube-prometheus-stack > prometheus-overrides.yaml
 ```
 

--- a/deploy/docs/v2_migration_doc.md
+++ b/deploy/docs/v2_migration_doc.md
@@ -352,7 +352,7 @@ to convert their existing `values.yaml` file into one that is compatible with th
     cat current_values.yaml | \
       docker run \
         --rm \
-        -i sumologic/kubernetes-tools:2.3.1 upgrade-2.0 | \
+        -i sumologic/kubernetes-tools:2.6.0 upgrade-2.0 | \
       tee new_values.yaml
     ```
 
@@ -367,7 +367,7 @@ to convert their existing `values.yaml` file into one that is compatible with th
         --quiet \
         --rm \
         --restart=Never \
-        --image sumologic/kubernetes-tools:2.3.1 -- upgrade-2.0 | \
+        --image sumologic/kubernetes-tools:2.6.0 -- upgrade-2.0 | \
       tee new_values.yaml
     ```
 

--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -29,7 +29,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     condition: metrics-server.enabled
   - name: telegraf-operator
-    version: 1.2.0
+    version: 1.3.3
     repository: https://helm.influxdata.com/
     condition: telegraf-operator.enabled
   - name: tailing-sidecar-operator

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -96,7 +96,7 @@ sumologic:
     job:
       image:
         repository: public.ecr.aws/sumologic/kubernetes-setup
-        tag: 3.0.0
+        tag: 3.1.1
         pullPolicy: IfNotPresent
       ## Optionally specify an array of pullSecrets.
       ## They will be added to serviceaccount that is used for Sumo Logic's

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1491,6 +1491,10 @@ kube-prometheus-stack:
       enabled: false
   ## Resource limits for kube-state-metrics
   kube-state-metrics:
+    ## Use the GCR repo, it's more recent and has ARM images starting from 1.9.8
+    image:
+      repository: k8s.gcr.io/kube-state-metrics/kube-state-metrics
+      tag: v1.9.8
     ## Custom labels to apply to service, deployment and pods
     customLabels: {}
     ## Additional annotations for pods in the DaemonSet

--- a/tests/helm/functions.sh
+++ b/tests/helm/functions.sh
@@ -38,7 +38,7 @@ function prepare_environment() {
   rm -rf "${repo_path}/tmpcharts"
   docker run --rm \
     -v "${repo_path}":/chart \
-    sumologic/kubernetes-tools:2.4.1 \
+    sumologic/kubernetes-tools:2.6.0 \
     helm dependency update /chart
 }
 
@@ -77,7 +77,7 @@ function generate_file {
   if ! docker run --rm \
     -v "${TEST_SCRIPT_PATH}/../../../deploy/helm/sumologic":/chart \
     -v "${TEST_STATICS_PATH}/${input_file}":/values.yaml \
-    sumologic/kubernetes-tools:2.4.1 \
+    sumologic/kubernetes-tools:2.6.0 \
     helm template /chart -f /values.yaml \
       ${kube_api_versions_flags} \
       --namespace sumologic \

--- a/vagrant/k8s/logs-generator.yaml
+++ b/vagrant/k8s/logs-generator.yaml
@@ -21,7 +21,7 @@ spec:
         name: logs-generator
     spec:
       containers:
-      - image: sumologic/kubernetes-tools:2.4.0
+      - image: sumologic/kubernetes-tools:2.6.0
         imagePullPolicy: Always
         name: logs-generator
         command:

--- a/vagrant/k8s/receiver-mock.yaml
+++ b/vagrant/k8s/receiver-mock.yaml
@@ -30,7 +30,7 @@ spec:
         - ports:
             - containerPort: 3000
             - containerPort: 3001
-          image: sumologic/kubernetes-tools:2.2.3
+          image: sumologic/kubernetes-tools:2.6.0
           name: receiver-mock
           args:
             - receiver-mock


### PR DESCRIPTION
###### Description

Updating some dependencies necessary for ARM support:
* telegraf-operator from 1.2.0 to 1.3.3 (1.3.0 is when they added ARM support)
* kube-state-metrics from implicit 1.9.7 to 1.9.8
* kubernetes-setup to from 3.0.0 to 3.1.1
* kubernetes-tools from 2.2.3 to 2.6.0

I updated the tools version to 2.6.0 everywhere we explicitly mention it in the documentation. I think this is fine, but let me know if you see some kind of problem.

Ran E2E tests on this and they passed.

---

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
