### PR TITLE
fix(helm): add metrics port to otelcol pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - fix(helm): add job and cronjob to clusterrole's permission set [#1983][#1983]
+- fix(helm): add metrics port to otelcol pods [#1992][#1992]
 
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.3.1...main
 [#1959]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1959
 [#1974]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1974
 [#1973]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1973
 [#1983]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1983
+[#1992]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1992
 
 ## [v2.3.1][v2_3_1] - 2021-12-14
 

--- a/deploy/helm/sumologic/templates/logs/otelcol/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/logs/otelcol/statefulset.yaml
@@ -125,6 +125,11 @@ spec:
         - name: fluent-bit
           containerPort: 24321
           protocol: TCP
+        {{- if eq .Values.otelcol.metrics.enabled true }}
+        - name: metrics
+          containerPort: 8888
+          protocol: TCP
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /

--- a/deploy/helm/sumologic/templates/metrics/otelcol/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics/otelcol/statefulset.yaml
@@ -120,6 +120,11 @@ spec:
         - name: prom-write
           containerPort: 9888
           protocol: TCP
+        {{- if eq .Values.otelcol.metrics.enabled true }}
+        - name: metrics
+          containerPort: 8888
+          protocol: TCP
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /

--- a/tests/helm/metadata_logs_otc_statefulset/static/basic.output.yaml
+++ b/tests/helm/metadata_logs_otc_statefulset/static/basic.output.yaml
@@ -80,6 +80,9 @@ spec:
         - name: fluent-bit
           containerPort: 24321
           protocol: TCP
+        - name: metrics
+          containerPort: 8888
+          protocol: TCP
         livenessProbe:
           httpGet:
             path: /

--- a/tests/helm/metadata_metrics_otc_statefulset/static/basic.output.yaml
+++ b/tests/helm/metadata_metrics_otc_statefulset/static/basic.output.yaml
@@ -80,6 +80,9 @@ spec:
         - name: prom-write
           containerPort: 9888
           protocol: TCP
+        - name: metrics
+          containerPort: 8888
+          protocol: TCP
         livenessProbe:
           httpGet:
             path: /


### PR DESCRIPTION
This PR adds port 8888 (aka `metrics`) to otelcol's pods (both metrics and logs) so that it can be used to gather otelcol's metrics

This should actually be done already but it seems we missed this somehow. Our docs already mention this:

```
 `otelcol.metrics.enabled` | Enable or disable generation of the metrics from Collector.
```