### PR TITLE
docs: fix "open explore" dead link

### DIFF
--- a/deploy/docs/SideBySidePrometheus.md
+++ b/deploy/docs/SideBySidePrometheus.md
@@ -224,7 +224,7 @@ If you do not see data in Sumo Logic, you can review our
 [troubleshooting guide](./Troubleshoot_Collection.md).
 
 [sumo-k8s-app-dashboards]: https://help.sumologic.com/07Sumo-Logic-Apps/10Containers_and_Orchestration/Kubernetes/Install_the_Kubernetes_App_and_view_the_Dashboards
-[open a new Explore tab]: https://help.sumologic.com/Observability_Solution/Kubernetes_Solution/Navigate_your_Kubernetes_environment
+[open a new Explore tab]: https://help.sumologic.com/Observability_Solution/Kubernetes_Solution/02Monitoring_Using_Kubernetes#open%C2%A0explore
 
 ### Troubleshooting Installation
 

--- a/deploy/docs/existingPrometheusDoc.md
+++ b/deploy/docs/existingPrometheusDoc.md
@@ -191,7 +191,7 @@ or [open a new Explore tab] in Sumo Logic.
 If you do not see data in Sumo Logic, you can review our [troubleshooting guide](./Troubleshoot_Collection.md).
 
 [sumo-k8s-app-dashboards]: https://help.sumologic.com/07Sumo-Logic-Apps/10Containers_and_Orchestration/Kubernetes/Install_the_Kubernetes_App_and_view_the_Dashboards
-[open a new Explore tab]: https://help.sumologic.com/Observability_Solution/Kubernetes_Solution/Navigate_your_Kubernetes_environment
+[open a new Explore tab]: https://help.sumologic.com/Observability_Solution/Kubernetes_Solution/02Monitoring_Using_Kubernetes#open%C2%A0explore
 
 ## Merge Prometheus Configuration
 

--- a/deploy/docs/standAlonePrometheus.md
+++ b/deploy/docs/standAlonePrometheus.md
@@ -165,7 +165,7 @@ If you do not see data in Sumo Logic, you can review our
 [troubleshooting guide](./Troubleshoot_Collection.md).
 
 [sumo-k8s-app-dashboards]: https://help.sumologic.com/07Sumo-Logic-Apps/10Containers_and_Orchestration/Kubernetes/Install_the_Kubernetes_App_and_view_the_Dashboards
-[open a new Explore tab]: https://help.sumologic.com/Observability_Solution/Kubernetes_Solution/Navigate_your_Kubernetes_environment
+[open a new Explore tab]: https://help.sumologic.com/Observability_Solution/Kubernetes_Solution/02Monitoring_Using_Kubernetes#open%C2%A0explore
 
 ## Customizing Installation
 


### PR DESCRIPTION
##### Description

A change of a dead link. A section of the documentation has been moved into another place and therefore the link has died.
Formerly: https://web.archive.org/web/20220121113033/https://help.sumologic.com/Observability_Solution/Kubernetes_Solution/Navigate_your_Kubernetes_environment
Currently: https://help.sumologic.com/Observability_Solution/Kubernetes_Solution/02Monitoring_Using_Kubernetes#open%C2%A0explore
