### PR TITLE
feat(tracing): add pprof extension to the collectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - feat(otellogs): add additional volumes and env configs [#2410]
 - feat(otellogs/systemd): add support for systemd logs to otellogs [#2364]
+- feat(tracing): add pprof extension to the collectors [#2434]
 
 ### Changed
 
@@ -19,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2410]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2410
 [#2422]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2422
 [#2364]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2364
+[#2434]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2434
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.11.0...main
 
 ## [v2.11.0]

--- a/deploy/helm/sumologic/templates/traces/otel-agent/daemonset.yaml
+++ b/deploy/helm/sumologic/templates/traces/otel-agent/daemonset.yaml
@@ -69,6 +69,9 @@ spec:
         resources:
           {{- toYaml .Values.otelagent.daemonset.resources | nindent 10 }}
         ports:
+        - name: pprof
+          containerPort: 1777
+          protocol: TCP
         - containerPort: 5778  # Default endpoint for Jaeger Sampling.
         - containerPort: 6831  # Default endpoint for Jaeger Thrift Compact receiver.
           protocol: UDP

--- a/deploy/helm/sumologic/templates/traces/otel-gateway/deployment.yaml
+++ b/deploy/helm/sumologic/templates/traces/otel-gateway/deployment.yaml
@@ -74,6 +74,9 @@ spec:
         resources:
           {{- toYaml .Values.otelgateway.deployment.resources | nindent 10 }}
         ports:
+        - name: pprof
+          containerPort: 1777
+          protocol: TCP
         - containerPort: 5778  # Default endpoint for Jaeger Sampling.
         - containerPort: 6831  # Default endpoint for Jaeger Thrift Compact receiver.
           protocol: UDP

--- a/deploy/helm/sumologic/templates/traces/otelcol/deployment.yaml
+++ b/deploy/helm/sumologic/templates/traces/otelcol/deployment.yaml
@@ -72,6 +72,9 @@ spec:
         resources:
           {{- toYaml .Values.otelcol.deployment.resources | nindent 10 }}
         ports:
+        - name: pprof
+          containerPort: 1777
+          protocol: TCP
         - containerPort: 5778  # Default endpoint for Jaeger Sampling.
         - containerPort: 6831  # Default endpoint for Jaeger Thrift Compact receiver.
           protocol: UDP

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -3407,6 +3407,7 @@ otelagent:
       memory_ballast:
         ## Memory Ballast size should be max 1/3 to 1/2 of memory.
         size_mib: 250
+      pprof: {}
     exporters:
       otlp:
         endpoint: 'exporters.otlp.endpoint.replace:4317'
@@ -3414,7 +3415,7 @@ otelagent:
           ## This disables TLS when communicating with the gateway (within the same cluster)
           insecure: true
     service:
-      extensions: [health_check, memory_ballast]
+      extensions: [health_check, memory_ballast, pprof]
       pipelines:
         traces:
           receivers: [jaeger, opencensus, otlp, otlp/deprecated, zipkin]
@@ -3587,6 +3588,7 @@ otelcol:
       memory_ballast:
         ## Memory Ballast size should be max 1/3 to 1/2 of memory.
         size_mib: 683
+      pprof: {}
     exporters:
       ## Following generates verbose logs with span content, useful to verify what
       ## metadata is being tagged. To enable, uncomment and add "logging" to exporters below.
@@ -3635,7 +3637,7 @@ otelcol:
           ## requests_per_second is the average number of requests per seconds.
           queue_size: 5000
     service:
-      extensions: [health_check, memory_ballast]
+      extensions: [health_check, memory_ballast, pprof]
       pipelines:
         traces:
           receivers: [jaeger, opencensus, otlp, otlp/deprecated, zipkin]
@@ -4726,6 +4728,7 @@ otelgateway:
       memory_ballast:
         ## Memory Ballast size should be max 1/3 to 1/2 of memory.
         size_mib: 250
+      pprof: {}
     exporters:
       loadbalancing:
         protocol:
@@ -4743,7 +4746,7 @@ otelgateway:
           ## This disables TLS when communicating with the gateway (within the same cluster)
           insecure: true
     service:
-      extensions: [health_check, memory_ballast]
+      extensions: [health_check, memory_ballast, pprof]
       pipelines:
         traces:
           receivers: [jaeger, opencensus, otlp, otlp/deprecated, zipkin]

--- a/tests/helm/tracing-agent-loadbalancing/static/otelagent-gateway-disabled.output.yaml
+++ b/tests/helm/tracing-agent-loadbalancing/static/otelagent-gateway-disabled.output.yaml
@@ -21,6 +21,7 @@ data:
       health_check: {}
       memory_ballast:
         size_mib: 250
+      pprof: {}
     processors:
       batch:
         send_batch_size: 256
@@ -83,6 +84,7 @@ data:
       extensions:
       - health_check
       - memory_ballast
+      - pprof
       pipelines:
         metrics:
           exporters:

--- a/tests/helm/tracing-agent-loadbalancing/static/otelagent-gateway-enabled.output.yaml
+++ b/tests/helm/tracing-agent-loadbalancing/static/otelagent-gateway-enabled.output.yaml
@@ -21,6 +21,7 @@ data:
       health_check: {}
       memory_ballast:
         size_mib: 250
+      pprof: {}
     processors:
       batch:
         send_batch_size: 256
@@ -83,6 +84,7 @@ data:
       extensions:
       - health_check
       - memory_ballast
+      - pprof
       pipelines:
         metrics:
           exporters:

--- a/tests/helm/tracing-gateway-loadbalancing/static/otelgateway-true.output.yaml
+++ b/tests/helm/tracing-gateway-loadbalancing/static/otelgateway-true.output.yaml
@@ -31,6 +31,7 @@ data:
       health_check: {}
       memory_ballast:
         size_mib: 250
+      pprof: {}
     processors:
       batch:
         send_batch_size: 256
@@ -68,6 +69,7 @@ data:
       extensions:
       - health_check
       - memory_ballast
+      - pprof
       pipelines:
         metrics:
           exporters:

--- a/tests/helm/tracing-otelcol/static/collection-monitoring-false.output.yaml
+++ b/tests/helm/tracing-otelcol/static/collection-monitoring-false.output.yaml
@@ -38,6 +38,7 @@ data:
       health_check: {}
       memory_ballast:
         size_mib: 683
+      pprof: {}
     processors:
       batch:
         send_batch_max_size: 512
@@ -103,6 +104,7 @@ data:
       extensions:
       - health_check
       - memory_ballast
+      - pprof
       pipelines:
         metrics:
           exporters:

--- a/tests/helm/tracing-otelcol/static/simple.output.yaml
+++ b/tests/helm/tracing-otelcol/static/simple.output.yaml
@@ -38,6 +38,7 @@ data:
       health_check: {}
       memory_ballast:
         size_mib: 683
+      pprof: {}
     processors:
       batch:
         send_batch_max_size: 512
@@ -103,6 +104,7 @@ data:
       extensions:
       - health_check
       - memory_ballast
+      - pprof
       pipelines:
         metrics:
           exporters:


### PR DESCRIPTION
##### Description

PR adds `pprof` extension to the `otelagent`, `otelgateway` and `otelcol` collectors.

---

##### Checklist

<!---
Remove items which don't apply to your PR.
-->

- [x] Changelog updated

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
