### PR TITLE
Shorter OT Operator label value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - feat(metrics): add service metrics [#2367]
 - fix(metrics): remove outdated API calls [#2372]
+- fix(ot-operator): shorter labels values [#2374]
 
 [#2367]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2367
 [#2372]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2372
+[#2374]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2374
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.10.0...main
 
 ## [v2.10.0]

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -172,11 +172,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "sumologic.labels.app.opentelemetry.operator" -}}
-{{- template "sumologic.fullname" . }}-opentelemetry-operator
+{{- template "sumologic.fullname" . }}-ot-operator
 {{- end -}}
 
 {{- define "sumologic.labels.app.opentelemetry.operator.instrumentation" -}}
-{{- template "sumologic.labels.app.opentelemetry.operator" . }}-instrumentation
+{{- template "sumologic.labels.app.opentelemetry.operator" . }}-instr
 {{- end -}}
 
 {{- define "sumologic.labels.app.otelcol" -}}
@@ -492,11 +492,11 @@ helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 {{- end -}}
 
 {{- define "sumologic.metadata.name.opentelemetry.operator" -}}
-{{ template "sumologic.fullname" . }}-opentelemetry-operator
+{{ template "sumologic.fullname" . }}-ot-operator
 {{- end -}}
 
 {{- define "sumologic.metadata.name.opentelemetry.operator.instrumentation" -}}
-{{ template "sumologic.metadata.name.opentelemetry.operator" . }}-instrumentation
+{{ template "sumologic.metadata.name.opentelemetry.operator" . }}-instr
 {{- end -}}
 
 {{- define "sumologic.metadata.name.otelcol" -}}

--- a/tests/helm/opentelemetry_operator_instrumentation_cr/static/instrumentation.output.yaml
+++ b/tests/helm/opentelemetry_operator_instrumentation_cr/static/instrumentation.output.yaml
@@ -4,9 +4,9 @@ apiVersion: opentelemetry.io/v1alpha1
 kind: Instrumentation
 metadata:
   namespace: ot-operator1
-  name: RELEASE-NAME-sumologic-opentelemetry-operator-instrumentation
+  name: RELEASE-NAME-sumologic-ot-operator-instr
   labels:
-    app: RELEASE-NAME-sumologic-opentelemetry-operator-instrumentation
+    app: RELEASE-NAME-sumologic-ot-operator-instr
     chart: "sumologic-%CURRENT_CHART_VERSION%"
     release: "RELEASE-NAME"
     heritage: "Helm"
@@ -56,9 +56,9 @@ apiVersion: opentelemetry.io/v1alpha1
 kind: Instrumentation
 metadata:
   namespace: ot-operator2
-  name: RELEASE-NAME-sumologic-opentelemetry-operator-instrumentation
+  name: RELEASE-NAME-sumologic-ot-operator-instr
   labels:
-    app: RELEASE-NAME-sumologic-opentelemetry-operator-instrumentation
+    app: RELEASE-NAME-sumologic-ot-operator-instr
     chart: "sumologic-%CURRENT_CHART_VERSION%"
     release: "RELEASE-NAME"
     heritage: "Helm"

--- a/tests/integration/helm_opentelemetry_operator_enabled_test.go
+++ b/tests/integration/helm_opentelemetry_operator_enabled_test.go
@@ -131,7 +131,7 @@ func Test_Helm_OpenTelemetry_Operator_Enabled(t *testing.T) {
 		Assess("instrumentation-cr in ot-operator1 namespace is created", func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
 			res := envConf.Client().Resources("ot-operator1")
 			releaseName := ctxopts.HelmRelease(ctx)
-			labelSelector := fmt.Sprintf("app=%s-sumologic-opentelemetry-operator-instrumentation", releaseName)
+			labelSelector := fmt.Sprintf("app=%s-sumologic-ot-operator-instr", releaseName)
 			instrs := otoperatorappsv1.InstrumentationList{}
 
 			require.NoError(t,
@@ -149,7 +149,7 @@ func Test_Helm_OpenTelemetry_Operator_Enabled(t *testing.T) {
 		Assess("instrumentation-cr in ot-operator2 namespace is created", func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
 			res := envConf.Client().Resources("ot-operator2")
 			releaseName := ctxopts.HelmRelease(ctx)
-			labelSelector := fmt.Sprintf("app=%s-sumologic-opentelemetry-operator-instrumentation", releaseName)
+			labelSelector := fmt.Sprintf("app=%s-sumologic-ot-operator-instr", releaseName)
 			instrs := otoperatorappsv1.InstrumentationList{}
 
 			require.NoError(t,


### PR DESCRIPTION
##### Description

Set shorter names to OT Operator resources.

Reson:
```
one or more objects failed to apply, reason: Instrumentation.opentelemetry.io "stag-collection-sumologic-opentelemetry-operator-instrumentation" is invalid: metadata.labels: Invalid value: "stag-collection-sumologic-opentelemetry-operator-instrumentation": must be no more than 63 characters
```

---

##### Checklist

<!---
Remove items which don't apply to your PR.
-->

- [x] Changelog updated

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
