### PR TITLE
feat(otellogs/systemd): add support for systemd logs to otellogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - feat(otellogs): add additional volumes and env configs [#2410]
+- feat(otellogs/systemd): add support for systemd logs to otellogs [#2364]
 
 ### Changed
 
@@ -17,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#2410]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2410
 [#2422]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2422
+[#2364]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2364
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.11.0...main
 
 ## [v2.11.0]

--- a/deploy/helm/sumologic/templates/logs/collector/otelcol/daemonset.yaml
+++ b/deploy/helm/sumologic/templates/logs/collector/otelcol/daemonset.yaml
@@ -77,9 +77,9 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.otellogs.config.extensions.file_storage.directory }}
           name: file-storage
-          - mountPath: /var/log/journal
-            name: varlogjournal
-            readOnly: true
+        - mountPath: /var/log/journal
+          name: varlogjournal
+          readOnly: true
 {{- if .Values.otellogs.daemonset.extraVolumeMounts }}
 {{ toYaml .Values.otellogs.daemonset.extraVolumeMounts | indent 8 }}
 {{- end }}
@@ -140,10 +140,10 @@ spec:
           path: /var/lib/otc
           type: DirectoryOrCreate
         name: file-storage
-        - hostPath:
-            path: /var/log/journal/
-            type: ""
-          name: varlogjournal
+      - hostPath:
+          path: /var/log/journal/
+          type: ""
+        name: varlogjournal
 {{- if .Values.otellogs.daemonset.extraVolumes }}
 {{ toYaml .Values.otellogs.daemonset.extraVolumes | indent 6 }}
 {{- end }}

--- a/deploy/helm/sumologic/templates/logs/collector/otelcol/daemonset.yaml
+++ b/deploy/helm/sumologic/templates/logs/collector/otelcol/daemonset.yaml
@@ -77,6 +77,9 @@ spec:
           readOnly: true
         - mountPath: {{ .Values.otellogs.config.extensions.file_storage.directory }}
           name: file-storage
+          - mountPath: /var/log/journal
+            name: varlogjournal
+            readOnly: true
 {{- if .Values.otellogs.daemonset.extraVolumeMounts }}
 {{ toYaml .Values.otellogs.daemonset.extraVolumeMounts | indent 8 }}
 {{- end }}
@@ -137,6 +140,10 @@ spec:
           path: /var/lib/otc
           type: DirectoryOrCreate
         name: file-storage
+        - hostPath:
+            path: /var/log/journal/
+            type: ""
+          name: varlogjournal
 {{- if .Values.otellogs.daemonset.extraVolumes }}
 {{ toYaml .Values.otellogs.daemonset.extraVolumes | indent 6 }}
 {{- end }}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -4138,6 +4138,9 @@ metadata:
           json_logs:
             add_timestamp: true
             timestamp_key: timestamp
+            ## use flatten_body, but OTLP won't require any flattening
+            ## fluent based logs will be all send as record attributes
+            ## otellogs based logs will be all send as body attributes
             flatten_body: true
           endpoint: ${SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE}
           source_name: "%{_sourceName}"
@@ -4386,6 +4389,11 @@ metadata:
           source_category: '{{ .Values.fluentd.logs.systemd.sourceCategory | quote }}'
           source_category_prefix: '{{ .Values.fluentd.logs.systemd.sourceCategoryPrefix | quote }}'
           source_category_replace_dash: '{{ .Values.fluentd.logs.systemd.sourceCategoryReplaceDash | quote }}'
+        ## Remove all attributes, so body won't by nested by SumoLogic receiver in case of using otlp format
+        transform/remove_attributes:
+          logs:
+            queries:
+              - limit(attributes, 0)
 
         ## kubelet related processors
         filter/include_kubelet:
@@ -4450,10 +4458,9 @@ metadata:
           #     - batch
           #   exporters:
           #     - sumologic/containers
-          logs/systemd:
+          logs/fluent/systemd:
             receivers:
               - fluentforward
-              - otlp
             processors:
               - memory_limiter
               - filter/include_fluent_tag_host
@@ -4471,9 +4478,54 @@ metadata:
               - batch
             exporters:
               - sumologic/systemd
-          logs/kubelet:
+          logs/fluent/kubelet:
             receivers:
               - fluentforward
+            processors:
+              - memory_limiter
+              - filter/include_fluent_tag_host
+              - filter/include_kubelet
+              - filter/exclude_kubelet_syslog
+              - filter/exclude_kubelet_hostname
+              - filter/exclude_kubelet_priority
+              - filter/exclude_kubelet_unit
+              - attributes/extract_systemd_source_fields
+              - attributes/remove_fluent_tag
+              - groupbyattrs/systemd
+              - resource/add_cluster
+              - source/kubelet
+              - batch
+            exporters:
+              - sumologic/systemd
+          ## This is the same pipeline like logs/fluent/systemd with the following changes:
+          ## - otlp receiver instead of fluentforward
+          ## - added transform/remove_attributes processor
+          logs/otlp/systemd:
+            receivers:
+              - otlp
+            processors:
+              - memory_limiter
+              - filter/include_fluent_tag_host
+              - filter/include_systemd
+              - filter/exclude_kubelet
+              - filter/exclude_systemd_syslog
+              - filter/exclude_systemd_hostname
+              - filter/exclude_systemd_priority
+              - filter/exclude_systemd_unit
+              - attributes/extract_systemd_source_fields
+              - attributes/remove_fluent_tag
+              - groupbyattrs/systemd
+              - resource/add_cluster
+              - source/systemd
+              - transform/remove_attributes
+              - batch
+            exporters:
+              - sumologic/systemd
+          ## This is the same pipeline like logs/fluent/kubelet with the following changes:
+          ## - otlp receiver instead of fluentforward
+          ## - added transform/remove_attributes processor
+          logs/otlp/kubelet:
+            receivers:
               - otlp
             processors:
               - memory_limiter
@@ -4488,6 +4540,7 @@ metadata:
               - groupbyattrs/systemd
               - resource/add_cluster
               - source/kubelet
+              - transform/remove_attributes
               - batch
             exporters:
               - sumologic/systemd

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -4397,7 +4397,7 @@ metadata:
         source/kubelet:
           collector: '{{ .Values.sumologic.collectorName | default .Values.sumologic.clusterName | quote }}'
           source_host: "%{_sourceHost}"
-          source_name: '{{ .Values.fluentd.logs.kubelet.sourceName | quote }}'
+          source_name: "%{_sourceName}"
           source_category: '{{ .Values.fluentd.logs.kubelet.sourceCategory | quote }}'
           source_category_prefix: '{{ .Values.fluentd.logs.kubelet.sourceCategoryPrefix | quote }}'
           source_category_replace_dash: '{{ .Values.fluentd.logs.kubelet.sourceCategoryReplaceDash | quote }}'

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -4138,21 +4138,6 @@ metadata:
           json_logs:
             add_timestamp: true
             timestamp_key: timestamp
-          endpoint: ${SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE}
-          source_name: "%{_sourceName}"
-          source_category: "%{_sourceCategory}"
-          source_host: "%{_sourceHost}"
-          ## Configuration for sending queue
-          ## ref: https://github.com/open-telemetry/opentelemetry-collector/tree/release/v0.37.x/exporter/exporterhelper#configuration
-          sending_queue:
-            enabled: true
-            persistent_storage_enabled: '{{ .Values.metadata.persistence.enabled }}'
-        ## This is the same like sumologic/systemd with additional `flatten_body` parameter
-        sumologic/systemd_flatten:
-          log_format: json
-          json_logs:
-            add_timestamp: true
-            timestamp_key: timestamp
             flatten_body: true
           endpoint: ${SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE}
           source_name: "%{_sourceName}"
@@ -4162,7 +4147,7 @@ metadata:
           ## ref: https://github.com/open-telemetry/opentelemetry-collector/tree/release/v0.37.x/exporter/exporterhelper#configuration
           sending_queue:
             enabled: true
-            persistent_storage_enabled: '{{ .Values.metadata.persistence.enabled }}'
+            persistent_storage_enabled: '{{ .Values.metadata.persistence.enabled }}'\
 
       processors:
         ## Common processors
@@ -4465,52 +4450,10 @@ metadata:
           #     - batch
           #   exporters:
           #     - sumologic/containers
-          # ## This is the same pipeline like logs/fluent/systemd
-          # ## except is uses otlp receiver and flatten body in exporter
-          # logs/otlp/systemd:
-          #   receivers:
-          #     - otlp
-          #   processors:
-          #     - memory_limiter
-          #     - filter/include_fluent_tag_host
-          #     - filter/include_systemd
-          #     - filter/exclude_kubelet
-          #     - filter/exclude_systemd_syslog
-          #     - filter/exclude_systemd_hostname
-          #     - filter/exclude_systemd_priority
-          #     - filter/exclude_systemd_unit
-          #     - attributes/extract_systemd_source_fields
-          #     - attributes/remove_fluent_tag
-          #     - groupbyattrs/systemd
-          #     - resource/add_cluster
-          #     - source/systemd
-          #     - batch
-          #   exporters:
-          #     - sumologic/systemd_flatten
-          # ## This is the same pipeline like logs/fluent/kubelet
-          # ## except is uses otlp receiver and flatten body in exporter
-          # logs/otlp/kubelet:
-          #   receivers:
-          #     - otlp
-          #   processors:
-          #     - memory_limiter
-          #     - filter/include_fluent_tag_host
-          #     - filter/include_kubelet
-          #     - filter/exclude_kubelet_syslog
-          #     - filter/exclude_kubelet_hostname
-          #     - filter/exclude_kubelet_priority
-          #     - filter/exclude_kubelet_unit
-          #     - attributes/extract_systemd_source_fields
-          #     - attributes/remove_fluent_tag
-          #     - groupbyattrs/systemd
-          #     - resource/add_cluster
-          #     - source/kubelet
-          #     - batch
-          #   exporters:
-          #     - sumologic/systemd_flatten
-          logs/fluent/systemd:
+          logs/systemd:
             receivers:
               - fluentforward
+              - otlp
             processors:
               - memory_limiter
               - filter/include_fluent_tag_host
@@ -4528,9 +4471,10 @@ metadata:
               - batch
             exporters:
               - sumologic/systemd
-          logs/fluent/kubelet:
+          logs/kubelet:
             receivers:
               - fluentforward
+              - otlp
             processors:
               - memory_limiter
               - filter/include_fluent_tag_host

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -4452,6 +4452,7 @@ metadata:
           logs/fluent/systemd:
             receivers:
               - fluentforward
+              - otlp
             processors:
               - memory_limiter
               - filter/include_fluent_tag_host
@@ -4472,6 +4473,7 @@ metadata:
           logs/fluent/kubelet:
             receivers:
               - fluentforward
+              - otlp
             processors:
               - memory_limiter
               - filter/include_fluent_tag_host
@@ -4849,6 +4851,14 @@ otellogs:
             - batch
           exporters:
             - otlphttp
+        logs/systemd:
+          receivers:
+            - journald
+          processors:
+            - logstransform/systemd
+            - batch
+          exporters:
+            - otlphttp
     receivers:
       filelog/containers:
         include:
@@ -5014,6 +5024,59 @@ otellogs:
           - type: move
             from: body.log
             to: body
+      journald:
+        directory: /var/log/journal
+        ## This is not a full equivalent of fluent-bit filtering as fluent-bit filters by `_SYSTEMD_UNIT`
+        ## Here is filtering by `UNIT`
+        units:
+          - addon-config.service
+          - addon-run.service
+          - cfn-etcd-environment.service
+          - cfn-signal.service
+          - clean-ca-certificates.service
+          - containerd.service
+          - coreos-metadata.service
+          - coreos-setup-environment.service
+          - coreos-tmpfiles.service
+          - dbus.service
+          - docker.service
+          - efs.service
+          - etcd-member.service
+          - etcd.service
+          - etcd2.service
+          - etcd3.service
+          - etcdadm-check.service
+          - etcdadm-reconfigure.service
+          - etcdadm-save.service
+          - etcdadm-update-status.service
+          - flanneld.service
+          - format-etcd2-volume.service
+          - kube-node-taint-and-uncordon.service
+          - kubelet.service
+          - ldconfig.service
+          - locksmithd.service
+          - logrotate.service
+          - lvm2-monitor.service
+          - mdmon.service
+          - nfs-idmapd.service
+          - nfs-mountd.service
+          - nfs-server.service
+          - nfs-utils.service
+          - node-problem-detector.service
+          - ntp.service
+          - oem-cloudinit.service
+          - rkt-gc.service
+          - rkt-metadata.service
+          - rpc-idmapd.service
+          - rpc-mountd.service
+          - rpc-statd.service
+          - rpcbind.service
+          - set-aws-environment.service
+          - system-cloudinit.service
+          - systemd-timesyncd.service
+          - update-ca-certificates.service
+          - user-cloudinit.service
+          - var-lib-etcd2.service
     exporters:
       otlphttp:
         endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local:4318
@@ -5026,6 +5089,26 @@ otellogs:
         send_batch_size: 10_240
         ## Time duration after which a batch will be sent regardless of size
         timeout: 1s
+      ## copy _SYSTEMD_UNIT, SYSLOG_FACILITY, _HOSTNAME and PRIORITY from body to attributes
+      ## so they can be used by metadata processors same way like for fluentd
+      ## build fluent.tag attribute as `host.{_SYSTEMD_UNIT}`
+      logstransform/systemd:
+        operators:
+          - type: copy
+            from: body._SYSTEMD_UNIT
+            to: attributes._SYSTEMD_UNIT
+          - type: copy
+            from: body.SYSLOG_FACILITY
+            to: attributes.SYSLOG_FACILITY
+          - type: copy
+            from: body._HOSTNAME
+            to: attributes._HOSTNAME
+          - type: copy
+            from: body.PRIORITY
+            to: attributes.PRIORITY
+          - type: add
+            field: attributes["fluent.tag"]
+            value: EXPR("host." + attributes["_SYSTEMD_UNIT"])
   daemonset:
     ## Set securityContext for containers running in pods in log collector daemonset
     securityContext:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -4147,7 +4147,7 @@ metadata:
           ## ref: https://github.com/open-telemetry/opentelemetry-collector/tree/release/v0.37.x/exporter/exporterhelper#configuration
           sending_queue:
             enabled: true
-            persistent_storage_enabled: '{{ .Values.metadata.persistence.enabled }}'\
+            persistent_storage_enabled: '{{ .Values.metadata.persistence.enabled }}'
 
       processors:
         ## Common processors

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -4147,6 +4147,22 @@ metadata:
           sending_queue:
             enabled: true
             persistent_storage_enabled: '{{ .Values.metadata.persistence.enabled }}'
+        ## This is the same like sumologic/systemd with additional `flatten_body` parameter
+        sumologic/otlp_systemd:
+          log_format: json
+          json_logs:
+            add_timestamp: true
+            timestamp_key: timestamp
+            flatten_body: true
+          endpoint: ${SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE}
+          source_name: "%{_sourceName}"
+          source_category: "%{_sourceCategory}"
+          source_host: "%{_sourceHost}"
+          ## Configuration for sending queue
+          ## ref: https://github.com/open-telemetry/opentelemetry-collector/tree/release/v0.37.x/exporter/exporterhelper#configuration
+          sending_queue:
+            enabled: true
+            persistent_storage_enabled: '{{ .Values.metadata.persistence.enabled }}'
 
       processors:
         ## Common processors
@@ -4449,10 +4465,52 @@ metadata:
           #     - batch
           #   exporters:
           #     - sumologic/containers
+          # ## This is the same pipeline like logs/fluent/systemd
+          # ## except is uses otlp receiver and flatten body in exporter
+          # logs/otlp/systemd:
+          #   receivers:
+          #     - otlp
+          #   processors:
+          #     - memory_limiter
+          #     - filter/include_fluent_tag_host
+          #     - filter/include_systemd
+          #     - filter/exclude_kubelet
+          #     - filter/exclude_systemd_syslog
+          #     - filter/exclude_systemd_hostname
+          #     - filter/exclude_systemd_priority
+          #     - filter/exclude_systemd_unit
+          #     - attributes/extract_systemd_source_fields
+          #     - attributes/remove_fluent_tag
+          #     - groupbyattrs/systemd
+          #     - resource/add_cluster
+          #     - source/systemd
+          #     - batch
+          #   exporters:
+          #     - sumologic/otlp_systemd
+          # ## This is the same pipeline like logs/fluent/kubelet
+          # ## except is uses otlp receiver and flatten body in exporter
+          # logs/otlp/kubelet:
+          #   receivers:
+          #     - otlp
+          #   processors:
+          #     - memory_limiter
+          #     - filter/include_fluent_tag_host
+          #     - filter/include_kubelet
+          #     - filter/exclude_kubelet_syslog
+          #     - filter/exclude_kubelet_hostname
+          #     - filter/exclude_kubelet_priority
+          #     - filter/exclude_kubelet_unit
+          #     - attributes/extract_systemd_source_fields
+          #     - attributes/remove_fluent_tag
+          #     - groupbyattrs/systemd
+          #     - resource/add_cluster
+          #     - source/kubelet
+          #     - batch
+          #   exporters:
+          #     - sumologic/otlp_systemd
           logs/fluent/systemd:
             receivers:
               - fluentforward
-              - otlp
             processors:
               - memory_limiter
               - filter/include_fluent_tag_host
@@ -4473,7 +4531,6 @@ metadata:
           logs/fluent/kubelet:
             receivers:
               - fluentforward
-              - otlp
             processors:
               - memory_limiter
               - filter/include_fluent_tag_host
@@ -5109,6 +5166,11 @@ otellogs:
           - type: add
             field: attributes["fluent.tag"]
             value: EXPR("host." + attributes["_SYSTEMD_UNIT"])
+          ## Removes __CURSOR and __MONOTONIC_TIMESTAMP keys from body
+          - type: remove
+            field: body.__CURSOR
+          - type: remove
+            field: body.__MONOTONIC_TIMESTAMP
   daemonset:
     ## Set securityContext for containers running in pods in log collector daemonset
     securityContext:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -4413,7 +4413,7 @@ metadata:
         source/kubelet:
           collector: '{{ .Values.sumologic.collectorName | default .Values.sumologic.clusterName | quote }}'
           source_host: "%{_sourceHost}"
-          source_name: "%{_sourceName}"
+          source_name: '{{ .Values.fluentd.logs.kubelet.sourceName | quote }}'
           source_category: '{{ .Values.fluentd.logs.kubelet.sourceCategory | quote }}'
           source_category_prefix: '{{ .Values.fluentd.logs.kubelet.sourceCategoryPrefix | quote }}'
           source_category_replace_dash: '{{ .Values.fluentd.logs.kubelet.sourceCategoryReplaceDash | quote }}'

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -4148,7 +4148,7 @@ metadata:
             enabled: true
             persistent_storage_enabled: '{{ .Values.metadata.persistence.enabled }}'
         ## This is the same like sumologic/systemd with additional `flatten_body` parameter
-        sumologic/otlp_systemd:
+        sumologic/systemd_flatten:
           log_format: json
           json_logs:
             add_timestamp: true
@@ -4486,7 +4486,7 @@ metadata:
           #     - source/systemd
           #     - batch
           #   exporters:
-          #     - sumologic/otlp_systemd
+          #     - sumologic/systemd_flatten
           # ## This is the same pipeline like logs/fluent/kubelet
           # ## except is uses otlp receiver and flatten body in exporter
           # logs/otlp/kubelet:
@@ -4507,7 +4507,7 @@ metadata:
           #     - source/kubelet
           #     - batch
           #   exporters:
-          #     - sumologic/otlp_systemd
+          #     - sumologic/systemd_flatten
           logs/fluent/systemd:
             receivers:
               - fluentforward

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -4497,7 +4497,7 @@ metadata:
               - batch
             exporters:
               - sumologic/systemd
-          ## This is the same pipeline like logs/fluent/systemd with the following changes:
+          ## This is the same pipeline like logs/fluent/systemd, but with the following changes:
           ## - otlp receiver instead of fluentforward
           ## - added transform/remove_attributes processor
           logs/otlp/systemd:
@@ -4521,7 +4521,7 @@ metadata:
               - batch
             exporters:
               - sumologic/systemd
-          ## This is the same pipeline like logs/fluent/kubelet with the following changes:
+          ## This is the same pipeline like logs/fluent/kubelet, but with the following changes:
           ## - otlp receiver instead of fluentforward
           ## - added transform/remove_attributes processor
           logs/otlp/kubelet:

--- a/tests/helm/logs_otc/static/basic.output.yaml
+++ b/tests/helm/logs_otc/static/basic.output.yaml
@@ -25,6 +25,27 @@ data:
       batch:
         send_batch_size: 10240
         timeout: 1s
+      logstransform/systemd:
+        operators:
+        - from: body._SYSTEMD_UNIT
+          to: attributes._SYSTEMD_UNIT
+          type: copy
+        - from: body.SYSLOG_FACILITY
+          to: attributes.SYSLOG_FACILITY
+          type: copy
+        - from: body._HOSTNAME
+          to: attributes._HOSTNAME
+          type: copy
+        - from: body.PRIORITY
+          to: attributes.PRIORITY
+          type: copy
+        - field: attributes["fluent.tag"]
+          type: add
+          value: EXPR("host." + attributes["_SYSTEMD_UNIT"])
+        - field: body.__CURSOR
+          type: remove
+        - field: body.__MONOTONIC_TIMESTAMP
+          type: remove
     receivers:
       filelog/containers:
         fingerprint_size: 17408
@@ -121,6 +142,57 @@ data:
           to: body
           type: move
         start_at: beginning
+      journald:
+        directory: /var/log/journal
+        units:
+        - addon-config.service
+        - addon-run.service
+        - cfn-etcd-environment.service
+        - cfn-signal.service
+        - clean-ca-certificates.service
+        - containerd.service
+        - coreos-metadata.service
+        - coreos-setup-environment.service
+        - coreos-tmpfiles.service
+        - dbus.service
+        - docker.service
+        - efs.service
+        - etcd-member.service
+        - etcd.service
+        - etcd2.service
+        - etcd3.service
+        - etcdadm-check.service
+        - etcdadm-reconfigure.service
+        - etcdadm-save.service
+        - etcdadm-update-status.service
+        - flanneld.service
+        - format-etcd2-volume.service
+        - kube-node-taint-and-uncordon.service
+        - kubelet.service
+        - ldconfig.service
+        - locksmithd.service
+        - logrotate.service
+        - lvm2-monitor.service
+        - mdmon.service
+        - nfs-idmapd.service
+        - nfs-mountd.service
+        - nfs-server.service
+        - nfs-utils.service
+        - node-problem-detector.service
+        - ntp.service
+        - oem-cloudinit.service
+        - rkt-gc.service
+        - rkt-metadata.service
+        - rpc-idmapd.service
+        - rpc-mountd.service
+        - rpc-statd.service
+        - rpcbind.service
+        - set-aws-environment.service
+        - system-cloudinit.service
+        - systemd-timesyncd.service
+        - update-ca-certificates.service
+        - user-cloudinit.service
+        - var-lib-etcd2.service
     service:
       extensions:
       - health_check
@@ -134,6 +206,14 @@ data:
           - batch
           receivers:
           - filelog/containers
+        logs/systemd:
+          exporters:
+          - otlphttp
+          processors:
+          - logstransform/systemd
+          - batch
+          receivers:
+          - journald
       telemetry:
         logs:
           level: info

--- a/tests/helm/logs_otc_daemonset/static/basic.output.yaml
+++ b/tests/helm/logs_otc_daemonset/static/basic.output.yaml
@@ -59,6 +59,9 @@ spec:
           readOnly: true
         - mountPath: /var/lib/storage/otc
           name: file-storage
+        - mountPath: /var/log/journal
+          name: varlogjournal
+          readOnly: true
         env:
         - name: LOGS_METADATA_SVC
           valueFrom:
@@ -111,4 +114,8 @@ spec:
           path: /var/lib/otc
           type: DirectoryOrCreate
         name: file-storage
+      - hostPath:
+          path: /var/log/journal/
+          type: ""
+        name: varlogjournal
       serviceAccountName: RELEASE-NAME-sumologic-otelcol-logs-collector

--- a/tests/helm/logs_otc_daemonset/static/complex.output.yaml
+++ b/tests/helm/logs_otc_daemonset/static/complex.output.yaml
@@ -141,8 +141,4 @@ spec:
         secret:
           defaultMode: 420
           secretName: es-certs
-<<<<<<< HEAD
       serviceAccountName: RELEASE-NAME-sumologic-otelcol-logs-collector
-=======
-        serviceAccountName: RELEASE-NAME-sumologic-otelcol-logs-collector
->>>>>>> 4f03e4fe (test: update template tests)

--- a/tests/helm/logs_otc_daemonset/static/complex.output.yaml
+++ b/tests/helm/logs_otc_daemonset/static/complex.output.yaml
@@ -141,4 +141,8 @@ spec:
         secret:
           defaultMode: 420
           secretName: es-certs
+<<<<<<< HEAD
       serviceAccountName: RELEASE-NAME-sumologic-otelcol-logs-collector
+=======
+        serviceAccountName: RELEASE-NAME-sumologic-otelcol-logs-collector
+>>>>>>> 4f03e4fe (test: update template tests)

--- a/tests/helm/logs_otc_daemonset/static/complex.output.yaml
+++ b/tests/helm/logs_otc_daemonset/static/complex.output.yaml
@@ -69,6 +69,9 @@ spec:
           readOnly: true
         - mountPath: /var/lib/storage/otc
           name: file-storage
+        - mountPath: /var/log/journal
+          name: varlogjournal
+          readOnly: true
         - mountPath: /certs
           name: es-certs
           readOnly: true
@@ -130,6 +133,10 @@ spec:
           path: /var/lib/otc
           type: DirectoryOrCreate
         name: file-storage
+      - hostPath:
+          path: /var/log/journal/
+          type: ""
+        name: varlogjournal
       - name: es-certs
         secret:
           defaultMode: 420

--- a/tests/helm/metadata_logs_otc/static/basic.output.yaml
+++ b/tests/helm/metadata_logs_otc/static/basic.output.yaml
@@ -25,7 +25,7 @@ data:
         source_category: '%{_sourceCategory}'
         source_host: '%{_sourceHost}'
         source_name: '%{_sourceName}'
-      sumologic/otlp_systemd:
+      sumologic/systemd_flatten:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE}
         json_logs:
           add_timestamp: true

--- a/tests/helm/metadata_logs_otc/static/basic.output.yaml
+++ b/tests/helm/metadata_logs_otc/static/basic.output.yaml
@@ -29,7 +29,7 @@ data:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE}
         json_logs:
           add_timestamp: true
-          flatten: true
+          flatten_body: true
           timestamp_key: timestamp
         log_format: json
         sending_queue:
@@ -324,6 +324,7 @@ data:
           - batch
           receivers:
           - fluentforward
+          - otlp
         logs/systemd:
           exporters:
           - sumologic/systemd
@@ -344,6 +345,7 @@ data:
           - batch
           receivers:
           - fluentforward
+          - otlp
       telemetry:
         logs:
           level: info

--- a/tests/helm/metadata_logs_otc/static/basic.output.yaml
+++ b/tests/helm/metadata_logs_otc/static/basic.output.yaml
@@ -29,19 +29,7 @@ data:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE}
         json_logs:
           add_timestamp: true
-          timestamp_key: timestamp
-        log_format: json
-        sending_queue:
-          enabled: true
-          persistent_storage_enabled: true
-        source_category: '%{_sourceCategory}'
-        source_host: '%{_sourceHost}'
-        source_name: '%{_sourceName}'
-      sumologic/systemd_flatten:
-        endpoint: ${SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE}
-        json_logs:
-          add_timestamp: true
-          flatten_body: true
+          flatten: true
           timestamp_key: timestamp
         log_format: json
         sending_queue:
@@ -317,7 +305,7 @@ data:
           - batch
           receivers:
           - fluentforward
-        logs/fluent/kubelet:
+        logs/kubelet:
           exporters:
           - sumologic/systemd
           processors:
@@ -336,7 +324,7 @@ data:
           - batch
           receivers:
           - fluentforward
-        logs/fluent/systemd:
+        logs/systemd:
           exporters:
           - sumologic/systemd
           processors:

--- a/tests/helm/metadata_logs_otc/static/basic.output.yaml
+++ b/tests/helm/metadata_logs_otc/static/basic.output.yaml
@@ -25,11 +25,10 @@ data:
         source_category: '%{_sourceCategory}'
         source_host: '%{_sourceHost}'
         source_name: '%{_sourceName}'
-      sumologic/systemd_flatten:
+      sumologic/systemd:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE}
         json_logs:
           add_timestamp: true
-          flatten_body: true
           timestamp_key: timestamp
         log_format: json
         sending_queue:
@@ -38,10 +37,11 @@ data:
         source_category: '%{_sourceCategory}'
         source_host: '%{_sourceHost}'
         source_name: '%{_sourceName}'
-      sumologic/systemd:
+      sumologic/systemd_flatten:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE}
         json_logs:
           add_timestamp: true
+          flatten_body: true
           timestamp_key: timestamp
         log_format: json
         sending_queue:

--- a/tests/helm/metadata_logs_otc/static/basic.output.yaml
+++ b/tests/helm/metadata_logs_otc/static/basic.output.yaml
@@ -279,7 +279,7 @@ data:
         source_category_prefix: "kubernetes/"
         source_category_replace_dash: "/"
         source_host: '%{_sourceHost}'
-        source_name: '%{_sourceName}'
+        source_name: "k8s_kubelet"
       source/systemd:
         collector: "kubernetes"
         source_category: "system"

--- a/tests/helm/metadata_logs_otc/static/basic.output.yaml
+++ b/tests/helm/metadata_logs_otc/static/basic.output.yaml
@@ -25,6 +25,19 @@ data:
         source_category: '%{_sourceCategory}'
         source_host: '%{_sourceHost}'
         source_name: '%{_sourceName}'
+      sumologic/otlp_systemd:
+        endpoint: ${SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE}
+        json_logs:
+          add_timestamp: true
+          flatten_body: true
+          timestamp_key: timestamp
+        log_format: json
+        sending_queue:
+          enabled: true
+          persistent_storage_enabled: true
+        source_category: '%{_sourceCategory}'
+        source_host: '%{_sourceHost}'
+        source_name: '%{_sourceName}'
       sumologic/systemd:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE}
         json_logs:
@@ -266,7 +279,7 @@ data:
         source_category_prefix: "kubernetes/"
         source_category_replace_dash: "/"
         source_host: '%{_sourceHost}'
-        source_name: "k8s_kubelet"
+        source_name: '%{_sourceName}'
       source/systemd:
         collector: "kubernetes"
         source_category: "system"

--- a/tests/helm/metadata_logs_otc/static/basic.output.yaml
+++ b/tests/helm/metadata_logs_otc/static/basic.output.yaml
@@ -275,6 +275,10 @@ data:
         source_category_replace_dash: "/"
         source_host: '%{_sourceHost}'
         source_name: '%{_sourceName}'
+      transform/remove_attributes:
+        logs:
+          queries:
+          - limit(attributes, 0)
     receivers:
       fluentforward:
         endpoint: 0.0.0.0:24321
@@ -305,7 +309,7 @@ data:
           - batch
           receivers:
           - fluentforward
-        logs/kubelet:
+        logs/fluent/kubelet:
           exporters:
           - sumologic/systemd
           processors:
@@ -324,8 +328,7 @@ data:
           - batch
           receivers:
           - fluentforward
-          - otlp
-        logs/systemd:
+        logs/fluent/systemd:
           exporters:
           - sumologic/systemd
           processors:
@@ -345,6 +348,46 @@ data:
           - batch
           receivers:
           - fluentforward
+        logs/otlp/kubelet:
+          exporters:
+          - sumologic/systemd
+          processors:
+          - memory_limiter
+          - filter/include_fluent_tag_host
+          - filter/include_kubelet
+          - filter/exclude_kubelet_syslog
+          - filter/exclude_kubelet_hostname
+          - filter/exclude_kubelet_priority
+          - filter/exclude_kubelet_unit
+          - attributes/extract_systemd_source_fields
+          - attributes/remove_fluent_tag
+          - groupbyattrs/systemd
+          - resource/add_cluster
+          - source/kubelet
+          - transform/remove_attributes
+          - batch
+          receivers:
+          - otlp
+        logs/otlp/systemd:
+          exporters:
+          - sumologic/systemd
+          processors:
+          - memory_limiter
+          - filter/include_fluent_tag_host
+          - filter/include_systemd
+          - filter/exclude_kubelet
+          - filter/exclude_systemd_syslog
+          - filter/exclude_systemd_hostname
+          - filter/exclude_systemd_priority
+          - filter/exclude_systemd_unit
+          - attributes/extract_systemd_source_fields
+          - attributes/remove_fluent_tag
+          - groupbyattrs/systemd
+          - resource/add_cluster
+          - source/systemd
+          - transform/remove_attributes
+          - batch
+          receivers:
           - otlp
       telemetry:
         logs:

--- a/tests/helm/metadata_logs_otc/static/templates.output.yaml
+++ b/tests/helm/metadata_logs_otc/static/templates.output.yaml
@@ -25,7 +25,7 @@ data:
         source_category: '%{_sourceCategory}'
         source_host: '%{_sourceHost}'
         source_name: '%{_sourceName}'
-      sumologic/otlp_systemd:
+      sumologic/systemd_flatten:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE}
         json_logs:
           add_timestamp: true

--- a/tests/helm/metadata_logs_otc/static/templates.output.yaml
+++ b/tests/helm/metadata_logs_otc/static/templates.output.yaml
@@ -29,7 +29,7 @@ data:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE}
         json_logs:
           add_timestamp: true
-          flatten: true
+          flatten_body: true
           timestamp_key: timestamp
         log_format: json
         sending_queue:
@@ -324,6 +324,7 @@ data:
           - batch
           receivers:
           - fluentforward
+          - otlp
         logs/systemd:
           exporters:
           - sumologic/systemd
@@ -344,6 +345,7 @@ data:
           - batch
           receivers:
           - fluentforward
+          - otlp
       telemetry:
         logs:
           level: info

--- a/tests/helm/metadata_logs_otc/static/templates.output.yaml
+++ b/tests/helm/metadata_logs_otc/static/templates.output.yaml
@@ -29,19 +29,7 @@ data:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE}
         json_logs:
           add_timestamp: true
-          timestamp_key: timestamp
-        log_format: json
-        sending_queue:
-          enabled: true
-          persistent_storage_enabled: true
-        source_category: '%{_sourceCategory}'
-        source_host: '%{_sourceHost}'
-        source_name: '%{_sourceName}'
-      sumologic/systemd_flatten:
-        endpoint: ${SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE}
-        json_logs:
-          add_timestamp: true
-          flatten_body: true
+          flatten: true
           timestamp_key: timestamp
         log_format: json
         sending_queue:
@@ -317,7 +305,7 @@ data:
           - batch
           receivers:
           - fluentforward
-        logs/fluent/kubelet:
+        logs/kubelet:
           exporters:
           - sumologic/systemd
           processors:
@@ -336,7 +324,7 @@ data:
           - batch
           receivers:
           - fluentforward
-        logs/fluent/systemd:
+        logs/systemd:
           exporters:
           - sumologic/systemd
           processors:

--- a/tests/helm/metadata_logs_otc/static/templates.output.yaml
+++ b/tests/helm/metadata_logs_otc/static/templates.output.yaml
@@ -275,6 +275,10 @@ data:
         source_category_replace_dash: "my_systemd_sourceCategoryReplaceDash"
         source_host: '%{_sourceHost}'
         source_name: '%{_sourceName}'
+      transform/remove_attributes:
+        logs:
+          queries:
+          - limit(attributes, 0)
     receivers:
       fluentforward:
         endpoint: 0.0.0.0:24321
@@ -305,7 +309,7 @@ data:
           - batch
           receivers:
           - fluentforward
-        logs/kubelet:
+        logs/fluent/kubelet:
           exporters:
           - sumologic/systemd
           processors:
@@ -324,8 +328,7 @@ data:
           - batch
           receivers:
           - fluentforward
-          - otlp
-        logs/systemd:
+        logs/fluent/systemd:
           exporters:
           - sumologic/systemd
           processors:
@@ -345,6 +348,46 @@ data:
           - batch
           receivers:
           - fluentforward
+        logs/otlp/kubelet:
+          exporters:
+          - sumologic/systemd
+          processors:
+          - memory_limiter
+          - filter/include_fluent_tag_host
+          - filter/include_kubelet
+          - filter/exclude_kubelet_syslog
+          - filter/exclude_kubelet_hostname
+          - filter/exclude_kubelet_priority
+          - filter/exclude_kubelet_unit
+          - attributes/extract_systemd_source_fields
+          - attributes/remove_fluent_tag
+          - groupbyattrs/systemd
+          - resource/add_cluster
+          - source/kubelet
+          - transform/remove_attributes
+          - batch
+          receivers:
+          - otlp
+        logs/otlp/systemd:
+          exporters:
+          - sumologic/systemd
+          processors:
+          - memory_limiter
+          - filter/include_fluent_tag_host
+          - filter/include_systemd
+          - filter/exclude_kubelet
+          - filter/exclude_systemd_syslog
+          - filter/exclude_systemd_hostname
+          - filter/exclude_systemd_priority
+          - filter/exclude_systemd_unit
+          - attributes/extract_systemd_source_fields
+          - attributes/remove_fluent_tag
+          - groupbyattrs/systemd
+          - resource/add_cluster
+          - source/systemd
+          - transform/remove_attributes
+          - batch
+          receivers:
           - otlp
       telemetry:
         logs:

--- a/tests/helm/metadata_logs_otc/static/templates.output.yaml
+++ b/tests/helm/metadata_logs_otc/static/templates.output.yaml
@@ -279,7 +279,7 @@ data:
         source_category_prefix: "my_kubelet_sourceCategoryPrefix"
         source_category_replace_dash: "my_kubelet_sourceCategoryReplaceDash"
         source_host: '%{_sourceHost}'
-        source_name: '%{_sourceName}'
+        source_name: "k8s_kubelet"
       source/systemd:
         collector: "my_collectorName"
         source_category: "system"

--- a/tests/helm/metadata_logs_otc/static/templates.output.yaml
+++ b/tests/helm/metadata_logs_otc/static/templates.output.yaml
@@ -25,11 +25,10 @@ data:
         source_category: '%{_sourceCategory}'
         source_host: '%{_sourceHost}'
         source_name: '%{_sourceName}'
-      sumologic/systemd_flatten:
+      sumologic/systemd:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE}
         json_logs:
           add_timestamp: true
-          flatten_body: true
           timestamp_key: timestamp
         log_format: json
         sending_queue:
@@ -38,10 +37,11 @@ data:
         source_category: '%{_sourceCategory}'
         source_host: '%{_sourceHost}'
         source_name: '%{_sourceName}'
-      sumologic/systemd:
+      sumologic/systemd_flatten:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE}
         json_logs:
           add_timestamp: true
+          flatten_body: true
           timestamp_key: timestamp
         log_format: json
         sending_queue:

--- a/tests/helm/metadata_logs_otc/static/templates.output.yaml
+++ b/tests/helm/metadata_logs_otc/static/templates.output.yaml
@@ -25,6 +25,19 @@ data:
         source_category: '%{_sourceCategory}'
         source_host: '%{_sourceHost}'
         source_name: '%{_sourceName}'
+      sumologic/otlp_systemd:
+        endpoint: ${SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE}
+        json_logs:
+          add_timestamp: true
+          flatten_body: true
+          timestamp_key: timestamp
+        log_format: json
+        sending_queue:
+          enabled: true
+          persistent_storage_enabled: true
+        source_category: '%{_sourceCategory}'
+        source_host: '%{_sourceHost}'
+        source_name: '%{_sourceName}'
       sumologic/systemd:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE}
         json_logs:
@@ -266,7 +279,7 @@ data:
         source_category_prefix: "my_kubelet_sourceCategoryPrefix"
         source_category_replace_dash: "my_kubelet_sourceCategoryReplaceDash"
         source_host: '%{_sourceHost}'
-        source_name: "k8s_kubelet"
+        source_name: '%{_sourceName}'
       source/systemd:
         collector: "my_collectorName"
         source_category: "system"

--- a/tests/integration/helm_otelcol_logs_test.go
+++ b/tests/integration/helm_otelcol_logs_test.go
@@ -143,6 +143,34 @@ func Test_Helm_Otelcol_Logs(t *testing.T) {
 			waitDuration,
 			tickDuration,
 		)).
+		Assess("logs from node systemd present", stepfuncs.WaitUntilExpectedLogsPresent(
+			10, // we don't really control this, just want to check if the logs show up
+			map[string]string{
+				"cluster":         "kubernetes",
+				"_sourceName":     "",
+				"_sourceCategory": "kubernetes/system",
+				"_sourceHost":     "",
+			},
+			internal.ReceiverMockNamespace,
+			internal.ReceiverMockServiceName,
+			internal.ReceiverMockServicePort,
+			waitDuration,
+			tickDuration,
+		)).
+		Assess("logs from kubelet present", stepfuncs.WaitUntilExpectedLogsPresent(
+			1, // we don't really control this, just want to check if the logs show up
+			map[string]string{
+				"cluster":         "kubernetes",
+				"_sourceName":     "k8s_kubelet",
+				"_sourceCategory": "kubernetes/kubelet",
+				"_sourceHost":     "",
+			},
+			internal.ReceiverMockNamespace,
+			internal.ReceiverMockServiceName,
+			internal.ReceiverMockServicePort,
+			waitDuration,
+			tickDuration,
+		)).
 		Teardown(
 			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
 				opts := *ctxopts.KubectlOptions(ctx)

--- a/tests/integration/values/values_helm_otelcol_logs.yaml
+++ b/tests/integration/values/values_helm_otelcol_logs.yaml
@@ -34,14 +34,6 @@ metadata:
               - batch
             exporters:
               - sumologic/containers
-          ## disable fluent pipelines
-          logs/fluent/containers: null
-          logs/systemd:
-            receivers:
-              - otlp
-          logs/kubelet:
-            receivers:
-              - otlp
 
 otellogs:
   enabled: true

--- a/tests/integration/values/values_helm_otelcol_logs.yaml
+++ b/tests/integration/values/values_helm_otelcol_logs.yaml
@@ -73,6 +73,10 @@ metadata:
               - batch
             exporters:
               - sumologic/systemd_flatten
+          ## disable fluent pipelines
+          logs/fluent/containers: null
+          logs/fluent/systemd: null
+          logs/fluent/kubelet: null
 
 
 otellogs:
@@ -96,3 +100,17 @@ otellogs:
             record_attributes:
               - key: k8s.container.name
                 value: receiver-mock
+    receivers:
+      journald:
+        directory: /run/log/journal
+  daemonset:
+    extraVolumeMounts:
+      - mountPath: /run/log/journal
+        name: run-log-journal
+    extraVolumes:
+      # kind doesn't enable journald persistence, and the journal resides at /run/log/journal
+      # instead of /var/log/journal
+      - hostPath:
+          path: /run/log/journal
+          type: DirectoryOrCreate
+        name: run-log-journal

--- a/tests/integration/values/values_helm_otelcol_logs.yaml
+++ b/tests/integration/values/values_helm_otelcol_logs.yaml
@@ -53,7 +53,7 @@ metadata:
               - source/systemd
               - batch
             exporters:
-              - sumologic/otlp_systemd
+              - sumologic/systemd_flatten
           logs/otlp/kubelet:
             receivers:
               - otlp
@@ -72,7 +72,7 @@ metadata:
               - source/kubelet
               - batch
             exporters:
-              - sumologic/otlp_systemd
+              - sumologic/systemd_flatten
 
 
 otellogs:

--- a/tests/integration/values/values_helm_otelcol_logs.yaml
+++ b/tests/integration/values/values_helm_otelcol_logs.yaml
@@ -34,50 +34,14 @@ metadata:
               - batch
             exporters:
               - sumologic/containers
-          logs/otlp/systemd:
-            receivers:
-              - otlp
-            processors:
-              - memory_limiter
-              - filter/include_fluent_tag_host
-              - filter/include_systemd
-              - filter/exclude_kubelet
-              - filter/exclude_systemd_syslog
-              - filter/exclude_systemd_hostname
-              - filter/exclude_systemd_priority
-              - filter/exclude_systemd_unit
-              - attributes/extract_systemd_source_fields
-              - attributes/remove_fluent_tag
-              - groupbyattrs/systemd
-              - resource/add_cluster
-              - source/systemd
-              - batch
-            exporters:
-              - sumologic/systemd_flatten
-          logs/otlp/kubelet:
-            receivers:
-              - otlp
-            processors:
-              - memory_limiter
-              - filter/include_fluent_tag_host
-              - filter/include_kubelet
-              - filter/exclude_kubelet_syslog
-              - filter/exclude_kubelet_hostname
-              - filter/exclude_kubelet_priority
-              - filter/exclude_kubelet_unit
-              - attributes/extract_systemd_source_fields
-              - attributes/remove_fluent_tag
-              - groupbyattrs/systemd
-              - resource/add_cluster
-              - source/kubelet
-              - batch
-            exporters:
-              - sumologic/systemd_flatten
           ## disable fluent pipelines
           logs/fluent/containers: null
-          logs/fluent/systemd: null
-          logs/fluent/kubelet: null
-
+          logs/systemd:
+            receivers:
+              - otlp
+          logs/kubelet:
+            receivers:
+              - otlp
 
 otellogs:
   enabled: true

--- a/tests/integration/values/values_helm_otelcol_logs.yaml
+++ b/tests/integration/values/values_helm_otelcol_logs.yaml
@@ -24,14 +24,55 @@ metadata:
               - otlp
             processors:
               - memory_limiter
+              - filter/include_containers
               - groupbyattrs/containers
               - k8s_tagger
               - resource/add_cluster
               - source/containers
+              - resource/drop_annotations
               - resource/containers_copy_node_to_host
               - batch
             exporters:
               - sumologic/containers
+          logs/otlp/systemd:
+            receivers:
+              - otlp
+            processors:
+              - memory_limiter
+              - filter/include_fluent_tag_host
+              - filter/include_systemd
+              - filter/exclude_kubelet
+              - filter/exclude_systemd_syslog
+              - filter/exclude_systemd_hostname
+              - filter/exclude_systemd_priority
+              - filter/exclude_systemd_unit
+              - attributes/extract_systemd_source_fields
+              - attributes/remove_fluent_tag
+              - groupbyattrs/systemd
+              - resource/add_cluster
+              - source/systemd
+              - batch
+            exporters:
+              - sumologic/otlp_systemd
+          logs/otlp/kubelet:
+            receivers:
+              - otlp
+            processors:
+              - memory_limiter
+              - filter/include_fluent_tag_host
+              - filter/include_kubelet
+              - filter/exclude_kubelet_syslog
+              - filter/exclude_kubelet_hostname
+              - filter/exclude_kubelet_priority
+              - filter/exclude_kubelet_unit
+              - attributes/extract_systemd_source_fields
+              - attributes/remove_fluent_tag
+              - groupbyattrs/systemd
+              - resource/add_cluster
+              - source/kubelet
+              - batch
+            exporters:
+              - sumologic/otlp_systemd
 
 
 otellogs:

--- a/vagrant/values.yaml
+++ b/vagrant/values.yaml
@@ -248,7 +248,7 @@ metadata:
               - batch
             exporters:
               - sumologic/containers
-          logs/fluent/systemd:
+          logs/systemd:
             processors:
               - memory_limiter
               - filter/include_fluent_tag_host
@@ -265,7 +265,7 @@ metadata:
               - resource/add_cluster
               - source/systemd
               - batch
-          logs/fluent/kubelet:
+          logs/kubelet:
             processors:
               - memory_limiter
               - filter/include_fluent_tag_host

--- a/vagrant/values.yaml
+++ b/vagrant/values.yaml
@@ -248,7 +248,7 @@ metadata:
               - batch
             exporters:
               - sumologic/containers
-          logs/systemd:
+          logs/fluent/systemd:
             processors:
               - memory_limiter
               - filter/include_fluent_tag_host
@@ -265,7 +265,7 @@ metadata:
               - resource/add_cluster
               - source/systemd
               - batch
-          logs/kubelet:
+          logs/fluent/kubelet:
             processors:
               - memory_limiter
               - filter/include_fluent_tag_host
@@ -279,4 +279,38 @@ metadata:
               - groupbyattrs/systemd
               - resource/add_cluster
               - source/kubelet
+              - batch
+          logs/otlp/systemd:
+            processors:
+              - memory_limiter
+              - filter/include_fluent_tag_host
+              - filter/include_systemd
+              - filter/exclude_systemd_snap_kubelite
+              - filter/exclude_kubelet
+              - filter/exclude_systemd_syslog
+              - filter/exclude_systemd_hostname
+              - filter/exclude_systemd_priority
+              - filter/exclude_systemd_unit
+              - attributes/extract_systemd_source_fields
+              - attributes/remove_fluent_tag
+              - groupbyattrs/systemd
+              - resource/add_cluster
+              - source/systemd
+              - transform/remove_attributes
+              - batch
+          logs/otlp/kubelet:
+            processors:
+              - memory_limiter
+              - filter/include_fluent_tag_host
+              - filter/include_systemd_snap_kubelite
+              - filter/exclude_kubelet_syslog
+              - filter/exclude_kubelet_hostname
+              - filter/exclude_kubelet_priority
+              - filter/exclude_kubelet_unit
+              - attributes/extract_systemd_source_fields
+              - attributes/remove_fluent_tag
+              - groupbyattrs/systemd
+              - resource/add_cluster
+              - source/kubelet
+              - transform/remove_attributes
               - batch


### PR DESCRIPTION
##### Description

Add support for journald receiver. This behaves like fluent-bit with one small exception. Units for filtering are taken from different place.

```
        ## This is not a full equivalent of fluent-bit filtering as fluent-bit filters by `_SYSTEMD_UNIT`
        ## Here is filtering by `UNIT`
```

---

##### Checklist

<!---
Remove items which don't apply to your PR.
-->

- [ ] Changelog updated

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
