### PR TITLE
chore: bump Thanos image to our build of v0.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - feat: add option to disable pod owners enrichment [#1959][#1959]
 
+### Changed
+
+- chore: bump Thanos image to our build of v0.23.1 [#1973][#1973]
+
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.3.0...main
 [#1959]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1959
 

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1676,8 +1676,10 @@ kube-prometheus-stack:
           cpu: 500m
           memory: 1Gi
       thanos:
-        baseImage: quay.io/thanos/thanos
-        version: v0.10.0
+        ## Use our own image until Thanos upstream adds arm64 docker images
+        ## to their registry.
+        baseImage: public.ecr.aws/sumologic/thanos
+        version: v0.23.1
         ## Defines the resource requirements for the Thanos sidecar
         ## Setting those as there are no default values in the upstream chart
         resources:


### PR DESCRIPTION
##### Description

Thanos upstream doesn't upload Docker images for arm64 to their registry yet. We're going to use our own image until that changes. The image is completely unmodified, using Thanos' own build process.

I ran integration tests on this change in an ARM EKS cluster and they passed. Considering how little Thanos does for us, I think it's safe to merge this.

---

##### Checklist

Remove items which don't apply to your PR.

- [x] Changelog updated

###### Testing performed

- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
