### PR TITLE
chore: remove support for Kops with Kubernetes 1.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - chore(deps): upgrade fluentd to 1.14.6-sumo-3 [#2287][#2287]
 - chore(tracing): switch from otc fork to otel distro [#2299][#2299]
 - chore: remove support for EKS with Kuberentes 1.18 [#2312][#2312]
+- chore: remove support for Kops with Kubernetes 1.18 [#2313][#2313]
 
 ### Fixed
 
@@ -23,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2291]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2291
 [#2299]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2299
 [#2312]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2312
+[#2313]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2313
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.8.0...main
 
 ## [v2.8.0]

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -74,15 +74,15 @@ The diagram below illustrates the components of the Kubernetes collection soluti
 
 The following table displays the tested Kubernetes and Helm versions.
 
-| Name          | Version                                  |
-|---------------|------------------------------------------|
-| K8s with EKS  | 1.19<br/>1.20<br/>1.21                   |
-| K8s with Kops | 1.18<br/>1.19<br/>1.20<br/>1.21<br/>1.22 |
-| K8s with GKE  | 1.20<br/>1.21                            |
-| K8s with AKS  | 1.19<br/>1.20<br/>1.21<br/>1.22          |
-| OpenShift     | 4.6<br/>4.7<br/>4.8                      |
-| Helm          | 3.5.4 (Linux)                            |
-| kubectl       | 1.16.0                                   |
+| Name          | Version                         |
+|---------------|---------------------------------|
+| K8s with EKS  | 1.19<br/>1.20<br/>1.21          |
+| K8s with Kops | 1.19<br/>1.20<br/>1.21<br/>1.22 |
+| K8s with GKE  | 1.20<br/>1.21                   |
+| K8s with AKS  | 1.19<br/>1.20<br/>1.21<br/>1.22 |
+| OpenShift     | 4.6<br/>4.7<br/>4.8             |
+| Helm          | 3.5.4 (Linux)                   |
+| kubectl       | 1.16.0                          |
 
 The following matrix displays the tested package versions for our Helm chart.
 


### PR DESCRIPTION
Support for Kubernetes version 1.18 will be removed in Kops 1.24 (currently alpha release is available)
https://kops.sigs.k8s.io/releases/1.24-notes/#other-breaking-changes