### PR TITLE
chore: upgrade nginx to 1.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- chore: upgrade nginx to 1.23 [#2544]
 - feat: enable remote write proxy by default [#2483]
 - chore: update kubernetes-tools to 2.13.0 [#2515]
 - feat(metadata): upgrade otelcol to v0.57.2-sumo-1 [#2526]
@@ -28,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2515]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2515
 [#2510]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2510
 [#2526]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2526
+[#2544]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2544
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.17.0...main
 
 ## [v2.17.0]

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -280,7 +280,7 @@ sumologic:
       replicaCount: 3
       image:
         repository: public.ecr.aws/sumologic/nginx-unprivileged
-        tag: 1.21-alpine
+        tag: 1.23-alpine
         pullPolicy: IfNotPresent
       resources:
         limits:

--- a/tests/helm/remote_write_proxy/static/basic.output.yaml
+++ b/tests/helm/remote_write_proxy/static/basic.output.yaml
@@ -28,7 +28,7 @@ spec:
         {}
       containers:
       - name: nginx
-        image: public.ecr.aws/sumologic/nginx-unprivileged:1.21-alpine
+        image: public.ecr.aws/sumologic/nginx-unprivileged:1.23-alpine
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080


### PR DESCRIPTION
##### Description

Upgrade nginx to the most recent stable version. 1.21 has some vulnerabilities in the alpine image.

---

##### Checklist

- [x] Changelog updated

