### PR TITLE
feat(events)!: switch from Fluentd to Otelcol as default events collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - move `fluentd.logs.default.excludePriorityRegex` to `sumologic.logs.defaultFluentd.excludePriorityRegex`
   - move `fluentd.logs.default.excludeUnitRegex` to `sumologic.logs.defaultFluentd.excludeUnitRegex`
 - feat(logs)!: switch from Fluent Bit to Otelcol as default logs collector [#2639]
+- feat(events)!: switch from Fluentd to Otelcol as default events collector [#2640]
 
 ### Changed
 
@@ -135,6 +136,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2652]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2652
 [#2635]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2635
 [#2639]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2639
+[#2640]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2640
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.17.0...main
 [telegraf_operator_comapare_1.3.5_and_1.3.10]: https://github.com/influxdata/helm-charts/compare/telegraf-operator-1.3.5...telegraf-operator-1.3.10
 [cert-manager-1.4]: https://github.com/cert-manager/cert-manager/releases/tag/v1.4.0

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -208,7 +208,7 @@ sumologic:
 
   ### Configuration for collection of Kubernetes events
   events:
-    provider: fluentd
+    provider: otelcol
 
     ## Source name for the Events source. Default: "events"
     sourceName: "events"

--- a/tests/helm/events/static/apiServerUrl.input.yaml
+++ b/tests/helm/events/static/apiServerUrl.input.yaml
@@ -1,2 +1,5 @@
+sumologic:
+  events:
+    provider: fluentd
 fluentd:
   apiServerUrl: "https://kubernetes.default.svc:443"

--- a/tests/helm/events/static/apiServerUrl_null.input.yaml
+++ b/tests/helm/events/static/apiServerUrl_null.input.yaml
@@ -1,2 +1,5 @@
+sumologic:
+  events:
+    provider: fluentd
 fluentd:
   apiServerUrl: null

--- a/tests/helm/events/static/customSourceCategory.input.yaml
+++ b/tests/helm/events/static/customSourceCategory.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
   events:
+    provider: fluentd
     sourceCategory: custom/sou-rce_categ
     sourceName: cus-tom/Sour_ce:NAME

--- a/tests/helm/events/static/default.input.yaml
+++ b/tests/helm/events/static/default.input.yaml
@@ -1,3 +1,6 @@
+sumologic:
+  events:
+    provider: fluentd
 fluentd:
   events:
     enabled: true

--- a/tests/helm/events/static/watchResourceEventsOverrides.input.yaml
+++ b/tests/helm/events/static/watchResourceEventsOverrides.input.yaml
@@ -1,3 +1,6 @@
+sumologic:
+  events:
+    provider: fluentd
 fluentd:
   events:
     enabled: true

--- a/tests/helm/events/static/watchResourceEventsOverrides_apiServerUrl.input.yaml
+++ b/tests/helm/events/static/watchResourceEventsOverrides_apiServerUrl.input.yaml
@@ -1,3 +1,6 @@
+sumologic:
+  events:
+    provider: fluentd
 fluentd:
   apiServerUrl: "https://kubernetes.default.svc:443"
   events:

--- a/tests/integration/helm_otc_fips_metadata_installation_test.go
+++ b/tests/integration/helm_otc_fips_metadata_installation_test.go
@@ -128,22 +128,22 @@ func Test_Helm_Default_OT_FIPS_Metadata(t *testing.T) {
 				)
 				return ctx
 			}).
-		Assess("fluentd events statefulset is ready",
+		Assess("otelcol events statefulset is ready",
 			stepfuncs.WaitUntilStatefulSetIsReady(
 				waitDuration,
 				tickDuration,
 				stepfuncs.WithNameF(
-					stepfuncs.ReleaseFormatter("%s-sumologic-fluentd-events"),
+					stepfuncs.ReleaseFormatter("%s-sumologic-otelcol-events"),
 				),
 				stepfuncs.WithLabelsF(
 					stepfuncs.LabelFormatterKV{
 						K: "app",
-						V: stepfuncs.ReleaseFormatter("%s-sumologic-fluentd-events"),
+						V: stepfuncs.ReleaseFormatter("%s-sumologic-otelcol-events"),
 					},
 				),
 			),
 		).
-		Assess("fluentd events buffers PVCs are created",
+		Assess("otelcol events buffers PVCs are created",
 			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
 				namespace := ctxopts.Namespace(ctx)
 				releaseName := ctxopts.HelmRelease(ctx)
@@ -157,7 +157,7 @@ func Test_Helm_Default_OT_FIPS_Metadata(t *testing.T) {
 					pvcs, err := cl.CoreV1().
 						PersistentVolumeClaims(namespace).
 						List(ctx, v1.ListOptions{
-							LabelSelector: fmt.Sprintf("app=%s-sumologic-fluentd-events", releaseName),
+							LabelSelector: fmt.Sprintf("app=%s-sumologic-otelcol-events", releaseName),
 						})
 					if !assert.NoError(t, err) {
 						return false

--- a/tests/integration/helm_otc_metadata_installation_test.go
+++ b/tests/integration/helm_otc_metadata_installation_test.go
@@ -128,22 +128,22 @@ func Test_Helm_Default_OT_Metadata(t *testing.T) {
 				)
 				return ctx
 			}).
-		Assess("fluentd events statefulset is ready",
+		Assess("otelcol events statefulset is ready",
 			stepfuncs.WaitUntilStatefulSetIsReady(
 				waitDuration,
 				tickDuration,
 				stepfuncs.WithNameF(
-					stepfuncs.ReleaseFormatter("%s-sumologic-fluentd-events"),
+					stepfuncs.ReleaseFormatter("%s-sumologic-otelcol-events"),
 				),
 				stepfuncs.WithLabelsF(
 					stepfuncs.LabelFormatterKV{
 						K: "app",
-						V: stepfuncs.ReleaseFormatter("%s-sumologic-fluentd-events"),
+						V: stepfuncs.ReleaseFormatter("%s-sumologic-otelcol-events"),
 					},
 				),
 			),
 		).
-		Assess("fluentd events buffers PVCs are created",
+		Assess("otelcol events buffers PVCs are created",
 			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
 				namespace := ctxopts.Namespace(ctx)
 				releaseName := ctxopts.HelmRelease(ctx)
@@ -157,7 +157,7 @@ func Test_Helm_Default_OT_Metadata(t *testing.T) {
 					pvcs, err := cl.CoreV1().
 						PersistentVolumeClaims(namespace).
 						List(ctx, v1.ListOptions{
-							LabelSelector: fmt.Sprintf("app=%s-sumologic-fluentd-events", releaseName),
+							LabelSelector: fmt.Sprintf("app=%s-sumologic-otelcol-events", releaseName),
 						})
 					if !assert.NoError(t, err) {
 						return false

--- a/tests/integration/values/values_common.yaml
+++ b/tests/integration/values/values_common.yaml
@@ -86,6 +86,13 @@ otelcol:
         memory: 64Mi
         cpu: 100m
 
+otelevents:
+  statefulset:
+    resources:
+      requests:
+        memory: 64Mi
+        cpu: 100m
+
 # Request less resources so that this fits on Github actions runners environment
 otelagent:
   enabled: true

--- a/tests/integration/values/values_helm_fluentbit_fluentd.yaml
+++ b/tests/integration/values/values_helm_fluentbit_fluentd.yaml
@@ -1,4 +1,6 @@
 sumologic:
+  events:
+    provider: fluentd
   logs:
     collector:
       otelcol:


### PR DESCRIPTION
The migration apparently already exists: https://github.com/SumoLogic/sumologic-kubernetes-tools/tree/v2.14.0/src/go/cmd/update-collection-v3/migrations/events.