### PR TITLE
test(integration): include control plane metrics in integration tests

### DIFF
--- a/tests/integration/internal/constants.go
+++ b/tests/integration/internal/constants.go
@@ -94,6 +94,26 @@ var (
 		"cloudprovider_aws_api_request_duration_seconds_count",
 		"cloudprovider_aws_api_request_duration_seconds_sum",
 	}
+	CoreDNSMetrics = []string{
+		"coredns_cache_entries",
+		"coredns_cache_hits_total",
+		"coredns_cache_misses_total",
+		"coredns_dns_request_duration_seconds_count",
+		"coredns_dns_request_duration_seconds_sum",
+		"coredns_dns_requests_total",
+		"coredns_dns_responses_total",
+		"coredns_forward_requests_total",
+		"process_cpu_seconds_total",
+		"process_open_fds",
+		"process_resident_memory_bytes",
+		// Deprecated in https://coredns.io/2020/06/15/coredns-1.7.0-release/#metric-changes
+		// "coredns_cache_size",
+		// "coredns_dns_response_rcode_count_total",
+		// "coredns_forward_request_count_total",
+		// No idea where this came from, doesn't seem to exist
+		// TODO: confirm it doesn't exist and remove it from values.yaml
+		// "coredns_dns_request_count_total",
+	}
 	CAdvisorMetrics = []string{
 		"container_cpu_usage_seconds_total",
 		// These metrics will be available in containerd after kind upgrades past
@@ -126,6 +146,7 @@ var (
 		KubeApiServerMetrics,
 		// Need to upgrade kube-prometheus stack to use the secure metrics endpoint for controller metrics
 		// KubeControllerManagerMetrics,
+		CoreDNSMetrics,
 		CAdvisorMetrics,
 		NodeExporterMetrics,
 	}

--- a/tests/integration/internal/constants.go
+++ b/tests/integration/internal/constants.go
@@ -75,6 +75,20 @@ var (
 		// TODO: Remove this and the values.yaml settings after we drop support for 1.20
 		// "scheduler_binding_duration_seconds",
 	}
+	KubeApiServerMetrics = []string{
+		"apiserver_request_total",
+		"apiserver_request_duration_seconds_count",
+		"apiserver_request_duration_seconds_sum",
+		// We have the following metrics in our values.yaml, but they've been deprecated for a while
+		// Kubernetes 1.14 deprecation notice: https://github.com/kubernetes/kubernetes/blob/8ac5d4d6a92d59bba70844fbd6e5de2383a08c96/CHANGELOG/CHANGELOG-1.14.md#deprecated-metrics
+		// Kubernetes 1.17 disablement notice: https://github.com/kubernetes/kubernetes/blob/ea0764452222146c47ec826977f49d7001b0ea8c/CHANGELOG/CHANGELOG-1.17.md#deprecatedchanged-metrics
+		// TODO: Remove these from values.yaml and replace them with non-deprecated equivalents
+		// "apiserver_request_latencies_count",
+		// "apiserver_request_latencies_sum",
+		// "apiserver_request_latencies_summary",
+		// "apiserver_request_latencies_summary_count",
+		// "apiserver_request_latencies_summary_sum",
+	}
 	CAdvisorMetrics = []string{
 		"container_cpu_usage_seconds_total",
 		// These metrics will be available in containerd after kind upgrades past
@@ -104,6 +118,7 @@ var (
 		KubePodMetrics,
 		KubeletMetrics,
 		KubeSchedulerMetrics,
+		KubeApiServerMetrics,
 		CAdvisorMetrics,
 		NodeExporterMetrics,
 	}

--- a/tests/integration/internal/constants.go
+++ b/tests/integration/internal/constants.go
@@ -89,6 +89,11 @@ var (
 		// "apiserver_request_latencies_summary_count",
 		// "apiserver_request_latencies_summary_sum",
 	}
+	KubeControllerManagerMetrics = []string{
+		"cloudprovider_aws_api_request_duration_seconds_bucket",
+		"cloudprovider_aws_api_request_duration_seconds_count",
+		"cloudprovider_aws_api_request_duration_seconds_sum",
+	}
 	CAdvisorMetrics = []string{
 		"container_cpu_usage_seconds_total",
 		// These metrics will be available in containerd after kind upgrades past
@@ -119,6 +124,8 @@ var (
 		KubeletMetrics,
 		KubeSchedulerMetrics,
 		KubeApiServerMetrics,
+		// Need to upgrade kube-prometheus stack to use the secure metrics endpoint for controller metrics
+		// KubeControllerManagerMetrics,
 		CAdvisorMetrics,
 		NodeExporterMetrics,
 	}

--- a/tests/integration/internal/constants.go
+++ b/tests/integration/internal/constants.go
@@ -64,6 +64,17 @@ var (
 		"kubelet_running_containers",
 		"kubelet_running_pods",
 	}
+	KubeSchedulerMetrics = []string{
+		"scheduler_e2e_scheduling_duration_seconds_count",
+		"scheduler_e2e_scheduling_duration_seconds_sum",
+		"scheduler_e2e_scheduling_duration_seconds_bucket",
+		"scheduler_scheduling_algorithm_duration_seconds_count",
+		"scheduler_scheduling_algorithm_duration_seconds_sum",
+		"scheduler_scheduling_algorithm_duration_seconds_bucket",
+		// Deprecated in Kubernetes 1.21: https://github.com/kubernetes/kubernetes/pull/96447
+		// TODO: Remove this and the values.yaml settings after we drop support for 1.20
+		// "scheduler_binding_duration_seconds",
+	}
 	CAdvisorMetrics = []string{
 		"container_cpu_usage_seconds_total",
 		// These metrics will be available in containerd after kind upgrades past
@@ -92,6 +103,7 @@ var (
 		KubeNodeMetrics,
 		KubePodMetrics,
 		KubeletMetrics,
+		KubeSchedulerMetrics,
 		CAdvisorMetrics,
 		NodeExporterMetrics,
 	}

--- a/tests/integration/internal/constants.go
+++ b/tests/integration/internal/constants.go
@@ -80,14 +80,51 @@ var (
 		"apiserver_request_duration_seconds_count",
 		"apiserver_request_duration_seconds_sum",
 		// We have the following metrics in our values.yaml, but they've been deprecated for a while
-		// Kubernetes 1.14 deprecation notice: https://github.com/kubernetes/kubernetes/blob/8ac5d4d6a92d59bba70844fbd6e5de2383a08c96/CHANGELOG/CHANGELOG-1.14.md#deprecated-metrics
-		// Kubernetes 1.17 disablement notice: https://github.com/kubernetes/kubernetes/blob/ea0764452222146c47ec826977f49d7001b0ea8c/CHANGELOG/CHANGELOG-1.17.md#deprecatedchanged-metrics
+		// Kubernetes 1.14 deprecation notice:
+		// https://github.com/kubernetes/kubernetes/blob/8ac5d4d6a92d59bba70844fbd6e5de2383a08c96/CHANGELOG/CHANGELOG-1.14.md#deprecated-metrics
+		// Kubernetes 1.17 disablement notice:
+		// https://github.com/kubernetes/kubernetes/blob/ea0764452222146c47ec826977f49d7001b0ea8c/CHANGELOG/CHANGELOG-1.17.md#deprecatedchanged-metrics
 		// TODO: Remove these from values.yaml and replace them with non-deprecated equivalents
 		// "apiserver_request_latencies_count",
 		// "apiserver_request_latencies_sum",
 		// "apiserver_request_latencies_summary",
 		// "apiserver_request_latencies_summary_count",
 		// "apiserver_request_latencies_summary_sum",
+	}
+	KubeEtcdMetrics = []string{
+		// Deprecated in etcd v3: https://github.com/kubernetes/kubernetes/pull/79520
+		// "etcd_request_cache_get_duration_seconds_count",
+		// "etcd_request_cache_get_duration_seconds_sum",
+		// "etcd_request_cache_add_duration_seconds_count",
+		// "etcd_request_cache_add_duration_seconds_sum",
+		// "etcd_request_cache_add_latencies_summary_count",
+		// "etcd_request_cache_add_latencies_summary_sum",
+		// "etcd_request_cache_get_latencies_summary_count",
+		// "etcd_request_cache_get_latencies_summary_sum",
+		// "etcd_helper_cache_hit_count",
+		// "etcd_helper_cache_hit_total",
+		// "etcd_helper_cache_miss_count",
+		// "etcd_helper_cache_miss_total",
+		// Deprecated in etcd 3.5: https://github.com/etcd-io/etcd/blob/e433d12656c5dbd41f4f6b085ced134647ffeb14/CHANGELOG-3.5.md#breaking-changes
+		// TODO: Replace with etcd_mvcc_db_total_size_in_bytes
+		//"etcd_debugging_mvcc_db_total_size_in_bytes",
+		"etcd_debugging_store_expires_total",
+		"etcd_debugging_store_watchers",
+		"etcd_disk_backend_commit_duration_seconds_bucket",
+		"etcd_disk_wal_fsync_duration_seconds_bucket",
+		"etcd_grpc_proxy_cache_hits_total",
+		"etcd_grpc_proxy_cache_misses_total",
+		"etcd_network_client_grpc_received_bytes_total",
+		"etcd_network_client_grpc_sent_bytes_total",
+		"etcd_server_has_leader",
+		"etcd_server_leader_changes_seen_total",
+		"etcd_server_proposals_applied_total",
+		"etcd_server_proposals_committed_total",
+		"etcd_server_proposals_failed_total",
+		"etcd_server_proposals_pending",
+		"process_cpu_seconds_total",
+		"process_open_fds",
+		"process_resident_memory_bytes",
 	}
 	KubeControllerManagerMetrics = []string{
 		"cloudprovider_aws_api_request_duration_seconds_bucket",
@@ -144,6 +181,7 @@ var (
 		KubeletMetrics,
 		KubeSchedulerMetrics,
 		KubeApiServerMetrics,
+		KubeEtcdMetrics,
 		// Need to upgrade kube-prometheus stack to use the secure metrics endpoint for controller metrics
 		// KubeControllerManagerMetrics,
 		CoreDNSMetrics,

--- a/tests/integration/values/values_common.yaml
+++ b/tests/integration/values/values_common.yaml
@@ -19,6 +19,12 @@ kube-prometheus-stack:
         requests:
           cpu: 100m
           memory: 128Mi
+  # kind exposes etcd metrics in http on a different port, and enables TLS for the default
+  # port. This change is simpler than configuring TLS for the default port.
+  # TODO: Should we use TLS for our default values.yaml here?
+  kubeEtcd:
+    service:
+      targetPort: 2381
 
 # Request less resources so that this fits on Github actions runners environment
 metadata:

--- a/tests/integration/yamls/cluster.yaml
+++ b/tests/integration/yamls/cluster.yaml
@@ -12,4 +12,6 @@ nodes:
         extraArgs:
           bind-address: 0.0.0.0
           port: "10251"
-
+    controllerManager:
+        extraArgs:
+          bind-address: 0.0.0.0

--- a/tests/integration/yamls/cluster.yaml
+++ b/tests/integration/yamls/cluster.yaml
@@ -2,3 +2,14 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
+  kubeadmConfigPatches:
+  # these changes allow us to scrape control plane metrics
+  # see kind docs on customizing kubeadm: https://kind.sigs.k8s.io/docs/user/configuration/#kubeadm-config-patches
+  # and kubeadm docs on configuring control plane components: https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/control-plane-flags/
+  - |
+    kind: ClusterConfiguration
+    scheduler:
+        extraArgs:
+          bind-address: 0.0.0.0
+          port: "10251"
+

--- a/tests/integration/yamls/cluster.yaml
+++ b/tests/integration/yamls/cluster.yaml
@@ -15,3 +15,7 @@ nodes:
     controllerManager:
         extraArgs:
           bind-address: 0.0.0.0
+    etcd:
+      local:
+        extraArgs:
+          listen-metrics-urls: http://0.0.0.0:2381


### PR DESCRIPTION
##### Description

With some configuration changes to the kind cluster, it's possible to see control plane metrics in integration tests. I've based the tests on ServiceMonitor definitions in values.yaml, and it turns out there's a few metrics which have been deprecated since the original config was written. I've clearly marked them in test definitions and added TODOs to remove them.

---

##### Checklist

Remove items which don't apply to your PR.
- [X] Confirm events, logs, and metrics are coming in
