### PR TITLE
feat(metrics): drop container label for non-container kube state metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - chore: bump sumo ot distro to 0.0.50-beta.0 [#2127][#2127]
+- feat(metrics): drop container label for non-container kube state metrics [#2144][#2144]
 
 ### Fixed
 
@@ -24,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2127]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2127
 [#2128]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2128
 [#2134]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2134
+[#2144]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2144
 
 ## [v2.5.2]
 

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1862,8 +1862,18 @@ kube-prometheus-stack:
               regex: (pod|service)
               replacement: service_discovery_${1}
             - action: labeldrop
-              regex: (pod|service)
+              regex: (pod|service|container)
         ## kube pod state metrics
+        ## kube_pod_status_phase
+        - url: http://$(FLUENTD_METRICS_SVC).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.state
+          remoteTimeout: 5s
+          writeRelabelConfigs:
+            - action: keep
+              regex: kube-state-metrics;(?:kube_pod_status_phase)
+              sourceLabels: [job, __name__]
+            - action: labeldrop
+              regex: container
+        ## kube container state metrics
         ## kube_pod_container_info
         ## kube_pod_container_resource_limits
         ## kube_pod_container_resource_requests
@@ -1871,12 +1881,11 @@ kube-prometheus-stack:
         ## kube_pod_container_status_restarts_total
         ## kube_pod_container_status_terminated_reason
         ## kube_pod_container_status_waiting_reason
-        ## kube_pod_status_phase
         - url: http://$(FLUENTD_METRICS_SVC).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.state
           remoteTimeout: 5s
           writeRelabelConfigs:
             - action: keep
-              regex: kube-state-metrics;(?:kube_pod_container_info|kube_pod_container_resource_requests|kube_pod_container_resource_limits|kube_pod_container_status_ready|kube_pod_container_status_terminated_reason|kube_pod_container_status_waiting_reason|kube_pod_container_status_restarts_total|kube_pod_status_phase)
+              regex: kube-state-metrics;(?:kube_pod_container_info|kube_pod_container_resource_requests|kube_pod_container_resource_limits|kube_pod_container_status_ready|kube_pod_container_status_terminated_reason|kube_pod_container_status_waiting_reason|kube_pod_container_status_restarts_total)
               sourceLabels: [job, __name__]
         ## controller manager metrics
         ## https://kubernetes.io/docs/concepts/cluster-administration/monitoring/#kube-controller-manager-metrics


### PR DESCRIPTION
##### Description

Drop container label for non-container kube state metrics. It requires to extract `kube_pod_status_phase` which shouldn't have container label but should have `pod`/`service` labels.

Fixes #2097

---

##### Checklist

Remove items which don't apply to your PR.

- [ ] Changelog updated

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
