### PR TITLE
test(integration): add tests for log count and basic metadata

### DIFF
--- a/tests/integration/helm_default_installation_test.go
+++ b/tests/integration/helm_default_installation_test.go
@@ -30,8 +30,9 @@ import (
 
 func Test_Helm_Default_FluentD_Metadata(t *testing.T) {
 	const (
-		tickDuration = 3 * time.Second
-		waitDuration = 3 * time.Minute
+		tickDuration            = 3 * time.Second
+		waitDuration            = 3 * time.Minute
+		logsGeneratorCount uint = 1000
 	)
 	var (
 		expectedMetrics = internal.DefaultExpectedMetrics
@@ -268,5 +269,56 @@ func Test_Helm_Default_FluentD_Metadata(t *testing.T) {
 		).
 		Feature()
 
-	testenv.Test(t, featInstall, featMetrics)
+	featLogs := features.New("logs").
+		Setup(stepfuncs.GenerateLogsWithDeployment(
+			logsGeneratorCount,
+			internal.LogsGeneratorName,
+			internal.LogsGeneratorNamespace,
+			internal.LogsGeneratorImage,
+		)).
+		Assess("logs from log generator present", stepfuncs.WaitUntilExpectedLogsPresent(
+			logsGeneratorCount,
+			map[string]string{
+				"namespace":      internal.LogsGeneratorName,
+				"pod_labels_app": internal.LogsGeneratorName,
+			},
+			internal.ReceiverMockNamespace,
+			internal.ReceiverMockServiceName,
+			internal.ReceiverMockServicePort,
+			waitDuration,
+			tickDuration,
+		)).
+		Assess("expected container log metadata is present", stepfuncs.WaitUntilExpectedLogsPresent(
+			logsGeneratorCount,
+			map[string]string{
+				"namespace":      internal.LogsGeneratorName,
+				"pod_labels_app": internal.LogsGeneratorName,
+				"container":      internal.LogsGeneratorName,
+				"deployment":     internal.LogsGeneratorName,
+				"replicaset":     "",
+				"namespace_id":   "",
+				"pod":            "",
+				"pod_id":         "",
+				"container_id":   "",
+				"host":           "",
+				"master_url":     "",
+				"node":           "",
+			},
+			internal.ReceiverMockNamespace,
+			internal.ReceiverMockServiceName,
+			internal.ReceiverMockServicePort,
+			waitDuration,
+			tickDuration,
+		)).
+		Teardown(
+			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
+				opts := *ctxopts.KubectlOptions(ctx)
+				opts.Namespace = internal.LogsGeneratorNamespace
+				k8s.RunKubectl(t, &opts, "delete", "deployment", internal.LogsGeneratorName)
+				return ctx
+			}).
+		Teardown(stepfuncs.KubectlDeleteNamespaceOpt(internal.LogsGeneratorNamespace)).
+		Feature()
+
+	testenv.Test(t, featInstall, featMetrics, featLogs)
 }

--- a/tests/integration/internal/constants.go
+++ b/tests/integration/internal/constants.go
@@ -18,6 +18,10 @@ const (
 	ReceiverMockServicePort = 3000
 	ReceiverMockServiceName = "receiver-mock"
 	ReceiverMockNamespace   = "receiver-mock"
+
+	LogsGeneratorNamespace = "logs-generator"
+	LogsGeneratorName      = "logs-generator"
+	LogsGeneratorImage     = "sumologic/kubernetes-tools:2.7.0"
 )
 
 // metrics we expect the receiver to get

--- a/tests/integration/internal/logsgenerator/logsgenerator.go
+++ b/tests/integration/internal/logsgenerator/logsgenerator.go
@@ -1,0 +1,134 @@
+package logsgenerator
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+/// This package wraps the logsgenerator utility in sumologic-kubernetes-tools in a procedural API
+/// easily consumable by tests.
+
+const deploymentSleepTime = time.Hour * 24 // how much time we spend sleeping after generating logs in a Deployment
+
+type LogsGeneratorOptions struct {
+	// For all of these options, 0 and "" respectively are treated as "not set"
+
+	// how long we should run in total
+	// the way Duration and TotalLogs interact, is that the program exits on the first condition achieved
+	// in particular, there isn't a way to make it continue running after generating a fixed number of logs
+	Duration uint
+	// how many log lines to generate in total
+	TotalLogs uint
+	// maximum number of logs generated per second
+	LogsThroughput uint
+	// maximum number of bytes generater per second
+	BytesThroughput uint
+	// should we print diagnostic messages?
+	Verbose bool
+
+	// Pattern options
+	// See https://github.com/SumoLogic/sumologic-kubernetes-tools/tree/main/src/rust/logs-generator#patterns
+
+	// These options control random pattern generation
+	RandomPatterns      uint
+	MinPatternLength    uint
+	MaxPatternLength    uint
+	KnownWordsInRatio   uint
+	RandomWordsInRatio  uint
+	RandomDigitsInRatio uint
+
+	// This option allows the pattern to be controlled directly
+	Pattern string
+}
+
+func NewDefaultGeneratorOptions() *LogsGeneratorOptions {
+	return &LogsGeneratorOptions{
+		Duration:            0,
+		TotalLogs:           0,
+		LogsThroughput:      0,
+		BytesThroughput:     0,
+		Verbose:             false,
+		RandomPatterns:      10,
+		MinPatternLength:    5,
+		MaxPatternLength:    20,
+		KnownWordsInRatio:   7,
+		RandomWordsInRatio:  2,
+		RandomDigitsInRatio: 1,
+		Pattern:             "",
+	}
+}
+
+func GetLogsGeneratorDeployment(
+	namespace string,
+	name string,
+	image string,
+	options LogsGeneratorOptions,
+) appsv1.Deployment {
+	var replicas int32 = 1
+	appLabels := map[string]string{
+		"app": name,
+	}
+	metadata := metav1.ObjectMeta{
+		Name:      name,
+		Namespace: namespace,
+		Labels:    appLabels,
+	}
+
+	// There's no way to tell the log generator to keep running after it's done generating logs. This is annoying if
+	// we want to run it in a Deployment and not have it be restarted after exiting. So we sleep after it exits.
+	generatorArgs := optionsToArgumentList(options)
+	logsGeneratorCommand := fmt.Sprintf("logs-generator %s", strings.Join(generatorArgs, " "))
+	logsGeneratorAndSleepCommand := fmt.Sprintf("%s; sleep %f", logsGeneratorCommand, deploymentSleepTime.Seconds())
+
+	podTemplateSpec := corev1.PodTemplateSpec{
+		ObjectMeta: metadata,
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:    name,
+					Image:   image,
+					Command: []string{"/bin/bash", "-c", "--"},
+					Args:    []string{logsGeneratorAndSleepCommand},
+				},
+			},
+		},
+	}
+	deployment := appsv1.Deployment{
+		ObjectMeta: metadata,
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: appLabels,
+			},
+			Template: podTemplateSpec,
+		},
+	}
+	return deployment
+}
+
+func optionsToArgumentList(options LogsGeneratorOptions) []string {
+	// Note: this could be made cleaner with reflection and struct field tags, but we don't
+	// really need the complexity, and this logic is unlikely to change a lot
+	args := []string{
+		fmt.Sprintf("--duration=%d", options.Duration),
+		fmt.Sprintf("--total-logs=%d", options.TotalLogs),
+		fmt.Sprintf("--logs-throughput=%d", options.LogsThroughput),
+		fmt.Sprintf("--throughput=%d", options.BytesThroughput),
+		fmt.Sprintf("--verbose=%v", options.Verbose),
+		fmt.Sprintf("--random-patterns=%d", options.RandomPatterns),
+		fmt.Sprintf("--min=%d", options.MinPatternLength),
+		fmt.Sprintf("--max=%d", options.MaxPatternLength),
+		fmt.Sprintf("--known_words=%d", options.KnownWordsInRatio),
+		fmt.Sprintf("--random_words=%d", options.RandomWordsInRatio),
+		fmt.Sprintf("--random_digits=%d", options.RandomDigitsInRatio),
+	}
+	if len(options.Pattern) > 0 { // logs-generator doesn't like directly setting an empty pattern
+		args = append(args, fmt.Sprintf("--pattern=%q", options.Pattern))
+	}
+	return args
+}

--- a/tests/integration/internal/logsgenerator/logsgenerator.go
+++ b/tests/integration/internal/logsgenerator/logsgenerator.go
@@ -98,7 +98,7 @@ func GetLogsGeneratorDeployment(
 			},
 		},
 	}
-	deployment := appsv1.Deployment{
+	return appsv1.Deployment{
 		ObjectMeta: metadata,
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
@@ -108,7 +108,6 @@ func GetLogsGeneratorDeployment(
 			Template: podTemplateSpec,
 		},
 	}
-	return deployment
 }
 
 func optionsToArgumentList(options LogsGeneratorOptions) []string {

--- a/tests/integration/internal/stepfuncs/logs.go
+++ b/tests/integration/internal/stepfuncs/logs.go
@@ -1,0 +1,44 @@
+package stepfuncs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/logsgenerator"
+)
+
+// Generate logsCount logs using a Deployment
+func GenerateLogsWithDeployment(
+	logsCount uint,
+	logsGeneratorName string,
+	logsGeneratorNamespace string,
+	logsGeneratorImage string,
+) features.Func {
+	return func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
+		client := envConf.Client()
+		generatorOptions := *logsgenerator.NewDefaultGeneratorOptions()
+		generatorOptions.TotalLogs = logsCount
+		deployment := logsgenerator.GetLogsGeneratorDeployment(
+			logsGeneratorNamespace,
+			logsGeneratorName,
+			logsGeneratorImage,
+			generatorOptions,
+		)
+
+		// create the namespace
+		namespace := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: logsGeneratorNamespace}}
+		require.NoError(t, client.Resources().Create(ctx, &namespace))
+
+		// create the deployment
+		client.Resources(logsGeneratorNamespace).Create(ctx, &deployment)
+
+		return ctx
+	}
+}

--- a/tests/integration/yamls/receiver-mock.yaml
+++ b/tests/integration/yamls/receiver-mock.yaml
@@ -34,6 +34,7 @@ spec:
             - --print-headers
             - --print-logs
             - --print-metrics
+            - --store-logs
             - --store-metrics
           resources: {}
           securityContext:


### PR DESCRIPTION
##### Description

Test log collection and delivery by generating a set of logs using logs-generator and then making assertions about the receiver having received them using the receiver's log counting API.

No systemd logs because:
* they don't have any metadata to query over, need https://github.com/SumoLogic/sumologic-kubernetes-tools/pull/193 first
* By default, kind doesn't enable persistence for journald, and the logs live in `/run/logs/journal` instead of `/var/log/journal` - and we don't have the former mounted in fluent-bit containers