### PR TITLE
feat: enable remote write proxy by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- feat: enable remote write proxy by default [#2483]
+
+[#2483]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2483
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.15.0...main
 
 ## [v2.15.0]

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -1317,6 +1317,17 @@ Example Usage:
 {{- end -}}
 
 {{/*
+Check if remote write proxy is enabled.
+Example Usage:
+{{- if eq (include "metrics.remoteWriteProxy.enabled" .) "true" }}
+
+*/}}
+{{- define "metrics.remoteWriteProxy.enabled" -}}
+{{ and (eq (include "metrics.enabled" .) "true") (eq .Values.sumologic.metrics.remoteWriteProxy.enabled true) }}
+{{- end -}}
+
+
+{{/*
 Check if any logs metadata provider is enabled
 
 Example Usage:

--- a/deploy/helm/sumologic/templates/metrics/remote-write-proxy/configmap.yaml
+++ b/deploy/helm/sumologic/templates/metrics/remote-write-proxy/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.sumologic.metrics.remoteWriteProxy.enabled }}
+{{- if eq (include "metrics.remoteWriteProxy.enabled" .) "true" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/deploy/helm/sumologic/templates/metrics/remote-write-proxy/deployment.yaml
+++ b/deploy/helm/sumologic/templates/metrics/remote-write-proxy/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.sumologic.metrics.remoteWriteProxy.enabled }}
+{{- if eq (include "metrics.remoteWriteProxy.enabled" .) "true" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/deploy/helm/sumologic/templates/metrics/remote-write-proxy/service.yaml
+++ b/deploy/helm/sumologic/templates/metrics/remote-write-proxy/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.sumologic.metrics.remoteWriteProxy.enabled }}
+{{- if eq (include "metrics.remoteWriteProxy.enabled" .) "true" }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -267,7 +267,7 @@ sumologic:
     ## This is an advanced feature, enable only if you're experiencing performance
     ## issues with metrics metadata enrichment.
     remoteWriteProxy:
-      enabled: false
+      enabled: true
       config:
         ## Increase this if you've increased samples_per_send in Prometheus to prevent nginx
         ## from spilling proxied request bodies to disk
@@ -286,7 +286,7 @@ sumologic:
           cpu: 1000m
           memory: 256Mi
         requests:
-          cpu: 200m
+          cpu: 100m
           memory: 128Mi
       livenessProbe:
         initialDelaySeconds: 30

--- a/tests/helm/remote_write_proxy/static/basic.output.yaml
+++ b/tests/helm/remote_write_proxy/static/basic.output.yaml
@@ -37,7 +37,7 @@ spec:
             cpu: 1000m
             memory: 256Mi
           requests:
-            cpu: 200m
+            cpu: 100m
             memory: 128Mi
         livenessProbe:
           tcpSocket:

--- a/tests/integration/values/values_common.yaml
+++ b/tests/integration/values/values_common.yaml
@@ -11,6 +11,13 @@ sumologic:
   accessKey: "dummy"
   endpoint: http://receiver-mock.receiver-mock:3000/terraform/api/
 
+  metrics:
+    remoteWriteProxy:
+      resources:
+        requests:
+          cpu: 5m
+          memory: 16Mi
+
 # Request less resources so that this fits on Github actions runners environment
 kube-prometheus-stack:
   prometheus:


### PR DESCRIPTION
##### Description

Remote write proxy helps metrics metadata enrichment efficiency by a lot, especially for larger clusters. It comes at a slight additional operational cost of the nginx Deployment, and a minimal resource cost. We've been running it in production for the past 6 months and never had any issue, so I believe we should enable it by default.

This isn't a breaking change, but it enables a new component, so I'm tagging it for v3.

---

##### Checklist

<!---
Remove items which don't apply to your PR.
-->

- [x] Changelog updated

###### Testing performed

- [X] Redeploy fluentd and fluentd-events pods
- [X] Confirm events, logs, and metrics are coming in
