### PR TITLE
fix: Handle empty or invalid Sumo base URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - fix: set source name and category in the FluentD output for events [#2222][#2222]
+- fix: proper handling of empty `sumologic.endpoint` in the setup script
 - docs: FluentD buffer size configuration [#2232][#2232]
 
 [#2232]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2232

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - fix: set source name and category in the FluentD output for events [#2222][#2222]
-- fix: proper handling of empty `sumologic.endpoint` in the setup script
+- fix: proper handling of empty `sumologic.endpoint` in the setup script [#2240][#2240]
 - docs: FluentD buffer size configuration [#2232][#2232]
 
 [#2232]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2232
+[#2240]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2240
 [#2222]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2222
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.6.0...main
 

--- a/deploy/helm/sumologic/conf/setup/setup.sh
+++ b/deploy/helm/sumologic/conf/setup/setup.sh
@@ -16,7 +16,8 @@ if [[ ${DEBUG_MODE,,} == "${DEBUG_MODE_ENABLED_FLAG}" ]]; then
 fi
 
 function fix_sumo_base_url() {
-  local BASE_URL=$SUMOLOGIC_BASE_URL
+  BASE_URL=${SUMOLOGIC_BASE_URL}
+  local BASE_URL
 
   if [[ "${BASE_URL}" =~ ^\s*$ ]]; then
     BASE_URL="https://api.sumologic.com/api/"

--- a/deploy/helm/sumologic/conf/setup/setup.sh
+++ b/deploy/helm/sumologic/conf/setup/setup.sh
@@ -28,7 +28,7 @@ function fix_sumo_base_url() {
           "${BASE_URL}"v1/collectors \
           | grep -Fi location )"
 
-  if [[ ! $OPTIONAL_REDIRECTION =~ ^\s*$ ]]; then
+  if [[ ! ${OPTIONAL_REDIRECTION} =~ ^\s*$ ]]; then
     BASE_URL=$( echo "${OPTIONAL_REDIRECTION}" | sed -E 's/.*: (https:\/\/.*(au|ca|de|eu|fed|in|jp|us2)?\.sumologic\.com\/api\/).*/\1/' )
   fi
 

--- a/deploy/helm/sumologic/conf/setup/setup.sh
+++ b/deploy/helm/sumologic/conf/setup/setup.sh
@@ -16,8 +16,8 @@ if [[ ${DEBUG_MODE,,} == "${DEBUG_MODE_ENABLED_FLAG}" ]]; then
 fi
 
 function fix_sumo_base_url() {
-  BASE_URL=${SUMOLOGIC_BASE_URL}
   local BASE_URL
+  BASE_URL=${SUMOLOGIC_BASE_URL}
 
   if [[ "${BASE_URL}" =~ ^\s*$ ]]; then
     BASE_URL="https://api.sumologic.com/api/"

--- a/deploy/helm/sumologic/conf/setup/setup.sh
+++ b/deploy/helm/sumologic/conf/setup/setup.sh
@@ -18,7 +18,7 @@ fi
 function fix_sumo_base_url() {
   local BASE_URL=$SUMOLOGIC_BASE_URL
 
-  if [[ ! "$BASE_URL" =~ ^https:\/\/.*sumologic\.com\/api\/.*$ ]]; then
+  if [[ "${BASE_URL}" =~ ^\s*$ ]]; then
     BASE_URL="https://api.sumologic.com/api/"
   fi
 
@@ -28,12 +28,12 @@ function fix_sumo_base_url() {
           | grep -Fi location )"
 
   if [[ ! $OPTIONAL_REDIRECTION =~ ^\s*$ ]]; then
-    BASE_URL=$( echo $OPTIONAL_REDIRECTION | sed -E 's/.*: (https:\/\/.*(au|ca|de|eu|fed|in|jp|us2)?\.sumologic\.com\/api\/).*/\1/' )
+    BASE_URL=$( echo "${OPTIONAL_REDIRECTION}" | sed -E 's/.*: (https:\/\/.*(au|ca|de|eu|fed|in|jp|us2)?\.sumologic\.com\/api\/).*/\1/' )
   fi
 
   BASE_URL=${BASE_URL%v1*}
 
-  echo $BASE_URL
+  echo "${BASE_URL}"
 }
 
 export SUMOLOGIC_BASE_URL=$(fix_sumo_base_url)

--- a/tests/helm/terraform/static/all_fields.output.yaml
+++ b/tests/helm/terraform/static/all_fields.output.yaml
@@ -288,7 +288,7 @@ data:
   
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
-    if [[ ${DEBUG_MODE,,} == ${DEBUG_MODE_ENABLED_FLAG} ]]; then
+    if [[ ${DEBUG_MODE,,} == "${DEBUG_MODE_ENABLED_FLAG}" ]]; then
         echo "Entering the debug mode with continuous sleep. No setup will be performed."
         echo "Please exec into the setup container and run the setup.sh by hand or set the sumologic.setup.debug=false and reinstall."
   
@@ -298,8 +298,29 @@ data:
         done
     fi
   
-    # Fix URL to remove "v1" or "v1/"
-    export SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL%v1*}
+    function fix_sumo_base_url() {
+      local BASE_URL=$SUMOLOGIC_BASE_URL
+  
+      if [[ "${BASE_URL}" =~ ^\s*$ ]]; then
+        BASE_URL="https://api.sumologic.com/api/"
+      fi
+  
+      OPTIONAL_REDIRECTION="$(curl -XGET -s -o /dev/null -D - \
+              -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+              "${BASE_URL}"v1/collectors \
+              | grep -Fi location )"
+  
+      if [[ ! $OPTIONAL_REDIRECTION =~ ^\s*$ ]]; then
+        BASE_URL=$( echo "${OPTIONAL_REDIRECTION}" | sed -E 's/.*: (https:\/\/.*(au|ca|de|eu|fed|in|jp|us2)?\.sumologic\.com\/api\/).*/\1/' )
+      fi
+  
+      BASE_URL=${BASE_URL%v1*}
+  
+      echo "${BASE_URL}"
+    }
+  
+    SUMOLOGIC_BASE_URL=$(fix_sumo_base_url)
+    export SUMOLOGIC_BASE_URL
     # Support proxy for Terraform
     export HTTP_PROXY=${HTTP_PROXY:=""}
     export HTTPS_PROXY=${HTTPS_PROXY:=""}
@@ -307,9 +328,10 @@ data:
   
     function get_remaining_fields() {
         local RESPONSE
-        readonly RESPONSE="$(curl -XGET -s \
+        RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields/quota)"
+        readonly RESPONSE
   
         echo "${RESPONSE}"
     }
@@ -318,7 +340,8 @@ data:
     # would be created for the collection
     function should_create_fields() {
         local RESPONSE
-        readonly RESPONSE=$(get_remaining_fields)
+        RESPONSE=$(get_remaining_fields)
+        readonly RESPONSE
   
         if ! jq -e <<< "${RESPONSE}" ; then
             printf "Failed requesting fields API:\n%s\n" "${RESPONSE}"
@@ -331,7 +354,8 @@ data:
         fi
   
         local REMAINING
-        readonly REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
+        REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
+        readonly REMAINING
         if [[ $(( REMAINING - 8 )) -ge 10 ]] ; then
             return 0
         else
@@ -349,9 +373,10 @@ data:
     # Sumo Logic fields
     if should_create_fields ; then
         readonly CREATE_FIELDS=1
-        readonly FIELDS_RESPONSE="$(curl -XGET -s \
+        FIELDS_RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"
+        readonly FIELDS_RESPONSE
   
         declare -ra FIELDS=("cluster" "container" "deployment" "host" "namespace" "node" "pod" "service")
         for FIELD in "${FIELDS[@]}" ; do

--- a/tests/helm/terraform/static/all_fields.output.yaml
+++ b/tests/helm/terraform/static/all_fields.output.yaml
@@ -311,7 +311,7 @@ data:
               "${BASE_URL}"v1/collectors \
               | grep -Fi location )"
   
-      if [[ ! $OPTIONAL_REDIRECTION =~ ^\s*$ ]]; then
+      if [[ ! ${OPTIONAL_REDIRECTION} =~ ^\s*$ ]]; then
         BASE_URL=$( echo "${OPTIONAL_REDIRECTION}" | sed -E 's/.*: (https:\/\/.*(au|ca|de|eu|fed|in|jp|us2)?\.sumologic\.com\/api\/).*/\1/' )
       fi
   

--- a/tests/helm/terraform/static/all_fields.output.yaml
+++ b/tests/helm/terraform/static/all_fields.output.yaml
@@ -299,7 +299,8 @@ data:
     fi
   
     function fix_sumo_base_url() {
-      local BASE_URL=$SUMOLOGIC_BASE_URL
+      BASE_URL=${SUMOLOGIC_BASE_URL}
+      local BASE_URL
   
       if [[ "${BASE_URL}" =~ ^\s*$ ]]; then
         BASE_URL="https://api.sumologic.com/api/"

--- a/tests/helm/terraform/static/all_fields.output.yaml
+++ b/tests/helm/terraform/static/all_fields.output.yaml
@@ -299,8 +299,8 @@ data:
     fi
   
     function fix_sumo_base_url() {
-      BASE_URL=${SUMOLOGIC_BASE_URL}
       local BASE_URL
+      BASE_URL=${SUMOLOGIC_BASE_URL}
   
       if [[ "${BASE_URL}" =~ ^\s*$ ]]; then
         BASE_URL="https://api.sumologic.com/api/"

--- a/tests/helm/terraform/static/collector_fields.output.yaml
+++ b/tests/helm/terraform/static/collector_fields.output.yaml
@@ -266,7 +266,7 @@ data:
               "${BASE_URL}"v1/collectors \
               | grep -Fi location )"
   
-      if [[ ! $OPTIONAL_REDIRECTION =~ ^\s*$ ]]; then
+      if [[ ! ${OPTIONAL_REDIRECTION} =~ ^\s*$ ]]; then
         BASE_URL=$( echo "${OPTIONAL_REDIRECTION}" | sed -E 's/.*: (https:\/\/.*(au|ca|de|eu|fed|in|jp|us2)?\.sumologic\.com\/api\/).*/\1/' )
       fi
   

--- a/tests/helm/terraform/static/collector_fields.output.yaml
+++ b/tests/helm/terraform/static/collector_fields.output.yaml
@@ -254,8 +254,8 @@ data:
     fi
   
     function fix_sumo_base_url() {
-      BASE_URL=${SUMOLOGIC_BASE_URL}
       local BASE_URL
+      BASE_URL=${SUMOLOGIC_BASE_URL}
   
       if [[ "${BASE_URL}" =~ ^\s*$ ]]; then
         BASE_URL="https://api.sumologic.com/api/"

--- a/tests/helm/terraform/static/collector_fields.output.yaml
+++ b/tests/helm/terraform/static/collector_fields.output.yaml
@@ -243,7 +243,7 @@ data:
   
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
-    if [[ ${DEBUG_MODE,,} == ${DEBUG_MODE_ENABLED_FLAG} ]]; then
+    if [[ ${DEBUG_MODE,,} == "${DEBUG_MODE_ENABLED_FLAG}" ]]; then
         echo "Entering the debug mode with continuous sleep. No setup will be performed."
         echo "Please exec into the setup container and run the setup.sh by hand or set the sumologic.setup.debug=false and reinstall."
   
@@ -253,8 +253,29 @@ data:
         done
     fi
   
-    # Fix URL to remove "v1" or "v1/"
-    export SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL%v1*}
+    function fix_sumo_base_url() {
+      local BASE_URL=$SUMOLOGIC_BASE_URL
+  
+      if [[ "${BASE_URL}" =~ ^\s*$ ]]; then
+        BASE_URL="https://api.sumologic.com/api/"
+      fi
+  
+      OPTIONAL_REDIRECTION="$(curl -XGET -s -o /dev/null -D - \
+              -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+              "${BASE_URL}"v1/collectors \
+              | grep -Fi location )"
+  
+      if [[ ! $OPTIONAL_REDIRECTION =~ ^\s*$ ]]; then
+        BASE_URL=$( echo "${OPTIONAL_REDIRECTION}" | sed -E 's/.*: (https:\/\/.*(au|ca|de|eu|fed|in|jp|us2)?\.sumologic\.com\/api\/).*/\1/' )
+      fi
+  
+      BASE_URL=${BASE_URL%v1*}
+  
+      echo "${BASE_URL}"
+    }
+  
+    SUMOLOGIC_BASE_URL=$(fix_sumo_base_url)
+    export SUMOLOGIC_BASE_URL
     # Support proxy for Terraform
     export HTTP_PROXY=${HTTP_PROXY:=""}
     export HTTPS_PROXY=${HTTPS_PROXY:=""}
@@ -262,9 +283,10 @@ data:
   
     function get_remaining_fields() {
         local RESPONSE
-        readonly RESPONSE="$(curl -XGET -s \
+        RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields/quota)"
+        readonly RESPONSE
   
         echo "${RESPONSE}"
     }
@@ -273,7 +295,8 @@ data:
     # would be created for the collection
     function should_create_fields() {
         local RESPONSE
-        readonly RESPONSE=$(get_remaining_fields)
+        RESPONSE=$(get_remaining_fields)
+        readonly RESPONSE
   
         if ! jq -e <<< "${RESPONSE}" ; then
             printf "Failed requesting fields API:\n%s\n" "${RESPONSE}"
@@ -286,7 +309,8 @@ data:
         fi
   
         local REMAINING
-        readonly REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
+        REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
+        readonly REMAINING
         if [[ $(( REMAINING - 8 )) -ge 10 ]] ; then
             return 0
         else
@@ -304,9 +328,10 @@ data:
     # Sumo Logic fields
     if should_create_fields ; then
         readonly CREATE_FIELDS=1
-        readonly FIELDS_RESPONSE="$(curl -XGET -s \
+        FIELDS_RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"
+        readonly FIELDS_RESPONSE
   
         declare -ra FIELDS=("cluster" "container" "deployment" "host" "namespace" "node" "pod" "service")
         for FIELD in "${FIELDS[@]}" ; do

--- a/tests/helm/terraform/static/collector_fields.output.yaml
+++ b/tests/helm/terraform/static/collector_fields.output.yaml
@@ -254,7 +254,8 @@ data:
     fi
   
     function fix_sumo_base_url() {
-      local BASE_URL=$SUMOLOGIC_BASE_URL
+      BASE_URL=${SUMOLOGIC_BASE_URL}
+      local BASE_URL
   
       if [[ "${BASE_URL}" =~ ^\s*$ ]]; then
         BASE_URL="https://api.sumologic.com/api/"

--- a/tests/helm/terraform/static/conditional_sources.output.yaml
+++ b/tests/helm/terraform/static/conditional_sources.output.yaml
@@ -182,7 +182,8 @@ data:
     fi
   
     function fix_sumo_base_url() {
-      local BASE_URL=$SUMOLOGIC_BASE_URL
+      BASE_URL=${SUMOLOGIC_BASE_URL}
+      local BASE_URL
   
       if [[ "${BASE_URL}" =~ ^\s*$ ]]; then
         BASE_URL="https://api.sumologic.com/api/"

--- a/tests/helm/terraform/static/conditional_sources.output.yaml
+++ b/tests/helm/terraform/static/conditional_sources.output.yaml
@@ -194,7 +194,7 @@ data:
               "${BASE_URL}"v1/collectors \
               | grep -Fi location )"
   
-      if [[ ! $OPTIONAL_REDIRECTION =~ ^\s*$ ]]; then
+      if [[ ! ${OPTIONAL_REDIRECTION} =~ ^\s*$ ]]; then
         BASE_URL=$( echo "${OPTIONAL_REDIRECTION}" | sed -E 's/.*: (https:\/\/.*(au|ca|de|eu|fed|in|jp|us2)?\.sumologic\.com\/api\/).*/\1/' )
       fi
   

--- a/tests/helm/terraform/static/conditional_sources.output.yaml
+++ b/tests/helm/terraform/static/conditional_sources.output.yaml
@@ -182,8 +182,8 @@ data:
     fi
   
     function fix_sumo_base_url() {
-      BASE_URL=${SUMOLOGIC_BASE_URL}
       local BASE_URL
+      BASE_URL=${SUMOLOGIC_BASE_URL}
   
       if [[ "${BASE_URL}" =~ ^\s*$ ]]; then
         BASE_URL="https://api.sumologic.com/api/"

--- a/tests/helm/terraform/static/conditional_sources.output.yaml
+++ b/tests/helm/terraform/static/conditional_sources.output.yaml
@@ -171,7 +171,7 @@ data:
   
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
-    if [[ ${DEBUG_MODE,,} == ${DEBUG_MODE_ENABLED_FLAG} ]]; then
+    if [[ ${DEBUG_MODE,,} == "${DEBUG_MODE_ENABLED_FLAG}" ]]; then
         echo "Entering the debug mode with continuous sleep. No setup will be performed."
         echo "Please exec into the setup container and run the setup.sh by hand or set the sumologic.setup.debug=false and reinstall."
   
@@ -181,8 +181,29 @@ data:
         done
     fi
   
-    # Fix URL to remove "v1" or "v1/"
-    export SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL%v1*}
+    function fix_sumo_base_url() {
+      local BASE_URL=$SUMOLOGIC_BASE_URL
+  
+      if [[ "${BASE_URL}" =~ ^\s*$ ]]; then
+        BASE_URL="https://api.sumologic.com/api/"
+      fi
+  
+      OPTIONAL_REDIRECTION="$(curl -XGET -s -o /dev/null -D - \
+              -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+              "${BASE_URL}"v1/collectors \
+              | grep -Fi location )"
+  
+      if [[ ! $OPTIONAL_REDIRECTION =~ ^\s*$ ]]; then
+        BASE_URL=$( echo "${OPTIONAL_REDIRECTION}" | sed -E 's/.*: (https:\/\/.*(au|ca|de|eu|fed|in|jp|us2)?\.sumologic\.com\/api\/).*/\1/' )
+      fi
+  
+      BASE_URL=${BASE_URL%v1*}
+  
+      echo "${BASE_URL}"
+    }
+  
+    SUMOLOGIC_BASE_URL=$(fix_sumo_base_url)
+    export SUMOLOGIC_BASE_URL
     # Support proxy for Terraform
     export HTTP_PROXY=${HTTP_PROXY:=""}
     export HTTPS_PROXY=${HTTPS_PROXY:=""}
@@ -190,9 +211,10 @@ data:
   
     function get_remaining_fields() {
         local RESPONSE
-        readonly RESPONSE="$(curl -XGET -s \
+        RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields/quota)"
+        readonly RESPONSE
   
         echo "${RESPONSE}"
     }
@@ -201,7 +223,8 @@ data:
     # would be created for the collection
     function should_create_fields() {
         local RESPONSE
-        readonly RESPONSE=$(get_remaining_fields)
+        RESPONSE=$(get_remaining_fields)
+        readonly RESPONSE
   
         if ! jq -e <<< "${RESPONSE}" ; then
             printf "Failed requesting fields API:\n%s\n" "${RESPONSE}"
@@ -214,7 +237,8 @@ data:
         fi
   
         local REMAINING
-        readonly REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
+        REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
+        readonly REMAINING
         if [[ $(( REMAINING - 8 )) -ge 10 ]] ; then
             return 0
         else
@@ -232,9 +256,10 @@ data:
     # Sumo Logic fields
     if should_create_fields ; then
         readonly CREATE_FIELDS=1
-        readonly FIELDS_RESPONSE="$(curl -XGET -s \
+        FIELDS_RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"
+        readonly FIELDS_RESPONSE
   
         declare -ra FIELDS=("cluster" "container" "deployment" "host" "namespace" "node" "pod" "service")
         for FIELD in "${FIELDS[@]}" ; do

--- a/tests/helm/terraform/static/custom.output.yaml
+++ b/tests/helm/terraform/static/custom.output.yaml
@@ -182,7 +182,8 @@ data:
     fi
   
     function fix_sumo_base_url() {
-      local BASE_URL=$SUMOLOGIC_BASE_URL
+      BASE_URL=${SUMOLOGIC_BASE_URL}
+      local BASE_URL
   
       if [[ "${BASE_URL}" =~ ^\s*$ ]]; then
         BASE_URL="https://api.sumologic.com/api/"

--- a/tests/helm/terraform/static/custom.output.yaml
+++ b/tests/helm/terraform/static/custom.output.yaml
@@ -194,7 +194,7 @@ data:
               "${BASE_URL}"v1/collectors \
               | grep -Fi location )"
   
-      if [[ ! $OPTIONAL_REDIRECTION =~ ^\s*$ ]]; then
+      if [[ ! ${OPTIONAL_REDIRECTION} =~ ^\s*$ ]]; then
         BASE_URL=$( echo "${OPTIONAL_REDIRECTION}" | sed -E 's/.*: (https:\/\/.*(au|ca|de|eu|fed|in|jp|us2)?\.sumologic\.com\/api\/).*/\1/' )
       fi
   

--- a/tests/helm/terraform/static/custom.output.yaml
+++ b/tests/helm/terraform/static/custom.output.yaml
@@ -182,8 +182,8 @@ data:
     fi
   
     function fix_sumo_base_url() {
-      BASE_URL=${SUMOLOGIC_BASE_URL}
       local BASE_URL
+      BASE_URL=${SUMOLOGIC_BASE_URL}
   
       if [[ "${BASE_URL}" =~ ^\s*$ ]]; then
         BASE_URL="https://api.sumologic.com/api/"

--- a/tests/helm/terraform/static/custom.output.yaml
+++ b/tests/helm/terraform/static/custom.output.yaml
@@ -171,7 +171,7 @@ data:
   
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
-    if [[ ${DEBUG_MODE,,} == ${DEBUG_MODE_ENABLED_FLAG} ]]; then
+    if [[ ${DEBUG_MODE,,} == "${DEBUG_MODE_ENABLED_FLAG}" ]]; then
         echo "Entering the debug mode with continuous sleep. No setup will be performed."
         echo "Please exec into the setup container and run the setup.sh by hand or set the sumologic.setup.debug=false and reinstall."
   
@@ -181,8 +181,29 @@ data:
         done
     fi
   
-    # Fix URL to remove "v1" or "v1/"
-    export SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL%v1*}
+    function fix_sumo_base_url() {
+      local BASE_URL=$SUMOLOGIC_BASE_URL
+  
+      if [[ "${BASE_URL}" =~ ^\s*$ ]]; then
+        BASE_URL="https://api.sumologic.com/api/"
+      fi
+  
+      OPTIONAL_REDIRECTION="$(curl -XGET -s -o /dev/null -D - \
+              -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+              "${BASE_URL}"v1/collectors \
+              | grep -Fi location )"
+  
+      if [[ ! $OPTIONAL_REDIRECTION =~ ^\s*$ ]]; then
+        BASE_URL=$( echo "${OPTIONAL_REDIRECTION}" | sed -E 's/.*: (https:\/\/.*(au|ca|de|eu|fed|in|jp|us2)?\.sumologic\.com\/api\/).*/\1/' )
+      fi
+  
+      BASE_URL=${BASE_URL%v1*}
+  
+      echo "${BASE_URL}"
+    }
+  
+    SUMOLOGIC_BASE_URL=$(fix_sumo_base_url)
+    export SUMOLOGIC_BASE_URL
     # Support proxy for Terraform
     export HTTP_PROXY=${HTTP_PROXY:=""}
     export HTTPS_PROXY=${HTTPS_PROXY:=""}
@@ -190,9 +211,10 @@ data:
   
     function get_remaining_fields() {
         local RESPONSE
-        readonly RESPONSE="$(curl -XGET -s \
+        RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields/quota)"
+        readonly RESPONSE
   
         echo "${RESPONSE}"
     }
@@ -201,7 +223,8 @@ data:
     # would be created for the collection
     function should_create_fields() {
         local RESPONSE
-        readonly RESPONSE=$(get_remaining_fields)
+        RESPONSE=$(get_remaining_fields)
+        readonly RESPONSE
   
         if ! jq -e <<< "${RESPONSE}" ; then
             printf "Failed requesting fields API:\n%s\n" "${RESPONSE}"
@@ -214,7 +237,8 @@ data:
         fi
   
         local REMAINING
-        readonly REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
+        REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
+        readonly REMAINING
         if [[ $(( REMAINING - 8 )) -ge 10 ]] ; then
             return 0
         else
@@ -232,9 +256,10 @@ data:
     # Sumo Logic fields
     if should_create_fields ; then
         readonly CREATE_FIELDS=1
-        readonly FIELDS_RESPONSE="$(curl -XGET -s \
+        FIELDS_RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"
+        readonly FIELDS_RESPONSE
   
         declare -ra FIELDS=("cluster" "container" "deployment" "host" "namespace" "node" "pod" "service")
         for FIELD in "${FIELDS[@]}" ; do

--- a/tests/helm/terraform/static/default.output.yaml
+++ b/tests/helm/terraform/static/default.output.yaml
@@ -241,7 +241,7 @@ data:
   
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
-    if [[ ${DEBUG_MODE,,} == ${DEBUG_MODE_ENABLED_FLAG} ]]; then
+    if [[ ${DEBUG_MODE,,} == "${DEBUG_MODE_ENABLED_FLAG}" ]]; then
         echo "Entering the debug mode with continuous sleep. No setup will be performed."
         echo "Please exec into the setup container and run the setup.sh by hand or set the sumologic.setup.debug=false and reinstall."
   
@@ -251,8 +251,29 @@ data:
         done
     fi
   
-    # Fix URL to remove "v1" or "v1/"
-    export SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL%v1*}
+    function fix_sumo_base_url() {
+      local BASE_URL=$SUMOLOGIC_BASE_URL
+  
+      if [[ "${BASE_URL}" =~ ^\s*$ ]]; then
+        BASE_URL="https://api.sumologic.com/api/"
+      fi
+  
+      OPTIONAL_REDIRECTION="$(curl -XGET -s -o /dev/null -D - \
+              -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+              "${BASE_URL}"v1/collectors \
+              | grep -Fi location )"
+  
+      if [[ ! $OPTIONAL_REDIRECTION =~ ^\s*$ ]]; then
+        BASE_URL=$( echo "${OPTIONAL_REDIRECTION}" | sed -E 's/.*: (https:\/\/.*(au|ca|de|eu|fed|in|jp|us2)?\.sumologic\.com\/api\/).*/\1/' )
+      fi
+  
+      BASE_URL=${BASE_URL%v1*}
+  
+      echo "${BASE_URL}"
+    }
+  
+    SUMOLOGIC_BASE_URL=$(fix_sumo_base_url)
+    export SUMOLOGIC_BASE_URL
     # Support proxy for Terraform
     export HTTP_PROXY=${HTTP_PROXY:=""}
     export HTTPS_PROXY=${HTTPS_PROXY:=""}
@@ -260,9 +281,10 @@ data:
   
     function get_remaining_fields() {
         local RESPONSE
-        readonly RESPONSE="$(curl -XGET -s \
+        RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields/quota)"
+        readonly RESPONSE
   
         echo "${RESPONSE}"
     }
@@ -271,7 +293,8 @@ data:
     # would be created for the collection
     function should_create_fields() {
         local RESPONSE
-        readonly RESPONSE=$(get_remaining_fields)
+        RESPONSE=$(get_remaining_fields)
+        readonly RESPONSE
   
         if ! jq -e <<< "${RESPONSE}" ; then
             printf "Failed requesting fields API:\n%s\n" "${RESPONSE}"
@@ -284,7 +307,8 @@ data:
         fi
   
         local REMAINING
-        readonly REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
+        REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
+        readonly REMAINING
         if [[ $(( REMAINING - 8 )) -ge 10 ]] ; then
             return 0
         else
@@ -302,9 +326,10 @@ data:
     # Sumo Logic fields
     if should_create_fields ; then
         readonly CREATE_FIELDS=1
-        readonly FIELDS_RESPONSE="$(curl -XGET -s \
+        FIELDS_RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"
+        readonly FIELDS_RESPONSE
   
         declare -ra FIELDS=("cluster" "container" "deployment" "host" "namespace" "node" "pod" "service")
         for FIELD in "${FIELDS[@]}" ; do

--- a/tests/helm/terraform/static/default.output.yaml
+++ b/tests/helm/terraform/static/default.output.yaml
@@ -252,8 +252,8 @@ data:
     fi
   
     function fix_sumo_base_url() {
-      BASE_URL=${SUMOLOGIC_BASE_URL}
       local BASE_URL
+      BASE_URL=${SUMOLOGIC_BASE_URL}
   
       if [[ "${BASE_URL}" =~ ^\s*$ ]]; then
         BASE_URL="https://api.sumologic.com/api/"

--- a/tests/helm/terraform/static/default.output.yaml
+++ b/tests/helm/terraform/static/default.output.yaml
@@ -264,7 +264,7 @@ data:
               "${BASE_URL}"v1/collectors \
               | grep -Fi location )"
   
-      if [[ ! $OPTIONAL_REDIRECTION =~ ^\s*$ ]]; then
+      if [[ ! ${OPTIONAL_REDIRECTION} =~ ^\s*$ ]]; then
         BASE_URL=$( echo "${OPTIONAL_REDIRECTION}" | sed -E 's/.*: (https:\/\/.*(au|ca|de|eu|fed|in|jp|us2)?\.sumologic\.com\/api\/).*/\1/' )
       fi
   

--- a/tests/helm/terraform/static/default.output.yaml
+++ b/tests/helm/terraform/static/default.output.yaml
@@ -252,7 +252,8 @@ data:
     fi
   
     function fix_sumo_base_url() {
-      local BASE_URL=$SUMOLOGIC_BASE_URL
+      BASE_URL=${SUMOLOGIC_BASE_URL}
+      local BASE_URL
   
       if [[ "${BASE_URL}" =~ ^\s*$ ]]; then
         BASE_URL="https://api.sumologic.com/api/"

--- a/tests/helm/terraform/static/disable_default_metrics.output.yaml
+++ b/tests/helm/terraform/static/disable_default_metrics.output.yaml
@@ -245,8 +245,8 @@ data:
     fi
   
     function fix_sumo_base_url() {
-      BASE_URL=${SUMOLOGIC_BASE_URL}
       local BASE_URL
+      BASE_URL=${SUMOLOGIC_BASE_URL}
   
       if [[ "${BASE_URL}" =~ ^\s*$ ]]; then
         BASE_URL="https://api.sumologic.com/api/"

--- a/tests/helm/terraform/static/disable_default_metrics.output.yaml
+++ b/tests/helm/terraform/static/disable_default_metrics.output.yaml
@@ -257,7 +257,7 @@ data:
               "${BASE_URL}"v1/collectors \
               | grep -Fi location )"
   
-      if [[ ! $OPTIONAL_REDIRECTION =~ ^\s*$ ]]; then
+      if [[ ! ${OPTIONAL_REDIRECTION} =~ ^\s*$ ]]; then
         BASE_URL=$( echo "${OPTIONAL_REDIRECTION}" | sed -E 's/.*: (https:\/\/.*(au|ca|de|eu|fed|in|jp|us2)?\.sumologic\.com\/api\/).*/\1/' )
       fi
   

--- a/tests/helm/terraform/static/disable_default_metrics.output.yaml
+++ b/tests/helm/terraform/static/disable_default_metrics.output.yaml
@@ -234,7 +234,7 @@ data:
   
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
-    if [[ ${DEBUG_MODE,,} == ${DEBUG_MODE_ENABLED_FLAG} ]]; then
+    if [[ ${DEBUG_MODE,,} == "${DEBUG_MODE_ENABLED_FLAG}" ]]; then
         echo "Entering the debug mode with continuous sleep. No setup will be performed."
         echo "Please exec into the setup container and run the setup.sh by hand or set the sumologic.setup.debug=false and reinstall."
   
@@ -244,8 +244,29 @@ data:
         done
     fi
   
-    # Fix URL to remove "v1" or "v1/"
-    export SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL%v1*}
+    function fix_sumo_base_url() {
+      local BASE_URL=$SUMOLOGIC_BASE_URL
+  
+      if [[ "${BASE_URL}" =~ ^\s*$ ]]; then
+        BASE_URL="https://api.sumologic.com/api/"
+      fi
+  
+      OPTIONAL_REDIRECTION="$(curl -XGET -s -o /dev/null -D - \
+              -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+              "${BASE_URL}"v1/collectors \
+              | grep -Fi location )"
+  
+      if [[ ! $OPTIONAL_REDIRECTION =~ ^\s*$ ]]; then
+        BASE_URL=$( echo "${OPTIONAL_REDIRECTION}" | sed -E 's/.*: (https:\/\/.*(au|ca|de|eu|fed|in|jp|us2)?\.sumologic\.com\/api\/).*/\1/' )
+      fi
+  
+      BASE_URL=${BASE_URL%v1*}
+  
+      echo "${BASE_URL}"
+    }
+  
+    SUMOLOGIC_BASE_URL=$(fix_sumo_base_url)
+    export SUMOLOGIC_BASE_URL
     # Support proxy for Terraform
     export HTTP_PROXY=${HTTP_PROXY:=""}
     export HTTPS_PROXY=${HTTPS_PROXY:=""}
@@ -253,9 +274,10 @@ data:
   
     function get_remaining_fields() {
         local RESPONSE
-        readonly RESPONSE="$(curl -XGET -s \
+        RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields/quota)"
+        readonly RESPONSE
   
         echo "${RESPONSE}"
     }
@@ -264,7 +286,8 @@ data:
     # would be created for the collection
     function should_create_fields() {
         local RESPONSE
-        readonly RESPONSE=$(get_remaining_fields)
+        RESPONSE=$(get_remaining_fields)
+        readonly RESPONSE
   
         if ! jq -e <<< "${RESPONSE}" ; then
             printf "Failed requesting fields API:\n%s\n" "${RESPONSE}"
@@ -277,7 +300,8 @@ data:
         fi
   
         local REMAINING
-        readonly REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
+        REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
+        readonly REMAINING
         if [[ $(( REMAINING - 8 )) -ge 10 ]] ; then
             return 0
         else
@@ -295,9 +319,10 @@ data:
     # Sumo Logic fields
     if should_create_fields ; then
         readonly CREATE_FIELDS=1
-        readonly FIELDS_RESPONSE="$(curl -XGET -s \
+        FIELDS_RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"
+        readonly FIELDS_RESPONSE
   
         declare -ra FIELDS=("cluster" "container" "deployment" "host" "namespace" "node" "pod" "service")
         for FIELD in "${FIELDS[@]}" ; do

--- a/tests/helm/terraform/static/disable_default_metrics.output.yaml
+++ b/tests/helm/terraform/static/disable_default_metrics.output.yaml
@@ -245,7 +245,8 @@ data:
     fi
   
     function fix_sumo_base_url() {
-      local BASE_URL=$SUMOLOGIC_BASE_URL
+      BASE_URL=${SUMOLOGIC_BASE_URL}
+      local BASE_URL
   
       if [[ "${BASE_URL}" =~ ^\s*$ ]]; then
         BASE_URL="https://api.sumologic.com/api/"

--- a/tests/helm/terraform/static/strip_extrapolation.output.yaml
+++ b/tests/helm/terraform/static/strip_extrapolation.output.yaml
@@ -253,8 +253,8 @@ data:
     fi
   
     function fix_sumo_base_url() {
-      BASE_URL=${SUMOLOGIC_BASE_URL}
       local BASE_URL
+      BASE_URL=${SUMOLOGIC_BASE_URL}
   
       if [[ "${BASE_URL}" =~ ^\s*$ ]]; then
         BASE_URL="https://api.sumologic.com/api/"

--- a/tests/helm/terraform/static/strip_extrapolation.output.yaml
+++ b/tests/helm/terraform/static/strip_extrapolation.output.yaml
@@ -265,7 +265,7 @@ data:
               "${BASE_URL}"v1/collectors \
               | grep -Fi location )"
   
-      if [[ ! $OPTIONAL_REDIRECTION =~ ^\s*$ ]]; then
+      if [[ ! ${OPTIONAL_REDIRECTION} =~ ^\s*$ ]]; then
         BASE_URL=$( echo "${OPTIONAL_REDIRECTION}" | sed -E 's/.*: (https:\/\/.*(au|ca|de|eu|fed|in|jp|us2)?\.sumologic\.com\/api\/).*/\1/' )
       fi
   

--- a/tests/helm/terraform/static/strip_extrapolation.output.yaml
+++ b/tests/helm/terraform/static/strip_extrapolation.output.yaml
@@ -242,7 +242,7 @@ data:
   
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
-    if [[ ${DEBUG_MODE,,} == ${DEBUG_MODE_ENABLED_FLAG} ]]; then
+    if [[ ${DEBUG_MODE,,} == "${DEBUG_MODE_ENABLED_FLAG}" ]]; then
         echo "Entering the debug mode with continuous sleep. No setup will be performed."
         echo "Please exec into the setup container and run the setup.sh by hand or set the sumologic.setup.debug=false and reinstall."
   
@@ -252,8 +252,29 @@ data:
         done
     fi
   
-    # Fix URL to remove "v1" or "v1/"
-    export SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL%v1*}
+    function fix_sumo_base_url() {
+      local BASE_URL=$SUMOLOGIC_BASE_URL
+  
+      if [[ "${BASE_URL}" =~ ^\s*$ ]]; then
+        BASE_URL="https://api.sumologic.com/api/"
+      fi
+  
+      OPTIONAL_REDIRECTION="$(curl -XGET -s -o /dev/null -D - \
+              -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+              "${BASE_URL}"v1/collectors \
+              | grep -Fi location )"
+  
+      if [[ ! $OPTIONAL_REDIRECTION =~ ^\s*$ ]]; then
+        BASE_URL=$( echo "${OPTIONAL_REDIRECTION}" | sed -E 's/.*: (https:\/\/.*(au|ca|de|eu|fed|in|jp|us2)?\.sumologic\.com\/api\/).*/\1/' )
+      fi
+  
+      BASE_URL=${BASE_URL%v1*}
+  
+      echo "${BASE_URL}"
+    }
+  
+    SUMOLOGIC_BASE_URL=$(fix_sumo_base_url)
+    export SUMOLOGIC_BASE_URL
     # Support proxy for Terraform
     export HTTP_PROXY=${HTTP_PROXY:=""}
     export HTTPS_PROXY=${HTTPS_PROXY:=""}
@@ -261,9 +282,10 @@ data:
   
     function get_remaining_fields() {
         local RESPONSE
-        readonly RESPONSE="$(curl -XGET -s \
+        RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields/quota)"
+        readonly RESPONSE
   
         echo "${RESPONSE}"
     }
@@ -272,7 +294,8 @@ data:
     # would be created for the collection
     function should_create_fields() {
         local RESPONSE
-        readonly RESPONSE=$(get_remaining_fields)
+        RESPONSE=$(get_remaining_fields)
+        readonly RESPONSE
   
         if ! jq -e <<< "${RESPONSE}" ; then
             printf "Failed requesting fields API:\n%s\n" "${RESPONSE}"
@@ -285,7 +308,8 @@ data:
         fi
   
         local REMAINING
-        readonly REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
+        REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
+        readonly REMAINING
         if [[ $(( REMAINING - 8 )) -ge 10 ]] ; then
             return 0
         else
@@ -303,9 +327,10 @@ data:
     # Sumo Logic fields
     if should_create_fields ; then
         readonly CREATE_FIELDS=1
-        readonly FIELDS_RESPONSE="$(curl -XGET -s \
+        FIELDS_RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"
+        readonly FIELDS_RESPONSE
   
         declare -ra FIELDS=("cluster" "container" "deployment" "host" "namespace" "node" "pod" "service")
         for FIELD in "${FIELDS[@]}" ; do

--- a/tests/helm/terraform/static/strip_extrapolation.output.yaml
+++ b/tests/helm/terraform/static/strip_extrapolation.output.yaml
@@ -253,7 +253,8 @@ data:
     fi
   
     function fix_sumo_base_url() {
-      local BASE_URL=$SUMOLOGIC_BASE_URL
+      BASE_URL=${SUMOLOGIC_BASE_URL}
+      local BASE_URL
   
       if [[ "${BASE_URL}" =~ ^\s*$ ]]; then
         BASE_URL="https://api.sumologic.com/api/"

--- a/tests/helm/terraform/static/traces.output.yaml
+++ b/tests/helm/terraform/static/traces.output.yaml
@@ -197,8 +197,8 @@ data:
     fi
   
     function fix_sumo_base_url() {
-      BASE_URL=${SUMOLOGIC_BASE_URL}
       local BASE_URL
+      BASE_URL=${SUMOLOGIC_BASE_URL}
   
       if [[ "${BASE_URL}" =~ ^\s*$ ]]; then
         BASE_URL="https://api.sumologic.com/api/"

--- a/tests/helm/terraform/static/traces.output.yaml
+++ b/tests/helm/terraform/static/traces.output.yaml
@@ -186,7 +186,7 @@ data:
   
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
-    if [[ ${DEBUG_MODE,,} == ${DEBUG_MODE_ENABLED_FLAG} ]]; then
+    if [[ ${DEBUG_MODE,,} == "${DEBUG_MODE_ENABLED_FLAG}" ]]; then
         echo "Entering the debug mode with continuous sleep. No setup will be performed."
         echo "Please exec into the setup container and run the setup.sh by hand or set the sumologic.setup.debug=false and reinstall."
   
@@ -196,8 +196,29 @@ data:
         done
     fi
   
-    # Fix URL to remove "v1" or "v1/"
-    export SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL%v1*}
+    function fix_sumo_base_url() {
+      local BASE_URL=$SUMOLOGIC_BASE_URL
+  
+      if [[ "${BASE_URL}" =~ ^\s*$ ]]; then
+        BASE_URL="https://api.sumologic.com/api/"
+      fi
+  
+      OPTIONAL_REDIRECTION="$(curl -XGET -s -o /dev/null -D - \
+              -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+              "${BASE_URL}"v1/collectors \
+              | grep -Fi location )"
+  
+      if [[ ! $OPTIONAL_REDIRECTION =~ ^\s*$ ]]; then
+        BASE_URL=$( echo "${OPTIONAL_REDIRECTION}" | sed -E 's/.*: (https:\/\/.*(au|ca|de|eu|fed|in|jp|us2)?\.sumologic\.com\/api\/).*/\1/' )
+      fi
+  
+      BASE_URL=${BASE_URL%v1*}
+  
+      echo "${BASE_URL}"
+    }
+  
+    SUMOLOGIC_BASE_URL=$(fix_sumo_base_url)
+    export SUMOLOGIC_BASE_URL
     # Support proxy for Terraform
     export HTTP_PROXY=${HTTP_PROXY:=""}
     export HTTPS_PROXY=${HTTPS_PROXY:=""}
@@ -205,9 +226,10 @@ data:
   
     function get_remaining_fields() {
         local RESPONSE
-        readonly RESPONSE="$(curl -XGET -s \
+        RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields/quota)"
+        readonly RESPONSE
   
         echo "${RESPONSE}"
     }
@@ -216,7 +238,8 @@ data:
     # would be created for the collection
     function should_create_fields() {
         local RESPONSE
-        readonly RESPONSE=$(get_remaining_fields)
+        RESPONSE=$(get_remaining_fields)
+        readonly RESPONSE
   
         if ! jq -e <<< "${RESPONSE}" ; then
             printf "Failed requesting fields API:\n%s\n" "${RESPONSE}"
@@ -229,7 +252,8 @@ data:
         fi
   
         local REMAINING
-        readonly REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
+        REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
+        readonly REMAINING
         if [[ $(( REMAINING - 8 )) -ge 10 ]] ; then
             return 0
         else
@@ -247,9 +271,10 @@ data:
     # Sumo Logic fields
     if should_create_fields ; then
         readonly CREATE_FIELDS=1
-        readonly FIELDS_RESPONSE="$(curl -XGET -s \
+        FIELDS_RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"
+        readonly FIELDS_RESPONSE
   
         declare -ra FIELDS=("cluster" "container" "deployment" "host" "namespace" "node" "pod" "service")
         for FIELD in "${FIELDS[@]}" ; do

--- a/tests/helm/terraform/static/traces.output.yaml
+++ b/tests/helm/terraform/static/traces.output.yaml
@@ -197,7 +197,8 @@ data:
     fi
   
     function fix_sumo_base_url() {
-      local BASE_URL=$SUMOLOGIC_BASE_URL
+      BASE_URL=${SUMOLOGIC_BASE_URL}
+      local BASE_URL
   
       if [[ "${BASE_URL}" =~ ^\s*$ ]]; then
         BASE_URL="https://api.sumologic.com/api/"

--- a/tests/helm/terraform/static/traces.output.yaml
+++ b/tests/helm/terraform/static/traces.output.yaml
@@ -209,7 +209,7 @@ data:
               "${BASE_URL}"v1/collectors \
               | grep -Fi location )"
   
-      if [[ ! $OPTIONAL_REDIRECTION =~ ^\s*$ ]]; then
+      if [[ ! ${OPTIONAL_REDIRECTION} =~ ^\s*$ ]]; then
         BASE_URL=$( echo "${OPTIONAL_REDIRECTION}" | sed -E 's/.*: (https:\/\/.*(au|ca|de|eu|fed|in|jp|us2)?\.sumologic\.com\/api\/).*/\1/' )
       fi
   


### PR DESCRIPTION
##### Description

It's allowed to left `sumologic.endpoint` empty. In such case `SUMOLOGIC_BASE_URL` is empty and breaks logic of `get_remaining_fields` and other API calls. 

##### Checklist

- [x] Changelog updated

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
