### PR TITLE
fix: invalid checksum source for remote write proxy deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+- fix: invalid checksum source for remote write proxy deployment [#2091][#2091]
+
+[#2091]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2091
+[Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.5.0...main
+
 ## [v2.5.0]
 
 ### Released 2022-02-07

--- a/deploy/helm/sumologic/templates/metrics/remote-write-proxy/deployment.yaml
+++ b/deploy/helm/sumologic/templates/metrics/remote-write-proxy/deployment.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/metrics/remote-write-proxy/remote-write-proxy.conf") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/metrics/remote-write-proxy/configmap.yaml") . | sha256sum }}
 {{- if .Values.sumologic.podAnnotations }}
 {{ toYaml .Values.sumologic.podAnnotations | indent 8 }}
 {{- end }}

--- a/tests/helm/functions.sh
+++ b/tests/helm/functions.sh
@@ -115,6 +115,9 @@ function perform_test {
   test_start "${test_name}"
   if ! generate_file "${template_name}"; then 
     test_failed "${test_name}"
+    # Set all tests as failed
+    # This file has been created in run.sh
+    echo "false" > "${TEST_SUCCESS_FILE}"
     return
   fi
 

--- a/tests/helm/remote_write_proxy/static/basic.output.yaml
+++ b/tests/helm/remote_write_proxy/static/basic.output.yaml
@@ -20,7 +20,7 @@ spec:
         checksum/config: "%CONFIG_CHECKSUM%"
       labels:
         app: RELEASE-NAME-sumologic-remote-write-proxy
-        chart: "sumologic-2.4.0"
+        chart: "sumologic-%CURRENT_CHART_VERSION%"
         release: "RELEASE-NAME"
         heritage: "Helm"
     spec:


### PR DESCRIPTION
##### Description

Fix an error in the Deployment for the remote write proxy, where the configmap hash target was incorrect. 

The reason template tests didn't catch this, is that Helm template errors weren't treated as a test failure. Fix this as well.

---

##### Checklist

Remove items which don't apply to your PR.

- [ ] Changelog updated
