### PR TITLE
feat(metrics): add service metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- feat(metrics): add service metrics [#2367]
 - fix(metrics): remove outdated API calls [#2372]
 
+[#2367]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2367
 [#2372]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2372
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.10.0...main
 

--- a/deploy/docs/scraped_metrics.md
+++ b/deploy/docs/scraped_metrics.md
@@ -170,6 +170,10 @@ The following table contains information about metrics scraped by Sumo Logic's P
 | `kube_pod_container_status_waiting_reason`               | kube-state-metrics | yes       |
 | `kube_pod_status_phase`                                  | kube-state-metrics | yes       |
 | `kube_pod_info`                                          | kube-state-metrics | no        |
+| `kube_service_info`                                      | kube-state-metrics | yes       |
+| `kube_service_spec_external_ip`                          | kube-state-metrics | yes       |
+| `kube_service_spec_type`                                 | kube-state-metrics | yes       |
+| `kube_service_status_load_balancer_ingress`              | kube-state-metrics | yes       |
 | `node_cpu_seconds_total`                                 | node-exporter      | yes       |
 | `node_load1`                                             | node-exporter      | yes       |
 | `node_load5`                                             | node-exporter      | yes       |

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1378,7 +1378,7 @@ kube-prometheus-stack:
     serviceMonitor:
       ## Scrape interval. If not set, the Prometheus default scrape interval is used.
       interval:
-      ## see docs/scrape_metrics.md
+      ## see docs/scraped_metrics.md
       ## apiserver_request_count
       ## apiserver_request_total
       ## apiserver_request_duration_seconds_count
@@ -1401,7 +1401,7 @@ kube-prometheus-stack:
       probes: false
       ## Enable scraping /metrics/resource/v1alpha1 from kubelet's service
       resource: false
-      ## see docs/scrape_metrics.md
+      ## see docs/scraped_metrics.md
       ## kubelet metrics:
       ## kubelet_docker_operations_errors
       ## kubelet_docker_operations_errors_total
@@ -1425,7 +1425,7 @@ kube-prometheus-stack:
           sourceLabels: [__name__]
         - action: labeldrop
           regex: id
-      ## see docs/scrape_metrics.md
+      ## see docs/scraped_metrics.md
       ## cadvisor container metrics
       ## container_cpu_usage_seconds_total
       ## container_fs_limit_bytes
@@ -1452,7 +1452,7 @@ kube-prometheus-stack:
     serviceMonitor:
       ## Scrape interval. If not set, the Prometheus default scrape interval is used.
       interval:
-      ## see docs/scrape_metrics.md
+      ## see docs/scraped_metrics.md
       ## controller manager metrics
       ## https://kubernetes.io/docs/concepts/cluster-administration/monitoring/#kube-controller-manager-metrics
       ## e.g.
@@ -1467,7 +1467,7 @@ kube-prometheus-stack:
     serviceMonitor:
       ## Scrape interval. If not set, the Prometheus default scrape interval is used.
       interval:
-      ## see docs/scrape_metrics.md
+      ## see docs/scraped_metrics.md
       ## coredns:
       ## coredns_cache_size
       ## coredns_cache_entries
@@ -1492,7 +1492,7 @@ kube-prometheus-stack:
     serviceMonitor:
       ## Scrape interval. If not set, the Prometheus default scrape interval is used.
       interval:
-      ## see docs/scrape_metrics.md
+      ## see docs/scraped_metrics.md
       ## etcd_request_cache_get_duration_seconds_count
       ## etcd_request_cache_get_duration_seconds_sum
       ## etcd_request_cache_add_duration_seconds_count
@@ -1532,7 +1532,7 @@ kube-prometheus-stack:
     serviceMonitor:
       ## Scrape interval. If not set, the Prometheus default scrape interval is used.
       interval:
-      ## see docs/scrape_metrics.md
+      ## see docs/scraped_metrics.md
       ## scheduler metrics_latency_microseconds
       ## scheduler_e2e_scheduling_duration_seconds_bucket
       ## scheduler_e2e_scheduling_duration_seconds_count
@@ -1554,7 +1554,7 @@ kube-prometheus-stack:
     serviceMonitor:
       ## Scrape interval. If not set, the Prometheus default scrape interval is used.
       interval:
-      ## see docs/scrape_metrics.md
+      ## see docs/scraped_metrics.md
       ## kube_daemonset_status_current_number_scheduled
       ## kube_daemonset_status_desired_number_scheduled
       ## kube_daemonset_status_number_misscheduled
@@ -1585,15 +1585,19 @@ kube-prometheus-stack:
       ## kube_pod_container_status_waiting_reason
       ## kube_pod_status_phase
       ## kube_pod_info
+      ## kube_service_info
+      ## kube_service_spec_external_ip
+      ## kube_service_spec_type
+      ## kube_service_status_load_balancer_ingress
       metricRelabelings:
         - action: keep
-          regex: (?:kube_statefulset_status_observed_generation|kube_statefulset_status_replicas|kube_statefulset_replicas|kube_statefulset_metadata_generation|kube_daemonset_status_current_number_scheduled|kube_daemonset_status_desired_number_scheduled|kube_daemonset_status_number_misscheduled|kube_daemonset_status_number_unavailable|kube_deployment_spec_replicas|kube_deployment_status_replicas_available|kube_deployment_status_replicas_unavailable|kube_node_info|kube_node_status_allocatable|kube_node_status_capacity|kube_node_status_condition|kube_hpa_spec_max_replicas|kube_hpa_spec_min_replicas|kube_hpa_status_(condition|(current|desired)_replicas)|kube_pod_container_info|kube_pod_container_resource_requests|kube_pod_container_resource_limits|kube_pod_container_status_ready|kube_pod_container_status_terminated_reason|kube_pod_container_status_waiting_reason|kube_pod_container_status_restarts_total|kube_pod_status_phase|kube_pod_info)
+          regex: (?:kube_statefulset_status_observed_generation|kube_statefulset_status_replicas|kube_statefulset_replicas|kube_statefulset_metadata_generation|kube_daemonset_status_current_number_scheduled|kube_daemonset_status_desired_number_scheduled|kube_daemonset_status_number_misscheduled|kube_daemonset_status_number_unavailable|kube_deployment_spec_replicas|kube_deployment_status_replicas_available|kube_deployment_status_replicas_unavailable|kube_node_info|kube_node_status_allocatable|kube_node_status_capacity|kube_node_status_condition|kube_hpa_spec_max_replicas|kube_hpa_spec_min_replicas|kube_hpa_status_(condition|(current|desired)_replicas)|kube_pod_container_info|kube_pod_container_resource_requests|kube_pod_container_resource_limits|kube_pod_container_status_ready|kube_pod_container_status_terminated_reason|kube_pod_container_status_waiting_reason|kube_pod_container_status_restarts_total|kube_pod_status_phase|kube_pod_info|kube_service_info|kube_service_spec_external_ip|kube_service_spec_type|kube_service_status_load_balancer_ingress)
           sourceLabels: [ __name__]
   nodeExporter:
     serviceMonitor:
       ## Scrape interval. If not set, the Prometheus default scrape interval is used.
       interval:
-      ## see docs/scrape_metrics.md
+      ## see docs/scraped_metrics.md
       ## node exporter metrics
       ## node_cpu_seconds_total
       ## node_load1
@@ -1925,11 +1929,15 @@ kube-prometheus-stack:
         ## kube_hpa_status_condition
         ## kube_hpa_status_current_replicas
         ## kube_hpa_status_desired_replicas
+        ## kube_service_info
+        ## kube_service_spec_external_ip
+        ## kube_service_spec_type
+        ## kube_service_status_load_balancer_ingress
         - url: http://$(FLUENTD_METRICS_SVC).$(NAMESPACE).svc.cluster.local:9888/prometheus.metrics.state
           remoteTimeout: 5s
           writeRelabelConfigs:
             - action: keep
-              regex: kube-state-metrics;(?:kube_statefulset_status_observed_generation|kube_statefulset_status_replicas|kube_statefulset_replicas|kube_statefulset_metadata_generation|kube_daemonset_status_current_number_scheduled|kube_daemonset_status_desired_number_scheduled|kube_daemonset_status_number_misscheduled|kube_daemonset_status_number_unavailable|kube_deployment_spec_replicas|kube_deployment_status_replicas_available|kube_deployment_status_replicas_unavailable|kube_node_info|kube_node_status_allocatable|kube_node_status_capacity|kube_node_status_condition|kube_hpa_spec_max_replicas|kube_hpa_spec_min_replicas|kube_hpa_status_(condition|(current|desired)_replicas))
+              regex: kube-state-metrics;(?:kube_statefulset_status_observed_generation|kube_statefulset_status_replicas|kube_statefulset_replicas|kube_statefulset_metadata_generation|kube_daemonset_status_current_number_scheduled|kube_daemonset_status_desired_number_scheduled|kube_daemonset_status_number_misscheduled|kube_daemonset_status_number_unavailable|kube_deployment_spec_replicas|kube_deployment_status_replicas_available|kube_deployment_status_replicas_unavailable|kube_node_info|kube_node_status_allocatable|kube_node_status_capacity|kube_node_status_condition|kube_hpa_spec_max_replicas|kube_hpa_spec_min_replicas|kube_hpa_status_(condition|(current|desired)_replicas)|kube_service_info|kube_service_spec_external_ip|kube_service_spec_type|kube_service_status_load_balancer_ingress)
               sourceLabels: [job, __name__]
             - action: labelmap
               regex: (pod|service)

--- a/examples/kube_prometheus_stack/values-prometheus.yaml
+++ b/examples/kube_prometheus_stack/values-prometheus.yaml
@@ -214,7 +214,7 @@ kubeApiServer:
   serviceMonitor:
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     interval:
-    ## see docs/scrape_metrics.md
+    ## see docs/scraped_metrics.md
     ## apiserver_request_count
     ## apiserver_request_total
     ## apiserver_request_duration_seconds_count
@@ -237,7 +237,7 @@ kubelet:
     probes: false
     ## Enable scraping /metrics/resource/v1alpha1 from kubelet's service
     resource: false
-    ## see docs/scrape_metrics.md
+    ## see docs/scraped_metrics.md
     ## kubelet metrics:
     ## kubelet_docker_operations_errors
     ## kubelet_docker_operations_errors_total
@@ -261,7 +261,7 @@ kubelet:
         sourceLabels: [__name__]
       - action: labeldrop
         regex: id
-    ## see docs/scrape_metrics.md
+    ## see docs/scraped_metrics.md
     ## cadvisor container metrics
     ## container_cpu_usage_seconds_total
     ## container_fs_limit_bytes
@@ -288,7 +288,7 @@ kubeControllerManager:
   serviceMonitor:
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     interval:
-    ## see docs/scrape_metrics.md
+    ## see docs/scraped_metrics.md
     ## controller manager metrics
     ## https://kubernetes.io/docs/concepts/cluster-administration/monitoring/#kube-controller-manager-metrics
     ## e.g.
@@ -303,7 +303,7 @@ coreDns:
   serviceMonitor:
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     interval:
-    ## see docs/scrape_metrics.md
+    ## see docs/scraped_metrics.md
     ## coredns:
     ## coredns_cache_size
     ## coredns_cache_entries
@@ -328,7 +328,7 @@ kubeEtcd:
   serviceMonitor:
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     interval:
-    ## see docs/scrape_metrics.md
+    ## see docs/scraped_metrics.md
     ## etcd_request_cache_get_duration_seconds_count
     ## etcd_request_cache_get_duration_seconds_sum
     ## etcd_request_cache_add_duration_seconds_count
@@ -368,7 +368,7 @@ kubeScheduler:
   serviceMonitor:
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     interval:
-    ## see docs/scrape_metrics.md
+    ## see docs/scraped_metrics.md
     ## scheduler metrics_latency_microseconds
     ## scheduler_e2e_scheduling_duration_seconds_bucket
     ## scheduler_e2e_scheduling_duration_seconds_count
@@ -390,7 +390,7 @@ kubeStateMetrics:
   serviceMonitor:
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     interval:
-    ## see docs/scrape_metrics.md
+    ## see docs/scraped_metrics.md
     ## kube_daemonset_status_current_number_scheduled
     ## kube_daemonset_status_desired_number_scheduled
     ## kube_daemonset_status_number_misscheduled
@@ -429,7 +429,7 @@ nodeExporter:
   serviceMonitor:
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     interval:
-    ## see docs/scrape_metrics.md
+    ## see docs/scraped_metrics.md
     ## node exporter metrics
     ## node_cpu_seconds_total
     ## node_load1


### PR DESCRIPTION
This adds the following metrics from [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics/blob/v1.9.8/docs/service-metrics.md):
- kube_service_info
- kube_service_spec_external_ip
- kube_service_spec_type
- kube_service_status_load_balancer_ingress

This should help answer questions like:
- what is the type of a given service?
- what is the cluster IP of a given service?
- what is the external IP of a given service?
