### PR TITLE
chore: upgrade kubernetes terraform provider to 2.4

### DIFF
--- a/deploy/helm/sumologic/conf/setup/main.tf
+++ b/deploy/helm/sumologic/conf/setup/main.tf
@@ -6,7 +6,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.13"
+      version = "~> 2.4"
     }
   }
 }

--- a/deploy/helm/sumologic/conf/setup/providers.tf
+++ b/deploy/helm/sumologic/conf/setup/providers.tf
@@ -19,7 +19,7 @@ provider "kubernetes" {
     }
     {{ end }}
   }
-  {{- else -}}
+  {{- else if not (eq $key "load_config_file") -}}
   {{ printf "  %-25s" $key }} = {{ include "terraform.print_value" $value }}
   {{- end }}
 {{- end }}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -56,6 +56,7 @@ sumologic:
     # config_context_auth_info:
     # config_context_cluster:
     token: "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/token\")}"
+    ## load_config_file is deprecated and no longer used
     load_config_file: false
     # exec:
     #   api_version:

--- a/tests/helm/terraform/static/all_fields.output.yaml
+++ b/tests/helm/terraform/static/all_fields.output.yaml
@@ -281,7 +281,7 @@ data:
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"
-          version = "~> 1.13"
+          version = "~> 2.4"
         }
       }
     }
@@ -373,7 +373,7 @@ data:
     
         cluster_ca_certificate    = file("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
         host                      = "https://kubernetes.default.svc"
-        load_config_file          = "false"
+      
         token                     = file("/var/run/secrets/kubernetes.io/serviceaccount/token")
     }
   resources.tf: |

--- a/tests/helm/terraform/static/collector_fields.output.yaml
+++ b/tests/helm/terraform/static/collector_fields.output.yaml
@@ -280,7 +280,7 @@ data:
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"
-          version = "~> 1.13"
+          version = "~> 2.4"
         }
       }
     }
@@ -372,7 +372,7 @@ data:
     
         cluster_ca_certificate    = file("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
         host                      = "https://kubernetes.default.svc"
-        load_config_file          = "false"
+      
         token                     = file("/var/run/secrets/kubernetes.io/serviceaccount/token")
     }
   resources.tf: |

--- a/tests/helm/terraform/static/conditional_sources.output.yaml
+++ b/tests/helm/terraform/static/conditional_sources.output.yaml
@@ -270,7 +270,7 @@ data:
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"
-          version = "~> 1.13"
+          version = "~> 2.4"
         }
       }
     }
@@ -362,7 +362,7 @@ data:
     
         cluster_ca_certificate    = file("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
         host                      = "https://kubernetes.default.svc"
-        load_config_file          = "false"
+      
         token                     = file("/var/run/secrets/kubernetes.io/serviceaccount/token")
     }
   resources.tf: |

--- a/tests/helm/terraform/static/custom.output.yaml
+++ b/tests/helm/terraform/static/custom.output.yaml
@@ -270,7 +270,7 @@ data:
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"
-          version = "~> 1.13"
+          version = "~> 2.4"
         }
       }
     }
@@ -362,7 +362,7 @@ data:
     
         cluster_ca_certificate    = file("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
         host                      = "https://kubernetes.default.svc"
-        load_config_file          = "false"
+      
         token                     = file("/var/run/secrets/kubernetes.io/serviceaccount/token")
     }
   resources.tf: |

--- a/tests/helm/terraform/static/default.output.yaml
+++ b/tests/helm/terraform/static/default.output.yaml
@@ -280,7 +280,7 @@ data:
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"
-          version = "~> 1.13"
+          version = "~> 2.4"
         }
       }
     }
@@ -372,7 +372,7 @@ data:
     
         cluster_ca_certificate    = file("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
         host                      = "https://kubernetes.default.svc"
-        load_config_file          = "false"
+      
         token                     = file("/var/run/secrets/kubernetes.io/serviceaccount/token")
     }
   resources.tf: |

--- a/tests/helm/terraform/static/disable_default_metrics.output.yaml
+++ b/tests/helm/terraform/static/disable_default_metrics.output.yaml
@@ -279,7 +279,7 @@ data:
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"
-          version = "~> 1.13"
+          version = "~> 2.4"
         }
       }
     }
@@ -371,7 +371,7 @@ data:
     
         cluster_ca_certificate    = file("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
         host                      = "https://kubernetes.default.svc"
-        load_config_file          = "false"
+      
         token                     = file("/var/run/secrets/kubernetes.io/serviceaccount/token")
     }
   resources.tf: |

--- a/tests/helm/terraform/static/disabled_dashboards.output.yaml
+++ b/tests/helm/terraform/static/disabled_dashboards.output.yaml
@@ -280,7 +280,7 @@ data:
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"
-          version = "~> 1.13"
+          version = "~> 2.4"
         }
       }
     }
@@ -372,7 +372,7 @@ data:
     
         cluster_ca_certificate    = file("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
         host                      = "https://kubernetes.default.svc"
-        load_config_file          = "false"
+      
         token                     = file("/var/run/secrets/kubernetes.io/serviceaccount/token")
     }
   resources.tf: |

--- a/tests/helm/terraform/static/disabled_monitors.output.yaml
+++ b/tests/helm/terraform/static/disabled_monitors.output.yaml
@@ -280,7 +280,7 @@ data:
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"
-          version = "~> 1.13"
+          version = "~> 2.4"
         }
       }
     }
@@ -372,7 +372,7 @@ data:
     
         cluster_ca_certificate    = file("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
         host                      = "https://kubernetes.default.svc"
-        load_config_file          = "false"
+      
         token                     = file("/var/run/secrets/kubernetes.io/serviceaccount/token")
     }
   resources.tf: |

--- a/tests/helm/terraform/static/monitors_with_email_notifications.output.yaml
+++ b/tests/helm/terraform/static/monitors_with_email_notifications.output.yaml
@@ -280,7 +280,7 @@ data:
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"
-          version = "~> 1.13"
+          version = "~> 2.4"
         }
       }
     }
@@ -378,7 +378,7 @@ data:
     
         cluster_ca_certificate    = file("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
         host                      = "https://kubernetes.default.svc"
-        load_config_file          = "false"
+      
         token                     = file("/var/run/secrets/kubernetes.io/serviceaccount/token")
     }
   resources.tf: |

--- a/tests/helm/terraform/static/monitors_with_single_email.output.yaml
+++ b/tests/helm/terraform/static/monitors_with_single_email.output.yaml
@@ -280,7 +280,7 @@ data:
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"
-          version = "~> 1.13"
+          version = "~> 2.4"
         }
       }
     }
@@ -378,7 +378,7 @@ data:
     
         cluster_ca_certificate    = file("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
         host                      = "https://kubernetes.default.svc"
-        load_config_file          = "false"
+      
         token                     = file("/var/run/secrets/kubernetes.io/serviceaccount/token")
     }
   resources.tf: |

--- a/tests/helm/terraform/static/strip_extrapolation.output.yaml
+++ b/tests/helm/terraform/static/strip_extrapolation.output.yaml
@@ -280,7 +280,7 @@ data:
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"
-          version = "~> 1.13"
+          version = "~> 2.4"
         }
       }
     }
@@ -373,7 +373,7 @@ data:
         cluster_ca_certificate    = file("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
         extrapolation             = "${file("/var/run/secrets/kubernetes.io/serviceaccount/token")}/${test}"
         host                      = "https://kubernetes.default.svc"
-        load_config_file          = "false"
+      
         token                     = file("/var/run/secrets/kubernetes.io/serviceaccount/token")
     }
   resources.tf: |

--- a/tests/helm/terraform/static/traces.output.yaml
+++ b/tests/helm/terraform/static/traces.output.yaml
@@ -272,7 +272,7 @@ data:
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"
-          version = "~> 1.13"
+          version = "~> 2.4"
         }
       }
     }
@@ -364,7 +364,7 @@ data:
     
         cluster_ca_certificate    = file("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
         host                      = "https://kubernetes.default.svc"
-        load_config_file          = "false"
+      
         token                     = file("/var/run/secrets/kubernetes.io/serviceaccount/token")
     }
   resources.tf: |


### PR DESCRIPTION
##### Description

Upgrade kubernetes terraform provider due to security issues

```
➜  ~ grype --add-cpes-if-none docker.io/library/kubernetes-setup:latest 
 ✔ Vulnerability DB        [no update available]
New version of grype is available: 0.40.1
 ✔ Loaded image            
 ✔ Parsed image            
 ✔ Cataloged packages      [387 packages]
 ✔ Scanned image           [39 vulnerabilities]
NAME                             INSTALLED                                     FIXED-IN  TYPE       VULNERABILITY        SEVERITY 
github.com/gogo/protobuf         v1.3.1                                        1.3.2     go-module  GHSA-c3h9-896r-86jm  High      
github.com/hashicorp/consul/api  v1.9.1                                                  go-module  CVE-2021-36213       High      
github.com/hashicorp/consul/api  v1.9.1                                                  go-module  CVE-2021-28156       High      
github.com/hashicorp/consul/api  v1.9.1                                                  go-module  CVE-2021-37219       High      
github.com/hashicorp/consul/api  v1.9.1                                                  go-module  CVE-2021-41805       High      
github.com/hashicorp/consul/api  v1.9.1                                                  go-module  CVE-2020-25864       Medium    
github.com/hashicorp/consul/api  v1.9.1                                                  go-module  CVE-2022-29153       High      
github.com/hashicorp/consul/api  v1.9.1                                                  go-module  CVE-2022-24687       Medium    
github.com/hashicorp/consul/api  v1.9.1                                                  go-module  CVE-2021-38698       Medium    
github.com/hashicorp/consul/api  v1.9.1                                                  go-module  CVE-2021-3121        High      
github.com/hashicorp/consul/api  v1.9.1                                                  go-module  CVE-2021-32574       High      
github.com/hashicorp/go-getter   v1.4.2-0.20200106182914-9813cbd4eb02                    go-module  CVE-2022-30321       Critical  
github.com/hashicorp/go-getter   v1.4.2-0.20200106182914-9813cbd4eb02                    go-module  CVE-2022-30322       Critical  
github.com/hashicorp/go-getter   v1.4.2-0.20200106182914-9813cbd4eb02          1.5.11    go-module  GHSA-27rq-4943-qcwp  Medium    
github.com/hashicorp/go-getter   v1.4.2-0.20200106182914-9813cbd4eb02          1.6.1     go-module  GHSA-fcgg-rvwg-jv58  Critical  
github.com/hashicorp/go-getter   v1.4.2-0.20200106182914-9813cbd4eb02                    go-module  CVE-2022-29810       Medium    
github.com/hashicorp/go-getter   v1.5.3                                                  go-module  CVE-2022-29810       Medium    
github.com/hashicorp/go-getter   v1.5.3                                                  go-module  CVE-2022-30321       Critical  
github.com/hashicorp/go-getter   v1.4.2-0.20200106182914-9813cbd4eb02          1.6.1     go-module  GHSA-cjr4-fv6c-f3mv  Critical  
github.com/hashicorp/go-getter   v1.5.3                                        1.6.1     go-module  GHSA-x24g-9w7v-vprh  Critical  
github.com/hashicorp/go-getter   v1.5.3                                        1.6.1     go-module  GHSA-fcgg-rvwg-jv58  Critical  
github.com/hashicorp/go-getter   v1.4.2-0.20200106182914-9813cbd4eb02                    go-module  CVE-2022-26945       Critical  
github.com/hashicorp/go-getter   v1.5.3                                        1.6.1     go-module  GHSA-28r2-q6m8-9hpx  High      
github.com/hashicorp/go-getter   v1.5.3                                        1.6.1     go-module  GHSA-cjr4-fv6c-f3mv  Critical  
github.com/hashicorp/go-getter   v1.5.3                                                  go-module  CVE-2022-30322       Critical  
github.com/hashicorp/go-getter   v1.5.3                                                  go-module  CVE-2022-30323       Critical  
github.com/hashicorp/go-getter   v1.5.3                                                  go-module  CVE-2022-26945       Critical  
github.com/hashicorp/go-getter   v1.4.2-0.20200106182914-9813cbd4eb02                    go-module  CVE-2022-30323       Critical  
github.com/hashicorp/go-getter   v1.4.2-0.20200106182914-9813cbd4eb02          1.6.1     go-module  GHSA-x24g-9w7v-vprh  Critical  
github.com/hashicorp/go-getter   v1.5.3                                        1.5.11    go-module  GHSA-27rq-4943-qcwp  Medium    
github.com/hashicorp/go-getter   v1.4.2-0.20200106182914-9813cbd4eb02          1.6.1     go-module  GHSA-28r2-q6m8-9hpx  High      
github.com/hashicorp/terraform   9cc7dbd4f514431cee31155663c16d4f7f77f979                go-module  CVE-2021-36230       High      
go.etcd.io/etcd                  v0.5.0-alpha.5.0.20210428180535-15715dcf1ace  3.4.0     go-module  GHSA-wf43-55jj-vwq8  Medium    
google.golang.org/protobuf       v1.27.1                                                 go-module  CVE-2021-22570       High      
google.golang.org/protobuf       v1.25.0                                                 go-module  CVE-2015-5237        High      
google.golang.org/protobuf       v1.27.1                                                 go-module  CVE-2015-5237        High      
google.golang.org/protobuf       v1.25.0                                                 go-module  CVE-2021-22570       High
```

---

##### Checklist

<!---
Remove items which don't apply to your PR.
-->

- [ ] Changelog updated

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
