### PR TITLE
chore: update telegraf to 1.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- chore: update the Telegraf image to 1.21.2 [#2036][#2036]
+
 ### Fixed
 
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.4.0...main
+[#2036]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2036
 
 ## [v2.4.0][v2_4_0]
 

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -4375,7 +4375,7 @@ otellogs:
 telegraf-operator:
   enabled: false
   image:
-    sidecarImage: public.ecr.aws/sumologic/telegraf:1.14.4
+    sidecarImage: public.ecr.aws/sumologic/telegraf:1.21.2
   replicaCount: 1
   classes:
     secretName: "telegraf-operator-classes"


### PR DESCRIPTION
##### Description

1.14 is pretty old and contains quite a few vulnerabilities. I ran E2E tests on 1.21 and they passed without issue.

---

##### Checklist

Remove items which don't apply to your PR.

- [x] Changelog updated

###### Testing performed

- [X] Confirm events, logs, and metrics are coming in
