### PR TITLE
ci: mute help.sumologic.com markdown link check failures

### DIFF
--- a/.markdown_link_check.json
+++ b/.markdown_link_check.json
@@ -11,6 +11,9 @@
   "ignorePatterns": [
     {
       "pattern": "^https://mikefarah.gitbook.io/yq"
+    },
+    {
+      "pattern": "^https://help.sumologic.com/Traces/03Advanced_Configuration/What_if_I.*"
     }
   ]
 }


### PR DESCRIPTION
In order to prevent failures like this: https://github.com/SumoLogic/sumologic-kubernetes-collection/runs/5588034154?check_suite_focus=true let's ignore this pattern.

```
https://help.sumologic.com/Traces/Getting_Started_with_Transaction_Tracing/What_if_I_don't_want_to_send_all_the_tracing_data_to_Sumo_Logic%3F 
```