### PR TITLE
Add an integration test for presence of expected metrics

### DIFF
--- a/tests/integration/helm_default_installation_test.go
+++ b/tests/integration/helm_default_installation_test.go
@@ -28,8 +28,9 @@ func Test_Helm_Default(t *testing.T) {
 		releaseName    = generateReleaseName(now)
 		valuesFilePath = "values/values_default.yaml"
 
-		tickDuration = time.Second
-		waitDuration = time.Minute * 2
+		tickDuration    = time.Second
+		waitDuration    = time.Minute * 2
+		expectedMetrics = internal.DefaultExpectedMetrics
 	)
 
 	feat := features.New("installation").
@@ -144,7 +145,17 @@ func Test_Helm_Default(t *testing.T) {
 
 				require.EqualValues(t, 0, daemonsets[0].Status.NumberUnavailable)
 				return ctx
-			}).
+						}).
+		Assess("metrics are present", // TODO: extract this out to a separate feature
+			stepfuncs.WaitUntilExpectedMetricsPresent(
+				expectedMetrics,
+				"receiver-mock",
+				"receiver-mock",
+				internal.ReceiverMockServicePort,
+				waitDuration,
+				tickDuration,
+			),
+		).
 		Feature()
 
 	testenv.Test(t, feat)

--- a/tests/integration/helm_otc_metadata_installation_test.go
+++ b/tests/integration/helm_otc_metadata_installation_test.go
@@ -28,8 +28,9 @@ func Test_Helm_OT_Metadata(t *testing.T) {
 		releaseName    = generateReleaseName(now)
 		valuesFilePath = "values/values_otc_metadata.yaml"
 
-		tickDuration = time.Second
-		waitDuration = time.Minute * 2
+		tickDuration    = time.Second
+		waitDuration    = time.Minute * 2
+		expectedMetrics = internal.DefaultExpectedMetrics
 	)
 
 	feat := features.New("installation").
@@ -145,7 +146,17 @@ func Test_Helm_OT_Metadata(t *testing.T) {
 
 				require.EqualValues(t, 0, daemonsets[0].Status.NumberUnavailable)
 				return ctx
-			}).
+		}).
+		Assess("metrics are present", // TODO: extract this out to a separate feature
+			stepfuncs.WaitUntilExpectedMetricsPresent(
+				expectedMetrics,
+				"receiver-mock",
+				"receiver-mock",
+				internal.ReceiverMockServicePort,
+				waitDuration,
+				tickDuration,
+			),
+		).
 		Feature()
 
 	testenv.Test(t, feat)

--- a/tests/integration/internal/constants.go
+++ b/tests/integration/internal/constants.go
@@ -13,12 +13,82 @@ const (
 
 	EnvNameKindImage = "KIND_NODE_IMAGE"
 
-	YamlPathReceiverMock = "yamls/receiver-mock.yaml"
+	YamlPathReceiverMock    = "yamls/receiver-mock.yaml"
+	ReceiverMockServicePort = 3000
+)
+
+// metrics we expect the receiver to get
+// metrics which are expected in current E2E tests but aren't present here, are commented out
+// TODO: figure out why the expected metrics aren't present
+var (
+	KubeStateMetrics = []string{
+		"kube_statefulset_status_observed_generation",
+		"kube_statefulset_status_replicas",
+		"kube_statefulset_replicas",
+		"kube_statefulset_metadata_generation",
+	}
+	KubeDaemonSetMetrics = []string{
+		"kube_daemonset_status_current_number_scheduled",
+		"kube_daemonset_status_desired_number_scheduled",
+		"kube_daemonset_status_number_misscheduled",
+		"kube_daemonset_status_number_unavailable",
+	}
+	KubeDeploymentMetrics = []string{
+		"kube_deployment_status_replicas_available",
+		"kube_deployment_status_replicas_unavailable",
+		"kube_deployment_spec_replicas",
+	}
+	KubeNodeMetrics = []string{
+		"kube_node_info",
+		"kube_node_status_allocatable",
+		"kube_node_status_capacity",
+		"kube_node_status_condition",
+	}
+	KubePodMetrics = []string{
+		"kube_pod_container_info",
+		"kube_pod_container_resource_requests",
+		"kube_pod_container_resource_limits",
+		"kube_pod_container_status_ready",
+		"kube_pod_container_status_terminated_reason",
+		"kube_pod_container_status_restarts_total",
+		"kube_pod_status_phase",
+	}
+	KubeletMetrics = []string{
+		"kubelet_running_containers",
+		"kubelet_running_pods",
+	}
+	CAdvisorMetrics = []string{
+		"container_cpu_usage_seconds_total",
+		// These metrics will be avaiable in containerd after kind upgrades past
+		// https://github.com/containerd/containerd/issues/5882
+		// "container_fs_usage_bytes",
+		// "container_fs_limit_bytes",
+		"container_network_receive_bytes_total",
+		"container_memory_working_set_bytes",
+		"container_network_transmit_bytes_total",
+	}
+	NodeExporterMetrics = []string{
+		"node_load1",
+		"node_load5",
+		"node_load15",
+		"node_cpu_seconds_total",
+	}
 )
 
 var (
-	HelmSumoLogicChartAbsPath string
-	KindImages                KindImagesSpec
+	HelmSumoLogicChartAbsPath    string
+	KindImages                   KindImagesSpec
+	DefaultExpectedMetricsGroups = [][]string{
+		KubeStateMetrics,
+		KubeDaemonSetMetrics,
+		KubeDeploymentMetrics,
+		KubeNodeMetrics,
+		KubePodMetrics,
+		KubeletMetrics,
+		CAdvisorMetrics,
+		NodeExporterMetrics,
+	}
+	DefaultExpectedMetrics []string
 )
 
 type KindImagesSpec struct {
@@ -39,6 +109,11 @@ func InitializeConstants() error {
 	}
 	if err = json.Unmarshal(b, &KindImages); err != nil {
 		return err
+	}
+
+	DefaultExpectedMetrics = []string{}
+	for _, metrics := range DefaultExpectedMetricsGroups {
+		DefaultExpectedMetrics = append(DefaultExpectedMetrics, metrics...)
 	}
 
 	log.Printf("Successfully read kind images spec")

--- a/tests/integration/internal/receivermock/receiver_mock.go
+++ b/tests/integration/internal/receivermock/receiver_mock.go
@@ -1,0 +1,70 @@
+package receivermock
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+
+	http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
+)
+
+// A HTTP client for the receiver-mock API
+type ReceiverMockClient struct {
+	baseUrl   url.URL
+	tlsConfig tls.Config
+	t         *testing.T
+}
+
+func NewReceiverMockClient(t *testing.T, baseUrl url.URL) *ReceiverMockClient {
+	return &ReceiverMockClient{baseUrl: baseUrl, t: t, tlsConfig: tls.Config{}}
+}
+
+func (client *ReceiverMockClient) GetMetricCounts() (map[string]int, error) {
+	path, err := url.Parse("metrics-list")
+	if err != nil {
+		client.t.Fatal(err)
+	}
+	url := client.baseUrl.ResolveReference(path)
+
+	statusCode, body := http_helper.HttpGet(
+		client.t,
+		url.String(),
+		&client.tlsConfig,
+	)
+	if statusCode != 200 {
+		return nil, fmt.Errorf("received status code %d in response to receiver request", statusCode)
+	}
+	metricCounts, err := parseMetricList(body)
+	if err != nil {
+		client.t.Fatal(err)
+	}
+	return metricCounts, nil
+}
+
+// parse metrics list returned by /metrics-list
+// https://github.com/SumoLogic/sumologic-kubernetes-tools/tree/main/src/rust/receiver-mock#statistics
+func parseMetricList(rawMetricsValues string) (map[string]int, error) {
+	metricNameToCount := make(map[string]int)
+	lines := strings.Split(rawMetricsValues, "\n")
+	for _, line := range lines {
+		if len(line) == 0 {
+			continue
+		}
+		// the last colon of the line is the split point
+		splitIndex := strings.LastIndex(line, ":")
+		if splitIndex == -1 || splitIndex == 0 {
+			return nil, fmt.Errorf("failed to parse metrics list line: '%s'", line)
+		}
+		metricName := line[:splitIndex]
+		metricCountString := strings.TrimSpace(line[splitIndex+1:])
+		metricCount, err := strconv.Atoi(metricCountString)
+		if err != nil {
+			return nil, err
+		}
+		metricNameToCount[metricName] = metricCount
+	}
+	return metricNameToCount, nil
+}

--- a/tests/integration/internal/stepfuncs/assess_funcs.go
+++ b/tests/integration/internal/stepfuncs/assess_funcs.go
@@ -2,15 +2,19 @@ package stepfuncs
 
 import (
 	"context"
+	"net/url"
 	"testing"
 	"time"
 
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
 	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/ctxopts"
-	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/k8s"
+	k8s_internal "github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/k8s"
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/receivermock"
 )
 
 // WaitUntilPodsAvailable returns a features.Func that can be used in `Assess` calls.
@@ -18,9 +22,58 @@ import (
 // `wait` and `tick` times as well as the provided list options and the desired count.
 func WaitUntilPodsAvailable(listOptions v1.ListOptions, count int, wait time.Duration, tick time.Duration) features.Func {
 	return func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
-		k8s.WaitUntilPodsAvailable(t, ctxopts.KubectlOptions(ctx),
+		k8s_internal.WaitUntilPodsAvailable(t, ctxopts.KubectlOptions(ctx),
 			listOptions, count, wait, tick,
 		)
+		return ctx
+	}
+}
+
+// WaitUntilExpectedMetricsPresent returns a features.Func that can be used in `Assess` calls.
+// It will wait until all the provided metrics are returned by receiver-mock's HTTP API on
+// the provided Service and port, until it succeeds or waitDuration passes.
+func WaitUntilExpectedMetricsPresent(
+	expectedMetrics []string,
+	receiverMockNamespace string,
+	receiverMockServiceName string,
+	receiverMockServicePort int,
+	waitDuration time.Duration,
+	tickDuration time.Duration,
+) features.Func {
+	return func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
+		kubectlOpts := *ctxopts.KubectlOptions(ctx)
+		kubectlOpts.Namespace = receiverMockNamespace
+		k8s.WaitUntilServiceAvailable(t, &kubectlOpts, receiverMockServiceName, int(waitDuration), tickDuration)
+		tunnel := k8s.NewTunnel(
+			&kubectlOpts,
+			k8s.ResourceTypeService,
+			receiverMockServiceName,
+			0,
+			receiverMockServicePort,
+		)
+		defer tunnel.Close()
+		tunnel.ForwardPort(t)
+		baseUrl := url.URL{
+			Scheme: "http",
+			Host:   tunnel.Endpoint(),
+			Path:   "/",
+		}
+		client := receivermock.NewReceiverMockClient(t, baseUrl)
+		require.Eventually(t, func() bool {
+			metricCounts, err := client.GetMetricCounts(t)
+			if err != nil {
+				t.Log(err)
+				return false
+			}
+			for _, expectedMetricName := range expectedMetrics {
+				_, ok := metricCounts[expectedMetricName]
+				if !ok {
+					t.Logf("Couldn't find metric %q in %v", expectedMetricName, metricCounts)
+					return false
+				}
+			}
+			return true
+		}, waitDuration, tickDuration)
 		return ctx
 	}
 }


### PR DESCRIPTION
##### Description

Add tests for the presence of metrics we expect to send to the receiver. Uses receiver-mock's `/metrics-list` endpoint. 

Adding it to the existing Features for now, as I don't want to duplicate setup in a new Feature, and it's not yet clear how we want to deal with this structurally.

