### PR TITLE
tests: add otc metadata integration tests

### DIFF
--- a/tests/integration/Makefile
+++ b/tests/integration/Makefile
@@ -2,15 +2,15 @@
 # For default and supported images used in tests please see kind_images.json
 KIND_NODE_IMAGE ?= $(shell jq '.default' kind_images.json)
 CLUSTER_NAME ?= sumologic
-KUBE_CONFIG ?= $(shell mktemp)
+KUBE_CONFIG := $(shell mktemp)
 
 .PHONY: create-cluster
 create-cluster:
 	kind create cluster \
+		--config yamls/cluster.yaml \
 		--name $(CLUSTER_NAME) \
 		--image $(KIND_NODE_IMAGE) \
 		--kubeconfig $(KUBE_CONFIG)
-	@echo "KUBECONFIG $(KUBE_CONFIG)"
 
 .PHONY: delete-cluster
 delete-cluster:

--- a/tests/integration/helm_helpers_test.go
+++ b/tests/integration/helm_helpers_test.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func generateNamespaceName(t time.Time) string {
+	return fmt.Sprintf("ns-test-%d", t.Unix())
+}
+
+func generateReleaseName(t time.Time) string {
+	return fmt.Sprintf("release-test-%d", t.Unix())
+}

--- a/tests/integration/values/values_otc_metadata.yaml
+++ b/tests/integration/values/values_otc_metadata.yaml
@@ -1,0 +1,58 @@
+sumologic:
+  setupEnabled: true
+  accessId: "dummy"
+  accessKey: "dummy"
+  endpoint: http://receiver-mock.receiver-mock:3000/terraform/api/
+
+  logs:
+    metadata:
+      provider: otelcol
+
+  metrics:
+    metadata:
+      provider: otelcol
+
+# Prevent snowball effect by filtering out receiver mock logs
+fluent-bit:
+  config:
+    filters: |
+      [FILTER]
+          Name    grep
+          Match   containers.var.log.containers.receiver-mock*
+          Exclude log .*
+
+# Request less resources so that this fits on Github actions runners environment
+kube-prometheus-stack:
+  prometheus:
+    prometheusSpec:
+      resources:
+        limits:
+          cpu: 100m
+          memory: 128Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
+
+# Request less resources so that this fits on Github actions runners environment
+metadata:
+  persistence:
+    size: 128Mi
+
+  logs:
+    statefulset:
+      resources:
+        limits:
+          cpu: 100m
+          memory: 128Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
+  metrics:
+    statefulset:
+      resources:
+        limits:
+          cpu: 100m
+          memory: 128Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi


### PR DESCRIPTION
Add OTC related integration metadata integration tests.

* use the following [`values.yaml`](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/add-sumo-ot-distro-metadata-integration-tests/tests/integration/values/values_otc_metadata.yaml)
* add some [assertions](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/add-sumo-ot-distro-metadata-integration-tests/tests/integration/helm_otc_metadata_installation_test.go)