### PR TITLE
fix(ci): only run integration test in dev builds

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -36,7 +36,7 @@ jobs:
         working-directory: ./tests/integration/
         # grep magic described in https://unix.stackexchange.com/a/13472
         run: |
-          echo "::set-output name=test_names::$(grep -rhoP "(?<=^func )(Test[a-zA-z_0-9]+)(?=\(t \*testing.T\) {)" . | jq -R . | jq -cs .)"
+          echo "::set-output name=test_names::$(grep -shoP "(?<=^func )(Test[a-zA-z_0-9]+)(?=\(t \*testing.T\) {)" * | jq -R . | jq -cs .)"
       - name: Print test names
         run: echo "Test names ${{ steps.set_test_names.outputs.test_names }}"
 


### PR DESCRIPTION
Don't run unit tests like it was run in https://github.com/SumoLogic/sumologic-kubernetes-collection/actions/runs/1592967035 i.e. the `TestValuesFileFromT` UT which shouldn't run.