### PR TITLE
test(metrics): add metrics labels test

### DIFF
--- a/tests/integration/Makefile
+++ b/tests/integration/Makefile
@@ -20,7 +20,7 @@ delete-cluster:
 .PHONY: test
 test:
 	KIND_NODE_IMAGE=$(KIND_NODE_IMAGE) \
-		go test -timeout 20m -v -count 1 -run=$(TEST_NAME) .
+		go test -timeout 20m -v -count 1 -run=$(TEST_NAME) . -args $(TEST_ARGS)
 
 .PHONY: gomod-tidy
 gomod-tidy:

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -99,7 +99,7 @@ The test framework has the following runtime options that can be utilized:
   HELM_NO_DEPENDENCY_UPDATE=1 make test
   ```
 
-## Running specified tests
+## Filtering tests
 
 [Testing framework][sig_e2e_testing_harness] that's used in the tests allows filtering
 tests by feature names, labels and step names.
@@ -108,7 +108,9 @@ This might be handy if you'd like to use those abstractions but its consequence 
 it will run all the code related to setup and/or teardown so e.g. all kind clusters
 that were supposed to be created for tests that got filtered out would be created anyway.
 
-Because of that reason we suggest to use `go` related test filtering like so:
+### Running specific tests
+
+In order to run specific tests you can use `go` related test filtering like so:
 
 ```shell
 make test TEST_NAME="Test_Helm_Default"
@@ -120,7 +122,23 @@ or
 go test -v -count 1 -run=Test_Helm_Default .
 ```
 
+### Running specific features/assessments
+
+In order to run specific features you can use `TEST_ARGS` makefile argument in
+which you can specify [e2e framework's flags][sig_e2e_testing_harness_filtering_tests]:
+
+```shell
+make test TEST_NAME="Test_Helm_Default_OT_Metadata" TEST_ARGS="--assess '(metrics)'"
+```
+
+or
+
+```shell
+make test TEST_NAME="Test_Helm_Default_OT_Metadata" TEST_ARGS="--feature '(installation)'"
+```
+
 [sig_e2e_testing_harness]: https://github.com/kubernetes-sigs/e2e-framework/blob/main/docs/design/test-harness-framework.md
+[sig_e2e_testing_harness_filtering_tests]: https://github.com/kubernetes-sigs/e2e-framework/blob/fee1391aeccdc260069bd5e0b25c6b187c2293c4/docs/design/test-harness-framework.md#filtering-feature-tests
 
 ## K8s node images matrix
 

--- a/tests/integration/go.mod
+++ b/tests/integration/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	k8s.io/api v0.22.4
 	k8s.io/apimachinery v0.22.4
+	k8s.io/klog/v2 v2.9.0
 	sigs.k8s.io/e2e-framework v0.0.5
 )
 
@@ -58,7 +59,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/client-go v0.22.4 // indirect
-	k8s.io/klog/v2 v2.9.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20211109043538-20434351676c // indirect
 	k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a // indirect
 	sigs.k8s.io/controller-runtime v0.9.0 // indirect

--- a/tests/integration/helm_default_installation_test.go
+++ b/tests/integration/helm_default_installation_test.go
@@ -3,11 +3,17 @@ package integration
 import (
 	"context"
 	"fmt"
+	"sort"
 	"testing"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	log "k8s.io/klog/v2"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
@@ -17,14 +23,15 @@ import (
 
 	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal"
 	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/ctxopts"
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/receivermock"
 	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/stepfuncs"
 	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/strings"
 )
 
 func Test_Helm_Default_FluentD_Metadata(t *testing.T) {
 	const (
-		tickDuration = time.Second
-		waitDuration = time.Minute * 2
+		tickDuration = 3 * time.Second
+		waitDuration = 3 * time.Minute
 	)
 	var (
 		expectedMetrics = internal.DefaultExpectedMetrics
@@ -36,7 +43,7 @@ func Test_Helm_Default_FluentD_Metadata(t *testing.T) {
 	// detail.
 	releaseName := strings.ReleaseNameFromT(t)
 
-	feat := features.New("installation").
+	featInstall := features.New("installation").
 		Assess("sumologic secret is created",
 			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
 				k8s.WaitUntilSecretAvailable(t, ctxopts.KubectlOptions(ctx), "sumologic", 60, tickDuration)
@@ -166,8 +173,11 @@ func Test_Helm_Default_FluentD_Metadata(t *testing.T) {
 
 				require.EqualValues(t, 0, daemonsets[0].Status.NumberUnavailable)
 				return ctx
-						}).
-		Assess("metrics are present", // TODO: extract this out to a separate feature
+			}).
+		Feature()
+
+	featMetrics := features.New("metrics").
+		Assess("expected metrics are present",
 			stepfuncs.WaitUntilExpectedMetricsPresent(
 				expectedMetrics,
 				"receiver-mock",
@@ -177,7 +187,86 @@ func Test_Helm_Default_FluentD_Metadata(t *testing.T) {
 				tickDuration,
 			),
 		).
+		Assess("expected labels are present",
+			// TODO: refactor into a step func?
+			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
+				// Get the receiver mock pod as metrics source
+				res := envConf.Client().Resources(internal.ReceiverMockNamespace)
+				podList := corev1.PodList{}
+				require.NoError(t,
+					wait.For(
+						conditions.New(res).
+							ResourceListN(
+								&podList,
+								1,
+								resources.WithLabelSelector("app=receiver-mock"),
+							),
+						wait.WithTimeout(waitDuration),
+						wait.WithInterval(tickDuration),
+					),
+				)
+				rClient, tunnelCloseFunc := receivermock.NewClientWithK8sTunnel(ctx, t)
+				defer tunnelCloseFunc()
+
+				assert.Eventually(t, func() bool {
+					filters := receivermock.MetadataFilters{
+						"__name__": "container_memory_working_set_bytes",
+						"pod":      podList.Items[0].Name,
+					}
+					metricsSamples, err := rClient.GetMetricsSamples(filters)
+					if err != nil {
+						log.ErrorS(err, "failed getting samples from receiver-mock")
+						return false
+					}
+
+					if len(metricsSamples) == 0 {
+						log.InfoS("got 0 metrics samples", "filters", filters)
+						return false
+					}
+
+					sort.Sort(receivermock.MetricsSamplesByTime(metricsSamples))
+					// For now let's take the newest metric sample only because it will have the most
+					// accurate labels and the most labels attached (for instance service/deployment
+					// labels might not be attached at the very first record).
+					sample := metricsSamples[0]
+					labels := sample.Labels
+					expectedLabels := receivermock.Labels{
+						"_origin":   "kubernetes",
+						"container": "receiver-mock",
+						// TODO: figure out why is this flaky and sometimes it's not there
+						// https://github.com/SumoLogic/sumologic-kubernetes-collection/runs/4508796836?check_suite_focus=true
+						// "deployment":                   "receiver-mock",
+						"endpoint":                     "https-metrics",
+						"image":                        "",
+						"instance":                     "",
+						"job":                          "kubelet",
+						"metrics_path":                 "/metrics/cadvisor",
+						"namespace":                    "receiver-mock",
+						"node":                         "",
+						"pod_labels_app":               "receiver-mock",
+						"pod_labels_pod-template-hash": "",
+						"pod_labels_service":           "receiver-mock",
+						"pod":                          podList.Items[0].Name,
+						"prometheus_replica":           "",
+						"prometheus_service":           "",
+						"prometheus":                   "",
+						// TODO: figure out why is this flaky and sometimes it's not there
+						// https://github.com/SumoLogic/sumologic-kubernetes-collection/runs/4508796836?check_suite_focus=true
+						// "replicaset":                   "",
+						"service": "receiver-mock",
+					}
+
+					log.V(0).InfoS("sample's labels", "labels", labels)
+					if !labels.MatchAll(expectedLabels) {
+						return false
+					}
+
+					return true
+				}, waitDuration, tickDuration)
+				return ctx
+			},
+		).
 		Feature()
 
-	testenv.Test(t, feat)
+	testenv.Test(t, featInstall, featMetrics)
 }

--- a/tests/integration/internal/constants.go
+++ b/tests/integration/internal/constants.go
@@ -13,8 +13,11 @@ const (
 
 	EnvNameKindImage = "KIND_NODE_IMAGE"
 
-	YamlPathReceiverMock    = "yamls/receiver-mock.yaml"
+	YamlPathReceiverMock = "yamls/receiver-mock.yaml"
+
 	ReceiverMockServicePort = 3000
+	ReceiverMockServiceName = "receiver-mock"
+	ReceiverMockNamespace   = "receiver-mock"
 )
 
 // metrics we expect the receiver to get

--- a/tests/integration/internal/k8s/tunnel.go
+++ b/tests/integration/internal/k8s/tunnel.go
@@ -1,0 +1,30 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	terrak8s "github.com/gruntwork-io/terratest/modules/k8s"
+
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal"
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/ctxopts"
+)
+
+// TunnelForReceiverMock creates a tunnel with port forward to receiver-mock service.
+func TunnelForReceiverMock(
+	ctx context.Context,
+	t *testing.T,
+) *terrak8s.Tunnel {
+	kubectlOptions := *ctxopts.KubectlOptions(ctx)
+	kubectlOptions.Namespace = internal.ReceiverMockNamespace
+
+	tunnel := terrak8s.NewTunnel(
+		&kubectlOptions,
+		terrak8s.ResourceTypeService,
+		internal.ReceiverMockServiceName,
+		0,
+		internal.ReceiverMockServicePort,
+	)
+	tunnel.ForwardPort(t)
+	return tunnel
+}

--- a/tests/integration/internal/receivermock/labels.go
+++ b/tests/integration/internal/receivermock/labels.go
@@ -1,0 +1,51 @@
+package receivermock
+
+import (
+	"regexp"
+
+	log "k8s.io/klog/v2"
+)
+
+// Labels represent a key value mapping of labels names and their values.
+// An empty label value indicates that we're interested in a label being present
+// but we don't care about it's value.
+type Labels map[string]string
+
+func (labels Labels) Match(label, value string) bool {
+	v, ok := labels[label]
+	if !ok {
+		log.Infof("Label: %q not present in labels", label)
+		return false
+	}
+
+	if value != "" && value != v {
+		log.Infof("Requested label %q exists in label set but has a different value %q", label, v)
+		return false
+	}
+	return true
+}
+
+func (labels Labels) MatchRegex(label string, re *regexp.Regexp) bool {
+	v, ok := labels[label]
+	if !ok {
+		log.Infof("Label: %q not present in labels", label)
+		return false
+	}
+	if !re.MatchString(v) {
+		log.Infof("Label %q (value %v) doesn't match the designated regex %q", label, v, re.String())
+		return false
+	}
+	return true
+}
+
+// MatchAll matches returns whether all the requested labels are present (if set as empty string - "")
+// and (if a corresponding value has been provided) that all values match.
+func (labels Labels) MatchAll(requested Labels) bool {
+	ret := true
+	for label, value := range requested {
+		if !labels.Match(label, value) {
+			ret = false
+		}
+	}
+	return ret
+}

--- a/tests/integration/internal/stepfuncs/assess_funcs.go
+++ b/tests/integration/internal/stepfuncs/assess_funcs.go
@@ -3,13 +3,12 @@ package stepfuncs
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"testing"
 	"time"
 
-	"github.com/gruntwork-io/terratest/modules/k8s"
+	terrak8s "github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/retry"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
@@ -21,7 +20,7 @@ import (
 // WaitUntilPodsAvailable returns a features.Func that can be used in `Assess` calls.
 // It will wait until the selected pods are available, using the provided total
 // `wait` and `tick` times as well as the provided list options and the desired count.
-func WaitUntilPodsAvailable(listOptions v1.ListOptions, count int, wait time.Duration, tick time.Duration) features.Func {
+func WaitUntilPodsAvailable(listOptions metav1.ListOptions, count int, wait time.Duration, tick time.Duration) features.Func {
 	return func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
 		k8s_internal.WaitUntilPodsAvailable(t, ctxopts.KubectlOptions(ctx),
 			listOptions, count, wait, tick,
@@ -44,22 +43,11 @@ func WaitUntilExpectedMetricsPresent(
 	return func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
 		kubectlOpts := *ctxopts.KubectlOptions(ctx)
 		kubectlOpts.Namespace = receiverMockNamespace
-		k8s.WaitUntilServiceAvailable(t, &kubectlOpts, receiverMockServiceName, int(waitDuration), tickDuration)
-		tunnel := k8s.NewTunnel(
-			&kubectlOpts,
-			k8s.ResourceTypeService,
-			receiverMockServiceName,
-			0,
-			receiverMockServicePort,
-		)
-		defer tunnel.Close()
-		tunnel.ForwardPort(t)
-		baseUrl := url.URL{
-			Scheme: "http",
-			Host:   tunnel.Endpoint(),
-			Path:   "/",
-		}
-		client := receivermock.NewReceiverMockClient(t, baseUrl)
+		terrak8s.WaitUntilServiceAvailable(t, &kubectlOpts, receiverMockServiceName, int(waitDuration), tickDuration)
+
+		client, closeTunnelFunc := receivermock.NewClientWithK8sTunnel(ctx, t)
+		defer closeTunnelFunc()
+
 		retries := int(waitDuration / tickDuration)
 		message, err := retry.DoWithRetryE(
 			t,

--- a/tests/integration/internal/stepfuncs/kubectl.go
+++ b/tests/integration/internal/stepfuncs/kubectl.go
@@ -45,7 +45,7 @@ func KubectlCreateNamespaceOpt(namespace string) features.Func {
 // a namespace name for test.
 func KubectlCreateNamespaceTestOpt() features.Func {
 	return func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
-		name := strings.NameFromT(t)
+		name := strings.NamespaceFromT(t)
 		return KubectlCreateNamespaceOpt(name)(ctx, t, envConf)
 	}
 }

--- a/tests/integration/internal/strings/strings.go
+++ b/tests/integration/internal/strings/strings.go
@@ -5,10 +5,15 @@ import (
 	"hash/fnv"
 	"strings"
 	"testing"
+	"time"
 )
 
 func NameFromT(t *testing.T) string {
 	return strings.ReplaceAll(strings.ToLower(t.Name()), "_", "-")
+}
+
+func NamespaceFromT(t *testing.T) string {
+	return fmt.Sprintf("%s-%d", NameFromT(t), time.Now().UnixMilli()%1000)
 }
 
 func ValueFileFromT(t *testing.T) string {

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -33,19 +33,20 @@ var (
 func TestMain(m *testing.M) {
 	internal.InitializeConstants()
 
+	cfg, err := envconf.NewFromFlags()
+	if err != nil {
+		log.Fatalf("envconf.NewFromFlags() failed: %s", err)
+	}
+
 	if useKubeConfig := os.Getenv(envNameUseKubeConfig); len(useKubeConfig) > 0 {
 		kubeconfig := os.Getenv(envNameKubeConfig)
 
-		testenv = env.
-			NewWithKubeConfig(kubeconfig).
+		cfg.WithKubeconfigFile(kubeconfig)
+		testenv = env.NewWithConfig(cfg).
 			BeforeEachTest(InjectKubectlOptionsFromKubeconfig(kubeconfig))
 
 		ConfigureTestEnv(testenv)
 	} else {
-		cfg, err := envconf.NewFromFlags()
-		if err != nil {
-			log.Fatalf("envconf.NewFromFlags() failed: %s", err)
-		}
 		testenv = env.NewWithConfig(cfg)
 
 		testenv.BeforeEachTest(CreateKindCluster())

--- a/tests/integration/yamls/receiver-mock.yaml
+++ b/tests/integration/yamls/receiver-mock.yaml
@@ -26,7 +26,7 @@ spec:
         - ports:
             - containerPort: 3000
             - containerPort: 3001
-          image: sumologic/kubernetes-tools:2.6.0
+          image: sumologic/kubernetes-tools:2.7.0
           name: receiver-mock
           args:
             - receiver-mock
@@ -34,6 +34,7 @@ spec:
             - --print-headers
             - --print-logs
             - --print-metrics
+            - --store-metrics
           resources: {}
           securityContext:
             capabilities:


### PR DESCRIPTION
* add tests making asserts on actual metrics labels (using https://github.com/SumoLogic/sumologic-kubernetes-tools/releases/tag/v2.7.0)
* change `strings.NamespaceFromT(t)` to include a partial timestamp so that users can run tests one after another without needing to wait for namespace to terminate
* add README change about `TEST_ARGS` in integration tests
* extract metrics to a separate feature
* introduce `receivermock.NewClientWithK8sTunnel()`
* introduce `k8s.TunnelForReceiverMock()`