### PR TITLE
chore: upgrade sumologic terraform provider to 2.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - feat: store Sumo credentials for the setup Job in a Secret [#2466]
 
+### Changed
+
+- chore: upgrade sumologic terraform provider to 2.18 [#2399]
+
 [#2466]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2466
+[#2399]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2399
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.14.1...main
 
 ## [v2.14.1]

--- a/deploy/helm/sumologic/conf/setup/main.tf
+++ b/deploy/helm/sumologic/conf/setup/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     sumologic = {
       source  = "sumologic/sumologic"
-      version = "~> 2.16"
+      version = "~> 2.18"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/deploy/helm/sumologic/conf/setup/main.tf
+++ b/deploy/helm/sumologic/conf/setup/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     sumologic = {
       source  = "sumologic/sumologic"
-      version = "~> 2.11"
+      version = "~> 2.16"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/tests/helm/terraform/static/all_fields.output.yaml
+++ b/tests/helm/terraform/static/all_fields.output.yaml
@@ -277,7 +277,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.11"
+          version = "~> 2.16"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/terraform/static/all_fields.output.yaml
+++ b/tests/helm/terraform/static/all_fields.output.yaml
@@ -277,7 +277,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.16"
+          version = "~> 2.18"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/terraform/static/collector_fields.output.yaml
+++ b/tests/helm/terraform/static/collector_fields.output.yaml
@@ -276,7 +276,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.16"
+          version = "~> 2.18"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/terraform/static/collector_fields.output.yaml
+++ b/tests/helm/terraform/static/collector_fields.output.yaml
@@ -276,7 +276,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.11"
+          version = "~> 2.16"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/terraform/static/conditional_sources.output.yaml
+++ b/tests/helm/terraform/static/conditional_sources.output.yaml
@@ -266,7 +266,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.11"
+          version = "~> 2.16"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/terraform/static/conditional_sources.output.yaml
+++ b/tests/helm/terraform/static/conditional_sources.output.yaml
@@ -266,7 +266,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.16"
+          version = "~> 2.18"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/terraform/static/custom.output.yaml
+++ b/tests/helm/terraform/static/custom.output.yaml
@@ -266,7 +266,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.11"
+          version = "~> 2.16"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/terraform/static/custom.output.yaml
+++ b/tests/helm/terraform/static/custom.output.yaml
@@ -266,7 +266,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.16"
+          version = "~> 2.18"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/terraform/static/default.output.yaml
+++ b/tests/helm/terraform/static/default.output.yaml
@@ -276,7 +276,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.16"
+          version = "~> 2.18"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/terraform/static/default.output.yaml
+++ b/tests/helm/terraform/static/default.output.yaml
@@ -276,7 +276,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.11"
+          version = "~> 2.16"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/terraform/static/disable_default_metrics.output.yaml
+++ b/tests/helm/terraform/static/disable_default_metrics.output.yaml
@@ -275,7 +275,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.11"
+          version = "~> 2.16"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/terraform/static/disable_default_metrics.output.yaml
+++ b/tests/helm/terraform/static/disable_default_metrics.output.yaml
@@ -275,7 +275,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.16"
+          version = "~> 2.18"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/terraform/static/disabled_dashboards.output.yaml
+++ b/tests/helm/terraform/static/disabled_dashboards.output.yaml
@@ -276,7 +276,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.16"
+          version = "~> 2.18"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/terraform/static/disabled_dashboards.output.yaml
+++ b/tests/helm/terraform/static/disabled_dashboards.output.yaml
@@ -276,7 +276,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.11"
+          version = "~> 2.16"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/terraform/static/disabled_monitors.output.yaml
+++ b/tests/helm/terraform/static/disabled_monitors.output.yaml
@@ -276,7 +276,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.16"
+          version = "~> 2.18"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/terraform/static/disabled_monitors.output.yaml
+++ b/tests/helm/terraform/static/disabled_monitors.output.yaml
@@ -276,7 +276,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.11"
+          version = "~> 2.16"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/terraform/static/monitors_with_email_notifications.output.yaml
+++ b/tests/helm/terraform/static/monitors_with_email_notifications.output.yaml
@@ -276,7 +276,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.16"
+          version = "~> 2.18"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/terraform/static/monitors_with_email_notifications.output.yaml
+++ b/tests/helm/terraform/static/monitors_with_email_notifications.output.yaml
@@ -276,7 +276,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.11"
+          version = "~> 2.16"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/terraform/static/monitors_with_single_email.output.yaml
+++ b/tests/helm/terraform/static/monitors_with_single_email.output.yaml
@@ -276,7 +276,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.16"
+          version = "~> 2.18"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/terraform/static/monitors_with_single_email.output.yaml
+++ b/tests/helm/terraform/static/monitors_with_single_email.output.yaml
@@ -276,7 +276,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.11"
+          version = "~> 2.16"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/terraform/static/strip_extrapolation.output.yaml
+++ b/tests/helm/terraform/static/strip_extrapolation.output.yaml
@@ -276,7 +276,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.16"
+          version = "~> 2.18"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/terraform/static/strip_extrapolation.output.yaml
+++ b/tests/helm/terraform/static/strip_extrapolation.output.yaml
@@ -276,7 +276,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.11"
+          version = "~> 2.16"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/terraform/static/traces.output.yaml
+++ b/tests/helm/terraform/static/traces.output.yaml
@@ -268,7 +268,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.11"
+          version = "~> 2.16"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/terraform/static/traces.output.yaml
+++ b/tests/helm/terraform/static/traces.output.yaml
@@ -268,7 +268,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.16"
+          version = "~> 2.18"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"


### PR DESCRIPTION
##### Description

chore: upgrade sumologic terraform provider to 2.16

Upgrade due to security isues

---

##### Checklist

<!---
Remove items which don't apply to your PR.
-->

- [ ] Changelog updated

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
