### PR TITLE
fix(makefile): work around helm lint strict check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,14 @@ helm-dependency-update:
 	helm dependency update deploy/helm/sumologic
 
 helm-lint:
-	helm lint --strict \
+# TODO: we should add back the --strict flag but because we have made the PodDisruptionBudget
+# API version dependent on cluster capabilities and because helm lint does not accept
+# an --api-versions flag like helm template does we cannot make this configurable.
+#
+# Perhaps we could at some point run this against a cluster with particular k8s version?
+#
+# https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1943
+	helm lint \
 		--set sumologic.accessId=X \
 		--set sumologic.accessKey=X \
 		deploy/helm/sumologic/


### PR DESCRIPTION
Recent versions of helm (`3.7.2` for me) report the following deprecations:

```shell
$ make helm-lint
helm lint --strict \
                --set sumologic.accessId=X \
                --set sumologic.accessKey=X \
                deploy/helm/sumologic/
==> Linting deploy/helm/sumologic/
[WARNING] templates/logs/fluentd/pdb.yaml: policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
[WARNING] templates/metrics/fluentd/pdb.yaml: policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget

Error: 1 chart(s) linted, 1 chart(s) failed
make: *** [helm-lint] Error 1
$ echo $?
2
```

which doesn't seem to be easily solvable (e.g. by configuration) so disable the `--strict` check and rethink this later.

Example of a failed CI run: https://github.com/SumoLogic/sumologic-kubernetes-collection/runs/4505639126?check_suite_focus=true