### PR TITLE
fix(ci): only run the backporter on merged PRs

### DIFF
--- a/.github/workflows/backport_bot.yaml
+++ b/.github/workflows/backport_bot.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   backport:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-20.04
     name: Backport
     steps:


### PR DESCRIPTION
##### Description

Running it on arbitrary PRs with the pull_request_target trigger is a security risk.
