### PR TITLE
chore(deps): upgrade fluentd to 1.14.6-sumo-3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - fix: use custom ServiceMonitor for Prometheus' own metrics [#2238]
-- chore(deps): upgrade fluentd to 1.14.6-sumo-2 [#2245][#2245]
+- chore(deps): upgrade fluentd to 1.14.6-sumo-3 [#2287][#2287]
 - feat(otellogs): upgrade to 0.49.0-sumo-0 [#2246][#2246]
 - feat(metadata/otc): upgrade to v0.50.0-sumo-0 [#2251][#2251]
 - chore: update Thanos to v0.25.2 [#2272][#2272]
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2222]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2222
 [#2238]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2238
 [#2244]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2244
-[#2245]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2245
+[#2287]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2287
 [#2246]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2246
 [#2250]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2250
 [#2251]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2251

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -284,7 +284,7 @@ sumologic:
 fluentd:
   image:
     repository: public.ecr.aws/sumologic/kubernetes-fluentd
-    tag: 1.14.6-sumo-2
+    tag: 1.14.6-sumo-3
     pullPolicy: IfNotPresent
 
   ## Specifies whether a PodSecurityPolicy should be created
@@ -564,11 +564,11 @@ fluentd:
       ## Defines whether container-level pod annotations are enabled.
       ## Setting this to `true` might slightly affect Fluentd performance.
       ## See below link for full reference:
-      ## https://github.com/SumoLogic/sumologic-kubernetes-fluentd/tree/v1.14.6-sumo-2/fluent-plugin-kubernetes-sumologic#container-level-pod-annotations
+      ## https://github.com/SumoLogic/sumologic-kubernetes-fluentd/tree/v1.14.6-sumo-3/fluent-plugin-kubernetes-sumologic#container-level-pod-annotations
       perContainerAnnotationsEnabled: false
       ## Defines the list of prefixes of container-level pod annotations.
       ## See below link for full reference:
-      ## https://github.com/SumoLogic/sumologic-kubernetes-fluentd/tree/v1.14.6-sumo-2/fluent-plugin-kubernetes-sumologic#container-level-pod-annotations
+      ## https://github.com/SumoLogic/sumologic-kubernetes-fluentd/tree/v1.14.6-sumo-3/fluent-plugin-kubernetes-sumologic#container-level-pod-annotations
       perContainerAnnotationPrefixes: []
 
       ## ref: https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter#configuration
@@ -587,8 +587,8 @@ fluentd:
         bearerTokenFile: ""
         ## Regex to match containers tag to `pod_name`, `namespace`, `container_name` and `docker_id`. All of them are obligatory
         ## See below links for reference:
-        ## https://github.com/SumoLogic/sumologic-kubernetes-fluentd/blob/v1.14.6-sumo-2/fluent-plugin-kubernetes-metadata-filter/lib/fluent/plugin/filter_kubernetes_metadata.rb#L322-L325
-        ## https://github.com/SumoLogic/sumologic-kubernetes-fluentd/tree/v1.14.6-sumo-2/fluent-plugin-kubernetes-metadata-filter#configuration
+        ## https://github.com/SumoLogic/sumologic-kubernetes-fluentd/blob/v1.14.6-sumo-3/fluent-plugin-kubernetes-metadata-filter/lib/fluent/plugin/filter_kubernetes_metadata.rb#L322-L325
+        ## https://github.com/SumoLogic/sumologic-kubernetes-fluentd/tree/v1.14.6-sumo-3/fluent-plugin-kubernetes-metadata-filter#configuration
         tagToMetadataRegexp: '.+?\.containers\.(?<pod_name>[^_]+)_(?<namespace>[^_]+)_(?<container_name>.+)-(?<docker_id>[a-z0-9]{64})\.log$'
 
       ## To use additional filter plugins


### PR DESCRIPTION
##### Description

The new version reloads ServiceAccount tokens periodically, correctly handling token expiration enabled in K8s 1.21.

This fixes #2280 

---

##### Checklist

<!---
Remove items which don't apply to your PR.
-->

- [X] Changelog updated

###### Testing performed

- [X] Redeploy fluentd and fluentd-events pods
- [X] Confirm events, logs, and metrics are coming in
