### PR TITLE
test(integration): run etcd in memory for kind

### DIFF
--- a/tests/integration/yamls/cluster.yaml
+++ b/tests/integration/yamls/cluster.yaml
@@ -17,5 +17,6 @@ nodes:
           bind-address: 0.0.0.0
     etcd:
       local:
+        dataDir: /tmp/etcd
         extraArgs:
           listen-metrics-urls: http://0.0.0.0:2381


### PR DESCRIPTION
##### Description

Etcd apparently does a lot of I/O on its storage, and this can be an issue in environments with slow disks, like CI runners. Put the storage in-memory instead.

This didn't really improve performance in testing, but I've recently seen some CI jobs fail due to etcd timing out, and I have hope that this will help.

See also: https://github.com/kubernetes-sigs/kind/issues/845
