### PR TITLE
fix(helm): fix helm template render tests

### DIFF
--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -965,8 +965,8 @@ Example:
 {{- define "kubernetes.sources.envs" -}}
 {{- $ctx := .Context -}}
 {{- $type := .Type -}}
-{{- range $name, $source := (index .Context.sumologic.collector.sources $type) }}
-{{ include "kubernetes.sources.env" (dict "Context" $ctx "Type" $type  "Name" $name ) }}
+{{- range $name, $source := (index .Context.sumologic.collector.sources $type) -}}
+{{- include "kubernetes.sources.env" (dict "Context" $ctx "Type" $type  "Name" $name ) | nindent 8 -}}
 {{- end }}
 {{- end -}}
 

--- a/deploy/helm/sumologic/templates/events/fluentd/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/events/fluentd/statefulset.yaml
@@ -98,7 +98,7 @@ spec:
           periodSeconds: 5
         env:
 {{- $ctx := .Values -}}
-{{ include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "events") | nindent 8 }}
+{{- include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "events") -}}
 {{- if .Values.fluentd.events.extraEnvVars }}
 {{ toYaml .Values.fluentd.events.extraEnvVars | nindent 8 }}
 {{- end }}

--- a/deploy/helm/sumologic/templates/logs/fluentd/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/logs/fluentd/statefulset.yaml
@@ -143,17 +143,19 @@ spec:
 {{- if .Values.fluentd.logs.extraVolumeMounts }}
 {{ toYaml .Values.fluentd.logs.extraVolumeMounts | indent 8 }}
 {{- end }}
+{{- if or .Values.sumologic.collector.sources .Values.fluentd.logs.extraEnvVars }}
         env:
 {{- $ctx := .Values -}}
-{{ include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "logs") | nindent 8 }}
+{{- include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "logs") -}}
 {{- if .Values.sumologic.traces.enabled }}
-{{ include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "traces") | nindent 8 }}
+{{- include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "traces") -}}
 {{- end }}
         {{- if .Values.fluentd.logs.extraEnvVars }}
 {{ toYaml .Values.fluentd.logs.extraEnvVars | nindent 8 }}
         {{- end }}
         - name: ADDITIONAL_PLUGINS
           value: {{ join " " .Values.fluentd.additionalPlugins | quote }}
+{{- end }}
 {{- if .Values.fluentd.persistence.enabled }}
   volumeClaimTemplates:
   - metadata:

--- a/deploy/helm/sumologic/templates/logs/otelcol/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/logs/otelcol/statefulset.yaml
@@ -144,12 +144,14 @@ spec:
 {{- if .Values.metadata.logs.statefulset.extraVolumeMounts }}
 {{ toYaml .Values.metadata.logs.statefulset.extraVolumeMounts | indent 8 }}
 {{- end }}
+{{- if or .Values.sumologic.collector.sources .Values.metadata.logs.statefulset.extraEnvVars }}
         env:
 {{- $ctx := .Values -}}
-{{ include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "logs")}}
-        {{- if .Values.metadata.logs.statefulset.extraEnvVars }}
-{{ toYaml .Values.metadata.logs.statefulset.extraEnvVars | nindent 8 }}
-        {{- end }}
+{{- include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "logs") -}}
+{{- if .Values.metadata.logs.statefulset.extraEnvVars }}
+{{- toYaml .Values.metadata.logs.statefulset.extraEnvVars | nindent 8 }}
+{{- end }}
+{{- end }}
 {{- if .Values.metadata.persistence.enabled }}
   volumeClaimTemplates:
   - metadata:

--- a/deploy/helm/sumologic/templates/metrics/fluentd/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics/fluentd/statefulset.yaml
@@ -138,14 +138,16 @@ spec:
 {{- if .Values.fluentd.metrics.extraVolumeMounts }}
 {{ toYaml .Values.fluentd.metrics.extraVolumeMounts | indent 8 }}
 {{- end }}
+{{- if or .Values.sumologic.collector.sources .Values.fluentd.metrics.extraEnvVars }}
         env:
 {{- $ctx := .Values -}}
-{{ include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "metrics") | nindent 8 }}
-        {{- if .Values.fluentd.metrics.extraEnvVars }}
+{{- include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "metrics") -}}
+{{- if .Values.fluentd.metrics.extraEnvVars }}
 {{ toYaml .Values.fluentd.metrics.extraEnvVars | nindent 8 }}
-        {{- end }}
+{{- end }}
         - name: ADDITIONAL_PLUGINS
           value: {{ join " " .Values.fluentd.additionalPlugins | quote }}
+{{- end }}
 {{- if .Values.fluentd.persistence.enabled }}
   volumeClaimTemplates:
   - metadata:

--- a/deploy/helm/sumologic/templates/metrics/otelcol/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics/otelcol/statefulset.yaml
@@ -141,7 +141,7 @@ spec:
 {{- end }}
         env:
 {{- $ctx := .Values -}}
-{{ include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "metrics")}}
+{{- include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "metrics") -}}
         {{- if .Values.metadata.metrics.statefulset.extraEnvVars }}
 {{ toYaml .Values.metadata.metrics.statefulset.extraEnvVars | nindent 8 }}
         {{- end }}

--- a/deploy/helm/sumologic/templates/traces/otelcol/deployment.yaml
+++ b/deploy/helm/sumologic/templates/traces/otelcol/deployment.yaml
@@ -65,8 +65,8 @@ spec:
         - name: GOGC
           value: "80"
 {{- $ctx := .Values -}}
-{{ include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "traces") | nindent 8 }}
-{{- include "kubernetes.sources.env" (dict "Context" $ctx "Type" "metrics" "Name" "default" ) | nindent 8 }}
+{{- include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "traces") -}}
+{{ include "kubernetes.sources.env" (dict "Context" $ctx "Type" "metrics" "Name" "default" ) | nindent 8 }}
 {{- if .Values.otelcol.deployment.extraEnvVars }}
 {{- toYaml .Values.otelcol.deployment.extraEnvVars | nindent 8 }}
 {{- end }}

--- a/tests/helm/functions.sh
+++ b/tests/helm/functions.sh
@@ -53,7 +53,7 @@ function cleanup_tests() {
     rm -rf "${TEST_TMP_PATH}"
   fi
 
-  for env_name in  $(env | grep -oE '^TEST_.*?=' | grep -v "TEST_SUCCESS" | sed 's/=//g'); do
+  for env_name in  $(env | grep -oE '^TEST_.*?=' | sed 's/=//g'); do
     unset "${env_name}"
   done
 }
@@ -114,8 +114,8 @@ function perform_test {
     echo -e "\tOutput diff (${TEST_STATICS_PATH}/${output_file}):\n${test_output}"
     test_failed "${test_name}"
     # Set all tests as failed
-    # This env comes from run.sh
-    export TEST_SUCCESS=false
+    # This file has been created in run.sh
+    echo "false" > "${TEST_SUCCESS_FILE}"
   else
     test_passed "${test_name}"
   fi

--- a/tests/helm/metadata_logs_otc_statefulset/static/basic.output.yaml
+++ b/tests/helm/metadata_logs_otc_statefulset/static/basic.output.yaml
@@ -65,7 +65,7 @@ spec:
       priorityClassName: "prio"
       containers:
       - name: otelcol
-        image: public.ecr.aws/sumologic/sumologic-otel-collector:0.0.38-beta.0
+        image: public.ecr.aws/sumologic/sumologic-otel-collector:0.0.42-beta.0
         imagePullPolicy: IfNotPresent
         args:
           - --config=/etc/otel/config.yaml
@@ -103,7 +103,6 @@ spec:
             secretKeyRef:
               name: sumologic
               key: endpoint-logs
-
         - name: VALUE_FROM_SECRET
           valueFrom:
             secretKeyRef:

--- a/tests/helm/metadata_metrics_otc_statefulset/static/basic.output.yaml
+++ b/tests/helm/metadata_metrics_otc_statefulset/static/basic.output.yaml
@@ -65,7 +65,7 @@ spec:
       priorityClassName: "prio"
       containers:
       - name: otelcol
-        image: public.ecr.aws/sumologic/sumologic-otel-collector:0.0.38-beta.0
+        image: public.ecr.aws/sumologic/sumologic-otel-collector:0.0.42-beta.0
         imagePullPolicy: IfNotPresent
         args:
           - --config=/etc/otel/config.yaml

--- a/tests/helm/run.sh
+++ b/tests/helm/run.sh
@@ -15,7 +15,11 @@ fi
 # shellcheck source=tests/helm/functions.sh
 source "${SCRIPT_PATH}/functions.sh"
 
-export TEST_SUCCESS=true
+# This ended up being a file because below we're using a subshell (in order to avoid 'leaking'
+# environment variable exported by commands in the subshell ) and we want to take all tests
+# results into account.
+export TEST_SUCCESS_FILE="$(mktemp)"
+echo "true" > "${TEST_SUCCESS_FILE}"
 
 prepare_environment "${SCRIPT_PATH}/../../deploy/helm/sumologic"
 
@@ -39,7 +43,7 @@ for config_file in ${CONFIG_FILES}; do
   )
 done
 
-if [[ "${TEST_SUCCESS}" = "true" ]]; then
+if [[ "$(cat "${TEST_SUCCESS_FILE}")" = "true" ]]; then
   exit 0
 else
   exit 1

--- a/tests/helm/tracing/static/collection-monitoring-false.output.yaml
+++ b/tests/helm/tracing/static/collection-monitoring-false.output.yaml
@@ -33,9 +33,9 @@ data:
           enabled: false
           num_consumers: 10
           queue_size: 5000
-        source_category: 
+        source_category: "%{namespace}/%{pod_name}"
         source_host: '%{host.name}'
-        source_name: 
+        source_name: "%{namespace}.%{pod}.%{container}"
         timeout: 5s
       zipkin:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_TRACES_SOURCE}

--- a/tests/helm/tracing/static/simple.output.yaml
+++ b/tests/helm/tracing/static/simple.output.yaml
@@ -33,9 +33,9 @@ data:
           enabled: false
           num_consumers: 10
           queue_size: 5000
-        source_category: 
+        source_category: "%{namespace}/%{pod_name}"
         source_host: '%{host.name}'
-        source_name: 
+        source_name: "%{namespace}.%{pod}.%{container}"
         timeout: 5s
       zipkin:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_TRACES_SOURCE}


### PR DESCRIPTION
Helm template render tests where broken in https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1865 (by introduction of a subshell in https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1865/files#diff-dd0c9cda3917fccebea6cea8d3fb46f46e4fbbeda2d6939864c9aaa9fc9c9571R29-R39)

Hence they were not reporting issues which they should report: e.g. https://github.com/SumoLogic/sumologic-kubernetes-collection/runs/4371102809?check_suite_focus=true#step:4:75

This PR fixes that by using a temporary file to report test success/failures https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1924/files#diff-a13b01bb0c50ed17f62903dbcbb0a1df693e4e0a921eefc8dd078fff56bc57f3R18 and by fixing already accumulated breakage in templates.