### PR TITLE
fix(setup): allow credentials to not be set if setup is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
+- fix(setup):allow credentials to not be set if setup is disabled [#2572]
 - fix(logs): prevent Fluent Bit from doing metadata enrichment [#2512]
 - chore(kube-prometheus-stack): update kube-prometheus-stack chart to 39.11.0 [#2446]
 
@@ -33,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2544]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2544
 [#2554]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2554
 [#2549]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2549
+[#2572]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2572
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.17.0...main
 
 ## [v2.17.0]

--- a/deploy/helm/sumologic/templates/setup/secret.yaml
+++ b/deploy/helm/sumologic/templates/setup/secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.sumologic.setupEnabled }}
 {{- if not .Values.sumologic.envFromSecret }}
 apiVersion: v1
 kind: Secret
@@ -11,4 +12,5 @@ metadata:
 data:
   SUMOLOGIC_ACCESSID: {{ required "A valid .Values.sumologic.accessId entry required!" .Values.sumologic.accessId | b64enc }}
   SUMOLOGIC_ACCESSKEY: {{ required "A valid .Values.sumologic.accessKey entry required!" .Values.sumologic.accessKey | b64enc }}
-{{ end }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
##### Description

A recent change moved setup credentials to a temporary Secret, but failed to make this Secret conditional on setup being enabled. As a result, it's necessary to provide credentials even if setup is disabled, which is incorrect.

This PR doesn't include a test because our Helm template test framework doesn't allow not setting credentials in tests. I'll look into adding a test using Terratest instead in a separate PR.

---

##### Checklist

<!---
Remove items which don't apply to your PR.
-->

- [ ] Changelog updated
