### PR TITLE
chore: bump fluentd version to 1.12.2-sumo-10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update fluentd to 1.12.2-sumo-10
 - Update dependencies for ARM support [#1919][#1919]
   - Update kube-state-metrics to 1.9.8
   - Update kubernetes-setup to 3.1.1

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -220,7 +220,7 @@ sumologic:
 fluentd:
   image:
     repository: public.ecr.aws/sumologic/kubernetes-fluentd
-    tag: 1.12.2-sumo-9
+    tag: 1.12.2-sumo-10
     pullPolicy: IfNotPresent
 
   ## Specifies whether a PodSecurityPolicy should be created


### PR DESCRIPTION
##### Description

This version has an important fix reducing the number of API server calls from the metrics metadata enrichment plugin by a significant amount. See: https://github.com/SumoLogic/sumologic-kubernetes-fluentd/pull/369

---

##### Checklist

Remove items which don't apply to your PR.

- [X] Changelog updated

###### Testing performed

- [X] Redeploy fluentd and fluentd-events pods
- [X] Confirm events, logs, and metrics are coming in
