### PR TITLE
feat(fluent-bit): drop all capabilities for container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - chore: bump sumo ot distro to 0.0.50-beta.0 [#2127][#2127]
 - feat(metrics): drop container label for non-container kube state metrics [#2144][#2144]
+- feat(fluent-bit): drop all capabilities for container [#2151][#2151]
 
 ### Fixed
 
@@ -30,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2134]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2134
 [#2143]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2143
 [#2144]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2144
+[#2151]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2151
 
 ## [v2.5.2]
 

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -974,8 +974,11 @@ fluent-bit:
   ## Add custom pod annotations to fluent-bit daemonset pods
   podAnnotations: {}
 
+  securityContext:
+    capabilities:
+      drop:
+      - ALL
   ## Set securityContext of fluent-bit daemonset containers as privileged for running in Openshift
-  # securityContext:
   #   privileged: true
 
   env:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -977,7 +977,7 @@ fluent-bit:
   securityContext:
     capabilities:
       drop:
-      - ALL
+        - ALL
   ## Set securityContext of fluent-bit daemonset containers as privileged for running in Openshift
   #   privileged: true
 


### PR DESCRIPTION
##### Description

We [do not allow any capability in openshift](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/d4d8ab61ed31608732e01d7877bce88d38ab5939/deploy/helm/sumologic/templates/scc.yaml#L21) and there is no need for any in another clusters

---

##### Checklist

Remove items which don't apply to your PR.

- [ ] Changelog updated

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
