### PR TITLE
fix: make metadata StatefulSets scale above 0.5 average CPU usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- fix: make metadata StatefulSets scale above 0.5 average CPU usage [#2114]
+
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.5.1...main
 [#2105]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2105
+[#2114]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2114
 
 ## [v2.5.1]
 

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -460,7 +460,7 @@ fluentd:
       enabled: false
       minReplicas: 3
       maxReplicas: 10
-      targetCPUUtilizationPercentage: 50
+      targetCPUUtilizationPercentage: 100
       # targetMemoryUtilizationPercentage: 50
 
     ## Option to specify PodDisrutionBudgets
@@ -751,7 +751,7 @@ fluentd:
       enabled: false
       minReplicas: 3
       maxReplicas: 10
-      targetCPUUtilizationPercentage: 50
+      targetCPUUtilizationPercentage: 100
       # targetMemoryUtilizationPercentage: 50
 
     ## Option to specify PodDisrutionBudgets
@@ -3831,7 +3831,7 @@ metadata:
       enabled: false
       minReplicas: 3
       maxReplicas: 10
-      targetCPUUtilizationPercentage: 50
+      targetCPUUtilizationPercentage: 100
       # targetMemoryUtilizationPercentage: 50
 
     ## Option to specify PodDisrutionBudgets
@@ -4214,7 +4214,7 @@ metadata:
       enabled: false
       minReplicas: 3
       maxReplicas: 10
-      targetCPUUtilizationPercentage: 50
+      targetCPUUtilizationPercentage: 100
       # targetMemoryUtilizationPercentage: 50
 
     ## Option to specify PodDisrutionBudgets


### PR DESCRIPTION
##### Description

All the metadata StatefulSets have requests.cpu set to 500m. Combined with a targetCPUUtilizationPercentage of 50 on the HPA, this meant that they'd try to keep an absolute CPU utilization of 250m = 500m * 0.5.

Changed the CPU utilization on the HPA to 100, so now the absolute utilization is 500m = 500m * 1.0.

---

##### Checklist

Remove items which don't apply to your PR.

- [ ] Changelog updated
