### PR TITLE
test(traces): add integration test for enabled traces

### DIFF
--- a/tests/integration/helm_traces_enabled_test.go
+++ b/tests/integration/helm_traces_enabled_test.go
@@ -1,0 +1,237 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	terrak8s "github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/ctxopts"
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/stepfuncs"
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/strings"
+)
+
+func Test_Helm_Traces_Enabled(t *testing.T) {
+	const (
+		tickDuration = time.Second
+		waitDuration = time.Minute * 2
+	)
+
+	// TODO:
+	// Refactor this: we should find a way to inject this into step func helpers
+	// like stepfuncs.WaitUntilPodsAvailable() instead of relying on an implementation
+	// detail.
+	releaseName := strings.ReleaseNameFromT(t)
+
+	featInstall := features.New("installation").
+		Assess("sumologic secret is created",
+			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
+				terrak8s.WaitUntilSecretAvailable(t, ctxopts.KubectlOptions(ctx), "sumologic", 60, tickDuration)
+				secret := terrak8s.GetSecret(t, ctxopts.KubectlOptions(ctx), "sumologic")
+				// Apart from 10 default entries it also has 1 for traces
+				require.Len(t, secret.Data, 11)
+				return ctx
+			}).
+		Assess("fluentd logs pods are available",
+			stepfuncs.WaitUntilPodsAvailable(
+				metav1.ListOptions{
+					LabelSelector: fmt.Sprintf("app=%s-sumologic-fluentd-logs", releaseName),
+				},
+				1,
+				waitDuration,
+				tickDuration,
+			),
+		).
+		Assess("fluentd logs buffers PVCs are created",
+			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
+				namespace := ctxopts.Namespace(ctx)
+				releaseName := ctxopts.HelmRelease(ctx)
+				kubectlOptions := ctxopts.KubectlOptions(ctx)
+
+				t.Logf("kubeconfig: %s", kubectlOptions.ConfigPath)
+				cl, err := terrak8s.GetKubernetesClientFromOptionsE(t, kubectlOptions)
+				require.NoError(t, err)
+
+				assert.Eventually(t, func() bool {
+					pvcs, err := cl.CoreV1().PersistentVolumeClaims(namespace).
+						List(ctx, metav1.ListOptions{
+							LabelSelector: fmt.Sprintf("app=%s-sumologic-fluentd-logs", releaseName),
+						})
+					if !assert.NoError(t, err) {
+						return false
+					}
+
+					return err == nil && len(pvcs.Items) == 1
+				}, waitDuration, tickDuration)
+				return ctx
+			}).
+		Assess("fluentd metrics pods are available",
+			stepfuncs.WaitUntilPodsAvailable(
+				metav1.ListOptions{
+					LabelSelector: fmt.Sprintf("app=%s-sumologic-fluentd-metrics", releaseName),
+				},
+				1,
+				waitDuration,
+				tickDuration,
+			),
+		).
+		Assess("fluentd metrics buffers PVCs are created",
+			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
+				namespace := ctxopts.Namespace(ctx)
+				releaseName := ctxopts.HelmRelease(ctx)
+				kubectlOptions := ctxopts.KubectlOptions(ctx)
+
+				t.Logf("kubeconfig: %s", kubectlOptions.ConfigPath)
+				cl, err := terrak8s.GetKubernetesClientFromOptionsE(t, kubectlOptions)
+				require.NoError(t, err)
+
+				assert.Eventually(t, func() bool {
+					pvcs, err := cl.CoreV1().PersistentVolumeClaims(namespace).
+						List(ctx, metav1.ListOptions{
+							LabelSelector: fmt.Sprintf("app=%s-sumologic-fluentd-metrics", releaseName),
+						})
+					if !assert.NoError(t, err) {
+						return false
+					}
+
+					return err == nil && len(pvcs.Items) == 1
+				}, waitDuration, tickDuration)
+				return ctx
+			}).
+		Assess("fluentd events pods are available",
+			stepfuncs.WaitUntilPodsAvailable(
+				metav1.ListOptions{
+					LabelSelector: fmt.Sprintf("app=%s-sumologic-fluentd-events", releaseName),
+				},
+				1,
+				waitDuration,
+				tickDuration,
+			),
+		).
+		Assess("fluentd events buffers PVCs are created",
+			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
+				namespace := ctxopts.Namespace(ctx)
+				releaseName := ctxopts.HelmRelease(ctx)
+				kubectlOptions := ctxopts.KubectlOptions(ctx)
+
+				t.Logf("kubeconfig: %s", kubectlOptions.ConfigPath)
+				cl, err := terrak8s.GetKubernetesClientFromOptionsE(t, kubectlOptions)
+				require.NoError(t, err)
+
+				assert.Eventually(t, func() bool {
+					pvcs, err := cl.CoreV1().PersistentVolumeClaims(namespace).
+						List(ctx, metav1.ListOptions{
+							LabelSelector: fmt.Sprintf("app=%s-sumologic-fluentd-events", releaseName),
+						})
+					if !assert.NoError(t, err) {
+						return false
+					}
+
+					return err == nil && len(pvcs.Items) == 1
+				}, waitDuration, tickDuration)
+				return ctx
+			}).
+		Assess("prometheus pods are available",
+			stepfuncs.WaitUntilPodsAvailable(
+				metav1.ListOptions{
+					LabelSelector: "app=prometheus",
+				},
+				1,
+				waitDuration,
+				tickDuration,
+			),
+		).
+		Assess("fluent-bit daemonset is running",
+			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
+				var daemonsets []appsv1.DaemonSet
+				require.Eventually(t, func() bool {
+					daemonsets = terrak8s.ListDaemonSets(t, ctxopts.KubectlOptions(ctx), metav1.ListOptions{
+						LabelSelector: "app.kubernetes.io/name=fluent-bit",
+					})
+
+					return len(daemonsets) == 1
+				}, waitDuration, tickDuration)
+
+				require.EqualValues(t, 0, daemonsets[0].Status.NumberUnavailable)
+				return ctx
+			}).
+		Feature()
+
+	featTraces := features.New("traces").
+		Assess("otelcol deployment is ready", func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
+			res := envConf.Client().Resources(ctxopts.Namespace(ctx))
+			labelSelector := fmt.Sprintf("app=%s-sumologic-otelcol", releaseName)
+			ds := appsv1.DeploymentList{}
+
+			require.NoError(t,
+				wait.For(
+					conditions.New(res).
+						ResourceListN(&ds, 1,
+							resources.WithLabelSelector(labelSelector),
+						),
+					wait.WithTimeout(waitDuration),
+					wait.WithInterval(tickDuration),
+				),
+			)
+			require.NoError(t,
+				wait.For(
+					conditions.New(res).
+						DeploymentConditionMatch(&ds.Items[0], appsv1.DeploymentAvailable, corev1.ConditionTrue),
+					wait.WithTimeout(waitDuration),
+					wait.WithInterval(tickDuration),
+				),
+			)
+			return ctx
+		}).
+		Assess("otelagent daemonset is ready", func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
+			res := envConf.Client().Resources(ctxopts.Namespace(ctx))
+			nl := corev1.NodeList{}
+			if !assert.NoError(t, res.List(ctx, &nl)) {
+				return ctx
+			}
+
+			labelSelector := fmt.Sprintf("app=%s-sumologic-otelagent", releaseName)
+			ds := appsv1.DaemonSetList{}
+
+			require.NoError(t,
+				wait.For(
+					conditions.New(res).
+						ResourceListN(&ds, 1,
+							resources.WithLabelSelector(labelSelector),
+						),
+					wait.WithTimeout(waitDuration),
+					wait.WithInterval(tickDuration),
+				),
+			)
+			require.NoError(t,
+				wait.For(
+					conditions.New(res).
+						ResourceMatch(&ds.Items[0], func(object k8s.Object) bool {
+							d := object.(*appsv1.DaemonSet)
+							return d.Status.NumberUnavailable == 0 &&
+								d.Status.NumberReady == int32(len(nl.Items))
+						}),
+					wait.WithTimeout(waitDuration),
+					wait.WithInterval(tickDuration),
+				),
+			)
+			return ctx
+		}).
+		Feature()
+
+	testenv.Test(t, featInstall, featTraces)
+}

--- a/tests/integration/values/values_helm_traces_enabled.yaml
+++ b/tests/integration/values/values_helm_traces_enabled.yaml
@@ -1,0 +1,68 @@
+sumologic:
+  setupEnabled: true
+  accessId: "dummy"
+  accessKey: "dummy"
+  endpoint: http://receiver-mock.receiver-mock:3000/terraform/api/
+
+  traces:
+    enabled: true
+
+# Prevent snowball effect by filtering out receiver mock logs
+fluent-bit:
+  config:
+    filters: |
+      [FILTER]
+          Name    grep
+          Match   containers.var.log.containers.receiver-mock*
+          Exclude log .*
+
+# Request less resources so that this fits on Github actions runners environment
+kube-prometheus-stack:
+  prometheus:
+    prometheusSpec:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+
+# Request less resources so that this fits on Github actions runners environment
+fluentd:
+  logs:
+    statefulset:
+      replicaCount: 1
+      resources:
+        requests:
+          memory: 64Mi
+          cpu: 100m
+  metrics:
+    statefulset:
+      replicaCount: 1
+      resources:
+        requests:
+          memory: 64Mi
+          cpu: 100m
+  events:
+    statefulset:
+      replicaCount: 1
+      resources:
+        requests:
+          memory: 64Mi
+          cpu: 100m
+
+# Request less resources so that this fits on Github actions runners environment
+otelcol:
+  deployment:
+    replicas: 1
+    resources:
+      requests:
+        memory: 64Mi
+        cpu: 100m
+
+# Request less resources so that this fits on Github actions runners environment
+otelagent:
+  enabled: true
+  daemonset:
+    resources:
+      requests:
+        memory: 64Mi
+        cpu: 50m


### PR DESCRIPTION
Related to recent problem fixed in: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1975

This PR adds a test with traces enabled to verify that traces work with the chart by actually installing it in a cluster.

Depends on https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1971