### PR TITLE
feat: add experimental otelcol log collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- feat: add experimental otelcol log collector [#1986][#1986]
 - feat: add option to disable pod owners enrichment [#1959][#1959]
 
 ### Changed
@@ -24,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix(helm): add metrics port to otelcol pods [#1992][#1992]
 
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.3.1...main
+[#1986]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1986
 [#1959]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1959
 [#1974]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1974
 [#1973]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1973

--- a/deploy/helm/sumologic/conf/logs/collector/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/collector/otelcol/config.yaml
@@ -1,0 +1,1 @@
+{{ tpl (toYaml .Values.otellogs.config | replace ": '{{" ": {{" | replace "}}'" "}}") . | nindent 2 }}

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -51,6 +51,42 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 
+{{- define "sumologic.logs.collector.name" -}}
+{{- template "sumologic.fullname" . }}-otelcol-logs-collector
+{{- end -}}
+
+{{- define "sumologic.logs.collector.name.configmap" -}}
+{{- template "sumologic.logs.collector.name" . }}
+{{- end -}}
+
+{{- define "sumologic.logs.collector.name.serviceaccount" -}}
+{{- template "sumologic.logs.collector.name" . }}
+{{- end -}}
+
+{{- define "sumologic.logs.collector.name.daemonset" -}}
+{{- template "sumologic.logs.collector.name" . }}
+{{- end -}}
+
+{{- define "sumologic.labels.app.logs.collector" -}}
+{{- template "sumologic.fullname" . }}-otelcol-logs-collector
+{{- end -}}
+
+{{- define "sumologic.labels.app.logs.collector.configmap" -}}
+{{- template "sumologic.labels.app.logs.collector" . }}
+{{- end -}}
+
+{{- define "sumologic.labels.app.logs.collector.serviceaccount" -}}
+{{- template "sumologic.labels.app.logs.collector" . }}
+{{- end -}}
+
+{{- define "sumologic.labels.app.logs.collector.daemonset" -}}
+{{- template "sumologic.labels.app.logs.collector" . }}
+{{- end -}}
+
+{{- define "sumologic.labels.app.logs.collector.pod" -}}
+{{- template "sumologic.labels.app.logs.collector" . }}
+{{- end -}}
+
 {{- define "sumologic.labels.app.logs.pod" -}}
 {{- template "sumologic.labels.app.logs" . }}
 {{- end -}}

--- a/deploy/helm/sumologic/templates/logs/collector/otelcol/configmap.yaml
+++ b/deploy/helm/sumologic/templates/logs/collector/otelcol/configmap.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.otellogs.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "sumologic.logs.collector.name.configmap" . }}
+  labels:
+    app: {{ template "sumologic.labels.app.logs.collector.configmap" . }}
+    {{- include "sumologic.labels.common" . | nindent 4 }}
+data:
+  {{- (tpl (.Files.Glob "conf/logs/collector/otelcol/config.yaml").AsConfig .) | nindent 2 }}
+{{- end }}

--- a/deploy/helm/sumologic/templates/logs/collector/otelcol/daemonset.yaml
+++ b/deploy/helm/sumologic/templates/logs/collector/otelcol/daemonset.yaml
@@ -1,0 +1,109 @@
+{{- if .Values.otellogs.enabled }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ template "sumologic.logs.collector.name.daemonset" . }}
+  labels:
+    app: {{ template "sumologic.labels.app.logs.collector.daemonset" . }}
+    {{- include "sumologic.labels.common" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "sumologic.labels.app.logs.collector.pod" . }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/logs/collector/otelcol/configmap.yaml") . | sha256sum }}
+{{- if .Values.sumologic.podAnnotations }}
+{{ toYaml .Values.sumologic.podAnnotations | indent 8 }}
+{{- end }}
+{{- if .Values.otellogs.daemonset.podAnnotations }}
+{{ toYaml .Values.otellogs.daemonset.podAnnotations | indent 8 }}
+{{- end }}
+      labels:
+        app.kubernetes.io/name: {{ template "sumologic.labels.app.logs.collector.pod" . }}
+        {{- include "sumologic.labels.common" . | nindent 8 }}
+{{- if .Values.sumologic.podLabels }}
+{{ toYaml .Values.sumologic.podLabels | indent 8 }}
+{{- end }}
+{{- if .Values.otellogs.daemonset.podLabels }}
+{{ toYaml .Values.otellogs.daemonset.podLabels | indent 8 }}
+{{- end }}
+    spec:
+      securityContext:
+        {{- toYaml .Values.otellogs.daemonset.securityContext | nindent 8 }}
+      {{- if .Values.otellogs.daemonset.priorityClassName }}
+      priorityClassName: {{ .Values.metadata.logs.daemonset.priorityClassName | quote }}
+      {{- end }}
+      containers:
+      - args:
+        - --config=/etc/otelcol/config.yaml
+        image: {{ .Values.otellogs.image.repository }}:{{ .Values.otellogs.image.tag }}
+        imagePullPolicy: {{ .Values.otellogs.image.pullPolicy }}
+        name: otelcol
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+        volumeMounts:
+        - mountPath: /etc/otelcol
+          name: otelcol-config
+        - mountPath: /var/log/pods
+          name: varlogpods
+          readOnly: true
+        - mountPath: /var/lib/docker/containers
+          name: varlibdockercontainers
+          readOnly: true
+        - mountPath: {{ .Values.otellogs.config.extensions.file_storage.directory }}
+          name: file-storage
+        env:
+        - name: LOGS_METADATA_SVC
+          valueFrom:
+            configMapKeyRef:
+              name: sumologic-configmap
+              key: fluentdLogs
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        securityContext: 
+          {{- toYaml .Values.otellogs.daemonset.containers.otelcol.securityContext | nindent 10 }}
+      initContainers: # ensure the host path is owned by the otel user group
+      - name: changeowner
+        image: busybox
+        command:
+        - "sh"
+        - "-c"
+        - |
+          chown -R \
+            {{ .Values.otellogs.daemonset.securityContext.fsGroup }}:{{ .Values.otellogs.daemonset.securityContext.fsGroup }} \
+            {{ .Values.otellogs.config.extensions.file_storage.directory }}
+        volumeMounts:
+        - mountPath: {{ .Values.otellogs.config.extensions.file_storage.directory }}
+          name: file-storage
+      volumes:
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: config.yaml
+            path: config.yaml
+          name: {{ template "sumologic.logs.collector.name.configmap" . }}
+        name: otelcol-config
+      - hostPath:
+          path: /var/log/pods
+          type: ""
+        name: varlogpods
+      - hostPath:
+          path: /var/lib/docker/containers
+          type: ""
+        name: varlibdockercontainers
+      - hostPath:
+          path: /var/lib/otc
+          type: DirectoryOrCreate
+        name: file-storage
+      serviceAccountName: {{ template "sumologic.logs.collector.name.serviceaccount" . }}
+{{- end }}

--- a/deploy/helm/sumologic/templates/logs/collector/otelcol/serviceaccount.yaml
+++ b/deploy/helm/sumologic/templates/logs/collector/otelcol/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.otellogs.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "sumologic.logs.collector.name.serviceaccount" . }}
+  labels:
+    app: {{ template "sumologic.labels.app.logs.collector.serviceaccount" . }}
+    {{- include "sumologic.labels.common" . | nindent 4 }}
+{{- end }}

--- a/deploy/helm/sumologic/templates/logs/common/service-headless.yaml
+++ b/deploy/helm/sumologic/templates/logs/common/service-headless.yaml
@@ -14,6 +14,10 @@ spec:
     app: {{ template "sumologic.labels.app.logs.pod" . }}
   clusterIP: None
   ports:
+  - name: otlphttp
+    port: 4318
+    targetPort: 4318
+    protocol: TCP
   {{- if .Values.sumologic.traces.enabled }}
   - name: zipkin-write
     port: 9411

--- a/deploy/helm/sumologic/templates/logs/common/service.yaml
+++ b/deploy/helm/sumologic/templates/logs/common/service.yaml
@@ -14,6 +14,10 @@ spec:
   selector:
     app: {{ template "sumologic.labels.app.logs.pod" . }}
   ports:
+  - name: otlphttp
+    port: 4318
+    targetPort: 4318
+    protocol: TCP
   {{- if .Values.sumologic.traces.enabled }}
   - name: zipkin-write
     port: 9411

--- a/deploy/helm/sumologic/templates/logs/otelcol/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/logs/otelcol/statefulset.yaml
@@ -130,6 +130,9 @@ spec:
           containerPort: 8888
           protocol: TCP
         {{- end }}
+        - name: otlphttp
+          containerPort: 4318
+          protocol: TCP
         livenessProbe:
           httpGet:
             path: /

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -4023,7 +4023,7 @@ metadata:
           - file_storage
           # - sumologic
         pipelines:
-          logs:
+          logs/fluent/containers:
             receivers:
               - fluentforward
             processors:
@@ -4038,7 +4038,7 @@ metadata:
               - batch
             exporters:
               - sumologic/containers
-          logs/systemd:
+          logs/fluent/systemd:
             receivers:
               - fluentforward
             processors:
@@ -4052,7 +4052,7 @@ metadata:
               - batch
             exporters:
               - sumologic/systemd
-          logs/kubelet:
+          logs/fluent/kubelet:
             receivers:
               - fluentforward
             processors:
@@ -4065,7 +4065,7 @@ metadata:
               - batch
             exporters:
               - sumologic/systemd
-          logs/otc/containers:
+          logs/otlp/containers:
             receivers:
               - otlp
             processors:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -3776,6 +3776,10 @@ metadata:
       receivers:
         fluentforward:
           endpoint: 0.0.0.0:24321
+        otlp:
+          protocols:
+            http:
+              endpoint: 0.0.0.0:4318
       extensions:
         health_check: {}
         ## Configuration for File Storage extension
@@ -4061,7 +4065,19 @@ metadata:
               - batch
             exporters:
               - sumologic/systemd
-
+          logs/otc/containers:
+            receivers:
+              - otlp
+            processors:
+              - memory_limiter
+              - attributes/containers
+              - groupbyattrs/containers
+              - k8s_tagger
+              - source/containers
+              - resource/containers_copy_node_to_host
+              - batch
+            exporters:
+              - sumologic/containers
     statefulset:
       nodeSelector: {}
       tolerations: []
@@ -4124,6 +4140,217 @@ metadata:
       minAvailable: 2
       ## To use maxUnavailable, set minAvailable to null and uncomment the below:
       # maxUnavailable: 1
+
+## Configure log collection with Otelcol
+## This is currently highly experimental and not recommended unless you really know what you're doing.
+## In particular, this configuration currently only covers container logs, and only supports docker-shim.
+## Unlike the fluent-bit configuration, it also reads logs from /var/log/pods instead of /var/log/containers
+## which is consistent with CRI, but may possibly cause issues on older K8s versions.
+## This is an alpha feature, and may change in the near future.
+otellogs:
+  enabled: false
+
+  ## Configure image for Opentelemetry Collector
+  image:
+    repository: public.ecr.aws/sumologic/sumologic-otel-collector
+    tag: 0.0.45-beta.0
+    pullPolicy: IfNotPresent
+
+  logLevel: info
+  config:
+    extensions:
+      health_check: {}
+      ## Configuration for File Storage extension
+      ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/release/v0.37.x/extension/storage/filestorage
+      file_storage:
+        directory: /var/lib/storage/otc
+        timeout: 10s
+    service:
+      telemetry:
+        logs:
+          level: '{{ .Values.otellogs.logLevel }}'
+      extensions:
+        - health_check
+        - file_storage
+      pipelines:
+        logs/containers:
+          receivers:
+            - filelog/containers
+          exporters:
+            - otlphttp
+    receivers:
+      filelog/containers:
+        include:
+          - /var/log/pods/*/*/*.log
+        start_at: beginning
+        include_file_path: true
+        include_file_name: false
+        operators:
+
+          ## parser-docker interprets the input string as JSON and moves the `time` field from the JSON to Timestamp field in the OTLP log
+          ## record.
+          # Input Body (string): '{"log":"2001-02-03 04:05:06 first line\n","stream":"stdout","time":"2021-11-25T09:59:13.23887954Z"}'
+          # Output Body (JSON): { "log": "2001-02-03 04:05:06 first line\n", "stream": "stdout" }
+          # Input Timestamp: _empty_
+          # Output Timestamp: 2021-11-25 09:59:13.23887954 +0000 UTC
+          - id: parser-docker
+            type: json_parser
+            # output: join-multipart-entries
+            timestamp:
+              parse_from: time
+              layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+
+          ## This operator is currently disabled as it adds additional newlines
+          ## https://github.com/open-telemetry/opentelemetry-log-collection/issues/314
+          #
+          ## merge-split-lines stitches back together log lines split by Docker logging driver.
+          # Input Body (JSON): { "log": "2001-02-03 04:05:06 very long li", "stream": "stdout" }
+          # Input Body (JSON): { "log": "ne that was split by the logging driver\n", "stream": "stdout" }
+          # Output Body (JSON): { "log": "2001-02-03 04:05:06 very long line that was split by the logging driver\n", "stream": "stdout" }
+          # - id: merge-split-lines
+          #   type: recombine
+          #   combine_field: log
+          #   is_last_entry: $$body.log matches "\n$"
+
+          ## This operator is currently disabled due to the following issues:
+          ## - Additional newlines being added between the merged logs:
+          ## https://github.com/open-telemetry/opentelemetry-log-collection/issues/314
+          ## - No flushing: https://github.com/open-telemetry/opentelemetry-log-collection/issues/306
+          #
+          ## merge-multiline-logs merges incoming log records into multiline logs.
+          # Input Body (JSON): { "log": "2001-02-03 04:05:06 first line\n", "stream": "stdout" }
+          # Input Body (JSON): { "log": "  second line\n", "stream": "stdout" }
+          # Input Body (JSON): { "log": "  third line\n", "stream": "stdout" }
+          # Output Body (JSON): { "log": "2001-02-03 04:05:06 first line\n  second line\n  third line\n", "stream": "stdout" }
+          # - id: merge-multiline-logs
+          #   type: recombine
+          #   combine_field: log
+          #   is_first_entry: $$body.log matches "^[^\\s]"
+
+          # extract-metadata-from-filepath extracts data from the `file.path` Attribute into the Body, removing the `file.path` attribute.
+          # Input Attributes:
+          # - file.path: '/var/log/pods/default_logger-multiline-4nvg4_aed49747-b541-4a07-8663-f7e1febc47d5/loggercontainer/0.log'
+          # Output Attributes: _none_
+          # Input Body (JSON): {
+          #   "log": "2001-02-03 04:05:06 loggerlog 1 first line\n",
+          #   "stream": "stdout"
+          # }
+          # Output Body (JSON): {
+          #   "container_name": "loggercontainer",
+          #   "log": "2001-02-03 04:05:06 loggerlog 1 first line\n",
+          #   "namespace": "default",
+          #   "pod_name": "logger-multiline-4nvg4",
+          #   "run_id": "0",
+          #   "stream": "stdout",
+          #   "uid": "aed49747-b541-4a07-8663-f7e1febc47d5"
+          # }
+          - id: extract-metadata-from-filepath
+            type: regex_parser
+            regex: '^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]+)\/(?P<container_name>[^\._]+)\/(?P<run_id>\d+)\.log$'
+            parse_from: $$attributes["file.path"]
+
+          # copy-attributes copies attributes from Body to Attributes.
+          # Input Body (JSON): {
+          #   "container_name": "loggercontainer",
+          #   "log": "2001-02-03 04:05:06 loggerlog 1 first line\n",
+          #   "namespace": "default",
+          #   "pod_name": "logger-multiline-4nvg4",
+          #   "run_id": "0",
+          #   "stream": "stdout",
+          #   "uid": "aed49747-b541-4a07-8663-f7e1febc47d5"
+          # }
+          # Output Body (JSON): {
+          #   "container_name": "loggercontainer",
+          #   "log": "2001-02-03 04:05:06 loggerlog 1 first line\n",
+          #   "namespace": "default",
+          #   "pod_name": "logger-multiline-4nvg4",
+          #   "run_id": "0",
+          #   "stream": "stdout",
+          #   "uid": "aed49747-b541-4a07-8663-f7e1febc47d5"
+          # }
+          # Input Attributes: _none_
+          # Output Attributes:
+          # - k8s.container.name: "loggercontainer"
+          # - k8s.namespace.name: "default"
+          # - k8s.pod.name: "logger-multiline-4nvg4"
+          # - k8s.pod.uid: "aed49747-b541-4a07-8663-f7e1febc47d5"
+          # - run_id: "0"
+          # - stream: "stdout"
+          - id: copy-attributes
+            type: metadata
+            attributes:
+              stream: 'EXPR($.stream)'
+              k8s.container.name: 'EXPR($.container_name)'
+              k8s.namespace.name: 'EXPR($.namespace)'
+              k8s.pod.name: 'EXPR($.pod_name)'
+              run_id: 'EXPR($.run_id)'
+              k8s.pod.uid: 'EXPR($.uid)'
+
+          # clean-up-log-body takes the values of the `log` field in the JSON Body and puts the value as the sole string value of Body.
+          #
+          # Input Body (JSON): {
+          #   "container_name": "",
+          #   "log": "2001-02-03 04:05:06 loggerlog 1 first line\n",
+          #   "namespace": "default",
+          #   "pod_name": "logger-multiline-4nvg4",
+          #   "run_id": "0",
+          #   "stream": "stdout",
+          #   "uid": "aed49747-b541-4a07-8663-f7e1febc47d5"
+          # }
+          # Output Body (string): "2001-02-03 04:05:06 loggerlog 1 first line\n"
+          #
+          # Input Attributes:
+          # - k8s.container.name: "loggercontainer"
+          # - k8s.namespace.name: "default"
+          # - k8s.pod.name: "logger-multiline-4nvg4"
+          # - k8s.pod.uid: "aed49747-b541-4a07-8663-f7e1febc47d5"
+          # - run_id: "0"
+          # - stream: "stdout"
+          # Output Attributes:
+          # - k8s.container.name: "loggercontainer"
+          # - k8s.namespace.name: "default"
+          # - k8s.pod.name: "logger-multiline-4nvg4"
+          # - k8s.pod.uid: "aed49747-b541-4a07-8663-f7e1febc47d5"
+          # - run_id: "0"
+          # - stream: "stdout"
+          - id: clean-up-log-body
+            type: restructure
+            ops:
+              - move:
+                  from: log
+                  to: $
+    exporters:
+      otlphttp:
+        endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local:4318
+  daemonset:
+    ## Set securityContext for containers running in pods in log collector daemonset
+    securityContext:
+    ## In order to reliably read logs from mounted node logging paths, we need to run as root
+      fsGroup: 0
+      runAsUser: 0
+      runAsGroup: 0
+
+    ## Add custom labels to all otelcol daemonset pods
+    podLabels: {}
+
+    ## Add custom annotations to all otelcol daemonset pods
+    podAnnotations: {}
+
+    resources:
+      limits:
+        memory: 1Gi
+        cpu: 1000m
+      requests:
+        memory: 32Mi
+        cpu: 100m
+    ## Option to define priorityClassName to assign a priority class to pods.
+    priorityClassName:
+
+    ## Set securityContext for containers running in pods in log collector daemonset
+    containers:
+      otelcol:
+        securityContext: {}
+
 
 ## Configure telegraf-operator
 ## ref: https://github.com/influxdata/helm-charts/blob/master/charts/telegraf-operator/values.yaml

--- a/tests/helm/logs_otc/config.sh
+++ b/tests/helm/logs_otc/config.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+export TEST_TEMPLATE="templates/logs/collector/otelcol/configmap.yaml"

--- a/tests/helm/logs_otc/static/basic.input.yaml
+++ b/tests/helm/logs_otc/static/basic.input.yaml
@@ -1,0 +1,2 @@
+otellogs:
+  enabled: true

--- a/tests/helm/logs_otc/static/basic.output.yaml
+++ b/tests/helm/logs_otc/static/basic.output.yaml
@@ -1,0 +1,67 @@
+---
+# Source: sumologic/templates/logs/collector/otelcol/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: RELEASE-NAME-sumologic-otelcol-logs-collector
+  labels:
+    app: RELEASE-NAME-sumologic-otelcol-logs-collector
+    chart: "sumologic-%CURRENT_CHART_VERSION%"
+    release: "RELEASE-NAME"
+    heritage: "Helm"
+data:
+  config.yaml: |
+    
+    exporters:
+      otlphttp:
+        endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local:4318
+    extensions:
+      file_storage:
+        directory: /var/lib/storage/otc
+        timeout: 10s
+      health_check: {}
+    receivers:
+      filelog/containers:
+        include:
+        - /var/log/pods/*/*/*.log
+        include_file_name: false
+        include_file_path: true
+        operators:
+        - id: parser-docker
+          timestamp:
+            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+            parse_from: time
+          type: json_parser
+        - id: extract-metadata-from-filepath
+          parse_from: $$attributes["file.path"]
+          regex: ^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]+)\/(?P<container_name>[^\._]+)\/(?P<run_id>\d+)\.log$
+          type: regex_parser
+        - attributes:
+            k8s.container.name: EXPR($.container_name)
+            k8s.namespace.name: EXPR($.namespace)
+            k8s.pod.name: EXPR($.pod_name)
+            k8s.pod.uid: EXPR($.uid)
+            run_id: EXPR($.run_id)
+            stream: EXPR($.stream)
+          id: copy-attributes
+          type: metadata
+        - id: clean-up-log-body
+          ops:
+          - move:
+              from: log
+              to: $
+          type: restructure
+        start_at: beginning
+    service:
+      extensions:
+      - health_check
+      - file_storage
+      pipelines:
+        logs/containers:
+          exporters:
+          - otlphttp
+          receivers:
+          - filelog/containers
+      telemetry:
+        logs:
+          level: info

--- a/tests/helm/logs_otc_daemonset/config.sh
+++ b/tests/helm/logs_otc_daemonset/config.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+export TEST_TEMPLATE="templates/logs/collector/otelcol/daemonset.yaml"

--- a/tests/helm/logs_otc_daemonset/static/basic.input.yaml
+++ b/tests/helm/logs_otc_daemonset/static/basic.input.yaml
@@ -1,0 +1,2 @@
+otellogs:
+  enabled: true

--- a/tests/helm/logs_otc_daemonset/static/basic.output.yaml
+++ b/tests/helm/logs_otc_daemonset/static/basic.output.yaml
@@ -1,0 +1,100 @@
+---
+# Source: sumologic/templates/logs/collector/otelcol/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: RELEASE-NAME-sumologic-otelcol-logs-collector
+  labels:
+    app: RELEASE-NAME-sumologic-otelcol-logs-collector
+    chart: "sumologic-%CURRENT_CHART_VERSION%"
+    release: "RELEASE-NAME"
+    heritage: "Helm"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: RELEASE-NAME-sumologic-otelcol-logs-collector
+  template:
+    metadata:
+      annotations:
+        checksum/config: "%CONFIG_CHECKSUM%"
+      labels:
+        app.kubernetes.io/name: RELEASE-NAME-sumologic-otelcol-logs-collector
+        chart: "sumologic-%CURRENT_CHART_VERSION%"
+        release: "RELEASE-NAME"
+        heritage: "Helm"
+    spec:
+      securityContext:
+        fsGroup: 0
+        runAsGroup: 0
+        runAsUser: 0
+      containers:
+      - args:
+        - --config=/etc/otelcol/config.yaml
+        image: public.ecr.aws/sumologic/sumologic-otel-collector:0.0.45-beta.0
+        imagePullPolicy: IfNotPresent
+        name: otelcol
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+        volumeMounts:
+        - mountPath: /etc/otelcol
+          name: otelcol-config
+        - mountPath: /var/log/pods
+          name: varlogpods
+          readOnly: true
+        - mountPath: /var/lib/docker/containers
+          name: varlibdockercontainers
+          readOnly: true
+        - mountPath: /var/lib/storage/otc
+          name: file-storage
+        env:
+        - name: LOGS_METADATA_SVC
+          valueFrom:
+            configMapKeyRef:
+              name: sumologic-configmap
+              key: fluentdLogs
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        securityContext:
+          {}
+      initContainers: # ensure the host path is owned by the otel user group
+      - name: changeowner
+        image: busybox
+        command:
+        - "sh"
+        - "-c"
+        - |
+          chown -R \
+            0:0 \
+            /var/lib/storage/otc
+        volumeMounts:
+        - mountPath: /var/lib/storage/otc
+          name: file-storage
+      volumes:
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: config.yaml
+            path: config.yaml
+          name: RELEASE-NAME-sumologic-otelcol-logs-collector
+        name: otelcol-config
+      - hostPath:
+          path: /var/log/pods
+          type: ""
+        name: varlogpods
+      - hostPath:
+          path: /var/lib/docker/containers
+          type: ""
+        name: varlibdockercontainers
+      - hostPath:
+          path: /var/lib/otc
+          type: DirectoryOrCreate
+        name: file-storage
+      serviceAccountName: RELEASE-NAME-sumologic-otelcol-logs-collector

--- a/tests/helm/metadata_logs_otc/static/basic.output.yaml
+++ b/tests/helm/metadata_logs_otc/static/basic.output.yaml
@@ -219,6 +219,10 @@ data:
     receivers:
       fluentforward:
         endpoint: 0.0.0.0:24321
+      otlp:
+        protocols:
+          http:
+            endpoint: 0.0.0.0:4318
     service:
       extensions:
       - health_check
@@ -252,6 +256,19 @@ data:
           - batch
           receivers:
           - fluentforward
+        logs/otc/containers:
+          exporters:
+          - sumologic/containers
+          processors:
+          - memory_limiter
+          - attributes/containers
+          - groupbyattrs/containers
+          - k8s_tagger
+          - source/containers
+          - resource/containers_copy_node_to_host
+          - batch
+          receivers:
+          - otlp
         logs/systemd:
           exporters:
           - sumologic/systemd

--- a/tests/helm/metadata_logs_otc/static/basic.output.yaml
+++ b/tests/helm/metadata_logs_otc/static/basic.output.yaml
@@ -228,7 +228,7 @@ data:
       - health_check
       - file_storage
       pipelines:
-        logs:
+        logs/fluent/containers:
           exporters:
           - sumologic/containers
           processors:
@@ -243,7 +243,7 @@ data:
           - batch
           receivers:
           - fluentforward
-        logs/kubelet:
+        logs/fluent/kubelet:
           exporters:
           - sumologic/systemd
           processors:
@@ -256,20 +256,7 @@ data:
           - batch
           receivers:
           - fluentforward
-        logs/otc/containers:
-          exporters:
-          - sumologic/containers
-          processors:
-          - memory_limiter
-          - attributes/containers
-          - groupbyattrs/containers
-          - k8s_tagger
-          - source/containers
-          - resource/containers_copy_node_to_host
-          - batch
-          receivers:
-          - otlp
-        logs/systemd:
+        logs/fluent/systemd:
           exporters:
           - sumologic/systemd
           processors:
@@ -283,6 +270,19 @@ data:
           - batch
           receivers:
           - fluentforward
+        logs/otlp/containers:
+          exporters:
+          - sumologic/containers
+          processors:
+          - memory_limiter
+          - attributes/containers
+          - groupbyattrs/containers
+          - k8s_tagger
+          - source/containers
+          - resource/containers_copy_node_to_host
+          - batch
+          receivers:
+          - otlp
       telemetry:
         logs:
           level: info

--- a/tests/helm/metadata_logs_otc/static/templates.output.yaml
+++ b/tests/helm/metadata_logs_otc/static/templates.output.yaml
@@ -219,6 +219,10 @@ data:
     receivers:
       fluentforward:
         endpoint: 0.0.0.0:24321
+      otlp:
+        protocols:
+          http:
+            endpoint: 0.0.0.0:4318
     service:
       extensions:
       - health_check
@@ -252,6 +256,19 @@ data:
           - batch
           receivers:
           - fluentforward
+        logs/otc/containers:
+          exporters:
+          - sumologic/containers
+          processors:
+          - memory_limiter
+          - attributes/containers
+          - groupbyattrs/containers
+          - k8s_tagger
+          - source/containers
+          - resource/containers_copy_node_to_host
+          - batch
+          receivers:
+          - otlp
         logs/systemd:
           exporters:
           - sumologic/systemd

--- a/tests/helm/metadata_logs_otc/static/templates.output.yaml
+++ b/tests/helm/metadata_logs_otc/static/templates.output.yaml
@@ -228,7 +228,7 @@ data:
       - health_check
       - file_storage
       pipelines:
-        logs:
+        logs/fluent/containers:
           exporters:
           - sumologic/containers
           processors:
@@ -243,7 +243,7 @@ data:
           - batch
           receivers:
           - fluentforward
-        logs/kubelet:
+        logs/fluent/kubelet:
           exporters:
           - sumologic/systemd
           processors:
@@ -256,20 +256,7 @@ data:
           - batch
           receivers:
           - fluentforward
-        logs/otc/containers:
-          exporters:
-          - sumologic/containers
-          processors:
-          - memory_limiter
-          - attributes/containers
-          - groupbyattrs/containers
-          - k8s_tagger
-          - source/containers
-          - resource/containers_copy_node_to_host
-          - batch
-          receivers:
-          - otlp
-        logs/systemd:
+        logs/fluent/systemd:
           exporters:
           - sumologic/systemd
           processors:
@@ -283,6 +270,19 @@ data:
           - batch
           receivers:
           - fluentforward
+        logs/otlp/containers:
+          exporters:
+          - sumologic/containers
+          processors:
+          - memory_limiter
+          - attributes/containers
+          - groupbyattrs/containers
+          - k8s_tagger
+          - source/containers
+          - resource/containers_copy_node_to_host
+          - batch
+          receivers:
+          - otlp
       telemetry:
         logs:
           level: info

--- a/tests/helm/metadata_logs_otc_statefulset/static/basic.output.yaml
+++ b/tests/helm/metadata_logs_otc_statefulset/static/basic.output.yaml
@@ -83,6 +83,9 @@ spec:
         - name: metrics
           containerPort: 8888
           protocol: TCP
+        - name: otlphttp
+          containerPort: 4318
+          protocol: TCP
         livenessProbe:
           httpGet:
             path: /

--- a/vagrant/values.yaml
+++ b/vagrant/values.yaml
@@ -199,7 +199,7 @@ otelcol:
             - health_check
             # - sumologic
           pipelines:
-            logs:
+            logs/fluent-bit/containers:
               receivers:
                 - fluentforward
               processors:
@@ -218,7 +218,7 @@ otelcol:
                 - batch
               exporters:
                 - sumologic/containers
-            logs/systemd:
+            logs/fluent-bit/systemd:
               receivers:
                 - fluentforward
               processors:
@@ -237,7 +237,7 @@ otelcol:
                 - batch
               exporters:
                 - sumologic/systemd
-            logs/kubelet:
+            logs/fluent-bit/kubelet:
               receivers:
                 - fluentforward
               processors:

--- a/vagrant/values.yaml
+++ b/vagrant/values.yaml
@@ -199,7 +199,7 @@ otelcol:
             - health_check
             # - sumologic
           pipelines:
-            logs/fluent-bit/containers:
+            logs/fluent/containers:
               receivers:
                 - fluentforward
               processors:
@@ -218,7 +218,7 @@ otelcol:
                 - batch
               exporters:
                 - sumologic/containers
-            logs/fluent-bit/systemd:
+            logs/fluent/systemd:
               receivers:
                 - fluentforward
               processors:
@@ -237,7 +237,7 @@ otelcol:
                 - batch
               exporters:
                 - sumologic/systemd
-            logs/fluent-bit/kubelet:
+            logs/fluent/kubelet:
               receivers:
                 - fluentforward
               processors:


### PR DESCRIPTION
##### Description

This is an alpha feature without a stable API. It only supports container logs from docker-shim. Fluent-bit needs to be manually disabled to avoid duplicate logs.

The namespacing in the internal configuration is currently a bit messy -  we have a top-level `sumologic.logs` key, which should probably be `sumologic.metadata.logs`, same with metrics. Same thing is true about the directory structure within the Helm chart. I'd like to change both of those in a separate PR after merging this one. Then this collector can live under `sumologic.logs.*` instead of `sumologic.logs.collector.*`.

The configuration for otelcol was originally prepared by @astencel-sumo, he gets credit for it actually doing the right thing.

---

##### Checklist

Remove items which don't apply to your PR.

- [x] Changelog updated

###### Testing performed

- [X] Confirm events, logs, and metrics are coming in
