### PR TITLE
chore(deps): bump prometheus node exporter tag to 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - feat(tracing): change otlp http receiver default port to 4318 [#2170][#2170]
+- chore(deps): bump prometheus node exporter tag to 2.3.1 [#2177][#2177]
 
 ### Fixed
 
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.6.0...main
 [#2170]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2170
+[#2177]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2177
 
 ## [v2.6.0][v2.6.0]
 

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1624,6 +1624,8 @@ kube-prometheus-stack:
       #   memory: 32Mi
   ## Resource limits for prometheus node exporter
   prometheus-node-exporter:
+    image:
+      tag: v1.3.1
     ## Additional labels for pods in the DaemonSet
     podLabels: {}
     ## Additional annotations for pods in the DaemonSet


### PR DESCRIPTION
related release: https://github.com/prometheus/node_exporter/releases/tag/v1.3.1

old release: https://github.com/prometheus/node_exporter/releases/tag/v1.0.1