### PR TITLE
Truncate the statefulset name (label and metadata) for otelcol-instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - move `otelgateway.deployment.nodeSelector` to `tracesGateway.deployment.nodeSelector`
 - feat: enable metrics and traces collection from instrumentation by default [#2154]
   - change parameter `sumologic.traces.enabled` default value from `false` to `true`
+[#2665]
+  - Truncate the statefulset name for sumologic-otelcol-instrumentation (label and metadata)
 
 ### Changed
 
@@ -159,6 +161,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2647]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2647
 [#2664]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2664
 [#2653]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2653
+[#2665]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2665
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.17.0...main
 [telegraf_operator_comapare_1.3.5_and_1.3.10]: https://github.com/influxdata/helm-charts/compare/telegraf-operator-1.3.5...telegraf-operator-1.3.10
 [cert-manager-1.4]: https://github.com/cert-manager/cert-manager/releases/tag/v1.4.0

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -3,7 +3,7 @@
 Expand the name of the chart.
 */}}
 {{- define "sumologic.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- default .Chart.Name .Values.nameOverride | trunc 33 | trimSuffix "-" }}
 {{- end -}}
 
 {{/*
@@ -12,10 +12,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "sumologic.fullname" -}}
 {{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- .Values.fullnameOverride | trunc 33 | trimSuffix "-" }}
 {{- else }}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- printf "%s-%s" .Release.Name $name | trunc 33 | trimSuffix "-" }}
 {{- end -}}
 {{- end -}}
 
@@ -224,7 +224,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "sumologic.labels.app.otelcolinstrumentation" -}}
-{{- template "sumologic.fullname" . }}-otelcol-instrumentation
+{{- template "sumologic.fullname" . }}-otelcol-instrument
 {{- end -}}
 
 {{- define "sumologic.labels.app.otelcolinstrumentation.pod" -}}
@@ -552,7 +552,7 @@ helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 {{- end -}}
 
 {{- define "sumologic.metadata.name.otelcolinstrumentation" -}}
-{{ template "sumologic.fullname" . }}-otelcol-instrumentation
+{{ template "sumologic.fullname" . }}-otelcol-instrument
 {{- end -}}
 
 {{- define "sumologic.metadata.name.otelcolinstrumentation.service" -}}

--- a/docs/v3-migration-doc.md
+++ b/docs/v3-migration-doc.md
@@ -169,11 +169,12 @@ Above special configuration values can be replaced either to direct values or be
 
 #### Otelcol StatefulSets
 
-If you're using `otelcol` as the logs/metrics metadata provider, please run one or both of the following commands to manually delete StatefulSets in helm chart v2 before upgrade:
+If you're using `otelcol` as the logs/metrics/traces metadata provider, please run one or all of the following commands to manually delete StatefulSets in helm chart v2 before upgrade:
 
   ```
   kubectl delete sts --namespace=my-namespace --cascade=false my-release-sumologic-otelcol-logs
   kubectl delete sts --namespace=my-namespace --cascade=false my-release-sumologic-otelcol-metrics
+  kubectl delete sts --namespace=my-namespace --cascade=false my-release-sumologic-otelcol-instrumentation
   ```
 
 ### Known issues

--- a/tests/helm/otelcol-instrumentation-config/static/traces-gateway-disabled.output.yaml
+++ b/tests/helm/otelcol-instrumentation-config/static/traces-gateway-disabled.output.yaml
@@ -3,9 +3,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: RELEASE-NAME-sumologic-otelcol-instrumentation
+  name: RELEASE-NAME-sumologic-otelcol-instrument
   labels:
-    app: RELEASE-NAME-sumologic-otelcol-instrumentation
+    app: RELEASE-NAME-sumologic-otelcol-instrument
     chart: "sumologic-%CURRENT_CHART_VERSION%"
     release: "RELEASE-NAME"
     heritage: "Helm"

--- a/tests/helm/otelcol-instrumentation-config/static/traces-gateway-enabled.output.yaml
+++ b/tests/helm/otelcol-instrumentation-config/static/traces-gateway-enabled.output.yaml
@@ -3,9 +3,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: RELEASE-NAME-sumologic-otelcol-instrumentation
+  name: RELEASE-NAME-sumologic-otelcol-instrument
   labels:
-    app: RELEASE-NAME-sumologic-otelcol-instrumentation
+    app: RELEASE-NAME-sumologic-otelcol-instrument
     chart: "sumologic-%CURRENT_CHART_VERSION%"
     release: "RELEASE-NAME"
     heritage: "Helm"

--- a/tests/helm/otelcol-instrumentation-statefulset/static/otelcol-instrumentation-statefulset.output.yaml
+++ b/tests/helm/otelcol-instrumentation-statefulset/static/otelcol-instrumentation-statefulset.output.yaml
@@ -3,18 +3,18 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: RELEASE-NAME-sumologic-otelcol-instrumentation
+  name: RELEASE-NAME-sumologic-otelcol-instrument
   labels:
-    app: RELEASE-NAME-sumologic-otelcol-instrumentation
-    component: RELEASE-NAME-sumologic-otelcol-instrumentation-component
+    app: RELEASE-NAME-sumologic-otelcol-instrument
+    component: RELEASE-NAME-sumologic-otelcol-instrument-component
     chart: "sumologic-%CURRENT_CHART_VERSION%"
     release: "RELEASE-NAME"
     heritage: "Helm"
 spec:
   selector:
     matchLabels:
-      app: RELEASE-NAME-sumologic-otelcol-instrumentation
-  serviceName: RELEASE-NAME-sumologic-otelcol-instrumentation
+      app: RELEASE-NAME-sumologic-otelcol-instrument
+  serviceName: RELEASE-NAME-sumologic-otelcol-instrument
   podManagementPolicy: "Parallel"
   replicas: 3
   template:
@@ -22,7 +22,7 @@ spec:
       annotations:
         checksum/config: "%CONFIG_CHECKSUM%"
       labels:
-        app: RELEASE-NAME-sumologic-otelcol-instrumentation
+        app: RELEASE-NAME-sumologic-otelcol-instrument
         chart: "sumologic-%CURRENT_CHART_VERSION%"
         release: "RELEASE-NAME"
         heritage: "Helm"
@@ -38,7 +38,7 @@ spec:
                 - key: app
                   operator: In
                   values:
-                  - RELEASE-NAME-sumologic-otelcol-instrumentation
+                  - RELEASE-NAME-sumologic-otelcol-instrument
                 - key: app
                   operator: In
                   values:
@@ -46,7 +46,7 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       volumes:
         - configMap:
-            name: RELEASE-NAME-sumologic-otelcol-instrumentation
+            name: RELEASE-NAME-sumologic-otelcol-instrument
           name: otelcolinstrumentation-config-vol
       securityContext:
         fsGroup: 999

--- a/tests/integration/helm_opentelemetry_operator_enabled_test.go
+++ b/tests/integration/helm_opentelemetry_operator_enabled_test.go
@@ -54,12 +54,12 @@ func Test_Helm_OpenTelemetry_Operator_Enabled(t *testing.T) {
 				waitDuration,
 				tickDuration,
 				stepfuncs.WithNameF(
-					stepfuncs.ReleaseFormatter("%s-sumologic-otelcol-instrumentation"),
+					stepfuncs.ReleaseFormatter("%s-sumologic-otelcol-instrument"),
 				),
 				stepfuncs.WithLabelsF(
 					stepfuncs.LabelFormatterKV{
 						K: "app",
-						V: stepfuncs.ReleaseFormatter("%s-sumologic-otelcol-instrumentation"),
+						V: stepfuncs.ReleaseFormatter("%s-sumologic-otelcol-instrument"),
 					},
 				),
 			),

--- a/tests/integration/helm_traces_enabled_test.go
+++ b/tests/integration/helm_traces_enabled_test.go
@@ -130,12 +130,12 @@ func Test_Helm_Traces_Enabled(t *testing.T) {
 				waitDuration,
 				tickDuration,
 				stepfuncs.WithNameF(
-					stepfuncs.ReleaseFormatter("%s-sumologic-otelcol-instrumentation"),
+					stepfuncs.ReleaseFormatter("%s-sumologic-otelcol-instrument"),
 				),
 				stepfuncs.WithLabelsF(
 					stepfuncs.LabelFormatterKV{
 						K: "app",
-						V: stepfuncs.ReleaseFormatter("%s-sumologic-otelcol-instrumentation"),
+						V: stepfuncs.ReleaseFormatter("%s-sumologic-otelcol-instrument"),
 					},
 				),
 			),


### PR DESCRIPTION
##### Description

Truncate the statefulset name (label and metadata) for otelcol-instrumentation

This change is needed because of the following errors in E2E tests

`  Warning  FailedCreate  8s (x15 over 90s)  statefulset-controller  create Pod sumologic1669896344692-sumologic-otelcol-instrumentation-0 in StatefulSet sumologic1669896344692-sumologic-otelcol-instrumentation failed error: Pod`

` "sumologic1669896344692-sumologic-otelcol-instrumentation-0" is invalid: metadata.labels: Invalid value: "sumologic1669896344692-sumologic-otelcol-instrumentation-998c76c49": must be no more than 63 characters`

---

##### Checklist

- [x] Changelog updated

###### Testing performed

- [x] Redeploy otelcol-instrument statefulset
- [x] Confirm events, logs, and metrics are coming in
