### PR TITLE
ci(integration-tests): set golangci-lint version to 1.47

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -134,6 +134,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
+          version: v1.47
           working-directory: ./tests/integration/
           # Optional: golangci-lint command line arguments.
           args: --timeout=10m --verbose


### PR DESCRIPTION
This used to be the latest version, and v1.48 started throwing some mysterious gofmt-related errors.