### PR TITLE
feat(tests/integration): add integration tests for otlp traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix(logs): prevent Fluent Bit from doing metadata enrichment [#2512]
 - chore(kube-prometheus-stack): update kube-prometheus-stack chart to 39.11.0 [#2446]
 
-### Added
-
 ### Changed
 
 - feat: enable remote write proxy by default [#2483]

--- a/tests/integration/helm_otelcol_traces_test.go
+++ b/tests/integration/helm_otelcol_traces_test.go
@@ -1,0 +1,126 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal"
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/ctxopts"
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/stepfuncs"
+	terrak8s "github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+func Test_Helm_Otelcol_Traces(t *testing.T) {
+	const (
+		tickDuration           = 3 * time.Second
+		waitDuration           = 3 * time.Minute
+		tracesPerExporter uint = 10 // number of traces generated
+		spansPerTrace     uint = 5
+	)
+	featInstall := features.New("traces").
+		Assess("sumologic secret is created with endpoints",
+			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
+				terrak8s.WaitUntilSecretAvailable(t, ctxopts.KubectlOptions(ctx), "sumologic", 60, tickDuration)
+				secret := terrak8s.GetSecret(t, ctxopts.KubectlOptions(ctx), "sumologic")
+				require.Len(t, secret.Data, 2, "Secret has incorrect number of endpoints. There should be 2 endpoints.")
+				return ctx
+			}).
+		// TODO: Rewrite into similar step func as WaitUntilStatefulSetIsReady but for deployments
+		Assess("otelcol deployment is ready", func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
+			res := envConf.Client().Resources(ctxopts.Namespace(ctx))
+			releaseName := ctxopts.HelmRelease(ctx)
+			labelSelector := fmt.Sprintf("app=%s-sumologic-otelcol", releaseName)
+			ds := appsv1.DeploymentList{}
+
+			require.NoError(t,
+				wait.For(
+					conditions.New(res).
+						ResourceListN(&ds, 1,
+							resources.WithLabelSelector(labelSelector),
+						),
+					wait.WithTimeout(waitDuration),
+					wait.WithInterval(tickDuration),
+				),
+			)
+			require.NoError(t,
+				wait.For(
+					conditions.New(res).
+						DeploymentConditionMatch(&ds.Items[0], appsv1.DeploymentAvailable, corev1.ConditionTrue),
+					wait.WithTimeout(waitDuration),
+					wait.WithInterval(tickDuration),
+				),
+			)
+			return ctx
+		}).
+		// TODO: Rewrite into similar step func as WaitUntilStatefulSetIsReady but for daemonsets
+		Assess("otelagent daemonset is ready", func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
+			res := envConf.Client().Resources(ctxopts.Namespace(ctx))
+			nl := corev1.NodeList{}
+			if !assert.NoError(t, res.List(ctx, &nl)) {
+				return ctx
+			}
+
+			releaseName := ctxopts.HelmRelease(ctx)
+			labelSelector := fmt.Sprintf("app=%s-sumologic-otelagent", releaseName)
+			ds := appsv1.DaemonSetList{}
+
+			require.NoError(t,
+				wait.For(
+					conditions.New(res).
+						ResourceListN(&ds, 1,
+							resources.WithLabelSelector(labelSelector),
+						),
+					wait.WithTimeout(waitDuration),
+					wait.WithInterval(tickDuration),
+				),
+			)
+			require.NoError(t,
+				wait.For(
+					conditions.New(res).
+						ResourceMatch(&ds.Items[0], func(object k8s.Object) bool {
+							d := object.(*appsv1.DaemonSet)
+							return d.Status.NumberUnavailable == 0 &&
+								d.Status.NumberReady == int32(len(nl.Items))
+						}),
+					wait.WithTimeout(waitDuration),
+					wait.WithInterval(tickDuration),
+				),
+			)
+			return ctx
+		}).Feature()
+
+	featTraces := features.New("traces").
+		Setup(stepfuncs.GenerateTraces(
+			tracesPerExporter,
+			spansPerTrace,
+			internal.TracesGeneratorName,
+			internal.TracesGeneratorNamespace,
+			internal.TracesGeneratorImage,
+		)).
+		Assess("wait for traces", func(c context.Context, _ *testing.T, _ *envconf.Config) context.Context {
+			time.Sleep(120 * time.Second)
+			return c
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
+			opts := *ctxopts.KubectlOptions(ctx)
+			opts.Namespace = internal.TracesGeneratorNamespace
+			terrak8s.RunKubectl(t, &opts, "delete", "daemonset", internal.TracesGeneratorName)
+			return ctx
+		}).
+		Teardown(stepfuncs.KubectlDeleteNamespaceOpt(internal.TracesGeneratorNamespace)).
+		Feature()
+
+	testenv.Test(t, featInstall, featTraces)
+}

--- a/tests/integration/internal/constants.go
+++ b/tests/integration/internal/constants.go
@@ -27,6 +27,10 @@ const (
 	LogsGeneratorName      = "logs-generator"
 	LogsGeneratorImage     = "sumologic/kubernetes-tools:2.13.0"
 
+	TracesGeneratorNamespace = "customer-trace-tester"
+	TracesGeneratorName      = "customer-trace-tester"
+	TracesGeneratorImage     = "sumologic/kubernetes-tools:2.13.0"
+
 	MultilineLogsNamespace = "multiline-logs-generator"
 	MultilineLogsPodName   = "multiline-logs-generator"
 	MultilineLogsGenerator = "yamls/multiline-logs-generator.yaml"

--- a/tests/integration/internal/stepfuncs/traces.go
+++ b/tests/integration/internal/stepfuncs/traces.go
@@ -1,0 +1,53 @@
+package stepfuncs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/tracesgenerator"
+)
+
+// Generate logsCount logs using a deployment.
+func GenerateTraces(
+	tracesPerExporter uint,
+	spansPerTrace uint,
+	tracesGeneratorName string,
+	tracesGeneratorNamespace string,
+	tracesGeneratorImage string,
+) features.Func {
+	return func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
+		client := envConf.Client()
+		generatorOptions := *tracesgenerator.NewDefaultGeneratorOptions()
+		generatorOptions.TracesPerExporter = tracesPerExporter
+		generatorOptions.SpansPerTrace = spansPerTrace
+
+		var namespace corev1.Namespace
+		err := client.Resources().Get(ctx, tracesGeneratorNamespace, "", &namespace)
+		if err != nil {
+			// create the namespace
+			namespace := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: tracesGeneratorNamespace}}
+			require.NoError(t, client.Resources().Create(ctx, &namespace))
+		}
+
+		deployment := tracesgenerator.GetTracesGeneratorDeployment(
+			ctx,
+			tracesGeneratorNamespace,
+			tracesGeneratorName,
+			tracesGeneratorImage,
+			generatorOptions,
+		)
+
+		// create the deployment
+		err = client.Resources(tracesGeneratorNamespace).Create(ctx, &deployment)
+		require.NoError(t, err)
+
+		return ctx
+	}
+}

--- a/tests/integration/internal/tracesgenerator/tracesgenerator.go
+++ b/tests/integration/internal/tracesgenerator/tracesgenerator.go
@@ -1,0 +1,127 @@
+package tracesgenerator
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/ctxopts"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	generatorBinaryName = "customer-trace-tester"
+	deploymentSleepTime = time.Hour * 24 // how much time we spend sleeping after generating logs in a Deployment
+)
+
+type TracesGeneratorOptions struct {
+	// For all of these options, 0 and "" respectively are treated as "not set"
+
+	// Total number of traces generated per exporter
+	TracesPerExporter uint
+	// Number of spans per every trace
+	SpansPerTrace uint
+
+	// Exporter options
+	otlpHttpEnabled  bool
+	otlpGrpcEnabled  bool
+	zipkinEnabled    bool
+	jaegerThriftHttp bool
+}
+
+func NewDefaultGeneratorOptions() *TracesGeneratorOptions {
+	return &TracesGeneratorOptions{
+		TracesPerExporter: 40,
+		SpansPerTrace:     5,
+		otlpHttpEnabled:   true,
+		otlpGrpcEnabled:   true,
+		zipkinEnabled:     true,
+		jaegerThriftHttp:  true,
+	}
+}
+
+func GetTracesGeneratorDeployment(
+	ctx context.Context,
+	namespace string,
+	name string,
+	image string,
+	options TracesGeneratorOptions,
+) appsv1.Deployment {
+	var replicas int32 = 1
+	appLabels := map[string]string{
+		"app": name,
+	}
+	metadata := metav1.ObjectMeta{
+		Name:      name,
+		Namespace: namespace,
+		Labels:    appLabels,
+	}
+
+	release := ctxopts.HelmRelease(ctx)
+	otelcolNamespace := ctxopts.Namespace(ctx)
+	colName := fmt.Sprintf("%s-sumologic-otelcol.%s", release, otelcolNamespace)
+
+	podTemplateSpec := corev1.PodTemplateSpec{
+		ObjectMeta: metadata,
+		Spec: corev1.PodSpec{
+			Containers: optionsToContainers(ctx, options, name, image, colName),
+		},
+	}
+	return appsv1.Deployment{
+		ObjectMeta: metadata,
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: appLabels,
+			},
+			Template: podTemplateSpec,
+		},
+	}
+}
+
+func optionsToContainers(ctx context.Context, options TracesGeneratorOptions, name string, image string, colName string) []corev1.Container {
+	// There's no way to tell the log generator to keep running after it's done generating logs. This is annoying if
+	// we want to run it in a Deployment and not have it be restarted after exiting. So we sleep after it exits.
+	command := fmt.Sprintf("%s; sleep %f", generatorBinaryName, deploymentSleepTime.Seconds())
+	return []corev1.Container{
+		{
+			Name:    name,
+			Image:   image,
+			Command: []string{"/bin/bash", "-c", "--"},
+			Args:    []string{command},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "COLLECTOR_HOSTNAME",
+					Value: colName,
+				},
+				{
+					Name:  "TOTAL_TRACES",
+					Value: strconv.Itoa(int(options.TracesPerExporter)),
+				},
+				{
+					Name:  "SPANS_PER_TRACE",
+					Value: strconv.Itoa(int(options.SpansPerTrace)),
+				},
+				{
+					Name:  "OTLP_HTTP",
+					Value: strconv.FormatBool(options.otlpHttpEnabled),
+				},
+				{
+					Name:  "OTLP_GRPC",
+					Value: strconv.FormatBool(options.otlpGrpcEnabled),
+				},
+				{
+					Name:  "ZIPKIN",
+					Value: strconv.FormatBool(options.zipkinEnabled),
+				},
+				{
+					Name:  "JAEGER_THRIFT_HTTP",
+					Value: strconv.FormatBool(options.jaegerThriftHttp),
+				},
+			},
+		},
+	}
+}

--- a/tests/integration/values/values_helm_otelcol_traces.yaml
+++ b/tests/integration/values/values_helm_otelcol_traces.yaml
@@ -1,0 +1,23 @@
+sumologic:
+  logs:
+    enabled: false
+
+  metrics:
+    enabled: false
+
+  traces:
+    enabled: true
+
+fluent-bit:
+  enabled: false
+
+fluentd:
+  events:
+    enabled: false
+
+otelcol:
+  config:
+  # TODO: Set a pipeline for traces
+    exporters:
+      otlphttp:
+        traces_endpoint: http://receiver-mock.receiver-mock:3000/receiver/v1/traces

--- a/tests/integration/values/values_helm_otelcol_traces.yaml
+++ b/tests/integration/values/values_helm_otelcol_traces.yaml
@@ -17,7 +17,7 @@ fluentd:
 
 otelcol:
   config:
-  # TODO: Set a pipeline for traces
+  # Default otlp pipeline from values.yaml is used.    
     exporters:
       otlphttp:
         traces_endpoint: http://receiver-mock.receiver-mock:3000/receiver/v1/traces

--- a/tests/integration/yamls/receiver-mock.yaml
+++ b/tests/integration/yamls/receiver-mock.yaml
@@ -34,6 +34,7 @@ spec:
             - --print-headers
             - --print-logs
             - --print-metrics
+            - --store-traces
             - --store-logs
             - --store-metrics
             - --print-spans

--- a/tests/integration/yamls/receiver-mock.yaml
+++ b/tests/integration/yamls/receiver-mock.yaml
@@ -36,6 +36,7 @@ spec:
             - --print-metrics
             - --store-logs
             - --store-metrics
+            - --print-spans
           resources: {}
           securityContext:
             capabilities:


### PR DESCRIPTION
This PR adds integration tests for otlp tracing.
The traces are generated using [customer-trace-tester](https://github.com/SumoLogic/sumologic-kubernetes-tools#customer-trace-tester) and then tested in a similar way to how logs are tested.