### PR TITLE
fix(vagrant): fix vagrant configuration for otc

### DIFF
--- a/vagrant/values.yaml
+++ b/vagrant/values.yaml
@@ -170,6 +170,13 @@ fluentd:
       multiline:
         enabled: false
 
+otellogs:
+  config:
+    receivers:
+      filelog/containers:
+        exclude:
+          - /var/log/pods/receiver-mock_*/*/*.log
+
 metadata:
   logs:
     config:
@@ -182,6 +189,8 @@ metadata:
             - action: insert
               key: k8s.pod.uid
               from_attribute: k8s_uid
+            - action: delete
+              key: k8s_uid
             - action: delete
               key: k8s_run_id
             - action: insert
@@ -199,85 +208,82 @@ metadata:
               from_attribute: k8s_container_name
             - action: delete
               key: k8s_container_name
-    # Filter out receiver-mock logs to prevent snowball effect
-    filter/exclude_fluent_tag_receiver_mock_container:
-      logs:
-        exclude:
-          match_type: regexp
-          record_attributes:
-            - key: fluent.tag
-              value: containers\.var\.log\.pods\.receiver-mock.*
-    filter/exclude_systemd_snap_kubelite:
-      logs:
-        exclude:
-          match_type: strict
-          record_attributes:
-            - key: _SYSTEMD_UNIT
-              value: snap.microk8s.daemon-kubelite.service
-    filter/include_systemd_snap_kubelite:
-      logs:
-        include:
-          match_type: strict
-          record_attributes:
-            - key: _SYSTEMD_UNIT
-              value: snap.microk8s.daemon-kubelite.service
-  service:
-    extensions:
-      - health_check
-      # - sumologic
-    pipelines:
-      logs/fluent/containers:
-        receivers:
-          - fluentforward
-        processors:
-          - memory_limiter
-          - filter/include_fluent_tag_containers
+        # Filter out receiver-mock logs to prevent snowball effect
+        filter/exclude_fluent_tag_receiver_mock_container:
+          logs:
+            exclude:
+              match_type: regexp
+              record_attributes:
+                - key: fluent.tag
+                  value: containers\.var\.log\.pods\.receiver-mock.*
+        filter/exclude_systemd_snap_kubelite:
+          logs:
+            exclude:
+              match_type: strict
+              record_attributes:
+                - key: _SYSTEMD_UNIT
+                  value: snap.microk8s.daemon-kubelite.service
+        filter/include_systemd_snap_kubelite:
+          logs:
+            include:
+              match_type: strict
+              record_attributes:
+                - key: _SYSTEMD_UNIT
+                  value: snap.microk8s.daemon-kubelite.service
+      service:
+        pipelines:
+          logs/fluent/containers:
+            receivers:
+              - fluentforward
+            processors:
+              - memory_limiter
+              - filter/include_fluent_tag_containers
 
-          # Vagrant specific
-          - filter/exclude_fluent_tag_receiver_mock_container
+              # Vagrant specific
+              - filter/exclude_fluent_tag_receiver_mock_container
 
-          - attributes/containers
-          - groupbyattrs/containers
-          - k8s_tagger
-          - source/containers
-          - attributes/remove_fluent_tag
-          - resource/containers_copy_node_to_host
-          - batch
-        exporters:
-          - sumologic/containers
-      logs/fluent/systemd:
-        receivers:
-          - fluentforward
-        processors:
-          - memory_limiter
-          - filter/include_fluent_tag_host
+              - attributes/containers
+              - groupbyattrs/containers
+              - k8s_tagger
+              - source/containers
+              - attributes/remove_fluent_tag
+              - resource/containers_copy_node_to_host
+              - batch
+            exporters:
+              - sumologic/containers
+          logs/fluent/systemd:
+            receivers:
+              - fluentforward
+            processors:
+              - memory_limiter
+              - filter/include_fluent_tag_host
 
-          # Vagrant specific
-          - filter/exclude_fluent_tag_receiver_mock_container
+              # Vagrant specific
+              - filter/exclude_fluent_tag_receiver_mock_container
 
-          - filter/include_systemd
-          - filter/exclude_systemd_snap_kubelite
-          - attributes/extract_systemd_source_name_from_fluent_tag
-          - groupbyattrs/systemd
-          - source/systemd
-          - attributes/remove_fluent_tag
-          - batch
-        exporters:
-          - sumologic/systemd
-      logs/fluent/kubelet:
-        receivers:
-          - fluentforward
-        processors:
-          - memory_limiter
-          - filter/include_fluent_tag_host
+              - filter/include_systemd
+              - filter/exclude_systemd_snap_kubelite
+              - attributes/extract_systemd_source_name_from_fluent_tag
+              - groupbyattrs/systemd
+              - source/systemd
+              - attributes/remove_fluent_tag
+              - batch
+            exporters:
+              - sumologic/systemd
+          logs/fluent/kubelet:
+            receivers:
+              - fluentforward
+            processors:
+              - memory_limiter
+              - filter/include_fluent_tag_host
 
-          # Vagrant specific
-          - filter/exclude_fluent_tag_receiver_mock_container
+              # Vagrant specific
+              - filter/exclude_fluent_tag_receiver_mock_container
 
-          - filter/include_systemd_snap_kubelite
-          - groupbyattrs/systemd
-          - source/kubelet
-          - attributes/remove_fluent_tag
-          - batch
-        exporters:
-          - sumologic/systemd
+              - filter/include_systemd_snap_kubelite
+              - groupbyattrs/systemd
+              - source/kubelet
+              - attributes/remove_fluent_tag
+              - batch
+            exporters:
+              - sumologic/systemd


### PR DESCRIPTION
- fix otelcol configuration for pipelines
- remove k8s_uid attribute
- do not scrape receiver-mock logs by otellogs