### PR TITLE
fix(otellogs): set resources on Otelcol logs collector daemonset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - fix: set cluster field in metadata pipelines [#2284][#2284]
+- fix(otellogs): set resources on Otelcol logs collector daemonset [#2291]
 
 [#2284]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2284
 [#2287]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2287
+[#2291]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2291
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.8.0...main
 
 ## [v2.8.0]

--- a/deploy/helm/sumologic/templates/logs/collector/otelcol/daemonset.yaml
+++ b/deploy/helm/sumologic/templates/logs/collector/otelcol/daemonset.yaml
@@ -64,6 +64,8 @@ spec:
           httpGet:
             path: /
             port: 13133 # Health Check extension default port.
+        resources:
+          {{- toYaml .Values.otellogs.daemonset.resources | nindent 10 }}
         volumeMounts:
         - mountPath: /etc/otelcol
           name: otelcol-config

--- a/tests/helm/logs_otc_daemonset/static/basic.output.yaml
+++ b/tests/helm/logs_otc_daemonset/static/basic.output.yaml
@@ -41,6 +41,13 @@ spec:
           httpGet:
             path: /
             port: 13133 # Health Check extension default port.
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 32Mi
         volumeMounts:
         - mountPath: /etc/otelcol
           name: otelcol-config


### PR DESCRIPTION
The resources were already defined in `values.yaml`
in the `otellogs.daemonset.resources` property,
but this property was not being used in the daemonset template.
