### PR TITLE
test(integration): improve teardown

### DIFF
--- a/tests/integration/internal/ctxopts/context_opts.go
+++ b/tests/integration/internal/ctxopts/context_opts.go
@@ -14,6 +14,7 @@ const (
 	ctxKeyNameHelmOptions    ctxKey = "helmoptions"
 	ctxKeyNameHelmRelease    ctxKey = "helmrelease"
 	ctxKeyNameNamespace      ctxKey = "namespace"
+	ctxKeyNameKindClusters   ctxKey = "kindClusters"
 )
 
 func WithKubectlOptions(ctx context.Context, kubectlOptions *k8s.KubectlOptions) context.Context {
@@ -50,4 +51,35 @@ func WithHelmRelease(ctx context.Context, namespace string) context.Context {
 func HelmRelease(ctx context.Context) string {
 	v := ctx.Value(ctxKeyNameHelmRelease)
 	return v.(string)
+}
+
+func Clusters(ctx context.Context) []string {
+	v := ctx.Value(ctxKeyNameKindClusters)
+	if v == nil {
+		return []string{}
+	}
+	return v.([]string)
+}
+
+func WithCluster(ctx context.Context, clusterName string) context.Context {
+	clusters := Clusters(ctx)
+	clusters = append(clusters, clusterName)
+	return context.WithValue(ctx, ctxKeyNameKindClusters, clusters)
+}
+
+func WithoutCluster(ctx context.Context, clusterName string) context.Context {
+	clusters := Clusters(ctx)
+	index := -1
+	for i, cluster := range clusters {
+		if cluster == clusterName {
+			index = i
+		}
+	}
+	if index == -1 {
+		return ctx
+	}
+
+	clusters[index] = clusters[len(clusters)-1]
+	clusters = clusters[:len(clusters)-1]
+	return context.WithValue(ctx, ctxKeyNameKindClusters, clusters)
 }

--- a/tests/integration/internal/stepfuncs/debug.go
+++ b/tests/integration/internal/stepfuncs/debug.go
@@ -21,7 +21,6 @@ import (
 // NOTE:
 // By default the default cluster namespace will be used. If you'd like to specify the namespace
 // use SetKubectlNamespaceOpt.
-//
 func PrintClusterStateOpt(force ...bool) features.Func {
 	return func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
 		if (len(force) == 1 && force[0]) || t.Failed() {

--- a/tests/integration/internal/stepfuncs/helm.go
+++ b/tests/integration/internal/stepfuncs/helm.go
@@ -61,7 +61,6 @@ func HelmDependencyUpdateOpt(path string) features.Func {
 // NOTE:
 // By default the default cluster namespace will be used. If you'd like to specify the namespace
 // use SetKubectlNamespaceOpt.
-//
 func HelmInstallOpt(path string, releaseName string) features.Func {
 	return func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
 		ctx = ctxopts.WithHelmRelease(ctx, releaseName)
@@ -94,7 +93,6 @@ func HelmInstallTestOpt(path string) features.Func {
 // NOTE:
 // By default the default cluster namespace will be used. If you'd like to specify the namespace
 // use SetKubectlNamespaceOpt.
-//
 func HelmDeleteOpt(release string) features.Func {
 	return func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
 		helm.Delete(t, ctxopts.HelmOptions(ctx), release, true)
@@ -117,7 +115,6 @@ func HelmDeleteTestOpt() features.Func {
 // NOTE:
 // By default the default cluster namespace will be used. If you'd like to specify the namespace
 // use SetKubectlNamespaceOpt.
-//
 func SetHelmOptionsOpt(valuesFilePath string, extraInstallationArgs map[string][]string) features.Func {
 	return func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
 		kubectlOptions := ctxopts.KubectlOptions(ctx)

--- a/tests/integration/internal/stepfuncs/options.go
+++ b/tests/integration/internal/stepfuncs/options.go
@@ -19,21 +19,22 @@ import (
 // Example:
 //
 // func WaitUntilStatefulSetIsReady(
-//   opts ...Option,
-// ) features.Func {
-//   return func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
-//     sts := appsv1.StatefulSet{
-//       ObjectMeta: v1.ObjectMeta{
-//         Namespace: ctxopts.Namespace(ctx),
-//       },
-//     }
-//     for _, opt := range opts {
-//       opt.Apply(ctx, &sts)
-//       ...
-//     }
-//   ...
-// }
 //
+//	opts ...Option,
+//
+//	) features.Func {
+//	  return func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
+//	    sts := appsv1.StatefulSet{
+//	      ObjectMeta: v1.ObjectMeta{
+//	        Namespace: ctxopts.Namespace(ctx),
+//	      },
+//	    }
+//	    for _, opt := range opts {
+//	      opt.Apply(ctx, &sts)
+//	      ...
+//	    }
+//	  ...
+//	}
 type Option interface {
 	Apply(ctx context.Context, obj k8s.Object)
 	GetListOption(ctx context.Context) resources.ListOption
@@ -112,13 +113,15 @@ func (lo labelsFOption) GetListOption(ctx context.Context) resources.ListOption 
 //
 // Example:
 // stepfuncs.WaitUntilStatefulSetIsReady(
-//   ...
-//   stepfuncs.WithLabelsF(
-//     stepfuncs.LabelFormatterKV{
-//       K: "app",
-//       V: stepfuncs.ReleaseFormatter("%s-sumologic-fluentd-events"),
-//     },
-//   ),
+//
+//	...
+//	stepfuncs.WithLabelsF(
+//	  stepfuncs.LabelFormatterKV{
+//	    K: "app",
+//	    V: stepfuncs.ReleaseFormatter("%s-sumologic-fluentd-events"),
+//	  },
+//	),
+//
 // ),
 //
 // The above snippet will use the helm release name (passed around in tests context)


### PR DESCRIPTION
##### Description

Add explicit teardown steps for resources created by integration tests.E2E framework's AfterEachTest actions are not actually called if the test errors out or panics, so we add explicit Finish actions for all of our resources.
