### PR TITLE
fix(metrics): remove outdated API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- fix(metrics): remove outdated API calls [#2372]
+
+[#2372]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2372
+[Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.10.0...main
+
 ## [v2.10.0]
 
 ### Released 2022-06-09

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1648,6 +1648,12 @@ kube-prometheus-stack:
     image:
       repository: k8s.gcr.io/kube-state-metrics/kube-state-metrics
       tag: v1.9.8
+    # Do not collect metrics for CertificateSigningRequest or Ingress resources.
+    # This is because the v1 version of kube-state-metrics uses API versions
+    # that are removed in Kubernetes v1.22.
+    collectors:
+      certificatesigningrequests: false
+      ingresses: false
     ## Custom labels to apply to service, deployment and pods
     customLabels: {}
     ## Additional annotations for pods in the DaemonSet


### PR DESCRIPTION
`kube-state-metrics` v1.9.8 collects metrics about `Ingress` and `CertificateSigningRequest` resources using outdated API versions:

- `extensions/v1beta1` for `Ingress`
- `certificates.k8s.io/v1beta1` for `CertificateSigningRequest`

These API versions have been [removed in Kubernetes v1.22](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22). We don't use those metrics anyway, so let's just tell kube-state-metrics to not collect metrics about these resources.
