### PR TITLE
chore: remove support for AKS with Kubernetes 1.19 & 1.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - chore: remove support for EKS with Kubernetes 1.18 [#2312][#2312]
 - chore: remove support for Kops with Kubernetes 1.18 [#2313][#2313]
 - chore: add support for GKE with Kubernetes 1.22 [#2314][#2314]
+- chore: remove support for AKS with Kubernetes 1.19 & 1.20 [#2315][#2315]
 
 ### Fixed
 
@@ -34,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2314]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2314
 [#2316]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2316
 [#2318]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2318
+[#2315]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2315
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.8.0...main
 
 ## [v2.8.0]

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -79,7 +79,7 @@ The following table displays the tested Kubernetes and Helm versions.
 | K8s with EKS  | 1.19<br/>1.20<br/>1.21          |
 | K8s with Kops | 1.19<br/>1.20<br/>1.21<br/>1.22 |
 | K8s with GKE  | 1.20<br/>1.21<br/>1.22          |
-| K8s with AKS  | 1.19<br/>1.20<br/>1.21<br/>1.22 |
+| K8s with AKS  | 1.21<br/>1.22                   |
 | OpenShift     | 4.6<br/>4.7<br/>4.8             |
 | Helm          | 3.5.4 (Linux)                   |
 | kubectl       | 1.16.0                          |


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar
<img width="889" alt="Screenshot 2022-05-31 at 15 57 10" src="https://user-images.githubusercontent.com/73836361/171191107-5ff9f163-f43c-482f-8033-83165fdc5d6b.png">

