### PR TITLE
feat(metrics): add imagePullSecrets to remote-write-proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- feat(metrics): add imagePullSecrets to remote-write-proxy [#2316]
+
 ### Changed
 
 - chore(deps): upgrade fluentd to 1.14.6-sumo-3 [#2287][#2287]
@@ -27,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2312]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2312
 [#2313]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2313
 [#2314]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2314
+[#2316]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2316
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.8.0...main
 
 ## [v2.8.0]

--- a/deploy/docs/Working_with_container_registries.md
+++ b/deploy/docs/Working_with_container_registries.md
@@ -46,6 +46,7 @@ Full list of `values.yaml` keys for all the images that are used, can be found b
 | setup job             | `sumologic.setup.job.pullSecrets`               |
 | fluentd               | `sumologic.pullSecrets`                         |
 | Sumo Logic OT distro  | `sumologic.pullSecrets`                         |
+| remote-write-proxy    | `sumologic.pullSecrets`                         |
 | kube-prometheus-stack | `kube-prometheus-stack.global.imagePullSecrets` |
 | metrics-server        | `metrics-server.image.pullSecrets`              |
 | telegraf-operator     | `telegraf-operator.imagePullSecrets`            |

--- a/deploy/helm/sumologic/templates/metrics/remote-write-proxy/deployment.yaml
+++ b/deploy/helm/sumologic/templates/metrics/remote-write-proxy/deployment.yaml
@@ -31,6 +31,10 @@ spec:
 {{ toYaml .Values.sumologic.metrics.remoteWriteProxy.podLabels | indent 8 }}
 {{- end }}
     spec:
+{{- if .Values.sumologic.pullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.sumologic.pullSecrets | indent 8 }}
+{{- end }}
 {{- if .Values.sumologic.metrics.remoteWriteProxy.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.sumologic.metrics.remoteWriteProxy.nodeSelector | indent 8 }}

--- a/tests/helm/remote_write_proxy/static/full_config.input.yaml
+++ b/tests/helm/remote_write_proxy/static/full_config.input.yaml
@@ -1,4 +1,6 @@
 sumologic:
+  pullSecrets:
+  - name: sumo-pull
   podLabels:
     cluster: sumo-demo
   metrics:

--- a/tests/helm/remote_write_proxy/static/full_config.output.yaml
+++ b/tests/helm/remote_write_proxy/static/full_config.output.yaml
@@ -28,6 +28,8 @@ spec:
         cluster: sumo-demo
         my-label: rwp
     spec:
+      imagePullSecrets:
+        - name: sumo-pull
       nodeSelector:
         disktype: ssd
       affinity:


### PR DESCRIPTION
Until now, it was not possible to specify imagePullSecrets
for the nginx image used by remote-write-proxy.
This change makes the remote-write-proxy use the pull secrets
specified in `sumologic.pullSecrets`, the same pull secrets that are used
by other components of the chart (Fluentd, OTC).
