### PR TITLE
docs: claim official ARM support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- docs: claim official ARM support [#2024][#2024]
 - feat: add batching to experimental otelcol log collector [#2018][#2018]
 - feat: add experimental otelcol log collector [#1986][#1986]
 - feat: add option to disable pod owners enrichment [#1959][#1959]
@@ -37,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2018]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2018
 [#2020]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2020
 [#2025]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2025
+[#2024]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2024
 
 ## [v2.3.2][v2_3_2]
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -117,3 +117,15 @@ The following matrix displays the tested package versions for our Helm chart.
 | 0.12.0                | 8.2.0                                     | 1.6.3   | 2.8.1                               | 1.0.9  | -              | -                 |                          |
 | 0.9.0 - 0.11.0        | 6.2.1                                     | 1.6.3   | 2.4.4                               | 1.0.8  | -              | -                 |                          |
 | 0.6.0 - 0.8.0         | 6.2.1                                     | 1.6.3   | 2.4.4                               | 1.0.5  | -              | -                 |                          |
+
+### ARM support
+
+The collection Helm Chart supports AWS Graviton CPUs, and has been tested in ARM-based EKS clusters. In principle, it
+should run fine on any ARM64 node, but there is currently no official support for non-AWS ARM environments. If you do
+however run into problems in such an environment, don't hesitate to open an [issue][issues] describing them.
+
+The only exception to the above is Falco, which currently lacks official ARM Docker images. See
+[this issue][falco] for more information.
+
+[falco]: https://github.com/falcosecurity/falco/issues/1589
+[issues]: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues


### PR DESCRIPTION
##### Description

With some recent image upgrades, we now officially support ARM, minus Falco. Internal E2E tests are passing for EKS on Graviton2 nodes, so we can claim this with a good amount of confidence. This should also resolve https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/1565.

---

##### Checklist

Remove items which don't apply to your PR.

- [X] Changelog updated
