### PR TITLE
ci: fix integration test status job

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -176,6 +176,7 @@ jobs:
   
   integration-test-status:
     runs-on: ubuntu-20.04
+    if: ${{ always() }}
     needs:
       - integration-tests
     steps:


### PR DESCRIPTION
The status job aggregates the results of integration test jobs, so it's easy to collective use them for PR checks. However, by default, the job only runs if all the tests complete, whereas the integration tests are skipped if some of them fail. In that event, the status job would be skipped as well, and PR checks would pass when they shouldn't.

As a fix, force the status job to always run.