### PR TITLE
fix(cleanup): fix cleanup job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - fix(openshift): fix remote write proxy - use unprivileged NGINX [#2510], [#2510]
 - fix: default.metrics source is not imported when metrics are disabled and traces are enabled [#2547]
+- fix(cleanup): fix cleanup job [#2600]
 
 [#2483]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2483
 [#2512]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2512
@@ -57,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2591]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2591
 [#2595]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2595
 [#2597]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2597
+[#2600]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2600
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.17.0...main
 [telegraf_operator_comapare_1.3.5_and_1.3.10]: https://github.com/influxdata/helm-charts/compare/telegraf-operator-1.3.5...telegraf-operator-1.3.10
 [cert-manager-1.4]: https://github.com/cert-manager/cert-manager/releases/tag/v1.4.0

--- a/deploy/helm/sumologic/conf/cleanup/cleanup.sh
+++ b/deploy/helm/sumologic/conf/cleanup/cleanup.sh
@@ -19,7 +19,7 @@ terraform import sumologic_collector.collector {{ template "terraform.collector.
 # shellcheck disable=SC1083
 terraform import kubernetes_secret.sumologic_collection_secret {{ template "terraform.secret.fullname" . }}
 
-terraform destroy -auto-approve .
+terraform destroy -auto-approve
 
 # Cleanup env variables
 export SUMOLOGIC_BASE_URL=


### PR DESCRIPTION
##### Description

Fix cleanup job

```
2022-10-31T13:42:38.999556351Z stderr F ╷
2022-10-31T13:42:38.999587967Z stderr F │ Error: Failed to load "." as a plan file
2022-10-31T13:42:38.999599464Z stderr F │ 
2022-10-31T13:42:38.999604853Z stderr F │ The specified path is a directory, not a plan file. You can use the global
2022-10-31T13:42:38.999611347Z stderr F │ -chdir flag to use this directory as the configuration root.
2022-10-31T13:42:38.999616627Z stderr F ╵
```

---

##### Checklist

- [ ] Changelog updated

###### Testing performed

- [ ] Redeploy fluentd and fluentd-events pods
- [ ] Confirm events, logs, and metrics are coming in
