### PR TITLE
feat: refactor OT log collector configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- feat: refactor OT log collector configuration [#2436]
 - feat: store Sumo credentials for the setup Job in a Secret [#2466]
 - feat: enable compaction for OT storage [#2486]
 
@@ -28,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2486]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2486
 [#2485]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2485
 [#2487]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2487
+[#2436]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2436
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.14.1...main
 
 ## [v2.14.1]

--- a/deploy/docs/opentelemetry_collector.md
+++ b/deploy/docs/opentelemetry_collector.md
@@ -1,6 +1,6 @@
-# Opentelemetry Collector
+# OpenTelemetry Collector
 
-Opentelemetry Collector is a software to receive, process and export logs, metrics and traces.
+OpenTelemetry Collector is a software to receive, process and export logs, metrics and traces.
 We offer it as drop-in replacement for Fluentd in our collection.
 
 > :warning: **This feature is currently in beta and its configuration can change. It is nonetheless production-ready and will become the default in the next major version.**
@@ -14,11 +14,11 @@ We offer it as drop-in replacement for Fluentd in our collection.
   - [SystemD Logs](#systemd-logs)
 - [Persistence](#persistence)
   - [Enabling persistence](#enabling-persistence)
-    - [Enabling Opentelemetry Collector persistence by recreating StatefulSet](#enabling-opentelemetry-collector-persistence-by-recreating-statefulset)
-    - [Enabling Opentelemetry Collector persistence by creating temporary instances and removing earlier created](#enabling-opentelemetry-collector-persistence-by-creating-temporary-instances-and-removing-earlier-created)
+    - [Enabling OpenTelemetry Collector persistence by recreating StatefulSet](#enabling-opentelemetry-collector-persistence-by-recreating-statefulset)
+    - [Enabling OpenTelemetry Collector persistence by creating temporary instances and removing earlier created](#enabling-opentelemetry-collector-persistence-by-creating-temporary-instances-and-removing-earlier-created)
   - [Disabling persistence](#disabling-persistence)
-    - [Disabling Opentelemetry Collector persistence by recreating StatefulSet](#disabling-opentelemetry-collector-persistence-by-recreating-statefulset)
-    - [Disabling Opentelemetry Collector persistence by creating temporary instances nd removing earlier created](#disabling-opentelemetry-collector-persistence-by-creating-temporary-instances-nd-removing-earlier-created)
+    - [Disabling OpenTelemetry Collector persistence by recreating StatefulSet](#disabling-opentelemetry-collector-persistence-by-recreating-statefulset)
+    - [Disabling OpenTelemetry Collector persistence by creating temporary instances nd removing earlier created](#disabling-opentelemetry-collector-persistence-by-creating-temporary-instances-nd-removing-earlier-created)
 - [Traces](#traces)
   - [Load balancing using the gateway](#load-balancing-using-the-gateway)
 - [Kubernetes Events](#kubernetes-events)
@@ -26,9 +26,9 @@ We offer it as drop-in replacement for Fluentd in our collection.
 
 ## Metrics
 
-We are using Opentelemetry Collector like Fluentd to enrich metadata and to filter data.
+We are using OpenTelemetry Collector like Fluentd to enrich metadata and to filter data.
 
-To enable Opentelemetry Collector for metrics, please use the following configuration:
+To enable OpenTelemetry Collector for metrics, please use the following configuration:
 
 ```yaml
 sumologic:
@@ -39,20 +39,20 @@ sumologic:
 
 As we are providing drop-in replacement, most of the configuration from
 [`values.yaml`][values] should work
-the same way for Opentelemetry Collector like for Fluentd.
+the same way for OpenTelemetry Collector like for Fluentd.
 
 ### Metrics Configuration
 
-All Opentelemetry Collector configuration for metrics is located in
+All OpenTelemetry Collector configuration for metrics is located in
 [`values.yaml`][values] as `metadata.metrics.config`.
 
-If you want to modify it, please see [Sumologic Opentelemetry Collector configuration][configuration]
+If you want to modify it, please see [Sumologic OpenTelemetry Collector configuration][configuration]
 for more information.
 
 ## Logs
 
-Opentelemetry Collector can be used for both log collection and metadata enrichment. For these roles,
-it replaces respectively Fluent-Bit and FluentD.
+OpenTelemetry Collector can be used for both log collection and metadata enrichment. For these roles,
+it replaces respectively Fluent Bit and Fluentd.
 
 For log collection, it can be enabled by setting:
 
@@ -67,7 +67,7 @@ fluent-bit:
   enabled: false
 ```
 
-> **NOTE** Fluent-Bit must be disabled for Opentelemetry Collector to be enabled, they are mutually exclusive.
+> **NOTE** Fluent Bit must be disabled for OpenTelemetry Collector to be enabled, they are mutually exclusive.
 
 For metadata enrichment, it can be enabled by setting:
 
@@ -78,12 +78,12 @@ sumologic:
       provider: otelcol
 ```
 
-If you haven't modified the FluentD or Fluent-Bit configuration, this should be a drop-in replacement with no
+If you haven't modified the Fluentd or Fluent Bit configuration, this should be a drop-in replacement with no
 further changes required.
 
 ### Logs Configuration
 
-High level Opentelemetry Collector configuration for logs is located in
+High level OpenTelemetry Collector configuration for logs is located in
 [`values.yaml`][values] under the `sumologic.logs` key.
 
 Configuration specific to the log collector DaemonSet can be found under the `otellogs` key.
@@ -92,7 +92,7 @@ Finally, configuration specific to the metadata enrichment StatefulSet can be fo
 
 In both of the aforementioned cases, the raw configuration can be overridden - this is done respectively by using
 the `otellogs.config.override` and `metadata.logs.config` sections. Only use these if your use case isn't covered
-by the high-level settings. See [Sumologic Opentelemetry Collector configuration][configuration]
+by the high-level settings. See [Sumologic OpenTelemetry Collector configuration][configuration]
 for more information
 
 [configuration]: https://github.com/SumoLogic/sumologic-otel-collector/blob/main/docs/Configuration.md
@@ -107,7 +107,7 @@ sumologic:
   logs:
     multiline:
       enabled: true
-      first_line_regex: "^\\[?\\d{4}-\\d{1,2}-\\d{1,2}.\\d{2}:\\d{2}:\\d{2}.*"
+      first_line_regex: "^\\[?\\d{4}-\\d{1,2}-\\d{1,2}.\\d{2}:\\d{2}:\\d{2}"
 ```
 
 where `first_line_regex` is a regular expression used to detect the first line of a multiline log.
@@ -147,7 +147,7 @@ sumologic:
 
 ## Persistence
 
-The persistence for Opentelemetry Collector can be configured in [`values.yaml`][values] by making changes under the `metadata.persistence`:
+The persistence for OpenTelemetry Collector can be configured in [`values.yaml`][values] by making changes under the `metadata.persistence`:
 
 ```yaml
 metadata:
@@ -158,15 +158,15 @@ metadata:
 along with changes in configuration under `metadata.metrics.config` and `metadata.logs.config`
 according to [Persistent Queue][persistent_queue] documentation.
 
-When Opentelemetry Collector persistence is to be changed (enabled or disabled)
-it is required to recreate or delete existing Opentelemetry Collector StatefulSets,
+When OpenTelemetry Collector persistence is to be changed (enabled or disabled)
+it is required to recreate or delete existing OpenTelemetry Collector StatefulSets,
 as it is not possible to add/remove `volumeClaimTemplate` for StatefulSet.
 
 [persistent_queue]: https://github.com/open-telemetry/opentelemetry-collector/tree/release/v0.37.x/exporter/exporterhelper#persistent-queue
 
 ### Enabling persistence
 
-To enable persistence for Opentelemetry Collector set following configuration in [`values.yaml`][values]:
+To enable persistence for OpenTelemetry Collector set following configuration in [`values.yaml`][values]:
 
 ```yaml
 metadata:
@@ -174,7 +174,7 @@ metadata:
     enabled: true
 ```
 
-Verify that Opentelemetry Collector configuration in [`values.yaml`][values] contains following sections
+Verify that OpenTelemetry Collector configuration in [`values.yaml`][values] contains following sections
 under `metadata.metrics.config` and `metadata.logs.config`:
 
 ```yaml
@@ -204,21 +204,21 @@ exporters:
       persistent_storage_enabled: '{{ .Values.metadata.persistence.enabled }}'
 ```
 
-When Opentelemetry Collector persistence is to be changed (persistence is disabled in existing Sumo Logic collection and
+When OpenTelemetry Collector persistence is to be changed (persistence is disabled in existing Sumo Logic collection and
 there is a need to enable persistence) please continue with steps described below and either
-recreate Opentelemetry Collector StatefulSet or create temporary instance of Opentelemetry Collector StatefulSet and
+recreate OpenTelemetry Collector StatefulSet or create temporary instance of OpenTelemetry Collector StatefulSet and
 remove earlier created.
 
-**_Notice:_** Below steps does not need to be done when Opentelemetry Collector is deployed the first time.
+**_Notice:_** Below steps does not need to be done when OpenTelemetry Collector is deployed the first time.
 
-#### Enabling Opentelemetry Collector persistence by recreating StatefulSet
+#### Enabling OpenTelemetry Collector persistence by recreating StatefulSet
 
 In a heavy used clusters with high load of logs and metrics it might be possible that
-recreating Opentelemetry Collector StatefulSets with new `volumeClaimTemplate` may cause logs and metrics
+recreating OpenTelemetry Collector StatefulSets with new `volumeClaimTemplate` may cause logs and metrics
 being unavailable for the time of recreation. It usually shouldn't take more than several seconds.
 
-To recreate Opentelemetry Collector StatefulSets with new `volumeClaimTemplate` one can run
-the following commands for all Opentelemetry Collector StatefulSets.
+To recreate OpenTelemetry Collector StatefulSets with new `volumeClaimTemplate` one can run
+the following commands for all OpenTelemetry Collector StatefulSets.
 
 Remember to adjust `volumeClaimTemplate` (`VOLUME_CLAIM_TEMPLATE` variable in command below)
 which will be added to `volumeClaimTemplates` in StatefulSet `spec` according to your needs,
@@ -287,15 +287,15 @@ one might expect a warning similar to this one:
 Warning: resource statefulsets/collection-sumologic-otelcol-metrics is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
 ```
 
-Upgrade collection with  Opentelemetry Collector persistence enabled, e.g.
+Upgrade collection with  OpenTelemetry Collector persistence enabled, e.g.
 
 ```bash
 helm upgrade <RELEASE-NAME> sumologic/sumologic --version=<VERSION> -f <VALUES>
 ```
 
-#### Enabling Opentelemetry Collector persistence by creating temporary instances and removing earlier created
+#### Enabling OpenTelemetry Collector persistence by creating temporary instances and removing earlier created
 
-To create a temporary instances of Opentelemetry Collector StatefulSets and avoid a loss of logs or metrics one can run the following commands.
+To create a temporary instances of OpenTelemetry Collector StatefulSets and avoid a loss of logs or metrics one can run the following commands.
 
 Remember to replace the `NAMESPACE` and `RELEASE_NAME`, variables with proper values.
 
@@ -325,7 +325,7 @@ yq w - "spec.selector.matchLabels[heritage]" "tmp" | \
 kubectl create --filename -
 ```
 
-Delete old instances of Opentelemetry Collector StatefulSets:
+Delete old instances of OpenTelemetry Collector StatefulSets:
 
 ```bash
 NAMESPACE=sumologic && \
@@ -337,13 +337,13 @@ kubectl delete statefulset --namespace ${NAMESPACE} ${RELEASE_NAME}-sumologic-ot
 kubectl delete statefulset --namespace ${NAMESPACE} ${RELEASE_NAME}-sumologic-otelcol-metrics
 ```
 
-Upgrade collection with  Opentelemetry Collector persistence enabled, e.g.
+Upgrade collection with  OpenTelemetry Collector persistence enabled, e.g.
 
 ```bash
 helm upgrade <RELEASE-NAME> sumologic/sumologic --version=<VERSION> -f <VALUES>
 ```
 
-**_Notice:_** After the Helm chart upgrade is done, in order to remove temporary Opentelemetry Collector
+**_Notice:_** After the Helm chart upgrade is done, in order to remove temporary OpenTelemetry Collector
 StatefulSets run the following command:
 
 ```bash
@@ -359,7 +359,7 @@ kubectl delete statefulset \
 
 ### Disabling persistence
 
-To disable persistence for Opentelemetry Collector set following configuration in [`values.yaml`][values]:
+To disable persistence for OpenTelemetry Collector set following configuration in [`values.yaml`][values]:
 
 ```yaml
 metadata:
@@ -376,23 +376,23 @@ and disable [File Storage][file_storage_extension] extension in[`values.yaml`][v
       # - file_storage
 ```
 
-When Opentelemetry Collector persistence is to be changed (persistence is enabled in existing Sumo Logic collection and
+When OpenTelemetry Collector persistence is to be changed (persistence is enabled in existing Sumo Logic collection and
 there is a need to disabled persistence) please continue with steps described below and either
-recreate Opentelemetry Collector StatefulSet or create temporary instance of Opentelemetry Collector StatefulSet and
+recreate OpenTelemetry Collector StatefulSet or create temporary instance of OpenTelemetry Collector StatefulSet and
 remove earlier created.
 
-**_Notice:_** Below steps does not need to be done when Opentelemetry Collector is deployed the first time.
+**_Notice:_** Below steps does not need to be done when OpenTelemetry Collector is deployed the first time.
 
 [file_storage_extension]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/release/v0.37.x/extension/storage/filestorage
 
-#### Disabling Opentelemetry Collector persistence by recreating StatefulSet
+#### Disabling OpenTelemetry Collector persistence by recreating StatefulSet
 
 In a heavy used clusters with high load of logs and metrics it might be possible that
-recreating Opentelemetry Collector StatefulSets with new `volumeClaimTemplate` may cause logs and metrics
+recreating OpenTelemetry Collector StatefulSets with new `volumeClaimTemplate` may cause logs and metrics
 being unavailable for the time of recreation. It usually shouldn't take more than several seconds.
 
-To recreate Opentelemetry Collector StatefulSets with new `volumeClaimTemplate` one can run
-the following commands for all Opentelemetry Collector StatefulSets.
+To recreate OpenTelemetry Collector StatefulSets with new `volumeClaimTemplate` one can run
+the following commands for all OpenTelemetry Collector StatefulSets.
 
 Remember to adjust `volumeClaimTemplate` (`VOLUME_CLAIM_TEMPLATE` variable in command below)
 which will be added to `volumeClaimTemplates` in StatefulSet `spec` according to your needs,
@@ -429,15 +429,15 @@ one might expect a warning similar to this one:
 Warning: resource statefulsets/collection-sumologic-otelcol-metrics is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
 ```
 
-Upgrade collection with  Opentelemetry Collector persistence disabled, e.g.
+Upgrade collection with  OpenTelemetry Collector persistence disabled, e.g.
 
 ```bash
 helm upgrade <RELEASE-NAME> sumologic/sumologic --version=<VERSION> -f <VALUES>
 ```
 
-#### Disabling Opentelemetry Collector persistence by creating temporary instances nd removing earlier created
+#### Disabling OpenTelemetry Collector persistence by creating temporary instances nd removing earlier created
 
-To create a temporary instances of Opentelemetry Collector StatefulSets and avoid a loss of logs or metrics one can run the following commands.
+To create a temporary instances of OpenTelemetry Collector StatefulSets and avoid a loss of logs or metrics one can run the following commands.
 
 Remember to replace the `NAMESPACE` and `RELEASE_NAME` variables with proper values.
 
@@ -467,7 +467,7 @@ yq w - "spec.selector.matchLabels[heritage]" "tmp" | \
 kubectl create --filename -
 ```
 
-Delete old instances of Opentelemetry Collector StatefulSets:
+Delete old instances of OpenTelemetry Collector StatefulSets:
 
 ```bash
 NAMESPACE=sumologic && \
@@ -479,14 +479,14 @@ kubectl delete statefulset --namespace ${NAMESPACE} ${RELEASE_NAME}-sumologic-ot
 kubectl delete statefulset --namespace ${NAMESPACE} ${RELEASE_NAME}-sumologic-otelcol-metrics
 ```
 
-Upgrade collection with  Opentelemetry Collector persistence disabled, e.g.
+Upgrade collection with  OpenTelemetry Collector persistence disabled, e.g.
 
 ```bash
 helm upgrade <RELEASE-NAME> sumologic/sumologic --version=<VERSION> -f <VALUES>
 ```
 
-**_Notice:_** After the Helm chart upgrade is done, it is needed to remove temporary Opentelemetry Collector StatefulSets
-and remaining `PersistentVolumeClaims` which are no longer used by Opentelemetry Collector StatefulSets.
+**_Notice:_** After the Helm chart upgrade is done, it is needed to remove temporary OpenTelemetry Collector StatefulSets
+and remaining `PersistentVolumeClaims` which are no longer used by OpenTelemetry Collector StatefulSets.
 
 ```bash
 NAMESPACE=sumologic && \

--- a/deploy/docs/opentelemetry_collector.md
+++ b/deploy/docs/opentelemetry_collector.md
@@ -67,7 +67,7 @@ fluent-bit:
   enabled: false
 ```
 
-> **NOTE** Fluent Bit must be disabled for OpenTelemetry Collector to be enabled, they are mutually exclusive.
+> **NOTE** Normally, Fluent Bit must be disabled for OpenTelemetry Collector to be enabled. This restriction can be lifted, see [here](#running-otelcol-and-fluent-bit-side-by-side).
 
 For metadata enrichment, it can be enabled by setting:
 
@@ -144,6 +144,28 @@ sumologic:
       units:
         - docker.service
 ```
+
+### Running otelcol and Fluent Bit side by side
+
+Normally, enabling both Otelcol and Fluent-Bit for log collection will fail with an error. The reason for this is that doing so naively results
+in each log line being delivered twice to Sumo Logic, incurring twice the cost without any benefit. However, there are reasons to do this; for example
+it makes for a smoother and less risky migration. Advanced users may also want to pin the different collectors to different Node groups.
+
+Because of this, we've included a way to allow running otelcol and Fluent Bit side by side. The minimal configuration enabling this is:
+
+```yaml
+sumologic:
+  logs:
+    collector:
+      otelcol:
+        enabled: true
+      allowSideBySide: true
+  
+fluent-bit:
+  enabled: true
+```
+
+> **WARNING** Without further modifications to Otelcol and Fluent Bit configuration, this will cause each log line to be ingested twice, potentially doubling the cost of logs ingestion.
 
 ## Persistence
 

--- a/deploy/helm/sumologic/conf/logs/collector/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/collector/otelcol/config.yaml
@@ -1,1 +1,298 @@
-{{ tpl (toYaml .Values.otellogs.config | replace ": '{{" ": {{" | replace "}}'" "}}") . | nindent 2 }}
+extensions:
+  health_check: {}
+  file_storage:
+    directory: /var/lib/storage/otc
+    timeout: 10s
+    compaction:
+      on_start: true
+      on_rebound: true
+      # Can't be /tmp yet, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13449
+      directory: /var/lib/storage/otc
+  pprof: {}
+service:
+  telemetry:
+    logs:
+      level: {{ .Values.otellogs.logLevel | quote }}
+  extensions:
+    - health_check
+    - file_storage
+    - pprof
+  pipelines:
+{{- if .Values.sumologic.logs.container.enabled }}
+    logs/containers:
+      receivers:
+        - filelog/containers
+      processors:
+        - batch
+      exporters:
+        - otlphttp
+{{- end }}
+{{- if .Values.sumologic.logs.systemd.enabled }}
+    logs/systemd:
+      receivers:
+        - journald
+      processors:
+        - logstransform/systemd
+        - batch
+      exporters:
+        - otlphttp
+{{- end }}
+receivers:
+{{- if .Values.sumologic.logs.container.enabled }}
+  filelog/containers:
+    include:
+      - /var/log/pods/*/*/*.log
+    start_at: beginning
+    ## sets fingerprint_size to 17kb in order to match the longest possible docker line (which by default is 16kb)
+    ## we want to include timestamp, which is at the end of the line
+    fingerprint_size: 17408
+    include_file_path: true
+    include_file_name: false
+    operators:
+      ## Detect the container runtime log format
+      ## Can be: docker-shim, CRI-O and containerd
+      - id: get-format
+        type: router
+        routes:
+          - output: parser-docker
+            expr: 'body matches "^\\{"'
+          - output: parser-crio
+            expr: 'body matches "^[^ Z]+ "'
+          - output: parser-containerd
+            expr: 'body matches "^[^ Z]+Z"'
+      ## Parse CRI-O format
+      - id: parser-crio
+        type: regex_parser
+        regex: '^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)( |)(?P<log>.*)$'
+        output: merge-cri-lines
+        parse_to: body
+        timestamp:
+          parse_from: body.time
+          layout_type: gotime
+          layout: '2006-01-02T15:04:05.000000000-07:00'
+      ## Parse CRI-Containerd format
+      - id: parser-containerd
+        type: regex_parser
+        regex: '^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)( |)(?P<log>.*)$'
+        output: merge-cri-lines
+        parse_to: body
+        timestamp:
+          parse_from: body.time
+          layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+      ## Parse docker-shim format
+      ## parser-docker interprets the input string as JSON and moves the `time` field from the JSON to Timestamp field in the OTLP log
+      ## record.
+      ## Input Body (string): '{"log":"2001-02-03 04:05:06 first line\n","stream":"stdout","time":"2021-11-25T09:59:13.23887954Z"}'
+      ## Output Body (JSON): { "log": "2001-02-03 04:05:06 first line\n", "stream": "stdout" }
+      ## Input Timestamp: _empty_
+      ## Output Timestamp: 2021-11-25 09:59:13.23887954 +0000 UTC
+      - id: parser-docker
+        type: json_parser
+        parse_to: body
+        output: merge-docker-lines
+        timestamp:
+          parse_from: body.time
+          layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+
+      ## merge-docker-lines stitches back together log lines split by Docker logging driver.
+      ## Input Body (JSON): { "log": "2001-02-03 04:05:06 very long li", "stream": "stdout" }
+      ## Input Body (JSON): { "log": "ne that was split by the logging driver\n", "stream": "stdout" }
+      ## Output Body (JSON): { "log": "2001-02-03 04:05:06 very long line that was split by the logging driver\n","stream":"stdout"}
+      - id: merge-docker-lines
+        type: recombine
+        source_identifier: attributes["log.file.path"]
+        output: {{ .Values.sumologic.logs.multiline.enabled | ternary "merge-multiline-logs" "extract-metadata-from-filepath" }}
+        combine_field: body.log
+        combine_with: ""
+        is_last_entry: body.log matches "\n$"
+
+      ## merge-cri-lines stitches back together log lines split by CRI logging drivers.
+      ## Input Body (JSON): { "log": "2001-02-03 04:05:06 very long li", "logtag": "P" }
+      ## Input Body (JSON): { "log": "ne that was split by the logging driver", "logtag": "F" }
+      ## Output Body (JSON): { "log": "2001-02-03 04:05:06 very long line that was split by the logging driver\n", "stream": "stdout" }
+      - id: merge-cri-lines
+        type: recombine
+        source_identifier: attributes["log.file.path"]
+        output: {{ .Values.sumologic.logs.multiline.enabled | ternary "merge-multiline-logs" "extract-metadata-from-filepath" }}
+        combine_field: body.log
+        combine_with: ""
+        is_last_entry: body.logtag == "F"
+        overwrite_with: newest
+
+      ## merge-multiline-logs merges incoming log records into multiline logs.
+      ## Input Body (JSON): { "log": "2001-02-03 04:05:06 first line\n", "stream": "stdout" }
+      ## Input Body (JSON): { "log": "  second line\n", "stream": "stdout" }
+      ## Input Body (JSON): { "log": "  third line\n", "stream": "stdout" }
+      ## Output Body (JSON): { "log": "2001-02-03 04:05:06 first line\n  second line\n  third line\n", "stream": "stdout" }
+{{- if .Values.sumologic.logs.multiline.enabled }}
+      - id: merge-multiline-logs
+        type: recombine
+        output: extract-metadata-from-filepath
+        source_identifier: attributes["log.file.path"]
+        combine_field: body.log
+        combine_with: ""
+        is_first_entry: body.log matches {{ .Values.sumologic.logs.multiline.first_line_regex | quote }}
+{{- end }}
+
+      ## extract-metadata-from-filepath extracts data from the `log.file.path` Attribute into the Attributes
+      ## Input Attributes:
+      ## - log.file.path: '/var/log/pods/default_logger-multiline-4nvg4_aed49747-b541-4a07-8663-f7e1febc47d5/loggercontainer/0.log'
+      ## Output Attributes:
+      ## - log.file.path: '/var/log/pods/default_logger-multiline-4nvg4_aed49747-b541-4a07-8663-f7e1febc47d5/loggercontainer/0.log'
+      ## - container_name: "loggercontainer",
+      ## - namespace: "default",
+      ## - pod_name: "logger-multiline-4nvg4",
+      ## - run_id: "0",
+      ## - uid: "aed49747-b541-4a07-8663-f7e1febc47d5"
+      ## }
+      - id: extract-metadata-from-filepath
+        type: regex_parser
+        regex: '^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]+)\/(?P<container_name>[^\._]+)\/(?P<run_id>\d+)\.log$'
+        parse_from: attributes["log.file.path"]
+
+      ## The following actions are being performed:
+      ## - renaming attributes
+      ## - moving stream from body to attribtues
+      ## - using body.log as body
+      ## - create fluent.tag attribute in order to route in metadata pods
+      ## Input Body (JSON): {
+      ##   "log": "2001-02-03 04:05:06 loggerlog 1 first line\n",
+      ##   "stream": "stdout",
+      ## }
+      ## Output Body (String): "2001-02-03 04:05:06 loggerlog 1 first line\n"
+      ## Input Attributes:
+      ## - log.file.path: '/var/log/pods/default_logger-multiline-4nvg4_aed49747-b541-4a07-8663-f7e1febc47d5/loggercontainer/0.log'
+      ## - container_name: "loggercontainer",
+      ## - namespace: "default",
+      ## - pod_name: "logger-multiline-4nvg4",
+      ## - run_id: "0",
+      ## - uid: "aed49747-b541-4a07-8663-f7e1febc47d5"
+      ## Output Attributes:
+      ## - k8s.container.name: "loggercontainer"
+      ## - k8s.namespace.name: "default"
+      ## - k8s.pod.name: "logger-multiline-4nvg4"
+      ## - k8s.pod.uid: "aed49747-b541-4a07-8663-f7e1febc47d5"
+      ## - run_id: "0"
+      ## - stream: "stdout"
+      ## - fluent.tag: "containers.loggercontainer"
+      - id: move-attributes
+        type: move
+        from: body.stream
+        to: attributes["stream"]
+      - type: move
+        from: attributes.container_name
+        to: attributes["k8s.container.name"]
+      - type: move
+        from: attributes.namespace
+        to: attributes["k8s.namespace.name"]
+      - type: move
+        from: attributes.pod_name
+        to: attributes["k8s.pod.name"]
+      - type: move
+        from: attributes.run_id
+        to: attributes["run_id"]
+      - type: move
+        from: attributes.uid
+        to: attributes["k8s.pod.uid"]
+      - type: add
+        field: attributes["fluent.tag"]
+        value: EXPR("containers." + attributes["k8s.container.name"])
+      - type: remove
+        field: attributes["log.file.path"]
+      - type: move
+        from: body.log
+        to: body
+{{- end }}
+{{- if .Values.sumologic.logs.systemd.enabled }}
+  journald:
+    directory: /var/log/journal
+    ## This is not a full equivalent of fluent-bit filtering as fluent-bit filters by `_SYSTEMD_UNIT`
+    ## Here is filtering by `UNIT`
+    units:
+{{- if .Values.sumologic.logs.systemd.units }}
+{{ toYaml .Values.sumologic.logs.systemd.units | nindent 6 }}
+{{- else }}
+      - addon-config.service
+      - addon-run.service
+      - cfn-etcd-environment.service
+      - cfn-signal.service
+      - clean-ca-certificates.service
+      - containerd.service
+      - coreos-metadata.service
+      - coreos-setup-environment.service
+      - coreos-tmpfiles.service
+      - dbus.service
+      - docker.service
+      - efs.service
+      - etcd-member.service
+      - etcd.service
+      - etcd2.service
+      - etcd3.service
+      - etcdadm-check.service
+      - etcdadm-reconfigure.service
+      - etcdadm-save.service
+      - etcdadm-update-status.service
+      - flanneld.service
+      - format-etcd2-volume.service
+      - kube-node-taint-and-uncordon.service
+      - kubelet.service
+      - ldconfig.service
+      - locksmithd.service
+      - logrotate.service
+      - lvm2-monitor.service
+      - mdmon.service
+      - nfs-idmapd.service
+      - nfs-mountd.service
+      - nfs-server.service
+      - nfs-utils.service
+      - node-problem-detector.service
+      - ntp.service
+      - oem-cloudinit.service
+      - rkt-gc.service
+      - rkt-metadata.service
+      - rpc-idmapd.service
+      - rpc-mountd.service
+      - rpc-statd.service
+      - rpcbind.service
+      - set-aws-environment.service
+      - system-cloudinit.service
+      - systemd-timesyncd.service
+      - update-ca-certificates.service
+      - user-cloudinit.service
+      - var-lib-etcd2.service
+{{- end }}
+{{- end }}
+exporters:
+  otlphttp:
+    endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local:4318
+processors:
+  batch:
+    send_batch_size: 1000
+    timeout: 1s
+  ## copy _SYSTEMD_UNIT, SYSLOG_FACILITY, _HOSTNAME and PRIORITY from body to attributes
+  ## so they can be used by metadata processors same way like for fluentd
+  ## build fluent.tag attribute as `host.{_SYSTEMD_UNIT}`
+{{- if .Values.sumologic.logs.systemd.enabled }}
+  logstransform/systemd:
+    operators:
+      - type: copy
+        from: body._SYSTEMD_UNIT
+        to: attributes._SYSTEMD_UNIT
+      - type: copy
+        from: body.SYSLOG_FACILITY
+        to: attributes.SYSLOG_FACILITY
+      - type: copy
+        from: body._HOSTNAME
+        to: attributes._HOSTNAME
+      - type: copy
+        from: body.PRIORITY
+        to: attributes.PRIORITY
+      - type: add
+        field: attributes["fluent.tag"]
+        value: EXPR("host." + attributes["_SYSTEMD_UNIT"])
+      ## Removes __CURSOR and __MONOTONIC_TIMESTAMP keys from body
+      - type: remove
+        field: body.__CURSOR
+      - type: remove
+        field: body.__MONOTONIC_TIMESTAMP
+{{- end }}

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -1384,7 +1384,8 @@ Example Usage:
 {{- if kindIs "invalid" $fluentBitEnabled -}}
 {{- $fluentBitEnabled = true -}}
 {{- end -}}
-{{- if and $enabled $fluentBitEnabled -}}
+{{- $sideBySideAllowed := .Values.sumologic.logs.collector.allowSideBySide -}}
+{{- if and $enabled $fluentBitEnabled (not $sideBySideAllowed) -}}
 {{- fail "Fluent-Bit and Otel log collector can't be enabled at the same time. Set either `fluent-bit.enabled` or `sumologic.logs.collector.otelcol.enabled` to false" -}}
 {{- end -}}
 {{ $enabled }}

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -1317,7 +1317,7 @@ Example Usage:
 {{- end -}}
 
 {{/*
-Check if any logs provider is enabled
+Check if any logs metadata provider is enabled
 
 Example Usage:
 {{- if eq (include "logs.enabled" .) "true" }}
@@ -1336,7 +1336,7 @@ Example Usage:
 
 
 {{/*
-Check if otelcol logs provider is enabled
+Check if otelcol logs metadata provider is enabled
 
 Example Usage:
 {{- if eq (include "logs.otelcol.enabled" .) "true" }}
@@ -1353,7 +1353,7 @@ Example Usage:
 {{- end -}}
 
 {{/*
-Check if fluentd logs provider is enabled
+Check if fluentd logs metadata provider is enabled
 
 Example Usage:
 {{- if eq (include "logs.fluentd.enabled" .) "true" }}
@@ -1365,6 +1365,27 @@ Example Usage:
 {{- if and (eq .Values.sumologic.logs.metadata.provider "fluentd") (eq .Values.fluentd.logs.enabled true) -}}
 {{- $enabled = true -}}
 {{- end -}}
+{{- end -}}
+{{ $enabled }}
+{{- end -}}
+
+{{/*
+Check if otelcol logs collector is enabled.
+It's enabled if both logs in general and the collector specifically are enabled.
+If both the collector and Fluent-Bit are enabled, we error.
+
+Example Usage:
+{{- if eq (include "logs.collector.otelcol.enabled" .) "true" }}
+
+*/}}
+{{- define "logs.collector.otelcol.enabled" -}}
+{{- $enabled := and (eq (include "logs.enabled" .) "true") (eq .Values.sumologic.logs.collector.otelcol.enabled true) -}}
+{{- $fluentBitEnabled := index .Values "fluent-bit" "enabled" -}}
+{{- if kindIs "invalid" $fluentBitEnabled -}}
+{{- $fluentBitEnabled = true -}}
+{{- end -}}
+{{- if and $enabled $fluentBitEnabled -}}
+{{- fail "Fluent-Bit and Otel log collector can't be enabled at the same time. Set either `fluent-bit.enabled` or `sumologic.logs.collector.otelcol.enabled` to false" -}}
 {{- end -}}
 {{ $enabled }}
 {{- end -}}

--- a/deploy/helm/sumologic/templates/logs/collector/otelcol/configmap.yaml
+++ b/deploy/helm/sumologic/templates/logs/collector/otelcol/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.otellogs.enabled }}
+{{- if eq (include "logs.collector.otelcol.enabled" .) "true" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,5 +7,9 @@ metadata:
     app: {{ template "sumologic.labels.app.logs.collector.configmap" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 data:
-  {{- (tpl (.Files.Glob "conf/logs/collector/otelcol/config.yaml").AsConfig .) | nindent 2 }}
+  {{- $baseConfig := (tpl (.Files.Get "conf/logs/collector/otelcol/config.yaml") .) | fromYaml -}}
+  {{- $overrideConfig := .Values.otellogs.config.override -}}
+  {{- $finalConfig := mergeOverwrite $baseConfig $overrideConfig }}
+  config.yaml: |
+  {{- $finalConfig | toYaml | nindent 4 }}
 {{- end }}

--- a/deploy/helm/sumologic/templates/logs/collector/otelcol/daemonset.yaml
+++ b/deploy/helm/sumologic/templates/logs/collector/otelcol/daemonset.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.otellogs.enabled }}
+{{- if eq (include "logs.collector.otelcol.enabled" .) "true" }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -77,7 +77,7 @@ spec:
         - mountPath: /var/lib/docker/containers
           name: varlibdockercontainers
           readOnly: true
-        - mountPath: {{ .Values.otellogs.config.extensions.file_storage.directory }}
+        - mountPath: /var/lib/storage/otc
           name: file-storage
         - mountPath: /var/log/journal
           name: varlogjournal
@@ -118,9 +118,9 @@ spec:
         - |
           chown -R \
             {{ .Values.otellogs.daemonset.securityContext.fsGroup }}:{{ .Values.otellogs.daemonset.securityContext.fsGroup }} \
-            {{ .Values.otellogs.config.extensions.file_storage.directory }}
+            /var/lib/storage/otc
         volumeMounts:
-        - mountPath: {{ .Values.otellogs.config.extensions.file_storage.directory }}
+        - mountPath: /var/lib/storage/otc
           name: file-storage
       volumes:
       - configMap:

--- a/deploy/helm/sumologic/templates/logs/collector/otelcol/service.yaml
+++ b/deploy/helm/sumologic/templates/logs/collector/otelcol/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.otellogs.enabled }}
+{{- if eq (include "logs.collector.otelcol.enabled" .) "true" }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/deploy/helm/sumologic/templates/logs/collector/otelcol/serviceaccount.yaml
+++ b/deploy/helm/sumologic/templates/logs/collector/otelcol/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.otellogs.enabled }}
+{{- if eq (include "logs.collector.otelcol.enabled" .) "true" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -222,6 +222,10 @@ sumologic:
       otelcol:
         enabled: false
 
+      ## Allow running otel and Fluent-Bit side by side. This will result in duplicated
+      ## logs being ingested. Only enabled this if you're **certain** it's what you want.
+      allowSideBySide: false
+
     multiline:
       enabled: true
       first_line_regex: "^\\[?\\d{4}-\\d{1,2}-\\d{1,2}.\\d{2}:\\d{2}:\\d{2}"

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -218,6 +218,23 @@ sumologic:
       ## Set provider service (either fluentd or otelcol).
       provider: fluentd
 
+    collector:
+      otelcol:
+        enabled: false
+
+    multiline:
+      enabled: true
+      first_line_regex: "^\\[?\\d{4}-\\d{1,2}-\\d{1,2}.\\d{2}:\\d{2}:\\d{2}"
+
+    container:
+      enabled: true
+
+    systemd:
+      enabled: true
+      # systemd units to collect logs from
+      # units:
+      #   - docker.service
+
     ## Fields to be created at Sumo Logic to ensure logs are tagged with
     ## relevant metadata.
     ## https://help.sumologic.com/Manage/Fields#Manage_fields
@@ -4906,9 +4923,6 @@ otelevents:
 ## which is consistent with CRI, but may possibly cause issues on older K8s versions.
 ## This is an alpha feature, and may change in the near future.
 otellogs:
-  ## In order to enable this feature, a configuration block under metadata.logs.config.service.pipelines.logs/otlp/containers
-  ## needs to be uncommented
-  enabled: false
 
   ## Metrics from Collector
   metrics:
@@ -4924,299 +4938,10 @@ otellogs:
     pullPolicy: IfNotPresent
 
   logLevel: info
+
   config:
-    extensions:
-      health_check: {}
-      ## Configuration for File Storage extension
-      ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/release/v0.37.x/extension/storage/filestorage
-      file_storage:
-        directory: /var/lib/storage/otc
-        timeout: 10s
-        compaction:
-          on_start: true
-          on_rebound: true
-          # Can't be /tmp yet, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13449
-          directory: /var/lib/storage/otc
-      pprof: {}
-    service:
-      telemetry:
-        logs:
-          level: '{{ .Values.otellogs.logLevel }}'
-      extensions:
-        - health_check
-        - file_storage
-        - pprof
-      pipelines:
-        logs/containers:
-          receivers:
-            - filelog/containers
-          processors:
-            - batch
-          exporters:
-            - otlphttp
-        logs/systemd:
-          receivers:
-            - journald
-          processors:
-            - logstransform/systemd
-            - batch
-          exporters:
-            - otlphttp
-    receivers:
-      filelog/containers:
-        include:
-          - /var/log/pods/*/*/*.log
-        start_at: beginning
-        ## sets fingerprint_size to 17kb in order to match the longest possible docker line (which by default is 16kb)
-        ## we want to include timestamp, which is at the end of the line
-        fingerprint_size: 17408
-        include_file_path: true
-        include_file_name: false
-        operators:
-          ## Detect the container runtime log format
-          ## Can be: docker-shim, CRI-O and containerd
-          - id: get-format
-            type: router
-            routes:
-              - output: parser-docker
-                expr: 'body matches "^\\{"'
-              - output: parser-crio
-                expr: 'body matches "^[^ Z]+ "'
-              - output: parser-containerd
-                expr: 'body matches "^[^ Z]+Z"'
-          ## Parse CRI-O format
-          - id: parser-crio
-            type: regex_parser
-            regex: '^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)( |)(?P<log>.*)$'
-            output: merge-cri-lines
-            parse_to: body
-            timestamp:
-              parse_from: body.time
-              layout_type: gotime
-              layout: '2006-01-02T15:04:05.000000000-07:00'
-          ## Parse CRI-Containerd format
-          - id: parser-containerd
-            type: regex_parser
-            regex: '^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)( |)(?P<log>.*)$'
-            output: merge-cri-lines
-            parse_to: body
-            timestamp:
-              parse_from: body.time
-              layout: '%Y-%m-%dT%H:%M:%S.%LZ'
-          ## Parse docker-shim format
-          ## parser-docker interprets the input string as JSON and moves the `time` field from the JSON to Timestamp field in the OTLP log
-          ## record.
-          ## Input Body (string): '{"log":"2001-02-03 04:05:06 first line\n","stream":"stdout","time":"2021-11-25T09:59:13.23887954Z"}'
-          ## Output Body (JSON): { "log": "2001-02-03 04:05:06 first line\n", "stream": "stdout" }
-          ## Input Timestamp: _empty_
-          ## Output Timestamp: 2021-11-25 09:59:13.23887954 +0000 UTC
-          - id: parser-docker
-            type: json_parser
-            parse_to: body
-            output: merge-docker-lines
-            timestamp:
-              parse_from: body.time
-              layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+    override: {}
 
-          ## merge-docker-lines stitches back together log lines split by Docker logging driver.
-          ## Input Body (JSON): { "log": "2001-02-03 04:05:06 very long li", "stream": "stdout" }
-          ## Input Body (JSON): { "log": "ne that was split by the logging driver\n", "stream": "stdout" }
-          ## Output Body (JSON): { "log": "2001-02-03 04:05:06 very long line that was split by the logging driver\n","stream":"stdout"}
-          - id: merge-docker-lines
-            type: recombine
-            source_identifier: attributes["log.file.path"]
-            output: merge-multiline-logs
-            combine_field: body.log
-            combine_with: ""
-            is_last_entry: body.log matches "\n$"
-
-          ## merge-cri-lines stitches back together log lines split by CRI logging drivers.
-          ## Input Body (JSON): { "log": "2001-02-03 04:05:06 very long li", "logtag": "P" }
-          ## Input Body (JSON): { "log": "ne that was split by the logging driver", "logtag": "F" }
-          ## Output Body (JSON): { "log": "2001-02-03 04:05:06 very long line that was split by the logging driver\n", "stream": "stdout" }
-          - id: merge-cri-lines
-            type: recombine
-            source_identifier: attributes["log.file.path"]
-            output: merge-multiline-logs
-            combine_field: body.log
-            combine_with: ""
-            is_last_entry: body.logtag == "F"
-            overwrite_with: newest
-
-          ## merge-multiline-logs merges incoming log records into multiline logs.
-          ## Input Body (JSON): { "log": "2001-02-03 04:05:06 first line\n", "stream": "stdout" }
-          ## Input Body (JSON): { "log": "  second line\n", "stream": "stdout" }
-          ## Input Body (JSON): { "log": "  third line\n", "stream": "stdout" }
-          ## Output Body (JSON): { "log": "2001-02-03 04:05:06 first line\n  second line\n  third line\n", "stream": "stdout" }
-          - id: merge-multiline-logs
-            type: recombine
-            output: extract-metadata-from-filepath
-            source_identifier: attributes["log.file.path"]
-            combine_field: body.log
-            combine_with: ""
-            is_first_entry: body.log matches "^\\[?\\d{4}-\\d{1,2}-\\d{1,2}.\\d{2}:\\d{2}:\\d{2}.*"
-
-          ## extract-metadata-from-filepath extracts data from the `log.file.path` Attribute into the Attributes
-          ## Input Attributes:
-          ## - log.file.path: '/var/log/pods/default_logger-multiline-4nvg4_aed49747-b541-4a07-8663-f7e1febc47d5/loggercontainer/0.log'
-          ## Output Attributes:
-          ## - log.file.path: '/var/log/pods/default_logger-multiline-4nvg4_aed49747-b541-4a07-8663-f7e1febc47d5/loggercontainer/0.log'
-          ## - container_name: "loggercontainer",
-          ## - namespace: "default",
-          ## - pod_name: "logger-multiline-4nvg4",
-          ## - run_id: "0",
-          ## - uid: "aed49747-b541-4a07-8663-f7e1febc47d5"
-          ## }
-          - id: extract-metadata-from-filepath
-            type: regex_parser
-            regex: '^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]+)\/(?P<container_name>[^\._]+)\/(?P<run_id>\d+)\.log$'
-            parse_from: attributes["log.file.path"]
-
-          ## The following actions are being performed:
-          ## - renaming attributes
-          ## - moving stream from body to attribtues
-          ## - using body.log as body
-          ## - create fluent.tag attribute in order to route in metadata pods
-          ## Input Body (JSON): {
-          ##   "log": "2001-02-03 04:05:06 loggerlog 1 first line\n",
-          ##   "stream": "stdout",
-          ## }
-          ## Output Body (String): "2001-02-03 04:05:06 loggerlog 1 first line\n"
-          ## Input Attributes:
-          ## - log.file.path: '/var/log/pods/default_logger-multiline-4nvg4_aed49747-b541-4a07-8663-f7e1febc47d5/loggercontainer/0.log'
-          ## - container_name: "loggercontainer",
-          ## - namespace: "default",
-          ## - pod_name: "logger-multiline-4nvg4",
-          ## - run_id: "0",
-          ## - uid: "aed49747-b541-4a07-8663-f7e1febc47d5"
-          ## Output Attributes:
-          ## - k8s.container.name: "loggercontainer"
-          ## - k8s.namespace.name: "default"
-          ## - k8s.pod.name: "logger-multiline-4nvg4"
-          ## - k8s.pod.uid: "aed49747-b541-4a07-8663-f7e1febc47d5"
-          ## - run_id: "0"
-          ## - stream: "stdout"
-          ## - fluent.tag: "containers.loggercontainer"
-          - id: move-attributes
-            type: move
-            from: body.stream
-            to: attributes["stream"]
-          - type: move
-            from: attributes.container_name
-            to: attributes["k8s.container.name"]
-          - type: move
-            from: attributes.namespace
-            to: attributes["k8s.namespace.name"]
-          - type: move
-            from: attributes.pod_name
-            to: attributes["k8s.pod.name"]
-          - type: move
-            from: attributes.run_id
-            to: attributes["run_id"]
-          - type: move
-            from: attributes.uid
-            to: attributes["k8s.pod.uid"]
-          - type: add
-            field: attributes["fluent.tag"]
-            value: EXPR("containers." + attributes["k8s.container.name"])
-          ## Use remove operator when available in opentelemetry collector:
-          ## https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/9524
-          - type: move
-            from: attributes["log.file.path"]
-            to: body["log.file.path"]
-          - type: move
-            from: body.log
-            to: body
-      journald:
-        directory: /var/log/journal
-        ## This is not a full equivalent of fluent-bit filtering as fluent-bit filters by `_SYSTEMD_UNIT`
-        ## Here is filtering by `UNIT`
-        units:
-          - addon-config.service
-          - addon-run.service
-          - cfn-etcd-environment.service
-          - cfn-signal.service
-          - clean-ca-certificates.service
-          - containerd.service
-          - coreos-metadata.service
-          - coreos-setup-environment.service
-          - coreos-tmpfiles.service
-          - dbus.service
-          - docker.service
-          - efs.service
-          - etcd-member.service
-          - etcd.service
-          - etcd2.service
-          - etcd3.service
-          - etcdadm-check.service
-          - etcdadm-reconfigure.service
-          - etcdadm-save.service
-          - etcdadm-update-status.service
-          - flanneld.service
-          - format-etcd2-volume.service
-          - kube-node-taint-and-uncordon.service
-          - kubelet.service
-          - ldconfig.service
-          - locksmithd.service
-          - logrotate.service
-          - lvm2-monitor.service
-          - mdmon.service
-          - nfs-idmapd.service
-          - nfs-mountd.service
-          - nfs-server.service
-          - nfs-utils.service
-          - node-problem-detector.service
-          - ntp.service
-          - oem-cloudinit.service
-          - rkt-gc.service
-          - rkt-metadata.service
-          - rpc-idmapd.service
-          - rpc-mountd.service
-          - rpc-statd.service
-          - rpcbind.service
-          - set-aws-environment.service
-          - system-cloudinit.service
-          - systemd-timesyncd.service
-          - update-ca-certificates.service
-          - user-cloudinit.service
-          - var-lib-etcd2.service
-    exporters:
-      otlphttp:
-        endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local:4318
-    processors:
-      ## The batch processor accepts spans and places them into batches grouped by node and resource
-      batch:
-        ## Number of spans after which a batch will be sent regardless of time
-        ## This is set to the 10240, to avoid loosing logs on the start of the collector
-        ## TODO: Figure out what the optimal values should be for different configurations
-        send_batch_size: 10_240
-        ## Time duration after which a batch will be sent regardless of size
-        timeout: 1s
-      ## copy _SYSTEMD_UNIT, SYSLOG_FACILITY, _HOSTNAME and PRIORITY from body to attributes
-      ## so they can be used by metadata processors same way like for fluentd
-      ## build fluent.tag attribute as `host.{_SYSTEMD_UNIT}`
-      logstransform/systemd:
-        operators:
-          - type: copy
-            from: body._SYSTEMD_UNIT
-            to: attributes._SYSTEMD_UNIT
-          - type: copy
-            from: body.SYSLOG_FACILITY
-            to: attributes.SYSLOG_FACILITY
-          - type: copy
-            from: body._HOSTNAME
-            to: attributes._HOSTNAME
-          - type: copy
-            from: body.PRIORITY
-            to: attributes.PRIORITY
-          - type: add
-            field: attributes["fluent.tag"]
-            value: EXPR("host." + attributes["_SYSTEMD_UNIT"])
-          ## Removes __CURSOR and __MONOTONIC_TIMESTAMP keys from body
-          - type: remove
-            field: body.__CURSOR
-          - type: remove
-            field: body.__MONOTONIC_TIMESTAMP
   daemonset:
     ## Set securityContext for containers running in pods in log collector daemonset
     securityContext:

--- a/tests/helm/logs_otc/static/basic.input.yaml
+++ b/tests/helm/logs_otc/static/basic.input.yaml
@@ -1,2 +1,8 @@
-otellogs:
-  enabled: true
+sumologic:
+  logs:
+    collector:
+      otelcol:
+        enabled: true
+
+fluent-bit:
+  enabled: false

--- a/tests/helm/logs_otc/static/options.input.yaml
+++ b/tests/helm/logs_otc/static/options.input.yaml
@@ -1,0 +1,19 @@
+sumologic:
+  logs:
+    collector:
+      otelcol:
+        enabled: true
+    multiline:
+      enabled: false
+    systemd:
+      enabled: true
+    container:
+      enabled: false
+
+fluent-bit:
+  enabled: false
+
+otellogs:
+  logLevel: debug
+
+

--- a/tests/helm/logs_otc/static/options.output.yaml
+++ b/tests/helm/logs_otc/static/options.output.yaml
@@ -1,0 +1,120 @@
+---
+# Source: sumologic/templates/logs/collector/otelcol/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: RELEASE-NAME-sumologic-otelcol-logs-collector
+  labels:
+    app: RELEASE-NAME-sumologic-otelcol-logs-collector
+    chart: "sumologic-%CURRENT_CHART_VERSION%"
+    release: "RELEASE-NAME"
+    heritage: "Helm"
+data:
+  config.yaml: |
+    exporters:
+      otlphttp:
+        endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local:4318
+    extensions:
+      file_storage:
+        compaction:
+          directory: /var/lib/storage/otc
+          on_rebound: true
+          on_start: true
+        directory: /var/lib/storage/otc
+        timeout: 10s
+      health_check: {}
+      pprof: {}
+    processors:
+      batch:
+        send_batch_size: 1000
+        timeout: 1s
+      logstransform/systemd:
+        operators:
+        - from: body._SYSTEMD_UNIT
+          to: attributes._SYSTEMD_UNIT
+          type: copy
+        - from: body.SYSLOG_FACILITY
+          to: attributes.SYSLOG_FACILITY
+          type: copy
+        - from: body._HOSTNAME
+          to: attributes._HOSTNAME
+          type: copy
+        - from: body.PRIORITY
+          to: attributes.PRIORITY
+          type: copy
+        - field: attributes["fluent.tag"]
+          type: add
+          value: EXPR("host." + attributes["_SYSTEMD_UNIT"])
+        - field: body.__CURSOR
+          type: remove
+        - field: body.__MONOTONIC_TIMESTAMP
+          type: remove
+    receivers:
+      journald:
+        directory: /var/log/journal
+        units:
+        - addon-config.service
+        - addon-run.service
+        - cfn-etcd-environment.service
+        - cfn-signal.service
+        - clean-ca-certificates.service
+        - containerd.service
+        - coreos-metadata.service
+        - coreos-setup-environment.service
+        - coreos-tmpfiles.service
+        - dbus.service
+        - docker.service
+        - efs.service
+        - etcd-member.service
+        - etcd.service
+        - etcd2.service
+        - etcd3.service
+        - etcdadm-check.service
+        - etcdadm-reconfigure.service
+        - etcdadm-save.service
+        - etcdadm-update-status.service
+        - flanneld.service
+        - format-etcd2-volume.service
+        - kube-node-taint-and-uncordon.service
+        - kubelet.service
+        - ldconfig.service
+        - locksmithd.service
+        - logrotate.service
+        - lvm2-monitor.service
+        - mdmon.service
+        - nfs-idmapd.service
+        - nfs-mountd.service
+        - nfs-server.service
+        - nfs-utils.service
+        - node-problem-detector.service
+        - ntp.service
+        - oem-cloudinit.service
+        - rkt-gc.service
+        - rkt-metadata.service
+        - rpc-idmapd.service
+        - rpc-mountd.service
+        - rpc-statd.service
+        - rpcbind.service
+        - set-aws-environment.service
+        - system-cloudinit.service
+        - systemd-timesyncd.service
+        - update-ca-certificates.service
+        - user-cloudinit.service
+        - var-lib-etcd2.service
+    service:
+      extensions:
+      - health_check
+      - file_storage
+      - pprof
+      pipelines:
+        logs/systemd:
+          exporters:
+          - otlphttp
+          processors:
+          - logstransform/systemd
+          - batch
+          receivers:
+          - journald
+      telemetry:
+        logs:
+          level: debug

--- a/tests/helm/logs_otc/static/override.input.yaml
+++ b/tests/helm/logs_otc/static/override.input.yaml
@@ -1,0 +1,16 @@
+sumologic:
+  logs:
+    collector:
+      otelcol:
+        enabled: true
+
+fluent-bit:
+  enabled: false
+
+otellogs:
+  config:
+    override:
+      receivers:
+        journald:
+          units:
+            - docker.service

--- a/tests/helm/logs_otc/static/override.output.yaml
+++ b/tests/helm/logs_otc/static/override.output.yaml
@@ -147,54 +147,7 @@ data:
       journald:
         directory: /var/log/journal
         units:
-        - addon-config.service
-        - addon-run.service
-        - cfn-etcd-environment.service
-        - cfn-signal.service
-        - clean-ca-certificates.service
-        - containerd.service
-        - coreos-metadata.service
-        - coreos-setup-environment.service
-        - coreos-tmpfiles.service
-        - dbus.service
         - docker.service
-        - efs.service
-        - etcd-member.service
-        - etcd.service
-        - etcd2.service
-        - etcd3.service
-        - etcdadm-check.service
-        - etcdadm-reconfigure.service
-        - etcdadm-save.service
-        - etcdadm-update-status.service
-        - flanneld.service
-        - format-etcd2-volume.service
-        - kube-node-taint-and-uncordon.service
-        - kubelet.service
-        - ldconfig.service
-        - locksmithd.service
-        - logrotate.service
-        - lvm2-monitor.service
-        - mdmon.service
-        - nfs-idmapd.service
-        - nfs-mountd.service
-        - nfs-server.service
-        - nfs-utils.service
-        - node-problem-detector.service
-        - ntp.service
-        - oem-cloudinit.service
-        - rkt-gc.service
-        - rkt-metadata.service
-        - rpc-idmapd.service
-        - rpc-mountd.service
-        - rpc-statd.service
-        - rpcbind.service
-        - set-aws-environment.service
-        - system-cloudinit.service
-        - systemd-timesyncd.service
-        - update-ca-certificates.service
-        - user-cloudinit.service
-        - var-lib-etcd2.service
     service:
       extensions:
       - health_check

--- a/tests/helm/logs_otc_daemonset/static/basic.input.yaml
+++ b/tests/helm/logs_otc_daemonset/static/basic.input.yaml
@@ -1,2 +1,8 @@
-otellogs:
-  enabled: true
+sumologic:
+  logs:
+    collector:
+      otelcol:
+        enabled: true
+
+fluent-bit:
+  enabled: false

--- a/tests/helm/logs_otc_daemonset/static/complex.input.yaml
+++ b/tests/helm/logs_otc_daemonset/static/complex.input.yaml
@@ -1,5 +1,13 @@
+sumologic:
+  logs:
+    collector:
+      otelcol:
+        enabled: true
+
+fluent-bit:
+  enabled: false
+
 otellogs:
-  enabled: true
   daemonset:
     ## Set securityContext for containers running in pods in log collector daemonset
     securityContext:

--- a/tests/integration/values/values_helm_otelcol_logs.yaml
+++ b/tests/integration/values/values_helm_otelcol_logs.yaml
@@ -2,6 +2,8 @@ sumologic:
   logs:
     metadata:
       provider: otelcol
+    collector:
+      enabled: true
 
   metrics:
     enabled: false
@@ -36,29 +38,14 @@ metadata:
               - sumologic/containers
 
 otellogs:
-  enabled: true
   config:
-    service:
-      pipelines:
-        logs/containers:
-          receivers:
-            - filelog/containers
-          exporters:
-            - otlphttp
-          processors:
-            - filter/exclude_receiver_mock_container
-    processors:
-      # Filter out receiver-mock logs to prevent snowball effect
-      filter/exclude_receiver_mock_container:
-        logs:
+    override:
+      receivers:
+        journald:
+          directory: /run/log/journal
+        filelog/containers:
           exclude:
-            match_type: strict
-            record_attributes:
-              - key: k8s.container.name
-                value: receiver-mock
-    receivers:
-      journald:
-        directory: /run/log/journal
+            - /var/log/pods/receiver-mock_*/*/*.log
   daemonset:
     extraVolumeMounts:
       - mountPath: /run/log/journal

--- a/tests/integration/values/values_helm_otelcol_logs.yaml
+++ b/tests/integration/values/values_helm_otelcol_logs.yaml
@@ -3,7 +3,8 @@ sumologic:
     metadata:
       provider: otelcol
     collector:
-      enabled: true
+      otelcol:
+        enabled: true
 
   metrics:
     enabled: false


### PR DESCRIPTION
##### Description

Change how log collection using OT is configured. The idea here is for the purely functional configuration to live under the `sumologic.logs` key and contain no application-specific configuration, and for the K8s specific and application specific (like raw OT configuration) configuration to be separate - currently I've left it under `otellogs`, but I'm open to alternatives.


TODO:
- [x] Add template tests for the new options
- [ ] setting for tailling additional files
- [x] documentation
---

##### Checklist

<!---
Remove items which don't apply to your PR.
-->

- [x] Changelog updated

###### Testing performed

- [X] Confirm events, logs, and metrics are coming in
