### PR TITLE
feat: export scheduler_framework_extension_point_duration metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- feat: export scheduler_framework_extension_point_duration metrics [#2033][#2033]
 - docs: claim official ARM support [#2024][#2024]
 - feat: add batching to experimental otelcol log collector [#2018][#2018]
 - feat: add experimental otelcol log collector [#1986][#1986]
@@ -39,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2020]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2020
 [#2025]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2025
 [#2024]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2024
+[#2033]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2024
 
 ## [v2.3.2][v2_3_2]
 

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1445,12 +1445,15 @@ kube-prometheus-stack:
       ## scheduler_binding_duration_seconds_bucket
       ## scheduler_binding_duration_seconds_count
       ## scheduler_binding_duration_seconds_sum
+      ## scheduler_framework_extension_point_duration_seconds_bucket
+      ## scheduler_framework_extension_point_duration_seconds_count
+      ## scheduler_framework_extension_point_duration_seconds_sum
       ## scheduler_scheduling_algorithm_duration_seconds_bucket
       ## scheduler_scheduling_algorithm_duration_seconds_count
       ## scheduler_scheduling_algorithm_duration_seconds_sum
       metricRelabelings:
         - action: keep
-          regex: (?:scheduler_(?:e2e_scheduling|binding|scheduling_algorithm)_duration_seconds.*)
+          regex: (?:scheduler_(?:e2e_scheduling|binding|scheduler_framework_extension_point|scheduling_algorithm)_duration_seconds.*)
           sourceLabels: [__name__]
   kubeStateMetrics:
     serviceMonitor:
@@ -1844,6 +1847,9 @@ kube-prometheus-stack:
         ## scheduler_binding_duration_seconds_bucket
         ## scheduler_binding_duration_seconds_count
         ## scheduler_binding_duration_seconds_sum
+        ## scheduler_framework_extension_point_duration_seconds_bucket
+        ## scheduler_framework_extension_point_duration_seconds_count
+        ## scheduler_framework_extension_point_duration_seconds_sum
         ## scheduler_scheduling_algorithm_duration_seconds_bucket
         ## scheduler_scheduling_algorithm_duration_seconds_count
         ## scheduler_scheduling_algorithm_duration_seconds_sum
@@ -1851,7 +1857,7 @@ kube-prometheus-stack:
           remoteTimeout: 5s
           writeRelabelConfigs:
             - action: keep
-              regex: kube-scheduler;scheduler_(?:e2e_scheduling|binding|scheduling_algorithm)_duration_seconds.*
+              regex: kube-scheduler;scheduler_(?:e2e_scheduling|binding|scheduler_framework_extension_point|scheduling_algorithm)_duration_seconds.*
               sourceLabels: [job, __name__]
         ## api server metrics:
         ## apiserver_request_count
@@ -1956,6 +1962,7 @@ kube-prometheus-stack:
         ## :node_net_utilisation:sum_irate
         ## cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
         ## cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile
+        ## cluster_quantile:scheduler_framework_extension_point_duration_seconds:histogram_quantile
         ## cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
         ## cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
         ## instance:node_filesystem_usage:sum  # no rules definition found
@@ -1983,7 +1990,7 @@ kube-prometheus-stack:
           remoteTimeout: 5s
           writeRelabelConfigs:
             - action: keep
-              regex: 'cluster_quantile:apiserver_request_duration_seconds:histogram_quantile|instance:node_filesystem_usage:sum|instance:node_network_receive_bytes:rate:sum|cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile|cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile|cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile|node_namespace_pod:kube_pod_info:|:kube_pod_info_node_count:|node:node_num_cpu:sum|:node_cpu_utilisation:avg1m|node:node_cpu_utilisation:avg1m|node:cluster_cpu_utilisation:ratio|:node_cpu_saturation_load1:|node:node_cpu_saturation_load1:|:node_memory_utilisation:|node:node_memory_bytes_total:sum|node:node_memory_utilisation:ratio|node:cluster_memory_utilisation:ratio|:node_memory_swap_io_bytes:sum_rate|node:node_memory_utilisation:|node:node_memory_utilisation_2:|node:node_memory_swap_io_bytes:sum_rate|:node_disk_utilisation:avg_irate|node:node_disk_utilisation:avg_irate|:node_disk_saturation:avg_irate|node:node_disk_saturation:avg_irate|node:node_filesystem_usage:|node:node_filesystem_avail:|:node_net_utilisation:sum_irate|node:node_net_utilisation:sum_irate|:node_net_saturation:sum_irate|node:node_net_saturation:sum_irate|node:node_inodes_total:|node:node_inodes_free:'
+              regex: 'cluster_quantile:apiserver_request_duration_seconds:histogram_quantile|instance:node_filesystem_usage:sum|instance:node_network_receive_bytes:rate:sum|cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile|cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile|cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile|cluster_quantile:scheduler_framework_extension_point_duration_seconds:histogram_quantile|node_namespace_pod:kube_pod_info:|:kube_pod_info_node_count:|node:node_num_cpu:sum|:node_cpu_utilisation:avg1m|node:node_cpu_utilisation:avg1m|node:cluster_cpu_utilisation:ratio|:node_cpu_saturation_load1:|node:node_cpu_saturation_load1:|:node_memory_utilisation:|node:node_memory_bytes_total:sum|node:node_memory_utilisation:ratio|node:cluster_memory_utilisation:ratio|:node_memory_swap_io_bytes:sum_rate|node:node_memory_utilisation:|node:node_memory_utilisation_2:|node:node_memory_swap_io_bytes:sum_rate|:node_disk_utilisation:avg_irate|node:node_disk_utilisation:avg_irate|:node_disk_saturation:avg_irate|node:node_disk_saturation:avg_irate|node:node_filesystem_usage:|node:node_filesystem_avail:|:node_net_utilisation:sum_irate|node:node_net_utilisation:sum_irate|:node_net_saturation:sum_irate|node:node_net_saturation:sum_irate|node:node_inodes_total:|node:node_inodes_free:'
               sourceLabels: [__name__]
         ## health
         ## fluentbit_input_bytes_total


### PR DESCRIPTION
##### Description

`scheduler_binding_duration` is deprecated in Kubernetes 1.21 and the generic framework extension metrics are the replacements. See: https://github.com/kubernetes/kubernetes/pull/96447.

I've tested this in kind by patching the control plane components. I'll submit those changes separately alongside tests for other control plane metrics.

---

##### Checklist

Remove items which don't apply to your PR.

- [x] Changelog updated

