### PR TITLE
tests/integration: verify that _sourceHost and _sourceName are not `undefined`

### DIFF
--- a/tests/integration/helm_otc_metadata_installation_test.go
+++ b/tests/integration/helm_otc_metadata_installation_test.go
@@ -380,9 +380,9 @@ func Test_Helm_Default_OT_Metadata(t *testing.T) {
 			10, // we don't really control this, just want to check if the logs show up
 			map[string]string{
 				"cluster":         "kubernetes",
-				"_sourceName":     "",
+				"_sourceName":     "(?!undefined$).*",
 				"_sourceCategory": "kubernetes/system",
-				"_sourceHost":     "",
+				"_sourceHost":     "(?!undefined$).*",
 			},
 			internal.ReceiverMockNamespace,
 			internal.ReceiverMockServiceName,
@@ -396,7 +396,7 @@ func Test_Helm_Default_OT_Metadata(t *testing.T) {
 				"cluster":         "kubernetes",
 				"_sourceName":     "k8s_kubelet",
 				"_sourceCategory": "kubernetes/kubelet",
-				"_sourceHost":     "",
+				"_sourceHost":     "(?!undefined$).*",
 			},
 			internal.ReceiverMockNamespace,
 			internal.ReceiverMockServiceName,

--- a/tests/integration/yamls/receiver-mock.yaml
+++ b/tests/integration/yamls/receiver-mock.yaml
@@ -26,7 +26,7 @@ spec:
         - ports:
             - containerPort: 3000
             - containerPort: 3001
-          image: sumologic/kubernetes-tools:2.13.0
+          image: sumologic/kubernetes-tools:2.14.0
           name: receiver-mock
           args:
             - receiver-mock


### PR DESCRIPTION
##### Description
Resolving https://jira.kumoroku.com/jira/browse/SUMO-194814
The tests check that systemd and kubelet logs have source fields set to something different than `undefined`.

