### PR TITLE
docs: ignore flaky yq book link

### DIFF
--- a/.markdown_link_check.json
+++ b/.markdown_link_check.json
@@ -7,5 +7,10 @@
       "pattern": "^/",
       "replacement": "{{BASEURL}}/"
     }
+  ],
+  "ignorePatterns": [
+    {
+      "pattern": "^https://mikefarah.gitbook.io/yq"
+    }
   ]
 }

--- a/ci/markdown_link_check.sh
+++ b/ci/markdown_link_check.sh
@@ -9,6 +9,6 @@ fi
 readonly FILES=$(find . -type f -name '*.md')
 
 for file in ${FILES}; do
-    markdown-link-check --progress --verbose \
+    markdown-link-check --progress --verbose --retry \
         --config .markdown_link_check.json "${file}"
 done

--- a/deploy/docs/opentelemetry_collector.md
+++ b/deploy/docs/opentelemetry_collector.md
@@ -218,8 +218,6 @@ Upgrade collection with  Opentelemetry Collector persistence enabled, e.g.
 helm upgrade <RELEASE-NAME> sumologic/sumologic --version=<VERSION> -f <VALUES>
 ```
 
-[yq]: https://mikefarah.gitbook.io/yq/v/v3.x/
-
 #### Enabling Opentelemetry Collector persistence by creating temporary instances and removing earlier created
 
 To create a temporary instances of Opentelemetry Collector StatefulSets and avoid a loss of logs or metrics one can run the following commands.
@@ -283,8 +281,6 @@ kubectl delete statefulset \
   --namespace ${NAMESPACE} \
   --selector "release==${RELEASE_NAME},heritage=tmp"
 ```
-
-[yq]: https://mikefarah.gitbook.io/yq/v/v3.x/
 
 ### Disabling persistence
 
@@ -364,8 +360,6 @@ Upgrade collection with  Opentelemetry Collector persistence disabled, e.g.
 ```bash
 helm upgrade <RELEASE-NAME> sumologic/sumologic --version=<VERSION> -f <VALUES>
 ```
-
-[yq]: https://mikefarah.gitbook.io/yq/v/v3.x/
 
 #### Disabling Opentelemetry Collector persistence by creating temporary instances nd removing earlier created
 


### PR DESCRIPTION
This link sometimes causes issue even though retries are (theoretically?) enabled.

Exemplar failed CI build: https://github.com/SumoLogic/sumologic-kubernetes-collection/runs/4555434282?check_suite_focus=true