### PR TITLE
chore(prometheus): update prometheus chart to 32.0.1

### DIFF
--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
     repository: https://fluent.github.io/helm-charts
     condition: fluent-bit.enabled,sumologic.logs.enabled
   - name: kube-prometheus-stack
-    version: 12.10.0
+    version: 32.0.1
     repository: https://prometheus-community.github.io/helm-charts
     condition: kube-prometheus-stack.enabled,sumologic.metrics.enabled
   - name: falco

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1596,7 +1596,7 @@ kube-prometheus-stack:
     ## Use the GCR repo, it's more recent and has ARM images starting from 1.9.8
     image:
       repository: k8s.gcr.io/kube-state-metrics/kube-state-metrics
-      tag: v1.9.8
+      tag: v2.3.0
     ## Custom labels to apply to service, deployment and pods
     customLabels: {}
     ## Additional annotations for pods in the DaemonSet
@@ -1741,8 +1741,8 @@ kube-prometheus-stack:
           requests:
             cpu: 1m
             memory: 8Mi
-      containers:
-        - name: "config-reloader"
+      initContainers:
+        - name: "init-config-reloader"
           env:
             - name: FLUENTD_METRICS_SVC
               valueFrom:


### PR DESCRIPTION
##### Description

Update kube-state-metrics to v2.3.0. I need to revisit this PR in order to upgrade to the newest possible version and also in order to add this change to migration script

---

##### Checklist

<!---
Remove items which don't apply to your PR.
-->

- [ ] Changelog updated

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
