### PR TITLE
chore: add warning for increased cpu limit for Fluentds

### DIFF
--- a/deploy/docs/Best_Practices.md
+++ b/deploy/docs/Best_Practices.md
@@ -195,6 +195,18 @@ To enable autoscaling for Fluentd:
         enabled: true
   ```
 
+### CPU resources warning
+
+When enabling the Fluentd Autoscaling please make sure to set Fluentd's `resources.requests.cpu` properly.
+Because of Fluentd's single threaded nature it rarely consumes more than `1000m` CPU (1 CPU core).
+
+For example setting `resources.requests.cpu=2000m` and the `autoscaling.targetCPUUtilizationPercentage=50` means
+that autoscaling will increase the number of application pods only if average CPU usage across all application pods
+in statefulset or daemonset is more than `1000m`. This combined with Fluentd's usage of around `1000m` at most will
+result in autoscaling not working properly.
+
+**For this reason we suggest to set the Fluentd's `resources.requests.cpu=1000m` or less when using autoscaling.**
+
 ## Fluentd File-Based Buffer
 
 Starting with `v2.0.0` we're using file-based buffer for Fluentd instead of less

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -423,6 +423,8 @@ fluentd:
           cpu: 1000m
         requests:
           memory: 768Mi
+          ## Warning! Increasing the CPU requests for Fluentd above 1000m might result in broken autoscaling
+          ## ref: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/main/deploy/docs/Best_Practises.md#cpu-resources-warning
           cpu: 500m
       ## Option to define priorityClassName to assign a priority class to pods.
       priorityClassName:
@@ -712,6 +714,8 @@ fluentd:
           cpu: 1000m
         requests:
           memory: 768Mi
+          ## Warning! Increasing the CPU requests for Fluentd above 1000m might result in broken autoscaling
+          ## ref: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/main/deploy/docs/Best_Practises.md#cpu-resources-warning
           cpu: 500m
       ## Option to define priorityClassName to assign a priority class to pods.
       priorityClassName:


### PR DESCRIPTION
HPA looks at request CPU for scaling.
Fluentd reaches 1 core at max.

Example:
When CPU request is set to eg. `3` (or `3000m`) with HPA's `targetCPUUtilizationPercentage: 50` means that HPA aims to get every Fluentd to 1.5 core utilization which won't happen.
Hence it will not scale it out.

CPU request for Fluentd should be always `1000m` at max.