### PR TITLE
Monitors in integrations folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - feat(fluentd): expose extra configuration for fluentd output plugin [#2244][#2244]
-- feat(monitors): the Sumo Logic monitors installation as part of the setup job [#2250][#2250]
+- feat(monitors): the Sumo Logic monitors installation as part of the setup job [#2250][#2250], [#2274][#2274]
 
 ### Changed
 
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2246]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2246
 [#2250]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2250
 [#2251]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2251
+[#2274]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2274
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.7.1...main
 
 ## [v2.7.1]

--- a/deploy/helm/sumologic/conf/setup/monitors.sh
+++ b/deploy/helm/sumologic/conf/setup/monitors.sh
@@ -44,8 +44,11 @@ if [[ -z "${MONITORS_FOLDER_ID}" ]]; then
   fi
 
 {{- if not (.Values.sumologic.setup.monitors.notificationEmails | empty) }}
-
+{{- if kindIs "slice" .Values.sumologic.setup.monitors.notificationEmails }}
   NOTIFICATIONS_RECIPIENTS='{{- .Values.sumologic.setup.monitors.notificationEmails | toRawJson }}'
+{{- else }}
+  NOTIFICATIONS_RECIPIENTS='[{{- .Values.sumologic.setup.monitors.notificationEmails | toRawJson }}]'
+{{- end }}
   NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{ printf `{{ TriggerType }}` }} on {{ printf `{{ Name }}` }}\",message_body=\"Triggered {{ printf `{{ TriggerType }}` }} Alert on {{ printf `{{ Name }}` }}: {{ printf `{{ QueryURL }}` }}\""
   NOTIFICATIONS_SETTINGS="recipients=${NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
 {{- end }}

--- a/deploy/helm/sumologic/conf/setup/monitors.sh
+++ b/deploy/helm/sumologic/conf/setup/monitors.sh
@@ -21,9 +21,11 @@ MONITORS_ROOT_ID="$(curl -XGET -s \
 readonly MONITORS_ROOT_ID
 
 # verify if the integrations folder already exists
-INTEGRATIONS_RESPONSE="$(curl -XGET -s \
+INTEGRATIONS_RESPONSE="$(curl -XGET -s -G \
         -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-        "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${INTEGRATIONS_FOLDER_NAME}" | jq '.[]' )"
+        "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
+        --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}" | \
+        jq '.[]' )"
 readonly INTEGRATIONS_RESPONSE
 
 INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
@@ -40,9 +42,11 @@ if [[ -z "${INTEGRATIONS_FOLDER_ID}" ]]; then
 fi
 
 # verify if the k8s monitors folder already exists
-MONITORS_RESPONSE="$(curl -XGET -s \
+MONITORS_RESPONSE="$(curl -XGET -s -G \
         -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-        "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${MONITORS_FOLDER_NAME}" | jq '.[]' )"
+        "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
+        --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}" | \
+        jq '.[]' )"
 readonly MONITORS_RESPONSE
 
 MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \

--- a/deploy/helm/sumologic/conf/setup/monitors.sh
+++ b/deploy/helm/sumologic/conf/setup/monitors.sh
@@ -7,6 +7,7 @@ readonly SUMOLOGIC_ACCESSKEY
 SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL:=""}
 readonly SUMOLOGIC_BASE_URL
 
+INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
 MONITORS_FOLDER_NAME="Kubernetes"
 {{- if eq .Values.sumologic.setup.monitors.monitorStatus "enabled" }}
 MONITORS_DISABLED="false"
@@ -14,18 +15,38 @@ MONITORS_DISABLED="false"
 MONITORS_DISABLED="true"
 {{- end}}
 
-# verify if the k8s monitors folder already exists
-MONITORS_RESPONSE="$(curl -XGET -s \
-        -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-        "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${MONITORS_FOLDER_NAME}" | jq '.[]' )"
-readonly MONITORS_RESPONSE
 MONITORS_ROOT_ID="$(curl -XGET -s \
         -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
         "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
 readonly MONITORS_ROOT_ID
 
+# verify if the integrations folder already exists
+INTEGRATIONS_RESPONSE="$(curl -XGET -s \
+        -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+        "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${INTEGRATIONS_FOLDER_NAME}" | jq '.[]' )"
+readonly INTEGRATIONS_RESPONSE
+
+INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
+        jq -r "select(.item.name == \"${INTEGRATIONS_FOLDER_NAME}\") | select(.item.parentId == \"${MONITORS_ROOT_ID}\") | .item.id" )"
+
+# and create it if necessary
+if [[ -z "${INTEGRATIONS_FOLDER_ID}" ]]; then
+  INTEGRATIONS_FOLDER_ID="$(curl -XPOST -s \
+              -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+              -H "Content-Type: application/json" \
+              -d "{\"name\":\"${INTEGRATIONS_FOLDER_NAME}\",\"type\":\"MonitorsLibraryFolder\",\"description\":\"Monitors provided by the Sumo Logic integrations.\"}" \
+              "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}" | \
+              jq -r " .id" )"
+fi
+
+# verify if the k8s monitors folder already exists
+MONITORS_RESPONSE="$(curl -XGET -s \
+        -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+        "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${MONITORS_FOLDER_NAME}" | jq '.[]' )"
+readonly MONITORS_RESPONSE
+
 MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \
-        jq -r "select(.item.name == \"${MONITORS_FOLDER_NAME}\") | select(.item.parentId == \"${MONITORS_ROOT_ID}\") | .item.id" )"
+        jq -r "select(.item.name == \"${MONITORS_FOLDER_NAME}\") | select(.item.parentId == \"${INTEGRATIONS_FOLDER_ID}\") | .item.id" )"
 readonly MONITORS_FOLDER_ID
 
 if [[ -z "${MONITORS_FOLDER_ID}" ]]; then
@@ -59,6 +80,7 @@ if [[ -z "${MONITORS_FOLDER_ID}" ]]; then
       -var="access_key=${SUMOLOGIC_ACCESSKEY}" \
       -var="environment=${SUMOLOGIC_ENV}" \
       -var="folder=${MONITORS_FOLDER_NAME}" \
+      -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}" \
       -var="monitors_disabled=${MONITORS_DISABLED}" \
 {{- if not (.Values.sumologic.setup.monitors.notificationEmails | empty) }}
       -var="email_notifications_critical=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Critical\", \"ResolvedCritical\"]}]" \

--- a/deploy/helm/sumologic/conf/setup/monitors.sh
+++ b/deploy/helm/sumologic/conf/setup/monitors.sh
@@ -70,7 +70,7 @@ if [[ -z "${MONITORS_FOLDER_ID}" ]]; then
 {{- else }}
   NOTIFICATIONS_RECIPIENTS='[{{- .Values.sumologic.setup.monitors.notificationEmails | toRawJson }}]'
 {{- end }}
-  NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{ printf `{{ TriggerType }}` }} on {{ printf `{{ Name }}` }}\",message_body=\"Triggered {{ printf `{{ TriggerType }}` }} Alert on {{ printf `{{ Name }}` }}: {{ printf `{{ QueryURL }}` }}\""
+  NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{ printf `{{TriggerType}}` }} on {{ printf `{{Name}}` }}\",message_body=\"Triggered {{ printf `{{TriggerType}}` }} alert on {{ printf `{{Name}}` }}: {{ printf `{{QueryURL}}` }}\""
   NOTIFICATIONS_SETTINGS="recipients=${NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
 {{- end }}
 

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -96,7 +96,7 @@ sumologic:
     job:
       image:
         repository: public.ecr.aws/sumologic/kubernetes-setup
-        tag: 3.2.2
+        tag: 3.3.0
         pullPolicy: IfNotPresent
       ## Optionally specify an array of pullSecrets.
       ## They will be added to serviceaccount that is used for Sumo Logic's

--- a/tests/helm/terraform/static/all_fields.output.yaml
+++ b/tests/helm/terraform/static/all_fields.output.yaml
@@ -165,9 +165,11 @@ data:
     readonly MONITORS_ROOT_ID
   
     # verify if the integrations folder already exists
-    INTEGRATIONS_RESPONSE="$(curl -XGET -s \
+    INTEGRATIONS_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${INTEGRATIONS_FOLDER_NAME}" | jq '.[]' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
+            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}" | \
+            jq '.[]' )"
     readonly INTEGRATIONS_RESPONSE
   
     INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
@@ -184,9 +186,11 @@ data:
     fi
   
     # verify if the k8s monitors folder already exists
-    MONITORS_RESPONSE="$(curl -XGET -s \
+    MONITORS_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${MONITORS_FOLDER_NAME}" | jq '.[]' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
+            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}" | \
+            jq '.[]' )"
     readonly MONITORS_RESPONSE
   
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \

--- a/tests/helm/terraform/static/all_fields.output.yaml
+++ b/tests/helm/terraform/static/all_fields.output.yaml
@@ -155,21 +155,42 @@ data:
     SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL:=""}
     readonly SUMOLOGIC_BASE_URL
   
+    INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
     MONITORS_DISABLED="false"
+  
+    MONITORS_ROOT_ID="$(curl -XGET -s \
+            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
+    readonly MONITORS_ROOT_ID
+  
+    # verify if the integrations folder already exists
+    INTEGRATIONS_RESPONSE="$(curl -XGET -s \
+            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${INTEGRATIONS_FOLDER_NAME}" | jq '.[]' )"
+    readonly INTEGRATIONS_RESPONSE
+  
+    INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
+            jq -r "select(.item.name == \"${INTEGRATIONS_FOLDER_NAME}\") | select(.item.parentId == \"${MONITORS_ROOT_ID}\") | .item.id" )"
+  
+    # and create it if necessary
+    if [[ -z "${INTEGRATIONS_FOLDER_ID}" ]]; then
+      INTEGRATIONS_FOLDER_ID="$(curl -XPOST -s \
+                  -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+                  -H "Content-Type: application/json" \
+                  -d "{\"name\":\"${INTEGRATIONS_FOLDER_NAME}\",\"type\":\"MonitorsLibraryFolder\",\"description\":\"Monitors provided by the Sumo Logic integrations.\"}" \
+                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}" | \
+                  jq -r " .id" )"
+    fi
   
     # verify if the k8s monitors folder already exists
     MONITORS_RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${MONITORS_FOLDER_NAME}" | jq '.[]' )"
     readonly MONITORS_RESPONSE
-    MONITORS_ROOT_ID="$(curl -XGET -s \
-            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
-    readonly MONITORS_ROOT_ID
   
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \
-            jq -r "select(.item.name == \"${MONITORS_FOLDER_NAME}\") | select(.item.parentId == \"${MONITORS_ROOT_ID}\") | .item.id" )"
+            jq -r "select(.item.name == \"${MONITORS_FOLDER_NAME}\") | select(.item.parentId == \"${INTEGRATIONS_FOLDER_ID}\") | .item.id" )"
     readonly MONITORS_FOLDER_ID
   
     if [[ -z "${MONITORS_FOLDER_ID}" ]]; then
@@ -193,6 +214,7 @@ data:
           -var="access_key=${SUMOLOGIC_ACCESSKEY}" \
           -var="environment=${SUMOLOGIC_ENV}" \
           -var="folder=${MONITORS_FOLDER_NAME}" \
+          -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}" \
           -var="monitors_disabled=${MONITORS_DISABLED}" \
           || { echo "Error during applying Terraform monitors."; exit 1; }
     else

--- a/tests/helm/terraform/static/collector_fields.output.yaml
+++ b/tests/helm/terraform/static/collector_fields.output.yaml
@@ -164,9 +164,11 @@ data:
     readonly MONITORS_ROOT_ID
   
     # verify if the integrations folder already exists
-    INTEGRATIONS_RESPONSE="$(curl -XGET -s \
+    INTEGRATIONS_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${INTEGRATIONS_FOLDER_NAME}" | jq '.[]' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
+            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}" | \
+            jq '.[]' )"
     readonly INTEGRATIONS_RESPONSE
   
     INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
@@ -183,9 +185,11 @@ data:
     fi
   
     # verify if the k8s monitors folder already exists
-    MONITORS_RESPONSE="$(curl -XGET -s \
+    MONITORS_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${MONITORS_FOLDER_NAME}" | jq '.[]' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
+            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}" | \
+            jq '.[]' )"
     readonly MONITORS_RESPONSE
   
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \

--- a/tests/helm/terraform/static/collector_fields.output.yaml
+++ b/tests/helm/terraform/static/collector_fields.output.yaml
@@ -154,21 +154,42 @@ data:
     SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL:=""}
     readonly SUMOLOGIC_BASE_URL
   
+    INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
     MONITORS_DISABLED="false"
+  
+    MONITORS_ROOT_ID="$(curl -XGET -s \
+            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
+    readonly MONITORS_ROOT_ID
+  
+    # verify if the integrations folder already exists
+    INTEGRATIONS_RESPONSE="$(curl -XGET -s \
+            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${INTEGRATIONS_FOLDER_NAME}" | jq '.[]' )"
+    readonly INTEGRATIONS_RESPONSE
+  
+    INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
+            jq -r "select(.item.name == \"${INTEGRATIONS_FOLDER_NAME}\") | select(.item.parentId == \"${MONITORS_ROOT_ID}\") | .item.id" )"
+  
+    # and create it if necessary
+    if [[ -z "${INTEGRATIONS_FOLDER_ID}" ]]; then
+      INTEGRATIONS_FOLDER_ID="$(curl -XPOST -s \
+                  -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+                  -H "Content-Type: application/json" \
+                  -d "{\"name\":\"${INTEGRATIONS_FOLDER_NAME}\",\"type\":\"MonitorsLibraryFolder\",\"description\":\"Monitors provided by the Sumo Logic integrations.\"}" \
+                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}" | \
+                  jq -r " .id" )"
+    fi
   
     # verify if the k8s monitors folder already exists
     MONITORS_RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${MONITORS_FOLDER_NAME}" | jq '.[]' )"
     readonly MONITORS_RESPONSE
-    MONITORS_ROOT_ID="$(curl -XGET -s \
-            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
-    readonly MONITORS_ROOT_ID
   
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \
-            jq -r "select(.item.name == \"${MONITORS_FOLDER_NAME}\") | select(.item.parentId == \"${MONITORS_ROOT_ID}\") | .item.id" )"
+            jq -r "select(.item.name == \"${MONITORS_FOLDER_NAME}\") | select(.item.parentId == \"${INTEGRATIONS_FOLDER_ID}\") | .item.id" )"
     readonly MONITORS_FOLDER_ID
   
     if [[ -z "${MONITORS_FOLDER_ID}" ]]; then
@@ -192,6 +213,7 @@ data:
           -var="access_key=${SUMOLOGIC_ACCESSKEY}" \
           -var="environment=${SUMOLOGIC_ENV}" \
           -var="folder=${MONITORS_FOLDER_NAME}" \
+          -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}" \
           -var="monitors_disabled=${MONITORS_DISABLED}" \
           || { echo "Error during applying Terraform monitors."; exit 1; }
     else

--- a/tests/helm/terraform/static/conditional_sources.output.yaml
+++ b/tests/helm/terraform/static/conditional_sources.output.yaml
@@ -154,9 +154,11 @@ data:
     readonly MONITORS_ROOT_ID
   
     # verify if the integrations folder already exists
-    INTEGRATIONS_RESPONSE="$(curl -XGET -s \
+    INTEGRATIONS_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${INTEGRATIONS_FOLDER_NAME}" | jq '.[]' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
+            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}" | \
+            jq '.[]' )"
     readonly INTEGRATIONS_RESPONSE
   
     INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
@@ -173,9 +175,11 @@ data:
     fi
   
     # verify if the k8s monitors folder already exists
-    MONITORS_RESPONSE="$(curl -XGET -s \
+    MONITORS_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${MONITORS_FOLDER_NAME}" | jq '.[]' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
+            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}" | \
+            jq '.[]' )"
     readonly MONITORS_RESPONSE
   
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \

--- a/tests/helm/terraform/static/conditional_sources.output.yaml
+++ b/tests/helm/terraform/static/conditional_sources.output.yaml
@@ -144,21 +144,42 @@ data:
     SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL:=""}
     readonly SUMOLOGIC_BASE_URL
   
+    INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
     MONITORS_DISABLED="false"
+  
+    MONITORS_ROOT_ID="$(curl -XGET -s \
+            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
+    readonly MONITORS_ROOT_ID
+  
+    # verify if the integrations folder already exists
+    INTEGRATIONS_RESPONSE="$(curl -XGET -s \
+            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${INTEGRATIONS_FOLDER_NAME}" | jq '.[]' )"
+    readonly INTEGRATIONS_RESPONSE
+  
+    INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
+            jq -r "select(.item.name == \"${INTEGRATIONS_FOLDER_NAME}\") | select(.item.parentId == \"${MONITORS_ROOT_ID}\") | .item.id" )"
+  
+    # and create it if necessary
+    if [[ -z "${INTEGRATIONS_FOLDER_ID}" ]]; then
+      INTEGRATIONS_FOLDER_ID="$(curl -XPOST -s \
+                  -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+                  -H "Content-Type: application/json" \
+                  -d "{\"name\":\"${INTEGRATIONS_FOLDER_NAME}\",\"type\":\"MonitorsLibraryFolder\",\"description\":\"Monitors provided by the Sumo Logic integrations.\"}" \
+                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}" | \
+                  jq -r " .id" )"
+    fi
   
     # verify if the k8s monitors folder already exists
     MONITORS_RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${MONITORS_FOLDER_NAME}" | jq '.[]' )"
     readonly MONITORS_RESPONSE
-    MONITORS_ROOT_ID="$(curl -XGET -s \
-            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
-    readonly MONITORS_ROOT_ID
   
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \
-            jq -r "select(.item.name == \"${MONITORS_FOLDER_NAME}\") | select(.item.parentId == \"${MONITORS_ROOT_ID}\") | .item.id" )"
+            jq -r "select(.item.name == \"${MONITORS_FOLDER_NAME}\") | select(.item.parentId == \"${INTEGRATIONS_FOLDER_ID}\") | .item.id" )"
     readonly MONITORS_FOLDER_ID
   
     if [[ -z "${MONITORS_FOLDER_ID}" ]]; then
@@ -182,6 +203,7 @@ data:
           -var="access_key=${SUMOLOGIC_ACCESSKEY}" \
           -var="environment=${SUMOLOGIC_ENV}" \
           -var="folder=${MONITORS_FOLDER_NAME}" \
+          -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}" \
           -var="monitors_disabled=${MONITORS_DISABLED}" \
           || { echo "Error during applying Terraform monitors."; exit 1; }
     else

--- a/tests/helm/terraform/static/custom.output.yaml
+++ b/tests/helm/terraform/static/custom.output.yaml
@@ -154,9 +154,11 @@ data:
     readonly MONITORS_ROOT_ID
   
     # verify if the integrations folder already exists
-    INTEGRATIONS_RESPONSE="$(curl -XGET -s \
+    INTEGRATIONS_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${INTEGRATIONS_FOLDER_NAME}" | jq '.[]' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
+            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}" | \
+            jq '.[]' )"
     readonly INTEGRATIONS_RESPONSE
   
     INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
@@ -173,9 +175,11 @@ data:
     fi
   
     # verify if the k8s monitors folder already exists
-    MONITORS_RESPONSE="$(curl -XGET -s \
+    MONITORS_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${MONITORS_FOLDER_NAME}" | jq '.[]' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
+            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}" | \
+            jq '.[]' )"
     readonly MONITORS_RESPONSE
   
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \

--- a/tests/helm/terraform/static/custom.output.yaml
+++ b/tests/helm/terraform/static/custom.output.yaml
@@ -144,21 +144,42 @@ data:
     SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL:=""}
     readonly SUMOLOGIC_BASE_URL
   
+    INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
     MONITORS_DISABLED="false"
+  
+    MONITORS_ROOT_ID="$(curl -XGET -s \
+            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
+    readonly MONITORS_ROOT_ID
+  
+    # verify if the integrations folder already exists
+    INTEGRATIONS_RESPONSE="$(curl -XGET -s \
+            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${INTEGRATIONS_FOLDER_NAME}" | jq '.[]' )"
+    readonly INTEGRATIONS_RESPONSE
+  
+    INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
+            jq -r "select(.item.name == \"${INTEGRATIONS_FOLDER_NAME}\") | select(.item.parentId == \"${MONITORS_ROOT_ID}\") | .item.id" )"
+  
+    # and create it if necessary
+    if [[ -z "${INTEGRATIONS_FOLDER_ID}" ]]; then
+      INTEGRATIONS_FOLDER_ID="$(curl -XPOST -s \
+                  -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+                  -H "Content-Type: application/json" \
+                  -d "{\"name\":\"${INTEGRATIONS_FOLDER_NAME}\",\"type\":\"MonitorsLibraryFolder\",\"description\":\"Monitors provided by the Sumo Logic integrations.\"}" \
+                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}" | \
+                  jq -r " .id" )"
+    fi
   
     # verify if the k8s monitors folder already exists
     MONITORS_RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${MONITORS_FOLDER_NAME}" | jq '.[]' )"
     readonly MONITORS_RESPONSE
-    MONITORS_ROOT_ID="$(curl -XGET -s \
-            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
-    readonly MONITORS_ROOT_ID
   
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \
-            jq -r "select(.item.name == \"${MONITORS_FOLDER_NAME}\") | select(.item.parentId == \"${MONITORS_ROOT_ID}\") | .item.id" )"
+            jq -r "select(.item.name == \"${MONITORS_FOLDER_NAME}\") | select(.item.parentId == \"${INTEGRATIONS_FOLDER_ID}\") | .item.id" )"
     readonly MONITORS_FOLDER_ID
   
     if [[ -z "${MONITORS_FOLDER_ID}" ]]; then
@@ -182,6 +203,7 @@ data:
           -var="access_key=${SUMOLOGIC_ACCESSKEY}" \
           -var="environment=${SUMOLOGIC_ENV}" \
           -var="folder=${MONITORS_FOLDER_NAME}" \
+          -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}" \
           -var="monitors_disabled=${MONITORS_DISABLED}" \
           || { echo "Error during applying Terraform monitors."; exit 1; }
     else

--- a/tests/helm/terraform/static/default.output.yaml
+++ b/tests/helm/terraform/static/default.output.yaml
@@ -164,9 +164,11 @@ data:
     readonly MONITORS_ROOT_ID
   
     # verify if the integrations folder already exists
-    INTEGRATIONS_RESPONSE="$(curl -XGET -s \
+    INTEGRATIONS_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${INTEGRATIONS_FOLDER_NAME}" | jq '.[]' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
+            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}" | \
+            jq '.[]' )"
     readonly INTEGRATIONS_RESPONSE
   
     INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
@@ -183,9 +185,11 @@ data:
     fi
   
     # verify if the k8s monitors folder already exists
-    MONITORS_RESPONSE="$(curl -XGET -s \
+    MONITORS_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${MONITORS_FOLDER_NAME}" | jq '.[]' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
+            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}" | \
+            jq '.[]' )"
     readonly MONITORS_RESPONSE
   
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \

--- a/tests/helm/terraform/static/default.output.yaml
+++ b/tests/helm/terraform/static/default.output.yaml
@@ -154,21 +154,42 @@ data:
     SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL:=""}
     readonly SUMOLOGIC_BASE_URL
   
+    INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
     MONITORS_DISABLED="false"
+  
+    MONITORS_ROOT_ID="$(curl -XGET -s \
+            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
+    readonly MONITORS_ROOT_ID
+  
+    # verify if the integrations folder already exists
+    INTEGRATIONS_RESPONSE="$(curl -XGET -s \
+            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${INTEGRATIONS_FOLDER_NAME}" | jq '.[]' )"
+    readonly INTEGRATIONS_RESPONSE
+  
+    INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
+            jq -r "select(.item.name == \"${INTEGRATIONS_FOLDER_NAME}\") | select(.item.parentId == \"${MONITORS_ROOT_ID}\") | .item.id" )"
+  
+    # and create it if necessary
+    if [[ -z "${INTEGRATIONS_FOLDER_ID}" ]]; then
+      INTEGRATIONS_FOLDER_ID="$(curl -XPOST -s \
+                  -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+                  -H "Content-Type: application/json" \
+                  -d "{\"name\":\"${INTEGRATIONS_FOLDER_NAME}\",\"type\":\"MonitorsLibraryFolder\",\"description\":\"Monitors provided by the Sumo Logic integrations.\"}" \
+                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}" | \
+                  jq -r " .id" )"
+    fi
   
     # verify if the k8s monitors folder already exists
     MONITORS_RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${MONITORS_FOLDER_NAME}" | jq '.[]' )"
     readonly MONITORS_RESPONSE
-    MONITORS_ROOT_ID="$(curl -XGET -s \
-            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
-    readonly MONITORS_ROOT_ID
   
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \
-            jq -r "select(.item.name == \"${MONITORS_FOLDER_NAME}\") | select(.item.parentId == \"${MONITORS_ROOT_ID}\") | .item.id" )"
+            jq -r "select(.item.name == \"${MONITORS_FOLDER_NAME}\") | select(.item.parentId == \"${INTEGRATIONS_FOLDER_ID}\") | .item.id" )"
     readonly MONITORS_FOLDER_ID
   
     if [[ -z "${MONITORS_FOLDER_ID}" ]]; then
@@ -192,6 +213,7 @@ data:
           -var="access_key=${SUMOLOGIC_ACCESSKEY}" \
           -var="environment=${SUMOLOGIC_ENV}" \
           -var="folder=${MONITORS_FOLDER_NAME}" \
+          -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}" \
           -var="monitors_disabled=${MONITORS_DISABLED}" \
           || { echo "Error during applying Terraform monitors."; exit 1; }
     else

--- a/tests/helm/terraform/static/disable_default_metrics.output.yaml
+++ b/tests/helm/terraform/static/disable_default_metrics.output.yaml
@@ -153,21 +153,42 @@ data:
     SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL:=""}
     readonly SUMOLOGIC_BASE_URL
   
+    INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
     MONITORS_DISABLED="false"
+  
+    MONITORS_ROOT_ID="$(curl -XGET -s \
+            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
+    readonly MONITORS_ROOT_ID
+  
+    # verify if the integrations folder already exists
+    INTEGRATIONS_RESPONSE="$(curl -XGET -s \
+            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${INTEGRATIONS_FOLDER_NAME}" | jq '.[]' )"
+    readonly INTEGRATIONS_RESPONSE
+  
+    INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
+            jq -r "select(.item.name == \"${INTEGRATIONS_FOLDER_NAME}\") | select(.item.parentId == \"${MONITORS_ROOT_ID}\") | .item.id" )"
+  
+    # and create it if necessary
+    if [[ -z "${INTEGRATIONS_FOLDER_ID}" ]]; then
+      INTEGRATIONS_FOLDER_ID="$(curl -XPOST -s \
+                  -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+                  -H "Content-Type: application/json" \
+                  -d "{\"name\":\"${INTEGRATIONS_FOLDER_NAME}\",\"type\":\"MonitorsLibraryFolder\",\"description\":\"Monitors provided by the Sumo Logic integrations.\"}" \
+                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}" | \
+                  jq -r " .id" )"
+    fi
   
     # verify if the k8s monitors folder already exists
     MONITORS_RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${MONITORS_FOLDER_NAME}" | jq '.[]' )"
     readonly MONITORS_RESPONSE
-    MONITORS_ROOT_ID="$(curl -XGET -s \
-            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
-    readonly MONITORS_ROOT_ID
   
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \
-            jq -r "select(.item.name == \"${MONITORS_FOLDER_NAME}\") | select(.item.parentId == \"${MONITORS_ROOT_ID}\") | .item.id" )"
+            jq -r "select(.item.name == \"${MONITORS_FOLDER_NAME}\") | select(.item.parentId == \"${INTEGRATIONS_FOLDER_ID}\") | .item.id" )"
     readonly MONITORS_FOLDER_ID
   
     if [[ -z "${MONITORS_FOLDER_ID}" ]]; then
@@ -191,6 +212,7 @@ data:
           -var="access_key=${SUMOLOGIC_ACCESSKEY}" \
           -var="environment=${SUMOLOGIC_ENV}" \
           -var="folder=${MONITORS_FOLDER_NAME}" \
+          -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}" \
           -var="monitors_disabled=${MONITORS_DISABLED}" \
           || { echo "Error during applying Terraform monitors."; exit 1; }
     else

--- a/tests/helm/terraform/static/disable_default_metrics.output.yaml
+++ b/tests/helm/terraform/static/disable_default_metrics.output.yaml
@@ -163,9 +163,11 @@ data:
     readonly MONITORS_ROOT_ID
   
     # verify if the integrations folder already exists
-    INTEGRATIONS_RESPONSE="$(curl -XGET -s \
+    INTEGRATIONS_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${INTEGRATIONS_FOLDER_NAME}" | jq '.[]' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
+            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}" | \
+            jq '.[]' )"
     readonly INTEGRATIONS_RESPONSE
   
     INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
@@ -182,9 +184,11 @@ data:
     fi
   
     # verify if the k8s monitors folder already exists
-    MONITORS_RESPONSE="$(curl -XGET -s \
+    MONITORS_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${MONITORS_FOLDER_NAME}" | jq '.[]' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
+            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}" | \
+            jq '.[]' )"
     readonly MONITORS_RESPONSE
   
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \

--- a/tests/helm/terraform/static/disabled_monitors.output.yaml
+++ b/tests/helm/terraform/static/disabled_monitors.output.yaml
@@ -164,9 +164,11 @@ data:
     readonly MONITORS_ROOT_ID
   
     # verify if the integrations folder already exists
-    INTEGRATIONS_RESPONSE="$(curl -XGET -s \
+    INTEGRATIONS_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${INTEGRATIONS_FOLDER_NAME}" | jq '.[]' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
+            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}" | \
+            jq '.[]' )"
     readonly INTEGRATIONS_RESPONSE
   
     INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
@@ -183,9 +185,11 @@ data:
     fi
   
     # verify if the k8s monitors folder already exists
-    MONITORS_RESPONSE="$(curl -XGET -s \
+    MONITORS_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${MONITORS_FOLDER_NAME}" | jq '.[]' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
+            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}" | \
+            jq '.[]' )"
     readonly MONITORS_RESPONSE
   
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \

--- a/tests/helm/terraform/static/disabled_monitors.output.yaml
+++ b/tests/helm/terraform/static/disabled_monitors.output.yaml
@@ -154,21 +154,42 @@ data:
     SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL:=""}
     readonly SUMOLOGIC_BASE_URL
   
+    INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
     MONITORS_DISABLED="true"
+  
+    MONITORS_ROOT_ID="$(curl -XGET -s \
+            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
+    readonly MONITORS_ROOT_ID
+  
+    # verify if the integrations folder already exists
+    INTEGRATIONS_RESPONSE="$(curl -XGET -s \
+            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${INTEGRATIONS_FOLDER_NAME}" | jq '.[]' )"
+    readonly INTEGRATIONS_RESPONSE
+  
+    INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
+            jq -r "select(.item.name == \"${INTEGRATIONS_FOLDER_NAME}\") | select(.item.parentId == \"${MONITORS_ROOT_ID}\") | .item.id" )"
+  
+    # and create it if necessary
+    if [[ -z "${INTEGRATIONS_FOLDER_ID}" ]]; then
+      INTEGRATIONS_FOLDER_ID="$(curl -XPOST -s \
+                  -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+                  -H "Content-Type: application/json" \
+                  -d "{\"name\":\"${INTEGRATIONS_FOLDER_NAME}\",\"type\":\"MonitorsLibraryFolder\",\"description\":\"Monitors provided by the Sumo Logic integrations.\"}" \
+                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}" | \
+                  jq -r " .id" )"
+    fi
   
     # verify if the k8s monitors folder already exists
     MONITORS_RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${MONITORS_FOLDER_NAME}" | jq '.[]' )"
     readonly MONITORS_RESPONSE
-    MONITORS_ROOT_ID="$(curl -XGET -s \
-            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
-    readonly MONITORS_ROOT_ID
   
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \
-            jq -r "select(.item.name == \"${MONITORS_FOLDER_NAME}\") | select(.item.parentId == \"${MONITORS_ROOT_ID}\") | .item.id" )"
+            jq -r "select(.item.name == \"${MONITORS_FOLDER_NAME}\") | select(.item.parentId == \"${INTEGRATIONS_FOLDER_ID}\") | .item.id" )"
     readonly MONITORS_FOLDER_ID
   
     if [[ -z "${MONITORS_FOLDER_ID}" ]]; then
@@ -192,6 +213,7 @@ data:
           -var="access_key=${SUMOLOGIC_ACCESSKEY}" \
           -var="environment=${SUMOLOGIC_ENV}" \
           -var="folder=${MONITORS_FOLDER_NAME}" \
+          -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}" \
           -var="monitors_disabled=${MONITORS_DISABLED}" \
           || { echo "Error during applying Terraform monitors."; exit 1; }
     else

--- a/tests/helm/terraform/static/monitors_with_email_notifications.output.yaml
+++ b/tests/helm/terraform/static/monitors_with_email_notifications.output.yaml
@@ -164,9 +164,11 @@ data:
     readonly MONITORS_ROOT_ID
   
     # verify if the integrations folder already exists
-    INTEGRATIONS_RESPONSE="$(curl -XGET -s \
+    INTEGRATIONS_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${INTEGRATIONS_FOLDER_NAME}" | jq '.[]' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
+            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}" | \
+            jq '.[]' )"
     readonly INTEGRATIONS_RESPONSE
   
     INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
@@ -183,9 +185,11 @@ data:
     fi
   
     # verify if the k8s monitors folder already exists
-    MONITORS_RESPONSE="$(curl -XGET -s \
+    MONITORS_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${MONITORS_FOLDER_NAME}" | jq '.[]' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
+            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}" | \
+            jq '.[]' )"
     readonly MONITORS_RESPONSE
   
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \

--- a/tests/helm/terraform/static/monitors_with_email_notifications.output.yaml
+++ b/tests/helm/terraform/static/monitors_with_email_notifications.output.yaml
@@ -154,21 +154,42 @@ data:
     SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL:=""}
     readonly SUMOLOGIC_BASE_URL
   
+    INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
     MONITORS_DISABLED="false"
+  
+    MONITORS_ROOT_ID="$(curl -XGET -s \
+            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
+    readonly MONITORS_ROOT_ID
+  
+    # verify if the integrations folder already exists
+    INTEGRATIONS_RESPONSE="$(curl -XGET -s \
+            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${INTEGRATIONS_FOLDER_NAME}" | jq '.[]' )"
+    readonly INTEGRATIONS_RESPONSE
+  
+    INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
+            jq -r "select(.item.name == \"${INTEGRATIONS_FOLDER_NAME}\") | select(.item.parentId == \"${MONITORS_ROOT_ID}\") | .item.id" )"
+  
+    # and create it if necessary
+    if [[ -z "${INTEGRATIONS_FOLDER_ID}" ]]; then
+      INTEGRATIONS_FOLDER_ID="$(curl -XPOST -s \
+                  -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+                  -H "Content-Type: application/json" \
+                  -d "{\"name\":\"${INTEGRATIONS_FOLDER_NAME}\",\"type\":\"MonitorsLibraryFolder\",\"description\":\"Monitors provided by the Sumo Logic integrations.\"}" \
+                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}" | \
+                  jq -r " .id" )"
+    fi
   
     # verify if the k8s monitors folder already exists
     MONITORS_RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${MONITORS_FOLDER_NAME}" | jq '.[]' )"
     readonly MONITORS_RESPONSE
-    MONITORS_ROOT_ID="$(curl -XGET -s \
-            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
-    readonly MONITORS_ROOT_ID
   
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \
-            jq -r "select(.item.name == \"${MONITORS_FOLDER_NAME}\") | select(.item.parentId == \"${MONITORS_ROOT_ID}\") | .item.id" )"
+            jq -r "select(.item.name == \"${MONITORS_FOLDER_NAME}\") | select(.item.parentId == \"${INTEGRATIONS_FOLDER_ID}\") | .item.id" )"
     readonly MONITORS_FOLDER_ID
   
     if [[ -z "${MONITORS_FOLDER_ID}" ]]; then
@@ -195,6 +216,7 @@ data:
           -var="access_key=${SUMOLOGIC_ACCESSKEY}" \
           -var="environment=${SUMOLOGIC_ENV}" \
           -var="folder=${MONITORS_FOLDER_NAME}" \
+          -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}" \
           -var="monitors_disabled=${MONITORS_DISABLED}" \
           -var="email_notifications_critical=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Critical\", \"ResolvedCritical\"]}]" \
           -var="email_notifications_warning=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Warning\", \"ResolvedWarning\"]}]" \

--- a/tests/helm/terraform/static/monitors_with_email_notifications.output.yaml
+++ b/tests/helm/terraform/static/monitors_with_email_notifications.output.yaml
@@ -207,7 +207,7 @@ data:
         SUMOLOGIC_ENV="us1"
       fi
       NOTIFICATIONS_RECIPIENTS='["test@test.lh","email@locahost.lh"]'
-      NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{ TriggerType }} on {{ Name }}\",message_body=\"Triggered {{ TriggerType }} Alert on {{ Name }}: {{ QueryURL }}\""
+      NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{TriggerType}} on {{Name}}\",message_body=\"Triggered {{TriggerType}} alert on {{Name}}: {{QueryURL}}\""
       NOTIFICATIONS_SETTINGS="recipients=${NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
   
       TF_LOG_PROVIDER=DEBUG terraform apply \

--- a/tests/helm/terraform/static/monitors_with_single_email.input.yaml
+++ b/tests/helm/terraform/static/monitors_with_single_email.input.yaml
@@ -1,0 +1,4 @@
+sumologic:
+  setup:
+    monitors:
+      notificationEmails: "email@locahost.lh"

--- a/tests/helm/terraform/static/monitors_with_single_email.output.yaml
+++ b/tests/helm/terraform/static/monitors_with_single_email.output.yaml
@@ -185,7 +185,7 @@ data:
       if [[ "${SUMOLOGIC_BASE_URL}" == "${SUMOLOGIC_ENV}" ]] ; then
         SUMOLOGIC_ENV="us1"
       fi
-      NOTIFICATIONS_RECIPIENTS='["test@test.lh","email@locahost.lh"]'
+      NOTIFICATIONS_RECIPIENTS='["email@locahost.lh"]'
       NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{ TriggerType }} on {{ Name }}\",message_body=\"Triggered {{ TriggerType }} Alert on {{ Name }}: {{ QueryURL }}\""
       NOTIFICATIONS_SETTINGS="recipients=${NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
   

--- a/tests/helm/terraform/static/monitors_with_single_email.output.yaml
+++ b/tests/helm/terraform/static/monitors_with_single_email.output.yaml
@@ -164,9 +164,11 @@ data:
     readonly MONITORS_ROOT_ID
   
     # verify if the integrations folder already exists
-    INTEGRATIONS_RESPONSE="$(curl -XGET -s \
+    INTEGRATIONS_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${INTEGRATIONS_FOLDER_NAME}" | jq '.[]' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
+            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}" | \
+            jq '.[]' )"
     readonly INTEGRATIONS_RESPONSE
   
     INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
@@ -183,9 +185,11 @@ data:
     fi
   
     # verify if the k8s monitors folder already exists
-    MONITORS_RESPONSE="$(curl -XGET -s \
+    MONITORS_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${MONITORS_FOLDER_NAME}" | jq '.[]' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
+            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}" | \
+            jq '.[]' )"
     readonly MONITORS_RESPONSE
   
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \

--- a/tests/helm/terraform/static/monitors_with_single_email.output.yaml
+++ b/tests/helm/terraform/static/monitors_with_single_email.output.yaml
@@ -207,7 +207,7 @@ data:
         SUMOLOGIC_ENV="us1"
       fi
       NOTIFICATIONS_RECIPIENTS='["email@locahost.lh"]'
-      NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{ TriggerType }} on {{ Name }}\",message_body=\"Triggered {{ TriggerType }} Alert on {{ Name }}: {{ QueryURL }}\""
+      NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{TriggerType}} on {{Name}}\",message_body=\"Triggered {{TriggerType}} alert on {{Name}}: {{QueryURL}}\""
       NOTIFICATIONS_SETTINGS="recipients=${NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
   
       TF_LOG_PROVIDER=DEBUG terraform apply \

--- a/tests/helm/terraform/static/monitors_with_single_email.output.yaml
+++ b/tests/helm/terraform/static/monitors_with_single_email.output.yaml
@@ -154,21 +154,42 @@ data:
     SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL:=""}
     readonly SUMOLOGIC_BASE_URL
   
+    INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
     MONITORS_DISABLED="false"
+  
+    MONITORS_ROOT_ID="$(curl -XGET -s \
+            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
+    readonly MONITORS_ROOT_ID
+  
+    # verify if the integrations folder already exists
+    INTEGRATIONS_RESPONSE="$(curl -XGET -s \
+            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${INTEGRATIONS_FOLDER_NAME}" | jq '.[]' )"
+    readonly INTEGRATIONS_RESPONSE
+  
+    INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
+            jq -r "select(.item.name == \"${INTEGRATIONS_FOLDER_NAME}\") | select(.item.parentId == \"${MONITORS_ROOT_ID}\") | .item.id" )"
+  
+    # and create it if necessary
+    if [[ -z "${INTEGRATIONS_FOLDER_ID}" ]]; then
+      INTEGRATIONS_FOLDER_ID="$(curl -XPOST -s \
+                  -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+                  -H "Content-Type: application/json" \
+                  -d "{\"name\":\"${INTEGRATIONS_FOLDER_NAME}\",\"type\":\"MonitorsLibraryFolder\",\"description\":\"Monitors provided by the Sumo Logic integrations.\"}" \
+                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}" | \
+                  jq -r " .id" )"
+    fi
   
     # verify if the k8s monitors folder already exists
     MONITORS_RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${MONITORS_FOLDER_NAME}" | jq '.[]' )"
     readonly MONITORS_RESPONSE
-    MONITORS_ROOT_ID="$(curl -XGET -s \
-            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
-    readonly MONITORS_ROOT_ID
   
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \
-            jq -r "select(.item.name == \"${MONITORS_FOLDER_NAME}\") | select(.item.parentId == \"${MONITORS_ROOT_ID}\") | .item.id" )"
+            jq -r "select(.item.name == \"${MONITORS_FOLDER_NAME}\") | select(.item.parentId == \"${INTEGRATIONS_FOLDER_ID}\") | .item.id" )"
     readonly MONITORS_FOLDER_ID
   
     if [[ -z "${MONITORS_FOLDER_ID}" ]]; then
@@ -195,6 +216,7 @@ data:
           -var="access_key=${SUMOLOGIC_ACCESSKEY}" \
           -var="environment=${SUMOLOGIC_ENV}" \
           -var="folder=${MONITORS_FOLDER_NAME}" \
+          -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}" \
           -var="monitors_disabled=${MONITORS_DISABLED}" \
           -var="email_notifications_critical=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Critical\", \"ResolvedCritical\"]}]" \
           -var="email_notifications_warning=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Warning\", \"ResolvedWarning\"]}]" \

--- a/tests/helm/terraform/static/strip_extrapolation.output.yaml
+++ b/tests/helm/terraform/static/strip_extrapolation.output.yaml
@@ -164,9 +164,11 @@ data:
     readonly MONITORS_ROOT_ID
   
     # verify if the integrations folder already exists
-    INTEGRATIONS_RESPONSE="$(curl -XGET -s \
+    INTEGRATIONS_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${INTEGRATIONS_FOLDER_NAME}" | jq '.[]' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
+            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}" | \
+            jq '.[]' )"
     readonly INTEGRATIONS_RESPONSE
   
     INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
@@ -183,9 +185,11 @@ data:
     fi
   
     # verify if the k8s monitors folder already exists
-    MONITORS_RESPONSE="$(curl -XGET -s \
+    MONITORS_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${MONITORS_FOLDER_NAME}" | jq '.[]' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
+            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}" | \
+            jq '.[]' )"
     readonly MONITORS_RESPONSE
   
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \

--- a/tests/helm/terraform/static/strip_extrapolation.output.yaml
+++ b/tests/helm/terraform/static/strip_extrapolation.output.yaml
@@ -154,21 +154,42 @@ data:
     SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL:=""}
     readonly SUMOLOGIC_BASE_URL
   
+    INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
     MONITORS_DISABLED="false"
+  
+    MONITORS_ROOT_ID="$(curl -XGET -s \
+            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
+    readonly MONITORS_ROOT_ID
+  
+    # verify if the integrations folder already exists
+    INTEGRATIONS_RESPONSE="$(curl -XGET -s \
+            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${INTEGRATIONS_FOLDER_NAME}" | jq '.[]' )"
+    readonly INTEGRATIONS_RESPONSE
+  
+    INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
+            jq -r "select(.item.name == \"${INTEGRATIONS_FOLDER_NAME}\") | select(.item.parentId == \"${MONITORS_ROOT_ID}\") | .item.id" )"
+  
+    # and create it if necessary
+    if [[ -z "${INTEGRATIONS_FOLDER_ID}" ]]; then
+      INTEGRATIONS_FOLDER_ID="$(curl -XPOST -s \
+                  -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+                  -H "Content-Type: application/json" \
+                  -d "{\"name\":\"${INTEGRATIONS_FOLDER_NAME}\",\"type\":\"MonitorsLibraryFolder\",\"description\":\"Monitors provided by the Sumo Logic integrations.\"}" \
+                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}" | \
+                  jq -r " .id" )"
+    fi
   
     # verify if the k8s monitors folder already exists
     MONITORS_RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${MONITORS_FOLDER_NAME}" | jq '.[]' )"
     readonly MONITORS_RESPONSE
-    MONITORS_ROOT_ID="$(curl -XGET -s \
-            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
-    readonly MONITORS_ROOT_ID
   
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \
-            jq -r "select(.item.name == \"${MONITORS_FOLDER_NAME}\") | select(.item.parentId == \"${MONITORS_ROOT_ID}\") | .item.id" )"
+            jq -r "select(.item.name == \"${MONITORS_FOLDER_NAME}\") | select(.item.parentId == \"${INTEGRATIONS_FOLDER_ID}\") | .item.id" )"
     readonly MONITORS_FOLDER_ID
   
     if [[ -z "${MONITORS_FOLDER_ID}" ]]; then
@@ -192,6 +213,7 @@ data:
           -var="access_key=${SUMOLOGIC_ACCESSKEY}" \
           -var="environment=${SUMOLOGIC_ENV}" \
           -var="folder=${MONITORS_FOLDER_NAME}" \
+          -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}" \
           -var="monitors_disabled=${MONITORS_DISABLED}" \
           || { echo "Error during applying Terraform monitors."; exit 1; }
     else

--- a/tests/helm/terraform/static/traces.output.yaml
+++ b/tests/helm/terraform/static/traces.output.yaml
@@ -156,9 +156,11 @@ data:
     readonly MONITORS_ROOT_ID
   
     # verify if the integrations folder already exists
-    INTEGRATIONS_RESPONSE="$(curl -XGET -s \
+    INTEGRATIONS_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${INTEGRATIONS_FOLDER_NAME}" | jq '.[]' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
+            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}" | \
+            jq '.[]' )"
     readonly INTEGRATIONS_RESPONSE
   
     INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
@@ -175,9 +177,11 @@ data:
     fi
   
     # verify if the k8s monitors folder already exists
-    MONITORS_RESPONSE="$(curl -XGET -s \
+    MONITORS_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${MONITORS_FOLDER_NAME}" | jq '.[]' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
+            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}" | \
+            jq '.[]' )"
     readonly MONITORS_RESPONSE
   
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \

--- a/tests/helm/terraform/static/traces.output.yaml
+++ b/tests/helm/terraform/static/traces.output.yaml
@@ -146,21 +146,42 @@ data:
     SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL:=""}
     readonly SUMOLOGIC_BASE_URL
   
+    INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
     MONITORS_DISABLED="false"
+  
+    MONITORS_ROOT_ID="$(curl -XGET -s \
+            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
+    readonly MONITORS_ROOT_ID
+  
+    # verify if the integrations folder already exists
+    INTEGRATIONS_RESPONSE="$(curl -XGET -s \
+            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${INTEGRATIONS_FOLDER_NAME}" | jq '.[]' )"
+    readonly INTEGRATIONS_RESPONSE
+  
+    INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
+            jq -r "select(.item.name == \"${INTEGRATIONS_FOLDER_NAME}\") | select(.item.parentId == \"${MONITORS_ROOT_ID}\") | .item.id" )"
+  
+    # and create it if necessary
+    if [[ -z "${INTEGRATIONS_FOLDER_ID}" ]]; then
+      INTEGRATIONS_FOLDER_ID="$(curl -XPOST -s \
+                  -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+                  -H "Content-Type: application/json" \
+                  -d "{\"name\":\"${INTEGRATIONS_FOLDER_NAME}\",\"type\":\"MonitorsLibraryFolder\",\"description\":\"Monitors provided by the Sumo Logic integrations.\"}" \
+                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}" | \
+                  jq -r " .id" )"
+    fi
   
     # verify if the k8s monitors folder already exists
     MONITORS_RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search?query=type:folder%20"${MONITORS_FOLDER_NAME}" | jq '.[]' )"
     readonly MONITORS_RESPONSE
-    MONITORS_ROOT_ID="$(curl -XGET -s \
-            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
-    readonly MONITORS_ROOT_ID
   
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \
-            jq -r "select(.item.name == \"${MONITORS_FOLDER_NAME}\") | select(.item.parentId == \"${MONITORS_ROOT_ID}\") | .item.id" )"
+            jq -r "select(.item.name == \"${MONITORS_FOLDER_NAME}\") | select(.item.parentId == \"${INTEGRATIONS_FOLDER_ID}\") | .item.id" )"
     readonly MONITORS_FOLDER_ID
   
     if [[ -z "${MONITORS_FOLDER_ID}" ]]; then
@@ -184,6 +205,7 @@ data:
           -var="access_key=${SUMOLOGIC_ACCESSKEY}" \
           -var="environment=${SUMOLOGIC_ENV}" \
           -var="folder=${MONITORS_FOLDER_NAME}" \
+          -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}" \
           -var="monitors_disabled=${MONITORS_DISABLED}" \
           || { echo "Error during applying Terraform monitors."; exit 1; }
     else


### PR DESCRIPTION
##### Description

Changes:
* the monitors will be installed inside "Sumo Logic Integrations > Kubernetes" folder
* `sumologic.setup.monitors.notificationEmails` is able to handle a single email passed as a string
* fix: removed spaces from variables in email templates

- [x] Requires: https://github.com/SumoLogic/sumologic-kubernetes-setup/pull/33

##### Checklist

- [x] Changelog updated

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
