### PR TITLE
chore: update kubernetes-tools to 2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- chore: update kubernetes-tools to 2.9.0 [#2013][#2013]
 - chore: bump Thanos image to our build of v0.23.1 [#1973][#1973]
 - Introduced option to add cache refresh delay for metadata enrichment calls [#1974][#1974]
 - chore(deps): bump Sumo OT distro to 0.0.43-beta.0 [#1993][#1993]
@@ -29,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1983]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1983
 [#1992]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1992
 [#1993]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1993
+[#2013]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2013
 
 ## [v2.3.1][v2_3_1] - 2021-12-14
 

--- a/ci/_build_functions.sh
+++ b/ci/_build_functions.sh
@@ -12,7 +12,7 @@ function helm() {
   docker run --rm \
     -v "$(pwd):/chart" \
     -w /chart \
-    sumologic/kubernetes-tools:2.6.0 \
+    sumologic/kubernetes-tools:2.9.0 \
     helm "$@"
 }
 

--- a/deploy/docs/Kube-Prometheus.md
+++ b/deploy/docs/Kube-Prometheus.md
@@ -9,12 +9,12 @@ You can generate mixin configuration using `kubectl` or `docker`:
  kubectl run tools \
   -it --quiet --rm \
   --restart=Never -n sumologic \
-  --image sumologic/kubernetes-tools:2.6.0 \
+  --image sumologic/kubernetes-tools:2.9.0 \
   -- template-prometheus-mixin > kube-prometheus-sumo-logic-mixin.libsonnet
 
  # or using docker
  docker run -it --rm \
-  sumologic/kubernetes-tools:2.6.0 \
+  sumologic/kubernetes-tools:2.9.0 \
   template-prometheus-mixin > kube-prometheus-sumo-logic-mixin.libsonnet
 ```
 

--- a/deploy/docs/Non_Helm_Installation.md
+++ b/deploy/docs/Non_Helm_Installation.md
@@ -91,7 +91,7 @@ First you will generate the YAML to apply to your cluster.  The following comman
 kubectl run tools \
   -i --quiet --rm \
   --restart=Never \
-  --image sumologic/kubernetes-tools:2.6.0 -- \
+  --image sumologic/kubernetes-tools:2.9.0 -- \
   template \
   --name-template 'collection' \
   --set sumologic.accessId='<ACCESS_ID>' \
@@ -128,7 +128,7 @@ The following will render the YAML and install in the `my-namespace` namespace.
 kubectl run tools \
   -i --quiet --rm \
   --restart=Never \
-  --image sumologic/kubernetes-tools:2.6.0 -- \
+  --image sumologic/kubernetes-tools:2.9.0 -- \
   template \
   --namespace 'my-namespace' \
   --name-template 'collection' \
@@ -177,7 +177,7 @@ you can do the following:
 kubectl run tools \
   -i --quiet --rm \
   --restart=Never \
-  --image sumologic/kubernetes-tools:2.6.0 -- \
+  --image sumologic/kubernetes-tools:2.9.0 -- \
   template \
   --namespace 'my-namespace' \
   --name-template 'collection' \
@@ -258,7 +258,7 @@ cat sumo-values.yaml | \
   kubectl run tools \
     -i --quiet --rm \
     --restart=Never \
-    --image sumologic/kubernetes-tools:2.6.0 -- \
+    --image sumologic/kubernetes-tools:2.9.0 -- \
     template \
       --name-template 'collection' \
       | tee sumologic.yaml
@@ -279,7 +279,7 @@ You can use the same commands used to create the YAML in the first place.
 kubectl run tools \
   -i --quiet --rm \
   --restart=Never \
-  --image sumologic/kubernetes-tools:2.6.0 -- \
+  --image sumologic/kubernetes-tools:2.9.0 -- \
   template \
   --namespace 'my-namespace' \
   --name-template 'collection' \
@@ -297,7 +297,7 @@ cat sumo-values.yaml | \
      kubectl run tools \
        -i --quiet --rm \
        --restart=Never \
-       --image sumologic/kubernetes-tools:2.6.0 -- \
+       --image sumologic/kubernetes-tools:2.9.0 -- \
        template \
          --name-template 'collection' \
          | tee sumologic.yaml
@@ -312,7 +312,7 @@ cat values.yaml | \
   kubectl run tools \
     -i --quiet --rm \
     --restart=Never \
-    --image sumologic/kubernetes-tools:2.6.0 -- \
+    --image sumologic/kubernetes-tools:2.9.0 -- \
     template \
       --name-template 'collection' \
       --version=1.0.0

--- a/deploy/docs/additional_prometheus_configuration.md
+++ b/deploy/docs/additional_prometheus_configuration.md
@@ -12,12 +12,12 @@ using `docker`/`kubectl` and [sumologic-kubernetes-tools](https://github.com/sum
  kubectl run tools \
   -it --quiet --rm \
   --restart=Never -n sumologic \
-  --image sumologic/kubernetes-tools:2.6.0 \
+  --image sumologic/kubernetes-tools:2.9.0 \
   -- template-dependency kube-prometheus-stack > prometheus-overrides.yaml
 
  # or using docker
  docker run -it --rm \
-  sumologic/kubernetes-tools:2.6.0 \
+  sumologic/kubernetes-tools:2.9.0 \
   template-dependency kube-prometheus-stack > prometheus-overrides.yaml
 ```
 

--- a/deploy/docs/existingPrometheusDoc.md
+++ b/deploy/docs/existingPrometheusDoc.md
@@ -142,12 +142,12 @@ First, generate the Prometheus Operator `prometheus-overrides.yaml` by running c
  kubectl run tools \
   -it --quiet --rm \
   --restart=Never -n sumologic \
-  --image sumologic/kubernetes-tools:2.6.0 \
+  --image sumologic/kubernetes-tools:2.9.0 \
   -- template-dependency kube-prometheus-stack > prometheus-overrides.yaml
 
  # or using docker
  docker run -it --rm \
-  sumologic/kubernetes-tools:2.6.0 \
+  sumologic/kubernetes-tools:2.9.0 \
   template-dependency kube-prometheus-stack > prometheus-overrides.yaml
 ```
 

--- a/deploy/docs/standAlonePrometheus.md
+++ b/deploy/docs/standAlonePrometheus.md
@@ -101,12 +101,12 @@ First, generate the Prometheus Operator `prometheus-overrides.yaml` by running
  kubectl run tool \
   -it --quiet --rm \
   --restart=Never -n sumologic \
-  --image sumologic/kubernetes-tools:2.6.0 \
+  --image sumologic/kubernetes-tools:2.9.0 \
   -- template-dependency kube-prometheus-stack > prometheus-overrides.yaml
 
  # or using Docker
  docker run -it --rm \
-  sumologic/kubernetes-tools:2.6.0 \
+  sumologic/kubernetes-tools:2.9.0 \
   template-dependency kube-prometheus-stack > prometheus-overrides.yaml
 ```
 

--- a/deploy/docs/v2_migration_doc.md
+++ b/deploy/docs/v2_migration_doc.md
@@ -352,7 +352,7 @@ to convert their existing `values.yaml` file into one that is compatible with th
     cat current_values.yaml | \
       docker run \
         --rm \
-        -i sumologic/kubernetes-tools:2.6.0 upgrade-2.0 | \
+        -i sumologic/kubernetes-tools:2.9.0 upgrade-2.0 | \
       tee new_values.yaml
     ```
 
@@ -367,7 +367,7 @@ to convert their existing `values.yaml` file into one that is compatible with th
         --quiet \
         --rm \
         --restart=Never \
-        --image sumologic/kubernetes-tools:2.6.0 -- upgrade-2.0 | \
+        --image sumologic/kubernetes-tools:2.9.0 -- upgrade-2.0 | \
       tee new_values.yaml
     ```
 

--- a/tests/helm/functions.sh
+++ b/tests/helm/functions.sh
@@ -38,7 +38,7 @@ function prepare_environment() {
   rm -rf "${repo_path}/tmpcharts"
   docker run --rm \
     -v "${repo_path}":/chart \
-    sumologic/kubernetes-tools:2.6.0 \
+    sumologic/kubernetes-tools:2.9.0 \
     helm dependency update /chart
 }
 
@@ -77,7 +77,7 @@ function generate_file {
   if ! docker run --rm \
     -v "${TEST_SCRIPT_PATH}/../../../deploy/helm/sumologic":/chart \
     -v "${TEST_STATICS_PATH}/${input_file}":/values.yaml \
-    sumologic/kubernetes-tools:2.6.0 \
+    sumologic/kubernetes-tools:2.9.0 \
     helm template /chart -f /values.yaml \
       ${kube_api_versions_flags} \
       --namespace sumologic \

--- a/tests/helm/sumologic.yaml
+++ b/tests/helm/sumologic.yaml
@@ -1,0 +1,1 @@
+standard_init_linux.go:228: exec user process caused: exec format error

--- a/tests/integration/internal/constants.go
+++ b/tests/integration/internal/constants.go
@@ -21,7 +21,7 @@ const (
 
 	LogsGeneratorNamespace = "logs-generator"
 	LogsGeneratorName      = "logs-generator"
-	LogsGeneratorImage     = "sumologic/kubernetes-tools:2.8.0"
+	LogsGeneratorImage     = "sumologic/kubernetes-tools:2.9.0"
 )
 
 // metrics we expect the receiver to get

--- a/tests/integration/yamls/receiver-mock.yaml
+++ b/tests/integration/yamls/receiver-mock.yaml
@@ -26,7 +26,7 @@ spec:
         - ports:
             - containerPort: 3000
             - containerPort: 3001
-          image: sumologic/kubernetes-tools:2.8.0
+          image: sumologic/kubernetes-tools:2.9.0
           name: receiver-mock
           args:
             - receiver-mock

--- a/vagrant/k8s/logs-generator.yaml
+++ b/vagrant/k8s/logs-generator.yaml
@@ -21,7 +21,7 @@ spec:
         name: logs-generator
     spec:
       containers:
-      - image: sumologic/kubernetes-tools:2.6.0
+      - image: sumologic/kubernetes-tools:2.9.0
         imagePullPolicy: Always
         name: logs-generator
         command:

--- a/vagrant/k8s/receiver-mock.yaml
+++ b/vagrant/k8s/receiver-mock.yaml
@@ -30,7 +30,7 @@ spec:
         - ports:
             - containerPort: 3000
             - containerPort: 3001
-          image: sumologic/kubernetes-tools:2.6.0
+          image: sumologic/kubernetes-tools:2.9.0
           name: receiver-mock
           args:
             - receiver-mock


### PR DESCRIPTION
##### Description

Update tools to fix an issue with external binaries being built for amd64 on arm. This affected helm, kubectl and yq.

---

##### Checklist

Remove items which don't apply to your PR.

- [x] Changelog updated
