### PR TITLE
[Backport release-v2.4] chore: update Telegraf to 1.21.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+### Changed
+
+- chore: update the Telegraf image to 1.21.2 [#2036][#2036]
+
+### Fixed
+
+[Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.4.0...main
+[#2036]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2036
+
 ## [v2.4.0][v2_4_0]
 
 ### Released 2022-01-25

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -4375,7 +4375,7 @@ otellogs:
 telegraf-operator:
   enabled: false
   image:
-    sidecarImage: public.ecr.aws/sumologic/telegraf:1.14.4
+    sidecarImage: public.ecr.aws/sumologic/telegraf:1.21.2
   replicaCount: 1
   classes:
     secretName: "telegraf-operator-classes"


### PR DESCRIPTION
##### Description

Backport the Telegraf update to 2.4.

---

##### Checklist

- [X] Changelog updated

