### PR TITLE
test(integration): increate wait time to 5 min so that pod ownership labels are present

### DIFF
--- a/tests/integration/helm_default_installation_test.go
+++ b/tests/integration/helm_default_installation_test.go
@@ -30,7 +30,7 @@ import (
 func Test_Helm_Default_FluentD_Metadata(t *testing.T) {
 	const (
 		tickDuration            = 3 * time.Second
-		waitDuration            = 3 * time.Minute
+		waitDuration            = 5 * time.Minute
 		logsGeneratorCount uint = 1000
 	)
 	expectedMetrics := internal.DefaultExpectedMetrics

--- a/tests/integration/helm_otc_metadata_installation_test.go
+++ b/tests/integration/helm_otc_metadata_installation_test.go
@@ -31,7 +31,7 @@ import (
 func Test_Helm_Default_OT_Metadata(t *testing.T) {
 	const (
 		tickDuration            = 3 * time.Second
-		waitDuration            = 3 * time.Minute
+		waitDuration            = 5 * time.Minute
 		logsGeneratorCount uint = 1000
 	)
 


### PR DESCRIPTION
Related to what's described in : https://github.com/SumoLogic/sumologic-otel-collector/pull/384