### PR TITLE
[Backport release-v2.2] docs: fix the Fluent Bit version in the versions matrix

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -96,7 +96,7 @@ The following matrix displays the tested package versions for our Helm chart.
 
 | Sumo Logic Helm Chart | kube-prometheus-stack/Prometheus Operator | FluentD | Fluent Bit                          | Falco  | Metrics Server | Telegraf Operator | Tailing Sidecar Operator |
 |:----------------------|:------------------------------------------|:--------|:------------------------------------|:-------|:---------------|:------------------|:-------------------------|
-| 2.2.0 - Latest        | 12.10.0                                   | 1.12.2  | 0.19.1                              | 1.7.10 | 5.8.4          | 1.2.0             | 0.3.1                    |
+| 2.2.0 - Latest        | 12.10.0                                   | 1.12.2  | 0.12.1                              | 1.7.10 | 5.8.4          | 1.2.0             | 0.3.1                    |
 | 2.1.6                 | 12.3.0                                    | 1.12.2  | 0.12.1                              | 1.7.10 | 5.8.4          | 1.2.0             | 0.3.0                    |
 | 2.1.1 - 2.1.5         | 12.3.0                                    | 1.12.2  | 0.12.1 (downgraded)                 | 1.7.10 | 5.8.4          | 1.1.5             | 0.3.0                    |
 | 2.1.0                 | 12.3.0                                    | 1.12.1  | 0.15.1                              | 1.7.10 | 5.8.1          | 1.1.5             | 0.3.0                    |


### PR DESCRIPTION
Backport 6b8a0eabd86dccbfb0c3a531c8499389ecbb8747 from #1964