### PR TITLE
feat(openshift): add projected volumes to SecurityContextConstraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat(priorityclass): add priority class for logs and traces daemonsets [#2433]
 - feat(tracing): add pprof extension to the collectors [#2434]
 - chore: add OpenShift 4.9 to supported platforms [#2441]
+- feat(openshift): add projected volumes to SecurityContextConstraints [#2443]
 
 ### Changed
 
@@ -29,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2433]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2433
 [#2434]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2434
 [#2441]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2441
+[#2443]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2443
 [v2.12.0]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.11.0...v2.12.0
 
 ## [v2.11.0]

--- a/deploy/helm/sumologic/templates/scc.yaml
+++ b/deploy/helm/sumologic/templates/scc.yaml
@@ -49,4 +49,5 @@ volumes:
 - secret
 - configMap
 - persistentVolumeClaim
+- projected
 {{- end }}


### PR DESCRIPTION
without this change Prometheus Pod was not created on OpenShift 4.10
in side by side deployment of k8s collection

I observed following error:
```
  Warning  FailedCreate  5m44s (x6 over 5m44s)       statefulset-controller  create Pod prometheus-collection-kube-prometheus-prometheus-0 in StatefulSet prometheus-collection-kube-prometheus-prometheus failed error: pods "prometheus-collection-kube-prometheus-prometheus-0" is forbidden: unable to validate against any security context constraint: [provider "anyuid": Forbidden: not usable by user or serviceaccount, provider restricted: .spec.securityContext.fsGroup: Invalid value: []int64{2000}: 2000 is not an allowed group, spec.initContainers[0].securityContext.runAsUser: Invalid value: 1000: must be in the ranges: [1000420000, 1000429999], spec.containers[0].securityContext.runAsUser: Invalid value: 1000: must be in the ranges: [1000420000, 1000429999], spec.containers[1].securityContext.runAsUser: Invalid value: 1000: must be in the ranges: [1000420000, 1000429999], spec.containers[2].securityContext.runAsUser: Invalid value: 1000: must be in the ranges: [1000420000, 1000429999], provider "nonroot": Forbidden: not usable by user or serviceaccount, provider "hostmount-anyuid": Forbidden: not usable by user or serviceaccount, provider "machine-api-termination-handler": Forbidden: not usable by user or serviceaccount, provider "hostnetwork": Forbidden: not usable by user or serviceaccount, provider "hostaccess": Forbidden: not usable by user or serviceaccount, provider "node-exporter": Forbidden: not usable by user or serviceaccount, provider "privileged": Forbidden: not usable by user or serviceaccount]  Warning  FailedCreate  <invalid> (x14 over 5m44s)  statefulset-controller  create Pod prometheus-collection-kube-prometheus-prometheus-0 in StatefulSet prometheus-collection-kube-prometheus-prometheus failed error: pods "prometheus-collection-kube-prometheus-prometheus-0" is forbidden: unable to validate against any security context constraint: [provider "anyuid": Forbidden: not usable by user or serviceaccount, provider restricted: .spec.securityContext.fsGroup: Invalid value: []int64{2000}: 2000 is not an allowed group, spec.initContainers[0].securityContext.runAsUser: Invalid value: 1000: must be in the ranges: [1000420000, 1000429999], spec.containers[0].securityContext.runAsUser: Invalid value: 1000: must be in the ranges: [1000420000, 1000429999], spec.containers[1].securityContext.runAsUser: Invalid value: 1000: must be in the ranges: [1000420000, 1000429999], spec.containers[2].securityContext.runAsUser: Invalid value: 1000: must be in the ranges: [1000420000, 1/Users/kkujawa/git/sumologic-kubernetes-collection-helm-operator/openshift4_10/statefulset.yaml000429999], provider "nonroot": Forbidden: not usable by user or serviceaccount, provider "hostmount-anyuid": Forbidden: not usable by user or serviceaccount, provider "machine-api-termination-handler": Forbidden: not usable by user or serviceaccount, provider "hostnetwork": Forbidden: not usable by user or serviceaccount, provider "hostaccess": Forbidden: not usable by user or serviceaccount, spec.volumes[1]: Invalid value: "projected": projected volumes are not allowed to be used, provider "node-exporter": Forbidden: not usable by user or serviceaccount, provider "privileged": Forbidden: not usable by user or serviceaccount]
```
