### PR TITLE
feat(metrics/otelcol): drop unwanted routing metric attribute

### DIFF
--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -3682,6 +3682,7 @@ metadata:
             - k8s.*
             - pod_labels_.*
             - namespace_labels_.*
+          routing_atttribute_to_drop: http_listener_v2_path
         sumologic/apiserver:
           metric_format: prometheus
           endpoint: ${SUMO_ENDPOINT_APISERVER_METRICS_SOURCE}
@@ -3697,6 +3698,7 @@ metadata:
             - k8s.*
             - pod_labels_.*
             - namespace_labels_.*
+          routing_atttribute_to_drop: http_listener_v2_path
         sumologic/control_plane:
           metric_format: prometheus
           endpoint: ${SUMO_ENDPOINT_CONTROL_PLANE_METRICS_SOURCE}
@@ -3712,6 +3714,7 @@ metadata:
             - k8s.*
             - pod_labels_.*
             - namespace_labels_.*
+          routing_atttribute_to_drop: http_listener_v2_path
         sumologic/controller:
           metric_format: prometheus
           endpoint: ${SUMO_ENDPOINT_CONTROLLER_METRICS_SOURCE}
@@ -3727,6 +3730,7 @@ metadata:
             - k8s.*
             - pod_labels_.*
             - namespace_labels_.*
+          routing_atttribute_to_drop: http_listener_v2_path
         sumologic/kubelet:
           metric_format: prometheus
           endpoint: ${SUMO_ENDPOINT_KUBELET_METRICS_SOURCE}
@@ -3742,6 +3746,7 @@ metadata:
             - k8s.*
             - pod_labels_.*
             - namespace_labels_.*
+          routing_atttribute_to_drop: http_listener_v2_path
         sumologic/node:
           metric_format: prometheus
           endpoint: ${SUMO_ENDPOINT_NODE_METRICS_SOURCE}
@@ -3757,6 +3762,7 @@ metadata:
             - k8s.*
             - pod_labels_.*
             - namespace_labels_.*
+          routing_atttribute_to_drop: http_listener_v2_path
         sumologic/scheduler:
           metric_format: prometheus
           endpoint: ${SUMO_ENDPOINT_SCHEDULER_METRICS_SOURCE}
@@ -3772,6 +3778,7 @@ metadata:
             - k8s.*
             - pod_labels_.*
             - namespace_labels_.*
+          routing_atttribute_to_drop: http_listener_v2_path
         sumologic/state:
           metric_format: prometheus
           endpoint: ${SUMO_ENDPOINT_STATE_METRICS_SOURCE}
@@ -3787,6 +3794,7 @@ metadata:
             - k8s.*
             - pod_labels_.*
             - namespace_labels_.*
+          routing_atttribute_to_drop: http_listener_v2_path
       processors:
         ## Configuration for Metrics Transform Processor
         ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/release/v0.37.x/processor/metricstransformprocessor

--- a/tests/integration/helm_otc_metadata_installation_test.go
+++ b/tests/integration/helm_otc_metadata_installation_test.go
@@ -258,7 +258,6 @@ func Test_Helm_Default_OT_Metadata(t *testing.T) {
 						// hence with longer time range the time series about a particular metric
 						// that we receive diverge into n, where n is the number of metrics
 						// enrichment pods.
-						"http_listener_v2_path":        "/prometheus.metrics.container",
 						"image":                        "",
 						"instance":                     "",
 						"job":                          "kubelet",


### PR DESCRIPTION
##### Description

drop unwanted routing metric attribute

---

##### Checklist

<!---
Remove items which don't apply to your PR.
-->

- [ ] Changelog updated

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
