### PR TITLE
ci: add PR job for reporting integration test status

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -173,3 +173,15 @@ jobs:
       - name: Run integration test - ${{ matrix.test_name }}
         working-directory: ./tests/integration/
         run: make test TEST_NAME=${{matrix.test_name}} KIND_NODE_IMAGE=${{matrix.kind_image}}
+  
+  integration-test-status:
+    runs-on: ubuntu-20.04
+    needs:
+      - integration-tests
+    steps:
+      - name: Tests passed
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - name: Tests failed
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1


### PR DESCRIPTION
We want to make integration tests a required check, but this is annoying to do given their number. Add a job that only reports their aggregate success for this purpose.