### PR TITLE
fix(openshift): fix remote write proxy - use unprivileged NGINX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: make creation of default Instrumentation object for opentelemetry operator configurable [#2506]
 - chore: update kubernetes-tools to 2.13.0 [#2515]
 
+### Fixed
+
+- fix(openshift): fix remote write proxy - use unprivileged NGINX [#2510][#2510]
+
 [#2483]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2483
 [#2502]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2502
 [#2506]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2506
 [#2512]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2512
 [#2515]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2515
-
+[#2510]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2510
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.15.0...main
 
 ## [v2.15.0]

--- a/deploy/helm/sumologic/conf/metrics/remote-write-proxy/remote-write-proxy.conf
+++ b/deploy/helm/sumologic/conf/metrics/remote-write-proxy/remote-write-proxy.conf
@@ -3,7 +3,7 @@ upstream remote {
 }
 
 server {
-    listen 80 default_server;
+    listen {{ .Values.sumologic.metrics.remoteWriteProxy.config.port }} default_server;
 
     location / {
         client_body_buffer_size {{ .Values.sumologic.metrics.remoteWriteProxy.config.clientBodyBufferSize }};

--- a/deploy/helm/sumologic/templates/metrics/remote-write-proxy/deployment.yaml
+++ b/deploy/helm/sumologic/templates/metrics/remote-write-proxy/deployment.yaml
@@ -57,16 +57,16 @@ spec:
         image: {{ .Values.sumologic.metrics.remoteWriteProxy.image.repository }}:{{ .Values.sumologic.metrics.remoteWriteProxy.image.tag }}
         imagePullPolicy: {{ .Values.sumologic.metrics.remoteWriteProxy.image.pullPolicy }}
         ports:
-        - containerPort: 80
+        - containerPort: {{ .Values.sumologic.metrics.remoteWriteProxy.config.port }}
         resources:
           {{- toYaml .Values.sumologic.metrics.remoteWriteProxy.resources | nindent 10 }}
         livenessProbe:
           tcpSocket:
-            port: 80
+            port: {{ .Values.sumologic.metrics.remoteWriteProxy.config.port }}
           {{- toYaml .Values.sumologic.metrics.remoteWriteProxy.livenessProbe | nindent 10 }}
         readinessProbe:
           tcpSocket:
-            port: 80
+            port: {{ .Values.sumologic.metrics.remoteWriteProxy.config.port }}
           {{- toYaml .Values.sumologic.metrics.remoteWriteProxy.readinessProbe | nindent 10 }}
         {{- if .Values.sumologic.metrics.remoteWriteProxy.config.workerCountAutotune }}
         env:

--- a/deploy/helm/sumologic/templates/metrics/remote-write-proxy/service.yaml
+++ b/deploy/helm/sumologic/templates/metrics/remote-write-proxy/service.yaml
@@ -10,7 +10,7 @@ spec:
   ports:
     - name: http
       port: 9888
-      targetPort: 80
+      targetPort: {{ .Values.sumologic.metrics.remoteWriteProxy.config.port }}
   selector:
     app: {{ template "sumologic.labels.app.remoteWriteProxy.pod" . }}
 {{- end }}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -275,10 +275,11 @@ sumologic:
         ## This feature autodetects how much CPU is assigned to the nginx instance and sets
         ## the right amount of workers based on that. Disable to use the default of 8 workers.
         workerCountAutotune: true
+        ## Nginx listen port
+        port: 8080
       replicaCount: 3
       image:
-        ## TODO: Serve this image from the sumologic public ECR
-        repository: public.ecr.aws/nginx/nginx
+        repository: public.ecr.aws/sumologic/nginx-unprivileged
         tag: 1.21-alpine
         pullPolicy: IfNotPresent
       resources:

--- a/tests/helm/remote_write_proxy/static/basic.output.yaml
+++ b/tests/helm/remote_write_proxy/static/basic.output.yaml
@@ -28,10 +28,10 @@ spec:
         {}
       containers:
       - name: nginx
-        image: public.ecr.aws/nginx/nginx:1.21-alpine
+        image: public.ecr.aws/sumologic/nginx-unprivileged:1.21-alpine
         imagePullPolicy: IfNotPresent
         ports:
-        - containerPort: 80
+        - containerPort: 8080
         resources:
           limits:
             cpu: 1000m
@@ -41,7 +41,7 @@ spec:
             memory: 128Mi
         livenessProbe:
           tcpSocket:
-            port: 80
+            port: 8080
           failureThreshold: 6
           initialDelaySeconds: 30
           periodSeconds: 10
@@ -49,7 +49,7 @@ spec:
           timeoutSeconds: 5
         readinessProbe:
           tcpSocket:
-            port: 80
+            port: 8080
           failureThreshold: 3
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/tests/helm/remote_write_proxy/static/full_config.input.yaml
+++ b/tests/helm/remote_write_proxy/static/full_config.input.yaml
@@ -13,6 +13,8 @@ sumologic:
         ## This feature autodetects how much CPU is assigned to the nginx instance and sets
         ## the right amount of workers based on that. Disable to use the default of 8 workers.
         workerCountAutotune: false
+        ## Nginx listen port
+        port: 80
       replicaCount: 4
       image:
         repository: public.ecr.aws/nginx/nginx-custom


### PR DESCRIPTION
ref: 
- https://github.com/nginxinc/docker-nginx-unprivileged
- https://hub.docker.com/r/nginxinc/nginx-unprivileged

NGINX Unprivileged Docker Image is owned and maintained by NGINX on both GitHub and Docker Hub, see https://github.com/nginxinc/docker-nginx-unprivileged/issues/19#issuecomment-479536708 

Some details about Nginx on OpenShift can be found here: https://torstenwalter.de/openshift/nginx/2017/08/04/nginx-on-openshift.html

With `public.ecr.aws/nginx/nginx:1.21-alpine` image following issue occurs on OpenShift 4.10:
```
% kubectl logs -n sumologic collection-sumologic-remote-write-proxy-5bb47649df-wv2dv  -p
/docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
/docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
/docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
10-listen-on-ipv6-by-default.sh: info: can not modify /etc/nginx/conf.d/default.conf (read-only file system?)
/docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
/docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
30-tune-worker-processes.sh: error: can not modify /etc/nginx/nginx.conf (read-only file system?)
/docker-entrypoint.sh: Configuration complete; ready for start up
2022/09/06 15:18:06 [warn] 1#1: the "user" directive makes sense only if the master process runs with super-user privileges, ignored in /etc/nginx/nginx.conf:2
nginx: [warn] the "user" directive makes sense only if the master process runs with super-user privileges, ignored in /etc/nginx/nginx.conf:2
2022/09/06 15:18:06 [emerg] 1#1: mkdir() "/var/cache/nginx/client_temp" failed (13: Permission denied)
nginx: [emerg] mkdir() "/var/cache/nginx/client_temp" failed (13: Permission denied)
```

```
kubectl get pods -n sumologic  | grep remote
collection-sumologic-remote-write-proxy-5bb47649df-68vcl     0/1     CrashLoopBackOff   9 (76s ago)   22m
collection-sumologic-remote-write-proxy-5bb47649df-gmlfg     0/1     CrashLoopBackOff   9 (69s ago)   22m
collection-sumologic-remote-write-proxy-5bb47649df-wv2dv     0/1     CrashLoopBackOff   9 (81s ago)   22m
```

