### PR TITLE
feat: store Sumo credentials for the setup Job in a Secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- feat: store Sumo credentials for the setup Job in a Secret [#2466]
+
+[#2466]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2466
+[Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.14.1...main
+
 ## [v2.14.1]
 
 ### Released 2022-08-01

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -311,6 +311,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- template "sumologic.fullname" . }}-setup-scc
 {{- end -}}
 
+{{- define "sumologic.labels.app.setup.secret" -}}
+{{- template "sumologic.labels.app.setup" . }}
+{{- end -}}
+
 {{- define "sumologic.labels.app.podsecuritypolicy" -}}
 {{- template "sumologic.fullname" . }}-psp
 {{- end -}}
@@ -613,6 +617,10 @@ helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 
 {{- define "sumologic.metadata.name.setup.securitycontextconstraints" -}}
 {{- template "sumologic.metadata.name.setup" . }}-scc
+{{- end -}}
+
+{{- define "sumologic.metadata.name.setup.secret" -}}
+{{ template "sumologic.metadata.name.setup" . }}
 {{- end -}}
 
 {{- define "sumologic.metadata.name.cleanup" -}}

--- a/deploy/helm/sumologic/templates/setup/job.yaml
+++ b/deploy/helm/sumologic/templates/setup/job.yaml
@@ -61,16 +61,10 @@ spec:
           mountPath: /etc/terraform
         - name: custom
           mountPath: /customer-scripts
-        {{- if .Values.sumologic.envFromSecret }}
         envFrom:
         - secretRef:
-            name: {{ .Values.sumologic.envFromSecret }}
-        {{ else }}
+            name: {{ .Values.sumologic.envFromSecret | default (include "sumologic.metadata.name.setup.secret" .)}}
         env:
-        - name: SUMOLOGIC_ACCESSID
-          value: {{ required "A valid .Values.sumologic.accessId entry required!" .Values.sumologic.accessId }}
-        - name: SUMOLOGIC_ACCESSKEY
-          value: {{ required "A valid .Values.sumologic.accessKey entry required!" .Values.sumologic.accessKey }}
         - name: SUMOLOGIC_BASE_URL
           value: {{ .Values.sumologic.endpoint }}
         - name: HTTP_PROXY
@@ -83,7 +77,6 @@ spec:
         - name: DEBUG_MODE
           value: "true"
 {{- end }}
-        {{ end }}
       securityContext:
         runAsUser: 999
 {{- end }}

--- a/deploy/helm/sumologic/templates/setup/secret.yaml
+++ b/deploy/helm/sumologic/templates/setup/secret.yaml
@@ -1,0 +1,14 @@
+{{- if not .Values.sumologic.envFromSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "sumologic.metadata.name.setup.secret" . }}
+  annotations:
+{{ include "sumologic.annotations.app.setup.helmsh" "3" | indent 4 }}
+  labels:
+    app: {{ template "sumologic.labels.app.setup.secret" . }}
+    {{- include "sumologic.labels.common" . | nindent 4 }}
+data:
+  SUMOLOGIC_ACCESSID: {{ required "A valid .Values.sumologic.accessId entry required!" .Values.sumologic.accessId | b64enc }}
+  SUMOLOGIC_ACCESSKEY: {{ required "A valid .Values.sumologic.accessKey entry required!" .Values.sumologic.accessKey | b64enc }}
+{{ end }}


### PR DESCRIPTION
##### Description

Adds some additional security. The setup Job is run as a Helm pre-install hook, so it gets deleted after it finishes. While it was running, it was possible to read the credentials from the Pod definition. With this change, they're stored in a Secret instead.

---

##### Checklist

<!---
Remove items which don't apply to your PR.
-->

- [x] Changelog updated

###### Testing performed

- [X] Redeploy fluentd and fluentd-events pods
- [X] Confirm events, logs, and metrics are coming in
