### PR TITLE
chore(vagrant): simplify jmx metric setup

### DIFF
--- a/vagrant/Makefile
+++ b/vagrant/Makefile
@@ -189,10 +189,6 @@ application-metrics-redis-bitnami-clean:
 	kubectl delete ns demo-redis-bitnami
 
 ## JMXExporter based JMX
-application-metrics-jmxexporter-docker-build:
-	docker build /sumologic/vagrant/k8s/application_metrics/jmx/jmxexporter/docker/ -t localhost:32000/jmxexporter/docker
-	docker push localhost:32000/jmxexporter/docker
-
 application-metrics-jmxexporter-docker-run:
 	kubectl create ns demo-jmxexporter-docker || true
 	kubectl -n demo-jmxexporter-docker apply -f ${k8s_path}/application_metrics/jmx/jmxexporter/docker/configmap.yaml
@@ -203,10 +199,6 @@ application-metrics-jmxexporter-docker-clean:
 
 ## Jolokia based JMX
 ### Jolokia as javagent
-application-metrics-jolokia-docker-build:
-	docker build /sumologic/vagrant/k8s/application_metrics/jmx/jolokia/docker/ -t localhost:32000/jolokia/docker
-	docker push localhost:32000/jolokia/docker
-
 application-metrics-jolokia-docker-run:
 	kubectl create ns demo-jolokia-docker || true
 	kubectl -n demo-jolokia-docker apply -f ${k8s_path}/application_metrics/jmx/jolokia/docker/statefulset.yaml
@@ -215,9 +207,6 @@ application-metrics-jolokia-docker-clean:
 	kubectl delete ns demo-jolokia-docker
 
 ### Jolokia as standalone application
-application-metrics-jolokia-agent-build:
-	docker build /sumologic/vagrant/k8s/application_metrics/jmx/jolokia/agent/ -t localhost:32000/jolokia/agent
-	docker push localhost:32000/jolokia/agent
 
 application-metrics-jolokia-agent-run:
 	kubectl create ns demo-jolokia-agent || true

--- a/vagrant/k8s/application_metrics/jmx/jmxexporter/docker/Dockerfile
+++ b/vagrant/k8s/application_metrics/jmx/jmxexporter/docker/Dockerfile
@@ -1,4 +1,0 @@
-FROM tomcat:jdk8-adoptopenjdk-openj9
-RUN apt-get update && apt-get install -y curl
-RUN curl -L https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.13.0/jmx_prometheus_javaagent-0.13.0.jar -o /jmx_prometheus_javaagent-0.13.0.jar
-ENV CATALINA_OPTS "-javaagent:/jmx_prometheus_javaagent-0.13.0.jar=8888:/config.yaml"

--- a/vagrant/k8s/application_metrics/jmx/jmxexporter/docker/statefulset.yaml
+++ b/vagrant/k8s/application_metrics/jmx/jmxexporter/docker/statefulset.yaml
@@ -13,18 +13,37 @@ spec:
     metadata:
       labels:
         app: jmxexporter
+      annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8888"
     spec:
       containers:
       - name: jolokia
-        image: localhost:32000/jmxexporter/docker
-        imagePullPolicy: Always
+        image: public.ecr.aws/docker/library/tomcat:jdk8-adoptopenjdk-openj9
+        env:
+        - name: CATALINA_OPTS
+          value: "-javaagent:/var/lib/jmx_agent/jmx_prometheus_javaagent-0.13.0.jar=8888:/config.yaml"
         volumeMounts:
+        - mountPath: /var/lib/jmx_agent
+          name: agent
         - name: config-volume
           mountPath: /config.yaml
           subPath: config.yaml
+      initContainers:
+      - name: downloadagent
+        image: public.ecr.aws/itx-devops/curlimages_curl:latest
+        command:
+        - "curl"
+        - "-L"
+        - "https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.13.0/jmx_prometheus_javaagent-0.13.0.jar"
+        - "-o"
+        - "/var/lib/jmx_agent/jmx_prometheus_javaagent-0.13.0.jar"
+        volumeMounts:
+        - mountPath: /var/lib/jmx_agent
+          name: agent
       volumes:
-        - name: config-volume
-          configMap:
-            name: jmxexporter-config
+       - name: agent
+         emptyDir:
+       - name: config-volume
+         configMap:
+           name: jmxexporter-config

--- a/vagrant/k8s/application_metrics/jmx/jolokia/agent/Dockerfile
+++ b/vagrant/k8s/application_metrics/jmx/jolokia/agent/Dockerfile
@@ -1,5 +1,0 @@
-FROM tomcat:jdk8-adoptopenjdk-openj9
-RUN apt-get update && apt-get install -y curl
-RUN curl -L https://search.maven.org/remotecontent?filepath=org/jolokia/jolokia-jvm/1.6.2/jolokia-jvm-1.6.2-agent.jar -o /jolokia-jvm-1.6.2-agent.jar
-COPY entrypoint.sh /entrypoint.sh
-CMD ["/entrypoint.sh"]

--- a/vagrant/k8s/application_metrics/jmx/jolokia/agent/entrypoint.sh
+++ b/vagrant/k8s/application_metrics/jmx/jolokia/agent/entrypoint.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-bash catalina.sh run 2>&1 | tee -a /tmp/stdout.log &
-sleep 5
-java -jar /jolokia-jvm-1.6.2-agent.jar start org.apache.catalina.startup.Bootstrap 2>&1 | tee -a /tmp/stdout.log &
-tail -f /tmp/stdout.log

--- a/vagrant/k8s/application_metrics/jmx/jolokia/agent/statefulset.yaml
+++ b/vagrant/k8s/application_metrics/jmx/jolokia/agent/statefulset.yaml
@@ -93,5 +93,32 @@ spec:
     spec:
       containers:
       - name: jolokia
-        image: localhost:32000/jolokia/agent
-        imagePullPolicy: Always
+        image: public.ecr.aws/docker/library/tomcat:jdk8-adoptopenjdk-openj9
+        command:
+        - "/bin/bash"
+        args:
+        - "-c"
+        - >-
+          bash catalina.sh run 2>&1 | tee -a /tmp/stdout.log &
+          sleep 5 &&
+          java -jar /var/lib/jolokia_agent/jolokia-jvm-1.6.2-agent.jar start org.apache.catalina.startup.Bootstrap 2>&1 | tee -a /tmp/stdout.log &
+          tail -f /tmp/stdout.log
+        volumeMounts:
+        - mountPath: /var/lib/jolokia_agent
+          name: agent
+      initContainers:
+      - name: downloadagent
+        image: public.ecr.aws/itx-devops/curlimages_curl:latest
+        command:
+        - "curl"
+        args:
+        - "-L"
+        - "https://search.maven.org/remotecontent?filepath=org/jolokia/jolokia-jvm/1.6.2/jolokia-jvm-1.6.2-agent.jar"
+        - "-o"
+        - "/var/lib/jolokia_agent/jolokia-jvm-1.6.2-agent.jar"
+        volumeMounts:
+        - mountPath: /var/lib/jolokia_agent
+          name: agent
+      volumes:
+       - name: agent
+         emptyDir:

--- a/vagrant/k8s/application_metrics/jmx/jolokia/docker/Dockerfile
+++ b/vagrant/k8s/application_metrics/jmx/jolokia/docker/Dockerfile
@@ -1,4 +1,0 @@
-FROM tomcat:jdk8-adoptopenjdk-openj9
-RUN apt-get update && apt-get install -y curl
-RUN curl -L https://search.maven.org/remotecontent?filepath=org/jolokia/jolokia-jvm/1.6.2/jolokia-jvm-1.6.2-agent.jar -o /jolokia-jvm-1.6.2-agent.jar
-ENV CATALINA_OPTS "-javaagent:/jolokia-jvm-1.6.2-agent.jar"

--- a/vagrant/k8s/application_metrics/jmx/jolokia/docker/statefulset.yaml
+++ b/vagrant/k8s/application_metrics/jmx/jolokia/docker/statefulset.yaml
@@ -92,4 +92,25 @@ spec:
     spec:
       containers:
       - name: jolokia
-        image: localhost:32000/jolokia/docker
+        image: tomcat:jdk8-adoptopenjdk-openj9
+        env:
+        - name: CATALINA_OPTS
+          value: "-javaagent:/var/lib/jolokia_agent/jolokia-jvm-1.6.2-agent.jar"
+        volumeMounts:
+        - mountPath: /var/lib/jolokia_agent
+          name: agent
+      initContainers:
+      - name: downloadagent
+        image: public.ecr.aws/itx-devops/curlimages_curl:latest
+        command:
+        - "curl"
+        - "-L"
+        - "https://search.maven.org/remotecontent?filepath=org/jolokia/jolokia-jvm/1.6.2/jolokia-jvm-1.6.2-agent.jar"
+        - "-o"
+        - "/var/lib/jolokia_agent/jolokia-jvm-1.6.2-agent.jar"
+        volumeMounts:
+        - mountPath: /var/lib/jolokia_agent
+          name: agent
+      volumes:
+       - name: agent
+         emptyDir:


### PR DESCRIPTION
##### Description

The setup for jmx metrics in vagrant required building custom docker containers. This was annoying to do, especially since we use these manifests in E2E tests where we run in a more constrained environment. Fortunately, the docker containers were really simple and could be replaced with `initContainers`.

In essence, we download the necessary java agent jar in an init container, and then launch the main container with the right options. This PR also fixes some quality of life stuff, like using images from public ECR everywhere instead of dockerhub.

