### PR TITLE
docs: using a custom CA certificate

### DIFF
--- a/deploy/docs/Installing_Behind_Proxy.md
+++ b/deploy/docs/Installing_Behind_Proxy.md
@@ -10,6 +10,21 @@ fluentd.proxyUri
 
 You should set these properties to the URL for your proxy environment.
 
+## TLS interception via a transparent proxy
+
+If the proxy in question is transparent and does TLS interception with a custom root CA, installation becomes
+a bit more complex. Installation involves the setup job using the Sumologic API in order to create
+some necessary resources, like collectors and fields. This will fail if the Sumologic API TLS certificate
+cannot be verified.
+
+There are two ways of dealing with this:
+
+- Disabling the setup job and creating the necessary resources manually: [see here][manual]
+- Injecting the custom root CA into the setup image: [see here][rebuilding]
+
+[rebuilding]: ./Security_Best_Practices.md#adding-a-custom-root-ca-certificate-by-rebuilding-container-images
+[manual]: ./Installation_with_Helm.md#prerequisite
+
 ## Troubleshooting
 
 ### Error: timed out waiting for the condition

--- a/deploy/docs/Working_with_container_registries.md
+++ b/deploy/docs/Working_with_container_registries.md
@@ -77,3 +77,13 @@ fluentd:
     tag: ${TAG}
     pullPolicy: IfNotPresent
 ```
+
+## Upgrading while rehosting images
+
+New versions of the Helm chart can include updating the default container image versions. When using
+a custom container registry, we strongly recommend updating the version to be in-line with the defaults.
+The [changelog][changelog] and [release_notes][release notes] will always mention these kinds of updates
+and can safely be used as a guiding tool when upgrading.
+
+[changelog]: ../../CHANGELOG.md
+[release_notes]: https://github.com/SumoLogic/sumologic-kubernetes-collection/releases


### PR DESCRIPTION
##### Description

Document how to integrate the Helm Chart with a TLS intercepting proxy and a custom CA certificate.

Also add a brief note about upgrading while rehosting container images.

