### PR TITLE
feat: add otelcol's liveness and readiness probes configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- feat: add otelcol's liveness and readiness probes configuration [#2105]
+
 ### Changed
 
 ### Fixed
 
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.5.1...main
+[#2105]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2105
 
 ## [v2.5.1]
 

--- a/deploy/helm/sumologic/templates/logs/otelcol/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/logs/otelcol/statefulset.yaml
@@ -137,10 +137,12 @@ spec:
           httpGet:
             path: /
             port: 13133 # Health Check extension default port.
+          {{- toYaml .Values.metadata.logs.statefulset.containers.otelcol.livenessProbe | nindent 10 }}
         readinessProbe:
           httpGet:
             path: /
             port: 13133 # Health Check extension default port.
+          {{- toYaml .Values.metadata.logs.statefulset.containers.otelcol.readinessProbe | nindent 10 }}
         volumeMounts:
         - name: config-volume
           mountPath: /etc/otel/config.yaml

--- a/deploy/helm/sumologic/templates/metrics/otelcol/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics/otelcol/statefulset.yaml
@@ -129,10 +129,12 @@ spec:
           httpGet:
             path: /
             port: 13133 # Health Check extension default port.
+          {{- toYaml .Values.metadata.metrics.statefulset.containers.otelcol.livenessProbe | nindent 10 }}
         readinessProbe:
           httpGet:
             path: /
             port: 13133 # Health Check extension default port.
+          {{- toYaml .Values.metadata.metrics.statefulset.containers.otelcol.readinessProbe | nindent 10 }}
         volumeMounts:
         - name: config-volume
           mountPath: /etc/otel/config.yaml

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -3794,6 +3794,14 @@ metadata:
       containers:
         otelcol:
           securityContext: {}
+          livenessProbe:
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
 
       ## Extra Environment Values - allows yaml definitions
       # extraEnvVars:
@@ -4169,6 +4177,14 @@ metadata:
       containers:
         otelcol:
           securityContext: {}
+          livenessProbe:
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
 
       ## Extra Environment Values - allows yaml definitions
       # extraEnvVars:

--- a/tests/helm/metadata_logs_otc_statefulset/static/basic.output.yaml
+++ b/tests/helm/metadata_logs_otc_statefulset/static/basic.output.yaml
@@ -90,10 +90,16 @@ spec:
           httpGet:
             path: /
             port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          periodSeconds: 10
+          timeoutSeconds: 3
         readinessProbe:
           httpGet:
             path: /
             port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - name: config-volume
           mountPath: /etc/otel/config.yaml

--- a/tests/helm/metadata_metrics_otc_statefulset/static/basic.output.yaml
+++ b/tests/helm/metadata_metrics_otc_statefulset/static/basic.output.yaml
@@ -87,10 +87,16 @@ spec:
           httpGet:
             path: /
             port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          periodSeconds: 10
+          timeoutSeconds: 3
         readinessProbe:
           httpGet:
             path: /
             port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          periodSeconds: 10
+          timeoutSeconds: 3
         volumeMounts:
         - name: config-volume
           mountPath: /etc/otel/config.yaml


### PR DESCRIPTION
This also changes the default settings to the following:

```yaml
livenessProbe:
  periodSeconds: 10
  timeoutSeconds: 3
  failureThreshold: 3
readinessProbe:
  periodSeconds: 10
  timeoutSeconds: 3
  failureThreshold: 3
```

---

Default until now for otc:

```yaml
livenessProbe:
  failureThreshold: 3
  httpGet:
    path: /
    port: 13133
    scheme: HTTP
  periodSeconds: 10
  successThreshold: 1
  timeoutSeconds: 1
```

For comparison fluentd probes are set like so:

```yaml
livenessProbe:
  failureThreshold: 3
  httpGet:
    path: /fluentd.pod.healthcheck?json=%7B%22log%22%3A+%22health+check%22%7D
    port: 9880
    scheme: HTTP
  initialDelaySeconds: 300
  periodSeconds: 30
  successThreshold: 1
  timeoutSeconds: 3
```