### PR TITLE
[Backport release-v2.5] fix: make metadata StatefulSets scale above 0.5 average CPU usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+- fix: make metadata StatefulSets scale above 0.5 average CPU usage [#2114]
+
+[Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.5.1...main
+[#2114]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2114
+
 ## [v2.5.1]
 
 ## Released 2022-02-07

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -461,7 +461,7 @@ fluentd:
       enabled: false
       minReplicas: 3
       maxReplicas: 10
-      targetCPUUtilizationPercentage: 50
+      targetCPUUtilizationPercentage: 100
       # targetMemoryUtilizationPercentage: 50
 
     ## Option to specify PodDisrutionBudgets
@@ -752,7 +752,7 @@ fluentd:
       enabled: false
       minReplicas: 3
       maxReplicas: 10
-      targetCPUUtilizationPercentage: 50
+      targetCPUUtilizationPercentage: 100
       # targetMemoryUtilizationPercentage: 50
 
     ## Option to specify PodDisrutionBudgets
@@ -3814,7 +3814,7 @@ metadata:
       enabled: false
       minReplicas: 3
       maxReplicas: 10
-      targetCPUUtilizationPercentage: 50
+      targetCPUUtilizationPercentage: 100
       # targetMemoryUtilizationPercentage: 50
 
     ## Option to specify PodDisrutionBudgets
@@ -4189,7 +4189,7 @@ metadata:
       enabled: false
       minReplicas: 3
       maxReplicas: 10
-      targetCPUUtilizationPercentage: 50
+      targetCPUUtilizationPercentage: 100
       # targetMemoryUtilizationPercentage: 50
 
     ## Option to specify PodDisrutionBudgets


### PR DESCRIPTION
Backport https://github.com/SumoLogic/sumologic-kubernetes-collection/commit/331d6469e5c299bb5b8a943fd01e9cdffa699cc1 from https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2114


