### PR TITLE
fix: disable the metadata pipeline for OTC log collector by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- fix: disable the metadata pipeline for OTC log collector by default [#2084][#2084]
 - fix: fix scheduler metrics remote write and relabel regex [#2058][#2058]
 
 [#2036]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2036
@@ -32,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2017]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2017
 [#2077]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2077
 [#2083]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2083
+[#2084]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2084
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.4.1...main
 
 ## [v2.4.1][v2_4_1]

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -4076,19 +4076,20 @@ metadata:
               - batch
             exporters:
               - sumologic/systemd
-          logs/otlp/containers:
-            receivers:
-              - otlp
-            processors:
-              - memory_limiter
-              - attributes/containers
-              - groupbyattrs/containers
-              - k8s_tagger
-              - source/containers
-              - resource/containers_copy_node_to_host
-              - batch
-            exporters:
-              - sumologic/containers
+          ## Uncomment this only if you're enabling the Otelcol Log Collector via otellogs.enabled
+          # logs/otlp/containers:
+          #   receivers:
+          #     - otlp
+          #   processors:
+          #     - memory_limiter
+          #     - attributes/containers
+          #     - groupbyattrs/containers
+          #     - k8s_tagger
+          #     - source/containers
+          #     - resource/containers_copy_node_to_host
+          #     - batch
+          #   exporters:
+          #     - sumologic/containers
     statefulset:
       nodeSelector: {}
       tolerations: []
@@ -4159,6 +4160,8 @@ metadata:
 ## which is consistent with CRI, but may possibly cause issues on older K8s versions.
 ## This is an alpha feature, and may change in the near future.
 otellogs:
+  ## In order to enable this feature, a configuration block under metadata.logs.config.service.pipelines.logs/otlp/containers
+  ## needs to be uncommented
   enabled: false
 
   ## Configure image for Opentelemetry Collector

--- a/tests/helm/metadata_logs_otc/static/basic.output.yaml
+++ b/tests/helm/metadata_logs_otc/static/basic.output.yaml
@@ -270,19 +270,6 @@ data:
           - batch
           receivers:
           - fluentforward
-        logs/otlp/containers:
-          exporters:
-          - sumologic/containers
-          processors:
-          - memory_limiter
-          - attributes/containers
-          - groupbyattrs/containers
-          - k8s_tagger
-          - source/containers
-          - resource/containers_copy_node_to_host
-          - batch
-          receivers:
-          - otlp
       telemetry:
         logs:
           level: info

--- a/tests/helm/metadata_logs_otc/static/templates.output.yaml
+++ b/tests/helm/metadata_logs_otc/static/templates.output.yaml
@@ -270,19 +270,6 @@ data:
           - batch
           receivers:
           - fluentforward
-        logs/otlp/containers:
-          exporters:
-          - sumologic/containers
-          processors:
-          - memory_limiter
-          - attributes/containers
-          - groupbyattrs/containers
-          - k8s_tagger
-          - source/containers
-          - resource/containers_copy_node_to_host
-          - batch
-          receivers:
-          - otlp
       telemetry:
         logs:
           level: info

--- a/tests/integration/values/values_helm_otelcol_logs.yaml
+++ b/tests/integration/values/values_helm_otelcol_logs.yaml
@@ -14,6 +14,26 @@ fluentd:
   events:
     enabled: false
 
+metadata:
+  logs:
+    config:
+      service:
+        pipelines:
+          logs/otlp/containers:
+            receivers:
+              - otlp
+            processors:
+              - memory_limiter
+              - attributes/containers
+              - groupbyattrs/containers
+              - k8s_tagger
+              - source/containers
+              - resource/containers_copy_node_to_host
+              - batch
+            exporters:
+              - sumologic/containers
+
+
 otellogs:
   enabled: true
   config:


### PR DESCRIPTION
##### Description

This pipeline was enabled by default by mistake, as the default configuration doesn't need it, and the k8s_tagger within puts some additional load on the API server. I'm commenting it out as we can't use conditional logic directly in values.yaml.

---

##### Checklist

Remove items which don't apply to your PR.

- [x] Changelog updated

###### Testing performed

- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
