### PR TITLE
[Manual backport of #1925] docs: update support matrix - add OpenShift 4.8

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -88,7 +88,7 @@ The following table displays the tested Kubernetes and Helm versions.
 | K8s with Kops | 1.18<br/>1.19<br/>1.20<br/>1.21          |
 | K8s with GKE  | 1.19<br/>1.20                            |
 | K8s with AKS  | 1.19<br/>1.20<br/>1.21                   |
-| OpenShift     | 4.6<br/>4.7                              |
+| OpenShift     | 4.6<br/>4.7<br/>4.8                      |
 | Helm          | 3.5.4 (Linux)                            |
 | kubectl       | 1.16.0                                   |
 


### PR DESCRIPTION
##### Description

docs: update support matrix - add OpenShift 4.8, manual backport of #1925
