### PR TITLE
feat(otelcol/metrics): do not add host to metrics

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -3421,6 +3421,7 @@ metadata:
             [agent]
               interval = "30s"
               flush_interval = "30s"
+              omit_hostname = true
 
             [[inputs.http_listener_v2]]
               # wait longer than prometheus

--- a/tests/integration/helm_otc_metadata_installation_test.go
+++ b/tests/integration/helm_otc_metadata_installation_test.go
@@ -258,7 +258,6 @@ func Test_Helm_Default_OT_Metadata(t *testing.T) {
 						// hence with longer time range the time series about a particular metric
 						// that we receive diverge into n, where n is the number of metrics
 						// enrichment pods.
-						"host":                         "",
 						"http_listener_v2_path":        "/prometheus.metrics.container",
 						"image":                        "",
 						"instance":                     "",
@@ -279,11 +278,8 @@ func Test_Helm_Default_OT_Metadata(t *testing.T) {
 					}
 
 					log.V(0).InfoS("sample's labels", "labels", labels)
-					if !labels.MatchAll(expectedLabels) {
-						return false
-					}
+					return labels.MatchAll(expectedLabels)
 
-					return true
 				}, waitDuration, tickDuration)
 				return ctx
 			},


### PR DESCRIPTION
##### Description

Do not add host dimension to metrics. If this is not set, it is set to otelcol name what is misleading

---

##### Checklist

Remove items which don't apply to your PR.

- [ ] Changelog updated

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
