### PR TITLE
chore(otellogs): increase send_batch_size to 10240

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat(fluent-bit): drop all capabilities for container [#2151][#2151]
 - feat: allow to collect logs from /var/log/pods and add instruction how to do it [#2153][#2153] [#2156][#2156]
 - feat(otellogs): support tolerations, nodeSelector and affinity for daemonset [#2158][#2158]
+- chore(otellogs): increase send_batch_size to 10240 [#2161][#2161]
 
 ### Fixed
 
@@ -37,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2153]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2153
 [#2156]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2156
 [#2158]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2158
+[#2161]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2161
 
 ## [v2.5.2]
 

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -4619,9 +4619,9 @@ otellogs:
       ## The batch processor accepts spans and places them into batches grouped by node and resource
       batch:
         ## Number of spans after which a batch will be sent regardless of time
-        ## This is set to the same value as in the metadata enricher
+        ## This is set to the 10240, to avoid loosing logs on the start of the collector
         ## TODO: Figure out what the optimal values should be for different configurations
-        send_batch_size: 256
+        send_batch_size: 10_240
         ## Time duration after which a batch will be sent regardless of size
         timeout: 1s
   daemonset:

--- a/tests/helm/logs_otc/static/basic.output.yaml
+++ b/tests/helm/logs_otc/static/basic.output.yaml
@@ -22,7 +22,7 @@ data:
       health_check: {}
     processors:
       batch:
-        send_batch_size: 256
+        send_batch_size: 10240
         timeout: 1s
     receivers:
       filelog/containers:


### PR DESCRIPTION
increase it to prevent data loss
during reading huge file from beginning I observed some data loss
because previous value was relatively low