### PR TITLE
[v2.4.x] docs(readme): add support for AKS 1.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-<!-- markdown-link-check-disable -->
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.4.1...release-v2.4
-<!-- markdown-link-check-enable -->
 
 ## [v2.4.1][v2_4_1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased][Unreleased]
+
+### Unreleased
+
+### Added
+
+- docs(readme): add support for AKS 1.22 [#2076][#2076]
+
+### Changed
+
+<!-- markdown-link-check-disable -->
+[Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.4.1...release-v2.4
+<!-- markdown-link-check-enable -->
+
 ## [v2.4.1][v2_4_1]
 
 ### Released 2022-02-02
@@ -19,11 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- markdown-link-check-disable -->
 [v2_4_1]: https://github.com/SumoLogic/sumologic-kubernetes-collection/releases/tag/v2.4.1
-[Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.4.1...main
 <!-- markdown-link-check-enable -->
 [#2036]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2036
 [#2066]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2066
 [#2064]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2064
+[#2076]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2076
 
 ## [v2.4.0][v2_4_0]
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -79,7 +79,7 @@ The following table displays the tested Kubernetes and Helm versions.
 | K8s with EKS  | 1.18<br/>1.19<br/>1.20<br/>1.21 |
 | K8s with Kops | 1.18<br/>1.19<br/>1.20<br/>1.21 |
 | K8s with GKE  | 1.20<br/>1.21                   |
-| K8s with AKS  | 1.19<br/>1.20<br/>1.21          |
+| K8s with AKS  | 1.19<br/>1.20<br/>1.21<br/>1.22 |
 | OpenShift     | 4.6<br/>4.7<br/>4.8             |
 | Helm          | 3.5.4 (Linux)                   |
 | kubectl       | 1.16.0                          |


### PR DESCRIPTION
##### Description

docs(readme): add support for AKS 1.22 (backported from #2075)

---

##### Checklist

Remove items which don't apply to your PR.

- [ ] Changelog updated

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
