### PR TITLE
Upgrade Kube-Prometheus-Stack to support hostRootFsMount

### DIFF
--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
     repository: https://fluent.github.io/helm-charts
     condition: fluent-bit.enabled,sumologic.logs.enabled
   - name: kube-prometheus-stack
-    version: 12.10.0
+    version: 14.7.1
     repository: https://prometheus-community.github.io/helm-charts
     condition: kube-prometheus-stack.enabled,sumologic.metrics.enabled
   - name: falco


### PR DESCRIPTION
##### Description

Refer to prometheus-community/helm-charts@201e9e8,
https://github.com/prometheus-community/helm-charts/blob/prometheus-node-exporter-1.17.0/charts/kube-prometheus-stack/Chart.yaml
14.7.1 is the lowerest version that supports hostRootFsMount.
Without the option to set hostRootFsMount as false, the node-exporter would crash in some cases, refer to prometheus-community/helm-charts#467.


---

##### Checklist

- [ ] Changelog updated

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
