### PR TITLE
docs: add NetworkPolicy examples to security best practices

### DIFF
--- a/deploy/docs/Security_Best_Practices.md
+++ b/deploy/docs/Security_Best_Practices.md
@@ -39,6 +39,72 @@ requests over the network.
 The log metadata enrichment service needs to be able to talk to the Sumo Logic backend receiver endpoints. It also needs
 to be able to access the Kubernetes API Server to obtain metadata.
 
+Example Kubernetes Network Policies restricting all but the necessary traffic for the logs pipeline:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: fluent-bit
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: fluent-bit
+  policyTypes:
+  - Ingress
+  - Egress
+  egress:
+  # send logs to FluentD
+  - to:
+    - podSelector:
+        matchLabels:
+          app: <release_name>-sumologic-fluentd-logs
+    ports:
+    - protocol: TCP
+      port: 24321
+  ingress:
+  # Allow Prometheus to scrape metrics
+  - from:
+    - podSelector:
+        matchLabels:
+          app: prometheus
+    ports:
+    - protocol: TCP
+      port: 2020
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: fluentd-logs
+spec:
+  podSelector:
+    matchLabels:
+      app: <release_name>-sumologic-fluentd-logs
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # allow logs from Fluent-Bit
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: fluent-bit
+    ports:
+    - protocol: TCP
+      port: 24321
+  # Allow Prometheus to scrape metrics
+  - from:
+    - podSelector:
+        matchLabels:
+          app: prometheus
+    ports:
+    - protocol: TCP
+      port: 24321
+  egress:
+  # Allow all outbound connections
+  - {}
+```
+
 ### Metrics
 
 Metrics collection is done via the Prometheus protocol, which means that the metrics collector needs to be able to
@@ -47,6 +113,82 @@ reach any service it needs to collect metadata from over the network. This inclu
 The metrics metadata enrichment service needs to be able to talk to the Sumo Logic backend receiver endpoints. It also needs
 to be able to access the Kubernetes API Server to obtain metadata.
 
+Example Kubernetes Network Policies restricting all but the necessary traffic for the traces pipeline:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus
+  namespace: sumologic
+spec:
+  podSelector:
+    matchLabels:
+      app: prometheus
+  policyTypes:
+  - Egress
+  - Ingress
+  ingress:
+    # Allow Prometheus to scrape metrics
+  - from:
+    - podSelector:
+        matchLabels:
+          app: prometheus
+    ports:
+    - protocol: TCP
+      port: 9090
+  egress:
+  # remote write to FluentD
+  - to:
+    - podSelector:
+        matchLabels:
+          app: <release_name>-sumologic-fluentd-metrics
+    ports:
+    - protocol: TCP
+      port: 9888
+  # scrape metrics
+  - ports:
+    - protocol: TCP
+      port: 2379
+      endPort: 24321
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: fluentd-metrics
+  namespace: sumologic
+spec:
+  podSelector:
+    matchLabels:
+      app: collection-sumologic-fluentd-metrics
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow data from Prometheus remote write
+  - from:
+    - podSelector:
+        matchLabels:
+          app: prometheus
+    ports:
+    - protocol: TCP
+      port: 9888
+  # Allow Prometheus to scrape metrics
+  - from:
+    - podSelector:
+        matchLabels:
+          app: prometheus
+    ports:
+    - protocol: TCP
+      port: 24321
+  egress:
+  # Allow all outbound connections
+  - {}
+```
+
+The above configuration is very permissive for Prometheus egress. You're encouraged to make it more restrictive based
+on your specific requirements.
+
 ### Tracing
 
 Traces are sent to the collector by applications themselves, so any application needing to publish traces needs to
@@ -54,6 +196,49 @@ be able to reach the collector over the network.
 
 The tracing collector and metadata enrichment are currently done by the same service. As such, this service needs to
 be able to talk to the Sumo Logic backend receiver endpoints, and the Kubernetes API Server.
+
+Example Kubernetes Network Policies restricting all but the necessary traffic for the traces pipeline:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: otelcol
+spec:
+  podSelector:
+    matchLabels:
+      app: <release_name>-sumologic-otelcol
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow inbound traffic on all the receiver ports
+  - ports:
+    - protocol: TCP
+      port: 4317
+    - protocol: TCP
+      port: 5778
+    - protocol: TCP
+      port: 6831
+    - protocol: TCP
+      port: 6832
+    - protocol: TCP
+      port: 9411
+    - protocol: TCP
+      port: 14268
+    - protocol: TCP
+      port: 55678
+    - protocol: TCP
+      port: 55680
+    - protocol: TCP
+      port: 55681
+  egress:
+  # Allow all outbound connections
+  - {}
+```
+
+You should only leave the ports for the protocol you're actually using to deliver spans to the receiver in the above definition. As with Prometheus,
+the above configuration is very permissive for ingress. You're encouraged to make it more restrictive based on your specific requirements.
 
 ## Hardening fluentd StatefulSet with `securityContext`
 


### PR DESCRIPTION
##### Description

Add some example Network Policies illustrating how to limit collection components to only necessary networking capabilities.
