### PR TITLE
Fix pod readiness checks in integration tests

### DIFF
--- a/tests/integration/helm_default_installation_test.go
+++ b/tests/integration/helm_default_installation_test.go
@@ -30,7 +30,7 @@ func Test_Helm_Default(t *testing.T) {
 		valuesFilePath = "values/values_default.yaml"
 
 		tickDuration = time.Second
-		waitDuration = time.Minute
+		waitDuration = time.Minute * 2
 	)
 
 	feat := features.New("installation").

--- a/tests/integration/helm_default_installation_test.go
+++ b/tests/integration/helm_default_installation_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal"
 	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/ctxopts"
+	k8sinternal "github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/k8s"
 	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/stepfuncs"
 )
 
@@ -52,19 +53,15 @@ func Test_Helm_Default(t *testing.T) {
 				require.Len(t, secret.Data, 10)
 				return ctx
 			}).
-		Assess("3 fluentd logs pods are created and running",
+		Assess("fluentd logs pods are available",
 			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
-				require.Eventually(t, func() bool {
-					pods := k8s.ListPods(t, ctxopts.KubectlOptions(ctx), v1.ListOptions{
-						LabelSelector: fmt.Sprintf("app=%s-sumologic-fluentd-logs", releaseName),
-						FieldSelector: "status.phase=Running",
-					})
-					return len(pods) == 3
-				}, waitDuration, tickDuration)
-
+				filters := v1.ListOptions{
+					LabelSelector: fmt.Sprintf("app=%s-sumologic-fluentd-logs", releaseName),
+				}
+				k8sinternal.WaitUntilPodsAvailable(t, ctxopts.KubectlOptions(ctx), filters, 3, waitDuration*2, tickDuration)
 				return ctx
 			}).
-		Assess("3 fluentd logs buffers PVCs are created",
+		Assess("fluentd logs buffers PVCs are created",
 			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
 				assert.Eventually(t, func() bool {
 					var pvcs corev1.PersistentVolumeClaimList
@@ -77,18 +74,15 @@ func Test_Helm_Default(t *testing.T) {
 				}, waitDuration, tickDuration)
 				return ctx
 			}).
-		Assess("3 fluentd metrics pods are created and running",
+		Assess("fluentd metrics pods are available",
 			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
-				require.Eventually(t, func() bool {
-					pods := k8s.ListPods(t, ctxopts.KubectlOptions(ctx), v1.ListOptions{
-						LabelSelector: fmt.Sprintf("app=%s-sumologic-fluentd-metrics", releaseName),
-						FieldSelector: "status.phase=Running",
-					})
-					return len(pods) == 3
-				}, waitDuration, tickDuration)
+				filters := v1.ListOptions{
+					LabelSelector: fmt.Sprintf("app=%s-sumologic-fluentd-metrics", releaseName),
+				}
+				k8sinternal.WaitUntilPodsAvailable(t, ctxopts.KubectlOptions(ctx), filters, 3, waitDuration, tickDuration)
 				return ctx
 			}).
-		Assess("3 fluentd metrics buffers PVCs are created",
+		Assess("fluentd metrics buffers PVCs are created",
 			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
 				assert.Eventually(t, func() bool {
 					var pvcs corev1.PersistentVolumeClaimList
@@ -101,18 +95,15 @@ func Test_Helm_Default(t *testing.T) {
 				}, waitDuration, tickDuration)
 				return ctx
 			}).
-		Assess("1 fluentd events pod is created and running",
+		Assess("fluentd events pods are available",
 			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
-				require.Eventually(t, func() bool {
-					pods := k8s.ListPods(t, ctxopts.KubectlOptions(ctx), v1.ListOptions{
-						LabelSelector: fmt.Sprintf("app=%s-sumologic-fluentd-events", releaseName),
-						FieldSelector: "status.phase=Running",
-					})
-					return len(pods) == 1
-				}, waitDuration, tickDuration)
+				filters := v1.ListOptions{
+					LabelSelector: fmt.Sprintf("app=%s-sumologic-fluentd-events", releaseName),
+				}
+				k8sinternal.WaitUntilPodsAvailable(t, ctxopts.KubectlOptions(ctx), filters, 1, waitDuration, tickDuration)
 				return ctx
 			}).
-		Assess("1 fluentd events buffers PVCs are created",
+		Assess("fluentd events buffers PVCs are created",
 			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
 				assert.Eventually(t, func() bool {
 					var pvcs corev1.PersistentVolumeClaimList
@@ -125,15 +116,12 @@ func Test_Helm_Default(t *testing.T) {
 				}, waitDuration, tickDuration)
 				return ctx
 			}).
-		Assess("1 prometheus pod is created and running",
+		Assess("prometheus pods are available",
 			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
-				require.Eventually(t, func() bool {
-					pods := k8s.ListPods(t, ctxopts.KubectlOptions(ctx), v1.ListOptions{
-						LabelSelector: "app=prometheus",
-						FieldSelector: "status.phase=Running",
-					})
-					return len(pods) == 1
-				}, waitDuration, tickDuration)
+				filters := v1.ListOptions{
+					LabelSelector: "app=prometheus",
+				}
+				k8sinternal.WaitUntilPodsAvailable(t, ctxopts.KubectlOptions(ctx), filters, 1, waitDuration, tickDuration)
 				return ctx
 			}).
 		Assess("fluent-bit daemonset is running",

--- a/tests/integration/helm_otc_metadata_installation_test.go
+++ b/tests/integration/helm_otc_metadata_installation_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal"
 	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/ctxopts"
+	k8sinternal "github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/k8s"
 	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/stepfuncs"
 )
 
@@ -52,31 +53,15 @@ func Test_Helm_OT_Metadata(t *testing.T) {
 				require.Len(t, secret.Data, 10)
 				return ctx
 			}).
-		Assess("3 otelcol logs pods are created, running and ready",
+		Assess("otelcol logs pods are available",
 			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
-				require.Eventually(t, func() bool {
-					pods := k8s.ListPods(t, ctxopts.KubectlOptions(ctx), v1.ListOptions{
-						LabelSelector: fmt.Sprintf("app=%s-sumologic-otelcol-logs", releaseName),
-						FieldSelector: "status.phase=Running",
-					})
-
-					if len(pods) != 3 {
-						return false
-					}
-
-					for _, pod := range pods {
-						for _, container := range pod.Status.ContainerStatuses {
-							if !container.Ready {
-								return false
-							}
-						}
-					}
-
-					return true
-				}, waitDuration, tickDuration)
+				filters := v1.ListOptions{
+					LabelSelector: fmt.Sprintf("app=%s-sumologic-otelcol-logs", releaseName),
+				}
+				k8sinternal.WaitUntilPodsAvailable(t, ctxopts.KubectlOptions(ctx), filters, 3, waitDuration, tickDuration)
 				return ctx
 			}).
-		Assess("3 otelcol logs buffers PVCs are created",
+		Assess("otelcol logs buffers PVCs are created",
 			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
 				assert.Eventually(t, func() bool {
 					var pvcs corev1.PersistentVolumeClaimList
@@ -90,31 +75,15 @@ func Test_Helm_OT_Metadata(t *testing.T) {
 				}, waitDuration, tickDuration)
 				return ctx
 			}).
-		Assess("3 otelcol metrics pods are created, running and ready",
+		Assess("otelcol metrics pods are available",
 			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
-				require.Eventually(t, func() bool {
-					pods := k8s.ListPods(t, ctxopts.KubectlOptions(ctx), v1.ListOptions{
-						LabelSelector: fmt.Sprintf("app=%s-sumologic-otelcol-metrics", releaseName),
-						FieldSelector: "status.phase=Running",
-					})
-
-					if len(pods) != 3 {
-						return false
-					}
-
-					for _, pod := range pods {
-						for _, container := range pod.Status.ContainerStatuses {
-							if !container.Ready {
-								return false
-							}
-						}
-					}
-
-					return true
-				}, waitDuration, tickDuration)
+				filters := v1.ListOptions{
+					LabelSelector: fmt.Sprintf("app=%s-sumologic-otelcol-metrics", releaseName),
+				}
+				k8sinternal.WaitUntilPodsAvailable(t, ctxopts.KubectlOptions(ctx), filters, 3, waitDuration, tickDuration)
 				return ctx
 			}).
-		Assess("3 otelcol metrics buffers PVCs are created",
+		Assess("otelcol metrics buffers PVCs are created",
 			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
 				assert.Eventually(t, func() bool {
 					var pvcs corev1.PersistentVolumeClaimList
@@ -127,18 +96,15 @@ func Test_Helm_OT_Metadata(t *testing.T) {
 				}, waitDuration, tickDuration)
 				return ctx
 			}).
-		Assess("1 fluentd events pod is created and running",
+		Assess("fluentd events pod is available",
 			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
-				require.Eventually(t, func() bool {
-					pods := k8s.ListPods(t, ctxopts.KubectlOptions(ctx), v1.ListOptions{
-						LabelSelector: fmt.Sprintf("app=%s-sumologic-fluentd-events", releaseName),
-						FieldSelector: "status.phase=Running",
-					})
-					return len(pods) == 1
-				}, waitDuration, tickDuration)
+				filters := v1.ListOptions{
+					LabelSelector: fmt.Sprintf("app=%s-sumologic-fluentd-events", releaseName),
+				}
+				k8sinternal.WaitUntilPodsAvailable(t, ctxopts.KubectlOptions(ctx), filters, 1, waitDuration, tickDuration)
 				return ctx
 			}).
-		Assess("1 fluentd events buffers PVCs are created",
+		Assess("fluentd events buffers PVCs are created",
 			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
 				assert.Eventually(t, func() bool {
 					var pvcs corev1.PersistentVolumeClaimList
@@ -151,15 +117,12 @@ func Test_Helm_OT_Metadata(t *testing.T) {
 				}, waitDuration, tickDuration)
 				return ctx
 			}).
-		Assess("1 prometheus pod is created and running",
+		Assess("prometheus pod is available",
 			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
-				require.Eventually(t, func() bool {
-					pods := k8s.ListPods(t, ctxopts.KubectlOptions(ctx), v1.ListOptions{
-						LabelSelector: "app=prometheus",
-						FieldSelector: "status.phase=Running",
-					})
-					return len(pods) == 1
-				}, waitDuration, tickDuration)
+				filters := v1.ListOptions{
+					LabelSelector: "app=prometheus",
+				}
+				k8sinternal.WaitUntilPodsAvailable(t, ctxopts.KubectlOptions(ctx), filters, 1, waitDuration, tickDuration)
 				return ctx
 			}).
 		Assess("fluent-bit daemonset is running",

--- a/tests/integration/helm_otc_metadata_installation_test.go
+++ b/tests/integration/helm_otc_metadata_installation_test.go
@@ -30,7 +30,7 @@ func Test_Helm_OT_Metadata(t *testing.T) {
 		valuesFilePath = "values/values_otc_metadata.yaml"
 
 		tickDuration = time.Second
-		waitDuration = time.Minute
+		waitDuration = time.Minute * 2
 	)
 
 	feat := features.New("installation").

--- a/tests/integration/internal/k8s/pods.go
+++ b/tests/integration/internal/k8s/pods.go
@@ -1,0 +1,67 @@
+package k8s
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/retry"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Same as WaitUntilPodsAvailableE, but terminates the test instead of returning an error.
+func WaitUntilPodsAvailable(
+	t *testing.T,
+	options *k8s.KubectlOptions,
+	filters v1.ListOptions,
+	minPods int,
+	sleepDuration time.Duration,
+	sleepBetweenRetries time.Duration,
+) {
+	require.NoError(t, WaitUntilPodsAvailableE(t, options, filters, minPods, sleepDuration, sleepBetweenRetries))
+}
+
+// WaitUntilPodsAvailableE waits until pods satisfying the provided filters are all available.
+// Availability is defined via terrastruct's k8s.IsPodAvailable function, which requires the Pod
+// to be Running and all of its containers to be started and ready.
+// Technically this condition is satisfied if no Pods exists, the minPods argument helps with this edge case.
+func WaitUntilPodsAvailableE(
+	t *testing.T,
+	options *k8s.KubectlOptions,
+	filters v1.ListOptions,
+	minPods int,
+	sleepDuration time.Duration,
+	sleepBetweenRetries time.Duration,
+) error {
+	statusMsg := fmt.Sprintf("Wait for pods with filters %v to be available.", filters)
+	retries := int(sleepDuration / sleepBetweenRetries)
+	message, err := retry.DoWithRetryE(
+		t,
+		statusMsg,
+		retries,
+		sleepBetweenRetries,
+		func() (string, error) {
+			pods, err := k8s.ListPodsE(t, options, filters)
+			if err != nil {
+				return "", err
+			}
+			if len(pods) < minPods {
+				return "", fmt.Errorf("found %d pods with filters %v, need at least %d", len(pods), filters, minPods)
+			}
+			for _, pod := range pods {
+				if !k8s.IsPodAvailable(&pod) {
+					return "", k8s.NewPodNotAvailableError(&pod)
+				}
+			}
+			return fmt.Sprintf("Pods with filters %v are now available.", filters), nil
+		},
+	)
+	if err != nil {
+		t.Logf("Timed out waiting for pods with filters %v to be available: %s", filters, err)
+		return err
+	}
+	t.Logf(message)
+	return nil
+}

--- a/tests/integration/values/values_default.yaml
+++ b/tests/integration/values/values_default.yaml
@@ -18,9 +18,6 @@ kube-prometheus-stack:
   prometheus:
     prometheusSpec:
       resources:
-        limits:
-          cpu: 100m
-          memory: 64Mi
         requests:
           cpu: 100m
           memory: 64Mi
@@ -30,27 +27,18 @@ fluentd:
   logs:
     statefulset:
       resources:
-        limits:
-          memory: 64Mi
-          cpu: 100m
         requests:
           memory: 64Mi
           cpu: 100m
   metrics:
     statefulset:
       resources:
-        limits:
-          memory: 64Mi
-          cpu: 100m
         requests:
           memory: 64Mi
           cpu: 100m
   events:
     statefulset:
       resources:
-        limits:
-          memory: 64Mi
-          cpu: 100m
         requests:
           memory: 64Mi
           cpu: 100m

--- a/tests/integration/values/values_otc_metadata.yaml
+++ b/tests/integration/values/values_otc_metadata.yaml
@@ -26,9 +26,6 @@ kube-prometheus-stack:
   prometheus:
     prometheusSpec:
       resources:
-        limits:
-          cpu: 100m
-          memory: 128Mi
         requests:
           cpu: 100m
           memory: 128Mi
@@ -41,18 +38,12 @@ metadata:
   logs:
     statefulset:
       resources:
-        limits:
-          cpu: 100m
-          memory: 128Mi
         requests:
           cpu: 100m
           memory: 128Mi
   metrics:
     statefulset:
       resources:
-        limits:
-          cpu: 100m
-          memory: 128Mi
         requests:
           cpu: 100m
           memory: 128Mi


### PR DESCRIPTION
##### Description

Use utilities from terratest to check pod availability instead of rolling our own. Our tests would actually pass despite some containers getting OOM killed.

The reason our containers were getting OOM killed were rather strict resource limits set for them in values.yaml we use for tests. Remove those limits, they don't serve any real purpose right now.
