### PR TITLE
Fixed typo in Sumologic fluentd v2.7.0 that fails installation

### DIFF
--- a/deploy/helm/sumologic/conf/setup/locals.tf
+++ b/deploy/helm/sumologic/conf/setup/locals.tf
@@ -12,7 +12,7 @@ locals {
     If traces are enabled and metrics are disabled, create default metrics source anyway
     */}}
     {{- if hasKey $sources "default" }}
-  {{ template "terraform.sources.local" (dict "Name" (include "terraform.sources.name" (dict "Name" "default" "Type" $type)) "Value" ( dig "default" "name" "(default-metrics)" $sources )) }}
+  {{ template "terraform.sources.local" (dict "Name" (include "terraform.sources.name" (dict "Name" "default" "Type" $type)) "Value" ( dict "default" "name" "(default-metrics)" $sources )) }}
     {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
##### Description

Fixed typo in Sumologic fluentd v2.7.0 that fails installation when done using Argocd / Devtron
Fixes #2261 

---

##### Checklist

<!---
Remove items which don't apply to your PR.
-->

- [ ] Changelog updated

###### Testing performed

- [x] Redeploy fluentd and fluentd-events pods
- [x] Confirm events, logs, and metrics are coming in
