### PR TITLE
test(helm): don't use yq for template tests

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -76,6 +76,8 @@ jobs:
 
   test:
     runs-on: ubuntu-20.04
+    env:
+      YQ_VERSION: 3.4.1
     needs:
       - markdownlint
       - shellcheck
@@ -88,7 +90,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: yq
         run: |
-            curl --retry 10 --retry-max-time 120 --retry-delay 5 -L -o /tmp/yq https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64
+            curl --retry 10 --retry-max-time 120 --retry-delay 5 -L -o /tmp/yq https://github.com/mikefarah/yq/releases/download/${{ env.YQ_VERSION }}/yq_linux_amd64
             chmod +x /tmp/yq
             sudo mv /tmp/yq /usr/local/bin/yq
       - name: test

--- a/tests/helm/functions.sh
+++ b/tests/helm/functions.sh
@@ -29,7 +29,7 @@ function set_variables() {
   # Path to the temporary output file
   TEST_OUT="${TEST_TMP_PATH}/new_values.yaml"
   # Current version wchich should override the placeholder in test
-  CURRENT_CHART_VERSION=$(yq r "${TEST_SCRIPT_PATH}/../../../deploy/helm/sumologic/Chart.yaml" version)
+  CURRENT_CHART_VERSION=$(grep "^version: .*" "${TEST_SCRIPT_PATH}/../../../deploy/helm/sumologic/Chart.yaml" | cut -f 2 -d " ")
 }
 
 # Update helm chart and remove the tmpcharts eventually


### PR DESCRIPTION
##### Description

It's easier to run the Helm tests locally if they use the latest major version of yq, as the versions are actually incompatible.

