### PR TITLE
test(integration): decrease expected kubelet logs count

### DIFF
--- a/tests/integration/helm_default_installation_test.go
+++ b/tests/integration/helm_default_installation_test.go
@@ -333,7 +333,7 @@ func Test_Helm_Default_FluentD_Metadata(t *testing.T) {
 			tickDuration,
 		)).
 		Assess("logs from kubelet present", stepfuncs.WaitUntilExpectedLogsPresent(
-			10, // we don't really control this, just want to check if the logs show up
+			1, // we don't really control this, just want to check if the logs show up
 			map[string]string{
 				"_sourceName":     "k8s_kubelet",
 				"_sourceCategory": "kubernetes/kubelet",

--- a/tests/integration/helm_otc_metadata_installation_test.go
+++ b/tests/integration/helm_otc_metadata_installation_test.go
@@ -348,7 +348,7 @@ func Test_Helm_Default_OT_Metadata(t *testing.T) {
 			tickDuration,
 		)).
 		Assess("logs from kubelet present", stepfuncs.WaitUntilExpectedLogsPresent(
-			10, // we don't really control this, just want to check if the logs show up
+			1, // we don't really control this, just want to check if the logs show up
 			map[string]string{
 				"_sourceName":     "k8s_kubelet",
 				"_sourceCategory": "kubernetes/kubelet",


### PR DESCRIPTION
It seems that sometimes we don't get 10 logs from kubelet ([failed CI](https://github.com/SumoLogic/sumologic-kubernetes-collection/runs/5034342403?check_suite_focus=true)) so decrease the number so that we don't get any more false failures.