### PR TITLE
fix: use custom ServiceMonitor for Prometheus' own metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- fix: use custom ServiceMonitor for Prometheus' own metrics [#2238]
+
 ### Fixed
 
 - fix: set source name and category in the FluentD output for events [#2222][#2222]
@@ -18,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#2232]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2232
 [#2222]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2222
+[#2238]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2238
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.6.0...main
 
 ## [v2.7.0][v2.7.0]

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1739,6 +1739,16 @@ kube-prometheus-stack:
           matchLabels:
             sumologic.com/app: otelcol
             sumologic.com/scrape: "true"
+      - name: collection-sumologic-prometheus
+        endpoints:
+          - port: web
+            path: /metrics
+        namespaceSelector:
+          matchNames:
+            - $(NAMESPACE)
+        selector:
+          matchLabels:
+            operated-prometheus: "true"
     prometheusSpec:
       ## Prometheus default scrape interval, default from upstream Kube Prometheus Stack Helm chart
       ## NOTE changing the scrape interval to be >1m can result in metrics
@@ -3218,6 +3228,9 @@ kube-prometheus-stack:
             - action: keep
               regex: (?:squid_(uptime|cache(Ip(Entries|Requests|Hits)|Fqdn(Entries|Requests|Misses|NegativeHits)|Dns(Requests|Replies|SvcTime5)|Sys(PageFaults|NumReads)|Current(FileDescrCnt|UnusedFDescrCnt|ResFileDescrCnt)|Server(Requests|InKb|OutKb)|Http(AllSvcTime5|Errors|InKb|OutKb|AllSvcTime1)|Mem(MaxSize|Usage)|NumObjCount|CpuTime|MaxResSize|ProtoClientHttpRequests|Clients)))
               sourceLabels: [__name__]
+
+      serviceMonitor:
+        selfMonitor: false
 
 ## Configure optional OpenTelemetry Collector in Agent mode
 otelagent:


### PR DESCRIPTION
Having the `kube-prometheus-stack` subchart generate the ServiceMonitor to scrape Prometheus' own metrics does not work correctly in a setup with an external Prometheus operator in a different (higher) version.
By "does not work correctly" I mean that the ServiceMonitor points to a Service that does not see any pods and in effect, Prometheus cannot scrape its own metrics.
This is because different versions of Prometheus operator create different labels on Prometheus pods.
To fix this, let's disable the `kube-prometheus-stack` subchart's built-in ServiceMonitor and create our own, just like we do for other collection resources (Fluent Bit, Fluentd, Otelcol).
