### PR TITLE
docs: add information about installation on OpenShift 4.9

### DIFF
--- a/deploy/docs/existingPrometheusDoc.md
+++ b/deploy/docs/existingPrometheusDoc.md
@@ -109,7 +109,7 @@ helm upgrade \
   --set sumologic.accessId=<SUMO_ACCESS_ID> \
   --set sumologic.accessKey=<SUMO_ACCESS_KEY> \
   --set sumologic.clusterName="<MY_CLUSTER_NAME>" \
-  --set kube-prometheus-stack.prometheusOperator.enabled=false \
+  --set kube-prometheus-stack.enabled=false \
   --set sumologic.scc.create=true \
   --set fluent-bit.securityContext.privileged=true
 ```


### PR DESCRIPTION
docs: add information about installation on OpenShift 4.9
docs: fix command to install on OpenShift with existing Prometheus - for normal k8s cluster kube-prometheus-stack is disabled
