### PR TITLE
fix(events): fix setting source category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - fix: set cluster field in metadata pipelines [#2284][#2284]
 - fix(otellogs): set resources on Otelcol logs collector daemonset [#2291]
+- fix(events): fix setting source category [#2318]
 
 [#2284]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2284
 [#2287]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2287
@@ -32,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2313]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2313
 [#2314]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2314
 [#2316]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2316
+[#2318]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2318
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.8.0...main
 
 ## [v2.8.0]

--- a/deploy/helm/sumologic/conf/events/events.conf
+++ b/deploy/helm/sumologic/conf/events/events.conf
@@ -58,7 +58,7 @@
     sumo_client {{ include "sumologic.sumo_client" . | quote }}
     endpoint "#{ENV['SUMO_ENDPOINT_DEFAULT_EVENTS_SOURCE']}"
     source_name {{ .Values.fluentd.events.sourceName }}
-    source_category {{ .Values.fluentd.events.source_category | default (printf "%s/%s"  (include "sumologic.clusterNameReplaceSpaceWithDash" .) (.Values.fluentd.events.sourceName ))}}
+    source_category {{ .Values.fluentd.events.sourceCategory | default (printf "%s/%s"  (include "sumologic.clusterNameReplaceSpaceWithDash" .) (.Values.fluentd.events.sourceName ))}}
     data_type logs
     disable_cookies true
     verify_ssl {{ .Values.fluentd.verifySsl | quote }}

--- a/tests/helm/events/static/customSourceCategory.input.yaml
+++ b/tests/helm/events/static/customSourceCategory.input.yaml
@@ -1,0 +1,5 @@
+fluentd:
+  events:
+    enabled: true
+    sourceCategory: custom/sou-rce_categ
+    sourceName: cus-tom/Sour_ce:NAME

--- a/tests/helm/events/static/customSourceCategory.output.yaml
+++ b/tests/helm/events/static/customSourceCategory.output.yaml
@@ -1,0 +1,79 @@
+---
+# Source: sumologic/templates/events/fluentd/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: RELEASE-NAME-sumologic-fluentd-events
+  labels:
+    app: RELEASE-NAME-sumologic-fluentd-events
+    chart: "sumologic-%CURRENT_CHART_VERSION%"
+    release: "RELEASE-NAME"
+    heritage: "Helm"
+data:
+  fluent.conf: |-
+    @include events.conf
+  events.conf: |
+    <source>
+      @type events
+      deploy_namespace sumologic
+    </source>
+    # Prevent fluentd from handling records containing its own logs.
+    <match fluentd.**>
+      @type null
+    </match>
+    # Set `cluster` metadata field
+    <filter **>
+      @type record_modifier
+      <record>
+        _sumo_metadata ${ {:fields => "cluster=kubernetes"} }
+      </record>
+    </filter>
+    # expose the Fluentd metrics to Prometheus
+    <source>
+      @type prometheus
+      metrics_path /metrics
+      port 24231
+    </source>
+    <source>
+      @type prometheus_output_monitor
+    </source>
+    <source>
+      @type http
+      port 9880
+      bind 0.0.0.0
+    </source>
+    <match kubernetes.**>
+      @type copy
+      <store>
+        @type sumologic
+        @id sumologic.endpoint.events
+        sumo_client "k8s_%CURRENT_CHART_VERSION%"
+        endpoint "#{ENV['SUMO_ENDPOINT_DEFAULT_EVENTS_SOURCE']}"
+        source_name cus-tom/Sour_ce:NAME
+        source_category custom/sou-rce_categ
+        data_type logs
+        disable_cookies true
+        verify_ssl "true"
+        proxy_uri ""
+        compress "true"
+        compress_encoding "gzip"
+        <buffer>
+          @type file
+          path /fluentd/buffer/events
+          @include buffer.output.conf
+        </buffer>
+      </store>
+    </match>
+    <system>
+      log_level info
+    </system>
+  buffer.output.conf: |
+    compress "gzip"
+    flush_interval "5s"
+    flush_thread_count "8"
+    chunk_limit_size "1m"
+    total_limit_size "128m"
+    queued_chunks_limit_size "128"
+    overflow_action drop_oldest_chunk
+    retry_max_interval "10m"
+    retry_forever "true"


### PR DESCRIPTION
A bug was introduced in v2.8.0 (#2222)
that made the `fluentd.events.sourceCategory` non-functional.
