### PR TITLE
fix(tracing): bump OT to v0.38.2-sumo which fixes cascadingfilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- fix: upgrade tracing collector to v0.38.2-sumo, which includes cascading filter fixes [#2285](#2285)
+
+[#2285]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2285
+
 ## [v2.8.0]
 
 ### Released 2022-05-10

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -3278,7 +3278,7 @@ otelagent:
     podAnnotations: {}
     image:
       repository: "public.ecr.aws/sumologic/opentelemetry-collector"
-      tag: "0.38.1-sumo"
+      tag: "0.38.2-sumo"
       pullPolicy: IfNotPresent
 
     ## Extra Environment Values - allows yaml definitions
@@ -3391,7 +3391,7 @@ otelcol:
     podAnnotations: {}
     image:
       repository: "public.ecr.aws/sumologic/opentelemetry-collector"
-      tag: "0.38.1-sumo"
+      tag: "0.38.2-sumo"
       pullPolicy: IfNotPresent
 
     ## Extra Environment Values - allows yaml definitions


### PR DESCRIPTION
##### Description

Bups OT version used for tracing to v0.38.2-sumo, which includes cascading filter fix for trace_reject_filter and metrics.

---

##### Checklist

- [ ] Changelog updated

###### Testing performed

- [x] Tested on local K8s cluster if installation is A-OK and OTC starts
