### PR TITLE
test(integration): disable kube-scheduler metrics

### DIFF
--- a/tests/integration/internal/constants.go
+++ b/tests/integration/internal/constants.go
@@ -179,7 +179,9 @@ var (
 		KubeNodeMetrics,
 		KubePodMetrics,
 		KubeletMetrics,
-		KubeSchedulerMetrics,
+		// See: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2079
+		// TODO: Enable this again after the above issue is resolved
+		// KubeSchedulerMetrics,
 		KubeApiServerMetrics,
 		KubeEtcdMetrics,
 		// Need to upgrade kube-prometheus stack to use the secure metrics endpoint for controller metrics


### PR DESCRIPTION
##### Description

Tests for kube-scheduler metrics are flaky in some environments. Disabling them until the issue is resolved.

Tracking the issue in #2079 
