### PR TITLE
chore: add support for GKE with Kuberentes 1.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - chore(deps): upgrade fluentd to 1.14.6-sumo-3 [#2287][#2287]
 - chore(tracing): switch from otc fork to otel distro [#2299][#2299]
-- chore: remove support for EKS with Kuberentes 1.18 [#2312][#2312]
+- chore: remove support for EKS with Kubernetes 1.18 [#2312][#2312]
 - chore: remove support for Kops with Kubernetes 1.18 [#2313][#2313]
+- chore: add support for GKE with Kubernetes 1.22 [#2314][#2314]
 
 ### Fixed
 
@@ -25,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2299]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2299
 [#2312]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2312
 [#2313]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2313
+[#2314]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2314
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.8.0...main
 
 ## [v2.8.0]

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -78,7 +78,7 @@ The following table displays the tested Kubernetes and Helm versions.
 |---------------|---------------------------------|
 | K8s with EKS  | 1.19<br/>1.20<br/>1.21          |
 | K8s with Kops | 1.19<br/>1.20<br/>1.21<br/>1.22 |
-| K8s with GKE  | 1.20<br/>1.21                   |
+| K8s with GKE  | 1.20<br/>1.21<br/>1.22          |
 | K8s with AKS  | 1.19<br/>1.20<br/>1.21<br/>1.22 |
 | OpenShift     | 4.6<br/>4.7<br/>4.8             |
 | Helm          | 3.5.4 (Linux)                   |


### PR DESCRIPTION
https://cloud.google.com/kubernetes-engine/docs/release-schedule

<img width="851" alt="Screenshot 2022-05-31 at 14 21 49" src="https://user-images.githubusercontent.com/73836361/171172009-71b5cddd-cd22-49a6-94ee-1b0b875c9588.png">

