### PR TITLE
chore: update Thanos to v0.25.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - chore(deps): upgrade fluentd to 1.14.6-sumo-2 [#2245][#2245]
 - feat(otellogs): upgrade to 0.49.0-sumo-0 [#2246][#2246]
 - feat(metadata/otc): upgrade to v0.50.0-sumo-0 [#2251][#2251]
+- chore: update Thanos to v0.25.2 [#2272][#2272]
 
 ### Fixed
 
@@ -34,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2246]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2246
 [#2250]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2250
 [#2251]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2251
+[#2272]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2272
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.7.1...main
 
 ## [v2.7.1]

--- a/deploy/docs/Best_Practices.md
+++ b/deploy/docs/Best_Practices.md
@@ -1139,13 +1139,6 @@ to work with our collection.
    - remove the following configuration:
 
      ```yaml
-     prometheus:
-       prometheusSpec:
-         thanos:
-           ## Use our own image until Thanos upstream adds arm64 docker images
-           ## to their registry.
-           baseImage: public.ecr.aws/sumologic/thanos
-           version: v0.23.1
      kube-state-metrics:
        ## Use the GCR repo, it's more recent and has ARM images starting from 1.9.8
        image:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1794,10 +1794,8 @@ kube-prometheus-stack:
           cpu: 500m
           memory: 1Gi
       thanos:
-        ## Use our own image until Thanos upstream adds arm64 docker images
-        ## to their registry.
-        baseImage: public.ecr.aws/sumologic/thanos
-        version: v0.23.1
+        # set this to a version with a ARM Docker image
+        version: v0.25.2
         ## Defines the resource requirements for the Thanos sidecar
         ## Setting those as there are no default values in the upstream chart
         resources:


### PR DESCRIPTION
##### Description

Thanos now has official ARM Docker images, so we can go back to using the upstream repository.

---

##### Checklist

- [x] Changelog updated
