### PR TITLE
chore: remove support for GKE 1.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat(metadata): upgrade otelcol to v0.57.2-sumo-1 [#2526]
 - docs: update documentation around additionalRemoteWrite for kube-prometheus-stack [#2549]
 - chore(opentelemetry-operator): upgrade opentelemetry-operator subchart to 0.13.0 [#2561]
+- chore: remove support for GKE 1.20 [#2578]
 
 ### Fixed
 
@@ -37,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2549]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2549
 [#2572]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2572
 [#2561]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2561
+[#2578]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2578
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.17.0...main
 
 ## [v2.17.0]

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -81,7 +81,7 @@ The following table displays the tested Kubernetes and Helm versions.
 |---------------|------------------------------------------|
 | K8s with EKS  | 1.19<br/>1.20<br/>1.21<br/>1.22<br/>1.23 |
 | K8s with Kops | 1.20<br/>1.21<br/>1.22<br/>1.23<br/>1.24 |
-| K8s with GKE  | 1.20<br/>1.21<br/>1.22<br/>1.23          |
+| K8s with GKE  | 1.21<br/>1.22<br/>1.23                   |
 | K8s with AKS  | 1.22<br/>1.23<br/>1.24                   |
 | OpenShift     | 4.6<br/>4.7<br/>4.8<br/>4.9<br/>4.10     |
 | Helm          | 3.8.2 (Linux)                            |


### PR DESCRIPTION
##### Description

ref: https://cloud.google.com/kubernetes-engine/docs/release-notes-nochannel#October_05_2022


---

##### Checklist

<!---
Remove items which don't apply to your PR.
-->

- [ ] Changelog updated

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
