### PR TITLE
fix(helm): add job and cronjob to clusterrole's permission set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - chore: bump Thanos image to our build of v0.23.1 [#1973][#1973]
 - Introduced option to add cache refresh delay for metadata enrichment calls [#1974][#1974]
 
+### Fixed
+
+- fix(helm): add job and cronjob to clusterrole's permission set [#1983][#1983]
+
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.3.1...main
 [#1959]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1959
 [#1974]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1974
 [#1973]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1973
+[#1983]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1983
 
 ## [v2.3.1][v2_3_1] - 2021-12-14
 

--- a/deploy/helm/sumologic/templates/clusterrole.yaml
+++ b/deploy/helm/sumologic/templates/clusterrole.yaml
@@ -20,6 +20,11 @@ rules:
   - services
   - statefulsets
   verbs: ["get", "list", "watch"]
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  - jobs
+  verbs: ["get", "list", "watch"]
 - apiGroups: [""]
   resources:
     - configmaps


### PR DESCRIPTION
This was observed when running integration tests with OTC:

```
E1214 14:59:05.716479       1 reflector.go:138] k8s.io/client-go@v0.22.4/tools/cache/reflector.go:167: Failed to watch *v1.Job: failed to list *v1.Job: jobs.batch is forbidden: User "system:serviceaccount:test-helm-default-ot-metadata-930:rel-1045518918-sumologic" cannot list resource "jobs" in API group "batch" at the
E1214 14:59:07.282898       1 reflector.go:138] k8s.io/client-go@v0.22.4/tools/cache/reflector.go:167: Failed to watch *v1.CronJob: failed to list *v1.CronJob: cronjobs.batch is forbidden: User "system:serviceaccount:test-helm-default-ot-metadata-930:rel-1045518918-sumologic" cannot list resource "cronjobs" in API grou
```

and reported internally by @sburton-sumo	