### PR TITLE
fix(docs): make the new version of markdownlint happy

### DIFF
--- a/deploy/docs/fluentd_otc_comparison.md
+++ b/deploy/docs/fluentd_otc_comparison.md
@@ -47,10 +47,10 @@ Additional behavior:
 
 | Description                                                                                                    | Opentelemetry Collector                                                               |
 |----------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|
-| [record[_sumo_metadata][source_name]][source_name_precedence] taking precedence over `source_name`             | Can be achieved by separate pipelines                                                 |
-| [record[_sumo_metadata][source_host]][source_host_precedence] taking precedence over `source_host`             | Can be achieved by separate pipelines                                                 |
-| [record[_sumo_metadata][source_category]][source_category_precedence] taking precedence over `source_category` | Can be achieved by separate pipelines                                                 |
-| [record[_sumo_metadata][fields]][fields_base] being base for fields                                            | Can be achieved using [resource processor][resource_processor] and separate pipelines |
+| [record\[_sumo_metadata\]\[source_name\]][source_name_precedence] taking precedence over `source_name`             | Can be achieved by separate pipelines                                                 |
+| [record\[_sumo_metadata\]\[source_host\]][source_host_precedence] taking precedence over `source_host`             | Can be achieved by separate pipelines                                                 |
+| [record\[_sumo_metadata\]\[source_category\]][source_category_precedence] taking precedence over `source_category` | Can be achieved by separate pipelines                                                 |
+| [record\[_sumo_metadata\]\[fields\]][fields_base] being base for fields                                            | Can be achieved using [resource processor][resource_processor] and separate pipelines |
 
 [fields_base]: https://github.com/SumoLogic/fluentd-output-sumologic/blob/1.7.2/lib/fluent/plugin/out_sumologic.rb#L284-L285
 [fluentd_output_plugin]: https://github.com/sumologic/fluentd-output-sumologic/tree/1.7.2#configuration


### PR DESCRIPTION
Newest version of markdownlint complaints about unescaped square brackets.
