### PR TITLE
chore(otelcol): upgrade to 0.0.58-beta.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - chore(deps): bump prometheus node exporter tag to 2.3.1 [#2177][#2177]
 - chore: upgrade Fluentd to 1.14.5-sumo-1 [#2196][#2196]
 - chore: upgrade Falco Helm Chart to 1.17.4 [#2197][#2197]
+- chore: bump sumo ot distro to 0.0.50-beta.0 [#2213][#2213]
 
 ### Fixed
 
@@ -39,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2200]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2200
 [#2201]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2201
 [#2211]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2211
+[#2213]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2213
 
 ## [v2.6.0][v2.6.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - chore(deps): bump prometheus node exporter tag to 2.3.1 [#2177][#2177]
 - chore: upgrade Fluentd to 1.14.5-sumo-1 [#2196][#2196]
 - chore: upgrade Falco Helm Chart to 1.17.4 [#2197][#2197]
-- chore: bump sumo ot distro to 0.0.50-beta.0 [#2213][#2213]
+- chore: bump sumo ot distro to 0.0.58-beta.0 [#2213][#2213]
 
 ### Fixed
 

--- a/deploy/docs/Best_Practices.md
+++ b/deploy/docs/Best_Practices.md
@@ -980,8 +980,8 @@ For [sumologic exporter][sumologic_exporter]:
 **The above in connection with PVC monitoring can lead to constant alerts (eg. [KubePersistentVolumeFillingUp][filling_up_alert]),**
 **because once filled in PVC never reduces its fill.**
 
-[batch_processor]: https://github.com/open-telemetry/opentelemetry-collector/tree/v0.44.0/processor/batchprocessor#batch-processor
-[sumologic_exporter]: https://github.com/SumoLogic/sumologic-otel-collector/tree/v0.0.50-beta.0/pkg/exporter/sumologicexporter#sumo-logic-exporter
+[batch_processor]: https://github.com/open-telemetry/opentelemetry-collector/tree/v0.47.0/processor/batchprocessor#batch-processor
+[sumologic_exporter]: https://github.com/SumoLogic/sumologic-otel-collector/tree/v0.0.58-beta.0/pkg/exporter/sumologicexporter#sumo-logic-exporter
 [filling_up_alert]: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepersistentvolumefillingup/
 
 ### Compaction

--- a/deploy/docs/fluentd_otc_comparison.md
+++ b/deploy/docs/fluentd_otc_comparison.md
@@ -54,12 +54,12 @@ Additional behavior:
 
 [fields_base]: https://github.com/SumoLogic/fluentd-output-sumologic/blob/1.7.2/lib/fluent/plugin/out_sumologic.rb#L284-L285
 [fluentd_output_plugin]: https://github.com/sumologic/fluentd-output-sumologic/tree/1.7.2#configuration
-[otelcol_basic_confg]: https://github.com/SumoLogic/sumologic-otel-collector/blob/v0.0.50-beta.0/docs/Configuration.md#basic-configuration
-[otelcol_proxy]: https://github.com/SumoLogic/sumologic-otel-collector/blob/v0.0.50-beta.0/docs/Configuration.md#proxy-support
-[otelcol_source_config]: https://github.com/SumoLogic/sumologic-otel-collector/tree/v0.0.50-beta.0/pkg/processor/sourceprocessor#config
-[otelcol_sumologic_config]: https://github.com/SumoLogic/sumologic-otel-collector/blob/v0.0.50-beta.0/pkg/exporter/sumologicexporter/README.md#sumo-logic-exporter
-[otelocl_tls_config]: https://github.com/open-telemetry/opentelemetry-collector/blob/v0.44.0/config/configtls/README.md#tls--mtls-configuration
-[resource_processor]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.44.0/processor/resourceprocessor#resource-processor
+[otelcol_basic_confg]: https://github.com/SumoLogic/sumologic-otel-collector/blob/v0.0.58-beta.0/docs/Configuration.md#basic-configuration
+[otelcol_proxy]: https://github.com/SumoLogic/sumologic-otel-collector/blob/v0.0.58-beta.0/docs/Configuration.md#proxy-support
+[otelcol_source_config]: https://github.com/SumoLogic/sumologic-otel-collector/tree/v0.0.58-beta.0/pkg/processor/sourceprocessor#config
+[otelcol_sumologic_config]: https://github.com/SumoLogic/sumologic-otel-collector/blob/v0.0.58-beta.0/pkg/exporter/sumologicexporter/README.md#sumo-logic-exporter
+[otelocl_tls_config]: https://github.com/open-telemetry/opentelemetry-collector/blob/v0.47.0/config/configtls/README.md#tls--mtls-configuration
+[resource_processor]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.47.0/processor/resourceprocessor#resource-processor
 [source_category_precedence]: https://github.com/SumoLogic/fluentd-output-sumologic/blob/1.7.2/lib/fluent/plugin/out_sumologic.rb#L278-L279
 [source_host_precedence]: https://github.com/SumoLogic/fluentd-output-sumologic/blob/1.7.2/lib/fluent/plugin/out_sumologic.rb#L281-L282
 [source_name_precedence]: https://github.com/SumoLogic/fluentd-output-sumologic/blob/1.7.2/lib/fluent/plugin/out_sumologic.rb#L275-L276
@@ -70,7 +70,7 @@ In order to receive prometheus data and for their initial processing [telegrafre
 It should cover [fluent-plugin-datapoint][fluent_plugin_datapoint] functionality and more.
 
 [fluent_plugin_datapoint]: https://github.com/SumoLogic/sumologic-kubernetes-fluentd/tree/v1.12.2-sumo-4/fluent-plugin-datapoint
-[telegrafreceiver]: https://github.com/SumoLogic/sumologic-otel-collector/tree/v0.0.50-beta.0/pkg/receiver/telegrafreceiver
+[telegrafreceiver]: https://github.com/SumoLogic/sumologic-otel-collector/tree/v0.0.58-beta.0/pkg/receiver/telegrafreceiver
 
 ### fluent-plugin-protobuf
 
@@ -78,7 +78,7 @@ In order to receive prometheus data and for their initial processing [telegrafre
 It should cover [fluent_plugin_protobuf][fluent_plugin_protobuf] functionality and more.
 
 [fluent_plugin_protobuf]: https://github.com/SumoLogic/sumologic-kubernetes-fluentd/tree/v1.12.2-sumo-4/fluent-plugin-protobuf
-[telegrafreceiver]: https://github.com/SumoLogic/sumologic-otel-collector/tree/v0.0.50-beta.0/pkg/receiver/telegrafreceiver
+[telegrafreceiver]: https://github.com/SumoLogic/sumologic-otel-collector/tree/v0.0.58-beta.0/pkg/receiver/telegrafreceiver
 
 ### fluent-plugin-prometheus-format
 
@@ -90,15 +90,15 @@ It should cover [fluent_plugin_protobuf][fluent_plugin_protobuf] functionality a
 | [exclusions][prom_form_excl]                                    | Use [filter processor][filter_processor]                                                                  |
 | [strict_exclusions][prom_form_strict_excl]                      | Use [filter processor][filter_processor]                                                                  |
 
-[filter_processor]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.44.0/processor/filterprocessor#filter-processor
+[filter_processor]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.47.0/processor/filterprocessor#filter-processor
 [fluent_plugin_prometheus_format]: https://github.com/SumoLogic/sumologic-kubernetes-fluentd/tree/v1.12.2-sumo-4/fluent-plugin-prometheus-format
-[groupbyattrs_processor]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.44.0/processor/groupbyattrsprocessor#group-by-attributes-processor
+[groupbyattrs_processor]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.47.0/processor/groupbyattrsprocessor#group-by-attributes-processor
 [prom_form_excl]: https://github.com/SumoLogic/sumologic-kubernetes-fluentd/tree/v1.12.2-sumo-4/fluent-plugin-prometheus-format#exclusions-hash-optional
 [prom_form_incl]: https://github.com/SumoLogic/sumologic-kubernetes-fluentd/tree/v1.12.2-sumo-4/fluent-plugin-prometheus-format#inclusions-hash-optional
 [prom_form_relabel]: https://github.com/SumoLogic/sumologic-kubernetes-fluentd/tree/v1.12.2-sumo-4/fluent-plugin-prometheus-format#relabel-hash-optional
 [prom_form_strict_excl]: https://github.com/SumoLogic/sumologic-kubernetes-fluentd/tree/v1.12.2-sumo-4/fluent-plugin-prometheus-format#strict_exclusions-bool-optional
 [prom_form_strict_incl]: https://github.com/SumoLogic/sumologic-kubernetes-fluentd/tree/v1.12.2-sumo-4/fluent-plugin-prometheus-format#strict_inclusions-bool-optional
-[resource_processor]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.44.0/processor/resourceprocessor#resource-processor
+[resource_processor]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.47.0/processor/resourceprocessor#resource-processor
 
 ### fluent-plugin-kubernetes-sumologic
 
@@ -162,17 +162,17 @@ Sanitized pod name is name portion of the pod. Please consider following example
 [kube_daemonset]: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
 [kube_deployment]: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 [kube_statefulset]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset
-[otelcol_annotations]: https://github.com/SumoLogic/sumologic-otel-collector/tree/v0.0.50-beta.0/pkg/processor/sourceprocessor#pod-annotations
+[otelcol_annotations]: https://github.com/SumoLogic/sumologic-otel-collector/tree/v0.0.58-beta.0/pkg/processor/sourceprocessor#pod-annotations
 [otelcol_annotations_exclude]: https://github.com/SumoLogic/sumologic-kubernetes-fluentd/blob/v1.12.2-sumo-4/fluent-plugin-kubernetes-sumologic/lib/fluent/plugin/filter_kubernetes_sumologic.rb#L171-L183
-[otelcol_source_templates]: https://github.com/SumoLogic/sumologic-otel-collector/tree/v0.0.50-beta.0/pkg/exporter/sumologicexporter#source-templates
-[otelcol_undefined]: https://github.com/SumoLogic/sumologic-otel-collector/blob/v0.0.50-beta.0/pkg/processor/sourceprocessor/attribute_filler.go#L113-L123
-[source_containers]: https://github.com/SumoLogic/sumologic-otel-collector/tree/v0.0.50-beta.0/pkg/processor/sourceprocessor#container-level-pod-annotations
-[source_filtering]: https://github.com/SumoLogic/sumologic-otel-collector/tree/v0.0.50-beta.0/pkg/processor/sourceprocessor#filtering-section
-[source_keys]: https://github.com/SumoLogic/sumologic-otel-collector/tree/v0.0.50-beta.0/pkg/processor/sourceprocessor#keys-section
-[source_processor]: https://github.com/SumoLogic/sumologic-otel-collector/tree/v0.0.50-beta.0/pkg/processor/sourceprocessor#config
-[source_processor_source_templates]: https://github.com/SumoLogic/sumologic-otel-collector/tree/v0.0.50-beta.0/pkg/processor/sourceprocessor#name-translation-and-template-keys
+[otelcol_source_templates]: https://github.com/SumoLogic/sumologic-otel-collector/tree/v0.0.58-beta.0/pkg/exporter/sumologicexporter#source-templates
+[otelcol_undefined]: https://github.com/SumoLogic/sumologic-otel-collector/blob/v0.0.58-beta.0/pkg/processor/sourceprocessor/attribute_filler.go#L113-L123
+[source_containers]: https://github.com/SumoLogic/sumologic-otel-collector/tree/v0.0.58-beta.0/pkg/processor/sourceprocessor#container-level-pod-annotations
+[source_filtering]: https://github.com/SumoLogic/sumologic-otel-collector/tree/v0.0.58-beta.0/pkg/processor/sourceprocessor#filtering-section
+[source_keys]: https://github.com/SumoLogic/sumologic-otel-collector/tree/v0.0.58-beta.0/pkg/processor/sourceprocessor#keys-section
+[source_processor]: https://github.com/SumoLogic/sumologic-otel-collector/tree/v0.0.58-beta.0/pkg/processor/sourceprocessor#config
+[source_processor_source_templates]: https://github.com/SumoLogic/sumologic-otel-collector/tree/v0.0.58-beta.0/pkg/processor/sourceprocessor#name-translation-and-template-keys
 [sumo_metadata]: https://github.com/SumoLogic/sumologic-kubernetes-fluentd/tree/v1.12.2-sumo-4/fluent-plugin-kubernetes-sumologic#fluent-plugin-kubernetes-sumologic
-[sumologic_exporter]: https://github.com/SumoLogic/sumologic-otel-collector/blob/v0.0.50-beta.0/pkg/exporter/sumologicexporter/README.md#sumo-logic-exporter
+[sumologic_exporter]: https://github.com/SumoLogic/sumologic-otel-collector/blob/v0.0.58-beta.0/pkg/exporter/sumologicexporter/README.md#sumo-logic-exporter
 
 ### fluent-plugin-kubernetes-metadata-filter
 
@@ -190,9 +190,9 @@ Sanitized pod name is name portion of the pod. Please consider following example
 | `cache_ttl`                                                | N/A                                                                                                   |
 
 [fluent_plugin_k8s_metadata]: https://github.com/SumoLogic/sumologic-kubernetes-fluentd/tree/v1.12.2-sumo-4/fluent-plugin-kubernetes-metadata-filter#configuration
-[k8sprocessor]: https://github.com/SumoLogic/sumologic-otel-collector/blob/v0.0.50-beta.0/pkg/processor/k8sprocessor
-[k8sprocessor_field_extract]: https://github.com/SumoLogic/sumologic-otel-collector/tree/v0.0.50-beta.0/pkg/processor/k8sprocessor#field-extract-config
-[kubeconfig_auth_type]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.44.0/internal/k8sconfig/config.go#L53-L60
+[k8sprocessor]: https://github.com/SumoLogic/sumologic-otel-collector/blob/v0.0.58-beta.0/pkg/processor/k8sprocessor
+[k8sprocessor_field_extract]: https://github.com/SumoLogic/sumologic-otel-collector/tree/v0.0.58-beta.0/pkg/processor/k8sprocessor#field-extract-config
+[kubeconfig_auth_type]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.47.0/internal/k8sconfig/config.go#L53-L60
 
 ### fluent-plugin-enhance-k8s-metadata
 
@@ -209,7 +209,7 @@ Sanitized pod name is name portion of the pod. Please consider following example
 | `data_type`                                                        | N/A                                                                                     |
 
 [fluent_plugin_enhance_k8s_metadata]: https://github.com/SumoLogic/sumologic-kubernetes-fluentd/tree/v1.12.2-sumo-4/fluent-plugin-enhance-k8s-metadata#configuration
-[pod_association]: https://github.com/SumoLogic/sumologic-otel-collector/blob/v0.0.50-beta.0/pkg/processor/k8sprocessor/doc.go#L17-L46
+[pod_association]: https://github.com/SumoLogic/sumologic-otel-collector/blob/v0.0.58-beta.0/pkg/processor/k8sprocessor/doc.go#L17-L46
 
 ### fluent-plugin-events
 
@@ -274,7 +274,7 @@ Events are not supported by `Opentelemetry Collector`
 | [sumologic.collectorName][readme]                                       | `metadata.metrics.config.processors.source.collector`                                                                                                       |
 | [sumologic.clusterName][readme]                                         | `metadata.metrics.config.processors.source.collector`                                                                                                       |
 
-[filter_processor]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.44.0/processor/filterprocessor#filter-processor
+[filter_processor]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.47.0/processor/filterprocessor#filter-processor
 [readme]: ../helm/sumologic/README.md
 [persistent_queue]: https://github.com/open-telemetry/opentelemetry-collector/tree/release/v0.37.x/exporter/exporterhelper#persistent-queue
 [file_storage_extension]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/release/v0.37.x/extension/storage/filestorage
@@ -356,9 +356,9 @@ Events are not supported by `Opentelemetry Collector`
 | [fluentd.logs.containers.extraFilterPluginConf][readme]              | [metadata.logs.config][readme]; mind that configuration is going to be merged unless you use `null`                                                                                                             |
 | [fluentd.logs.containers.extraOutputPluginConf][readme]              | [metadata.logs.config][readme]; mind that configuration is going to be merged unless you use `null`                                                                                                             |
 
-[filter_processor]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.44.0/processor/filterprocessor#filter-processor
+[filter_processor]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.47.0/processor/filterprocessor#filter-processor
 [readme]: ../helm/sumologic/README.md
-[source_containers]: https://github.com/SumoLogic/sumologic-otel-collector/tree/v0.0.50-beta.0/pkg/processor/sourceprocessor#container-level-pod-annotations
+[source_containers]: https://github.com/SumoLogic/sumologic-otel-collector/tree/v0.0.58-beta.0/pkg/processor/sourceprocessor#container-level-pod-annotations
 [persistent_queue]: https://github.com/open-telemetry/opentelemetry-collector/tree/release/v0.37.x/exporter/exporterhelper#persistent-queue
 [file_storage_extension]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/release/v0.37.x/extension/storage/filestorage
 

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -3570,7 +3570,7 @@ metadata:
   ## Configure image for Opentelemetry Collector (for logs and metrics)
   image:
     repository: public.ecr.aws/sumologic/sumologic-otel-collector
-    tag: 0.0.50-beta.0
+    tag: 0.0.58-beta.0
     pullPolicy: IfNotPresent
 
   securityContext:
@@ -4455,7 +4455,7 @@ otelgateway:
     podAnnotations: {}
     image:
       repository: public.ecr.aws/sumologic/sumologic-otel-collector
-      tag: 0.0.50-beta.0
+      tag: 0.0.58-beta.0
       pullPolicy: IfNotPresent
     livenessProbe:
       periodSeconds: 15
@@ -4577,7 +4577,7 @@ otellogs:
   ## Configure image for Opentelemetry Collector
   image:
     repository: public.ecr.aws/sumologic/sumologic-otel-collector
-    tag: 0.0.50-beta.0
+    tag: 0.0.58-beta.0
     pullPolicy: IfNotPresent
 
   logLevel: info

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -3899,6 +3899,9 @@ metadata:
 
           ## Maximum amount of memory, in %, targeted to be allocated by the process heap.
           limit_percentage: 75
+          ## Spike limit (calculated from available memory). Must be less than limit_percentage.
+          spike_limit_percentage: 20
+
         ## Configuration for Batch Processor
         ## The batch processor accepts spans and places them into batches grouped by node and resource
         ## ref: https://github.com/SumoLogic/opentelemetry-collector/blob/main/processor/batchprocessor
@@ -4118,6 +4121,9 @@ metadata:
 
           ## Maximum amount of memory, in %, targeted to be allocated by the process heap.
           limit_percentage: 75
+          ## Spike limit (calculated from available memory). Must be less than limit_percentage.
+          spike_limit_percentage: 20
+
         ## The batch processor accepts spans and places them into batches grouped by node and resource
         batch:
           ## Number of spans after which a batch will be sent regardless of time
@@ -4517,6 +4523,8 @@ otelgateway:
 
         ## Maximum amount of memory, in %, targeted to be allocated by the process heap.
         limit_percentage: 75
+        ## Spike limit (calculated from available memory). Must be less than limit_percentage.
+        spike_limit_percentage: 20
 
       ## The batch processor accepts spans and places them into batches grouped by node and resource
       batch:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -3897,10 +3897,8 @@ metadata:
           ## it can result in unnecessary CPU consumption.
           check_interval: 5s
 
-          ## Maximum amount of memory, in MiB, targeted to be allocated by the process heap.
-          ## Note that typically the total memory usage of process will be about 50MiB higher
-          ## than this value.
-          limit_mib: 1900
+          ## Maximum amount of memory, in %, targeted to be allocated by the process heap.
+          limit_percentage: 75
         ## Configuration for Batch Processor
         ## The batch processor accepts spans and places them into batches grouped by node and resource
         ## ref: https://github.com/SumoLogic/opentelemetry-collector/blob/main/processor/batchprocessor
@@ -4118,10 +4116,8 @@ metadata:
           ## it can result in unnecessary CPU consumption.
           check_interval: 5s
 
-          ## Maximum amount of memory, in MiB, targeted to be allocated by the process heap.
-          ## Note that typically the total memory usage of process will be about 50MiB higher
-          ## than this value.
-          limit_mib: 1900
+          ## Maximum amount of memory, in %, targeted to be allocated by the process heap.
+          limit_percentage: 75
         ## The batch processor accepts spans and places them into batches grouped by node and resource
         batch:
           ## Number of spans after which a batch will be sent regardless of time
@@ -4519,10 +4515,8 @@ otelgateway:
         ## it can result in unnecessary CPU consumption.
         check_interval: 5s
 
-        ## Maximum amount of memory, in MiB, targeted to be allocated by the process heap.
-        ## Note that typically the total memory usage of process will be about 50MiB higher
-        ## than this value.
-        limit_mib: 1900
+        ## Maximum amount of memory, in %, targeted to be allocated by the process heap.
+        limit_percentage: 75
 
       ## The batch processor accepts spans and places them into batches grouped by node and resource
       batch:

--- a/tests/helm/logs_otc_daemonset/static/basic.output.yaml
+++ b/tests/helm/logs_otc_daemonset/static/basic.output.yaml
@@ -30,7 +30,7 @@ spec:
       containers:
       - args:
         - --config=/etc/otelcol/config.yaml
-        image: public.ecr.aws/sumologic/sumologic-otel-collector:0.0.50-beta.0
+        image: public.ecr.aws/sumologic/sumologic-otel-collector:0.0.58-beta.0
         imagePullPolicy: IfNotPresent
         name: otelcol
         livenessProbe:

--- a/tests/helm/metadata_logs_otc/static/basic.output.yaml
+++ b/tests/helm/metadata_logs_otc/static/basic.output.yaml
@@ -168,7 +168,8 @@ data:
         - from: build_hostname
       memory_limiter:
         check_interval: 5s
-        limit_mib: 1900
+        limit_percentage: 75
+        spike_limit_percentage: 20
       resource/containers_copy_node_to_host:
         attributes:
         - action: upsert

--- a/tests/helm/metadata_logs_otc/static/templates.output.yaml
+++ b/tests/helm/metadata_logs_otc/static/templates.output.yaml
@@ -168,7 +168,8 @@ data:
         - from: build_hostname
       memory_limiter:
         check_interval: 5s
-        limit_mib: 1900
+        limit_percentage: 75
+        spike_limit_percentage: 20
       resource/containers_copy_node_to_host:
         attributes:
         - action: upsert

--- a/tests/helm/metadata_logs_otc_statefulset/static/basic.output.yaml
+++ b/tests/helm/metadata_logs_otc_statefulset/static/basic.output.yaml
@@ -65,7 +65,7 @@ spec:
       priorityClassName: "prio"
       containers:
       - name: otelcol
-        image: public.ecr.aws/sumologic/sumologic-otel-collector:0.0.50-beta.0
+        image: public.ecr.aws/sumologic/sumologic-otel-collector:0.0.58-beta.0
         imagePullPolicy: IfNotPresent
         args:
           - --config=/etc/otel/config.yaml

--- a/tests/helm/metadata_metrics_otc_statefulset/static/basic.output.yaml
+++ b/tests/helm/metadata_metrics_otc_statefulset/static/basic.output.yaml
@@ -65,7 +65,7 @@ spec:
       priorityClassName: "prio"
       containers:
       - name: otelcol
-        image: public.ecr.aws/sumologic/sumologic-otel-collector:0.0.50-beta.0
+        image: public.ecr.aws/sumologic/sumologic-otel-collector:0.0.58-beta.0
         imagePullPolicy: IfNotPresent
         args:
           - --config=/etc/otel/config.yaml

--- a/tests/helm/tracing-gateway-loadbalancing/static/otelgateway-true.output.yaml
+++ b/tests/helm/tracing-gateway-loadbalancing/static/otelgateway-true.output.yaml
@@ -37,7 +37,8 @@ data:
         timeout: 5s
       memory_limiter:
         check_interval: 5s
-        limit_mib: 1900
+        limit_percentage: 75
+        spike_limit_percentage: 20
     receivers:
       jaeger:
         protocols:


### PR DESCRIPTION
##### Description

upgrade OTC to 0.0.58-beta.0
change memory limit for otc to be 75% of available memory with 20% spike
 
---

##### Checklist

<!---
Remove items which don't apply to your PR.
-->

- [ ] Changelog updated

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
