### PR TITLE
fix: increase OTC liveness timeout and period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- fix: increase OTC liveness timeout and period [#2165][#2165]
 - chore: bump sumo ot distro to 0.0.50-beta.0 [#2127][#2127]
 - feat(metrics): drop container label for non-container kube state metrics [#2144][#2144]
 - feat(fluent-bit): drop all capabilities for container [#2151][#2151]
@@ -43,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2158]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2158
 [#2161]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2161
 [#2162]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2162
+[#2165]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2165
 
 ## [v2.5.2]
 

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -3977,8 +3977,8 @@ metadata:
         otelcol:
           securityContext: {}
           livenessProbe:
-            periodSeconds: 10
-            timeoutSeconds: 3
+            periodSeconds: 15
+            timeoutSeconds: 10
             failureThreshold: 3
           readinessProbe:
             periodSeconds: 10
@@ -4360,8 +4360,8 @@ metadata:
         otelcol:
           securityContext: {}
           livenessProbe:
-            periodSeconds: 10
-            timeoutSeconds: 3
+            periodSeconds: 15
+            timeoutSeconds: 10
             failureThreshold: 3
           readinessProbe:
             periodSeconds: 10

--- a/tests/helm/metadata_logs_otc_statefulset/static/basic.output.yaml
+++ b/tests/helm/metadata_logs_otc_statefulset/static/basic.output.yaml
@@ -91,8 +91,8 @@ spec:
             path: /
             port: 13133 # Health Check extension default port.
           failureThreshold: 3
-          periodSeconds: 10
-          timeoutSeconds: 3
+          periodSeconds: 15
+          timeoutSeconds: 10
         readinessProbe:
           httpGet:
             path: /

--- a/tests/helm/metadata_metrics_otc_statefulset/static/basic.output.yaml
+++ b/tests/helm/metadata_metrics_otc_statefulset/static/basic.output.yaml
@@ -88,8 +88,8 @@ spec:
             path: /
             port: 13133 # Health Check extension default port.
           failureThreshold: 3
-          periodSeconds: 10
-          timeoutSeconds: 3
+          periodSeconds: 15
+          timeoutSeconds: 10
         readinessProbe:
           httpGet:
             path: /


### PR DESCRIPTION
##### Description

The current liveness probe doesn't actually check liveness in any meaningful way - it merely checks if the health_check extension is functional. We really don't want it to cause restarts under load, which it can with the current settings. Increase the timeout and period to mitigate this. We can revisit once the liveness check is more meaningful.

---

##### Checklist

Remove items which don't apply to your PR.

- [ ] Changelog updated

###### Testing performed

- [X] Confirm events, logs, and metrics are coming in
