### PR TITLE
chore: remove support for EKS with Kuberentes 1.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - chore(deps): upgrade fluentd to 1.14.6-sumo-3 [#2287][#2287]
 - chore(tracing): switch from otc fork to otel distro [#2299][#2299]
+- chore: remove support for EKS with Kuberentes 1.18 [#2312][#2312]
 
 ### Fixed
 
@@ -21,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2287]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2287
 [#2291]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2291
 [#2299]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2299
+[#2312]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2312
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.8.0...main
 
 ## [v2.8.0]

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -5,10 +5,10 @@ enriching them with deployment, pod, and service level metadata; and sending the
 See our [documentation guide](https://help.sumologic.com/Solutions/Kubernetes_Solution)
 for details on our Kubernetes Solution.
 
-- [Documentation versions](#documentation-versions)
 - [Solution overview](#solution-overview)
 - [Minimum Requirements](#minimum-requirements)
 - [Support Matrix](#support-matrix)
+  - [ARM support](#arm-support)
 
 Documentation for other versions can be found in the [main README file](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/main/README.md#documentation).
 
@@ -76,7 +76,7 @@ The following table displays the tested Kubernetes and Helm versions.
 
 | Name          | Version                                  |
 |---------------|------------------------------------------|
-| K8s with EKS  | 1.18<br/>1.19<br/>1.20<br/>1.21          |
+| K8s with EKS  | 1.19<br/>1.20<br/>1.21                   |
 | K8s with Kops | 1.18<br/>1.19<br/>1.20<br/>1.21<br/>1.22 |
 | K8s with GKE  | 1.20<br/>1.21                            |
 | K8s with AKS  | 1.19<br/>1.20<br/>1.21<br/>1.22          |


### PR DESCRIPTION
Amazon EKS end of support: March 31, 2022
https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar

<img width="684" alt="Screenshot 2022-05-31 at 12 52 50" src="https://user-images.githubusercontent.com/73836361/171157491-5704771b-ad80-4648-a67a-fdca2ade4250.png">

