### PR TITLE
feat: add cri support to experimental otelcol log collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- feat: add CRI support to experimental otelcol log collector[#2017][#2017]
 - docs(readme): add support for AKS 1.22 [#2075][#2075]
 
 ### Changed
@@ -28,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2058]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2058
 [#2063]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2063
 [#2075]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2075
+[#2017]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2017
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.4.1...main
 
 ## [v2.4.1][v2_4_1]

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -4195,7 +4195,35 @@ otellogs:
         include_file_path: true
         include_file_name: false
         operators:
-
+          ## Detect the container runtime log format
+          ## Can be: docker-shim, CRI-O and containerd
+          - id: get-format
+            type: router
+            routes:
+              - output: parser-docker
+                expr: '$$body matches "^\\{"'
+              - output: parser-crio
+                expr: '$$body matches "^[^ Z]+ "'
+              - output: parser-containerd
+                expr: '$$body matches "^[^ Z]+Z"'
+          ## Parse CRI-O format
+          - id: parser-crio
+            type: regex_parser
+            regex: '^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) (?P<log>.*)$'
+            output: extract-metadata-from-filepath
+            timestamp:
+              parse_from: time
+              layout_type: gotime
+              layout: '2006-01-02T15:04:05.000000000-07:00'
+          ## Parse CRI-Containerd format
+          - id: parser-containerd
+            type: regex_parser
+            regex: '^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) (?P<log>.*)$'
+            output: extract-metadata-from-filepath
+            timestamp:
+              parse_from: time
+              layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+          ## Parse docker-shim format
           ## parser-docker interprets the input string as JSON and moves the `time` field from the JSON to Timestamp field in the OTLP log
           ## record.
           # Input Body (string): '{"log":"2001-02-03 04:05:06 first line\n","stream":"stdout","time":"2021-11-25T09:59:13.23887954Z"}'
@@ -4204,7 +4232,7 @@ otellogs:
           # Output Timestamp: 2021-11-25 09:59:13.23887954 +0000 UTC
           - id: parser-docker
             type: json_parser
-            # output: join-multipart-entries
+            output: extract-metadata-from-filepath
             timestamp:
               parse_from: time
               layout: '%Y-%m-%dT%H:%M:%S.%LZ'

--- a/tests/helm/logs_otc/static/basic.output.yaml
+++ b/tests/helm/logs_otc/static/basic.output.yaml
@@ -31,7 +31,32 @@ data:
         include_file_name: false
         include_file_path: true
         operators:
+        - id: get-format
+          routes:
+          - expr: $$body matches "^\\{"
+            output: parser-docker
+          - expr: $$body matches "^[^ Z]+ "
+            output: parser-crio
+          - expr: $$body matches "^[^ Z]+Z"
+            output: parser-containerd
+          type: router
+        - id: parser-crio
+          output: extract-metadata-from-filepath
+          regex: ^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) (?P<log>.*)$
+          timestamp:
+            layout: "2006-01-02T15:04:05.000000000-07:00"
+            layout_type: gotime
+            parse_from: time
+          type: regex_parser
+        - id: parser-containerd
+          output: extract-metadata-from-filepath
+          regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) (?P<log>.*)$
+          timestamp:
+            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+            parse_from: time
+          type: regex_parser
         - id: parser-docker
+          output: extract-metadata-from-filepath
           timestamp:
             layout: '%Y-%m-%dT%H:%M:%S.%LZ'
             parse_from: time

--- a/tests/integration/helm_otelcol_logs_test.go
+++ b/tests/integration/helm_otelcol_logs_test.go
@@ -1,0 +1,152 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	terrak8s "github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	log "k8s.io/klog/v2"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
+
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal"
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/ctxopts"
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/stepfuncs"
+)
+
+func Test_Helm_Otelcol_Logs(t *testing.T) {
+	const (
+		tickDuration            = 3 * time.Second
+		waitDuration            = 3 * time.Minute
+		logsGeneratorCount uint = 1000
+	)
+
+	featInstall := features.New("installation").
+		Assess("sumologic secret is created",
+			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
+				terrak8s.WaitUntilSecretAvailable(t, ctxopts.KubectlOptions(ctx), "sumologic", 60, tickDuration)
+				secret := terrak8s.GetSecret(t, ctxopts.KubectlOptions(ctx), "sumologic")
+				require.Len(t, secret.Data, 2)
+				return ctx
+			}).
+		Assess("otelcol logs statefulset is ready",
+			stepfuncs.WaitUntilStatefulSetIsReady(
+				waitDuration,
+				tickDuration,
+				stepfuncs.WithNameF(
+					stepfuncs.ReleaseFormatter("%s-sumologic-otelcol-logs"),
+				),
+				stepfuncs.WithLabelsF(
+					stepfuncs.LabelFormatterKV{
+						K: "app",
+						V: stepfuncs.ReleaseFormatter("%s-sumologic-otelcol-logs"),
+					},
+				),
+			),
+		).
+		Assess("otelcol logs buffers PVCs are created and bound",
+			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
+				res := envConf.Client().Resources(ctxopts.Namespace(ctx))
+				pvcs := corev1.PersistentVolumeClaimList{}
+				cond := conditions.
+					New(res).
+					ResourceListMatchN(&pvcs, 3,
+						func(object k8s.Object) bool {
+							pvc := object.(*corev1.PersistentVolumeClaim)
+							if pvc.Status.Phase != corev1.ClaimBound {
+								log.V(0).Infof("PVC %q not bound yet", pvc.Name)
+								return false
+							}
+							return true
+						},
+						resources.WithLabelSelector(
+							fmt.Sprintf("app=%s-sumologic-otelcol-logs", ctxopts.HelmRelease(ctx)),
+						),
+					)
+				require.NoError(t,
+					wait.For(cond,
+						wait.WithTimeout(waitDuration),
+						wait.WithInterval(tickDuration),
+					),
+				)
+				return ctx
+			}).
+		Assess("otelcol daemonset is ready",
+			stepfuncs.WaitUntilDaemonSetIsReady(
+				waitDuration,
+				tickDuration,
+				stepfuncs.WithNameF(
+					stepfuncs.ReleaseFormatter("%s-sumologic-otelcol-logs-collector"),
+				),
+				stepfuncs.WithLabelsF(
+					stepfuncs.LabelFormatterKV{
+						K: "app",
+						V: stepfuncs.ReleaseFormatter("%s-sumologic-otelcol-logs-collector"),
+					},
+				),
+			),
+		).
+		Feature()
+	featLogs := features.New("logs").
+		Setup(stepfuncs.GenerateLogsWithDeployment(
+			logsGeneratorCount,
+			internal.LogsGeneratorName,
+			internal.LogsGeneratorNamespace,
+			internal.LogsGeneratorImage,
+		)).
+		Assess("logs from log generator present", stepfuncs.WaitUntilExpectedLogsPresent(
+			logsGeneratorCount,
+			map[string]string{
+				"namespace":      internal.LogsGeneratorName,
+				"pod_labels_app": internal.LogsGeneratorName,
+			},
+			internal.ReceiverMockNamespace,
+			internal.ReceiverMockServiceName,
+			internal.ReceiverMockServicePort,
+			waitDuration,
+			tickDuration,
+		)).
+		Assess("expected container log metadata is present", stepfuncs.WaitUntilExpectedLogsPresent(
+			logsGeneratorCount,
+			map[string]string{
+				"_collector":       "kubernetes",
+				"namespace":        internal.LogsGeneratorName,
+				"pod_labels_app":   internal.LogsGeneratorName,
+				"container":        internal.LogsGeneratorName,
+				"deployment":       internal.LogsGeneratorName,
+				"replicaset":       "",
+				"pod":              "",
+				"k8s.pod.id":       "",
+				"k8s.pod.pod_name": "",
+				// "k8s.container.id": "", // TODO: disable this for other tests, it's not reliable
+				"host": "",
+				"node": "",
+			},
+			internal.ReceiverMockNamespace,
+			internal.ReceiverMockServiceName,
+			internal.ReceiverMockServicePort,
+			waitDuration,
+			tickDuration,
+		)).
+		Teardown(
+			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
+				opts := *ctxopts.KubectlOptions(ctx)
+				opts.Namespace = internal.LogsGeneratorNamespace
+				terrak8s.RunKubectl(t, &opts, "delete", "deployment", internal.LogsGeneratorName)
+				return ctx
+			}).
+		Teardown(stepfuncs.KubectlDeleteNamespaceOpt(internal.LogsGeneratorNamespace)).
+		Feature()
+
+	testenv.Test(t, featInstall, featLogs)
+}

--- a/tests/integration/values/values_helm_otelcol_logs.yaml
+++ b/tests/integration/values/values_helm_otelcol_logs.yaml
@@ -1,0 +1,37 @@
+sumologic:
+  logs:
+    metadata:
+      provider: otelcol
+
+  metrics:
+    enabled: false
+
+# We're using otelcol instead
+fluent-bit:
+  enabled: false
+
+fluentd:
+  events:
+    enabled: false
+
+otellogs:
+  enabled: true
+  config:
+    service:
+      pipelines:
+        logs/containers:
+          receivers:
+            - filelog/containers
+          exporters:
+            - otlphttp
+          processors:
+            - filter/exclude_receiver_mock_container
+    processors:
+      # Filter out receiver-mock logs to prevent snowball effect
+      filter/exclude_receiver_mock_container:
+        logs:
+          exclude:
+            match_type: strict
+            record_attributes:
+              - key: k8s.container.name
+                value: receiver-mock


### PR DESCRIPTION
##### Description

Add CRI log format support to the OTC log collector. This gives us containerd support and enables integration tests for the collector on kind. Based on https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/examples/kubernetes/otel-collector-config.yml courtesy of @sumo-drosiek 🙇 .

---

##### Checklist

Remove items which don't apply to your PR.

- [x] Changelog updated

###### Testing performed

- [X] Confirm events, logs, and metrics are coming in
