### PR TITLE
chore(vagrant): add prometheus-adapter to vagrant's makefile

### DIFF
--- a/vagrant/Makefile
+++ b/vagrant/Makefile
@@ -258,3 +258,15 @@ apply-logs-generator:
 
 remove-logs-generator:
 	kubectl delete -f ${k8s_path}/logs-generator.yaml --ignore-not-found=true
+
+## Prometheus adapter can be used to expose custom metrics for HPA
+## This is just an example deployment
+## See https://github.com/kubernetes-sigs/prometheus-adapter for more informations
+apply-prometheus-adapter:
+	helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+	helm repo update
+	helm upgrade adapter \
+		--namespace prometheus-adapter \
+		--create-namespace \
+		--install prometheus-community/prometheus-adapter \
+		-f "${k8s_path}/prometheus-adapter.yaml"

--- a/vagrant/k8s/prometheus-adapter.yaml
+++ b/vagrant/k8s/prometheus-adapter.yaml
@@ -1,0 +1,15 @@
+rules:
+  default: false
+  custom:
+  - seriesQuery: 'kube_pod_info{namespace!="",pod!=""}'
+    name:
+      matches: "kube_pod_info"
+      as: "pod_info"
+    resources:
+      overrides:
+        namespace: {resource: "namespace"}
+        pod: {resource: "pod"}
+    metricsQuery: 'sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)'
+
+prometheus:
+  url: http://collection-kube-prometheus-prometheus.sumologic.svc

--- a/vagrant/k8s/prometheus-adapter.yaml
+++ b/vagrant/k8s/prometheus-adapter.yaml
@@ -1,13 +1,17 @@
+# https://github.com/kubernetes-sigs/prometheus-adapter/blob/9008b12a0173e2604e794c1614081b63c17e0340/docs/config.md#metrics-discovery-and-presentation-configuration
 rules:
   default: false
   custom:
   - seriesQuery: 'kube_pod_info{namespace!="",pod!=""}'
+    # Renames kube_pod_info to pod_info
     name:
       matches: "kube_pod_info"
       as: "pod_info"
     resources:
       overrides:
+        # overrides query namespace label with the namespace from kubernetes api
         namespace: {resource: "namespace"}
+        # overrides query pod label with the pod from kubernetes api
         pod: {resource: "pod"}
     metricsQuery: 'sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)'
 


### PR DESCRIPTION
##### Description

add prometheus-adapter to vagrant's makefile

See https://github.com/kubernetes-sigs/prometheus-adapter for more informations

I am adding it here, because it take me some time to set it up, and It can be useful in the future. We can close it if you don't like it

---

##### Checklist

<!---
Remove items which don't apply to your PR.
-->

- [ ] Changelog updated

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
