### PR TITLE
test(helm): add builtin label test

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -96,7 +96,7 @@ jobs:
             sudo mv /tmp/yq /usr/local/bin/yq
       - name: test
         run: make test-templates-bash
-  
+
   test-templates:
     runs-on: ubuntu-20.04
     needs:
@@ -201,7 +201,7 @@ jobs:
       - name: Run integration test - ${{ matrix.test_name }}
         working-directory: ./tests/integration/
         run: make test TEST_NAME=${{matrix.test_name}} KIND_NODE_IMAGE=${{matrix.kind_image}}
-  
+
   integration-test-status:
     runs-on: ubuntu-20.04
     if: ${{ always() }}

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ vdestroy:
 
 # Template tests
 test-templates:
+	make helm-dependency-update
 	make -C ./tests/helm test
 
 lint-template-tests:

--- a/deploy/helm/sumologic/templates/chart-configmap.yaml
+++ b/deploy/helm/sumologic/templates/chart-configmap.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: sumologic-configmap
+  labels:
+    {{- include "sumologic.labels.common" . | nindent 4 }}
 data:
   metadataLogs: {{ template "sumologic.metadata.name.logs.service" . }}
   metadataMetrics: {{ template "sumologic.metrics.metadata.endpoint" . }}

--- a/deploy/helm/sumologic/templates/events/common/service-headless.yaml
+++ b/deploy/helm/sumologic/templates/events/common/service-headless.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ template "sumologic.metadata.name.events.service-headless" . }}
   labels:
     app: {{ template "sumologic.labels.app.events.service-headless" . }}
+    {{- include "sumologic.labels.common" . | nindent 4 }}
     {{- include "sumologic.labels.events" . | nindent 4 }}
 {{- if .Values.fluentd.serviceLabels }}
 {{ toYaml .Values.fluentd.serviceLabels | indent 4 }}

--- a/deploy/helm/sumologic/templates/logs/common/pdb.yaml
+++ b/deploy/helm/sumologic/templates/logs/common/pdb.yaml
@@ -4,6 +4,8 @@ apiVersion: {{ include "apiVersion.podDisruptionBudget" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "sumologic.metadata.name.logs.pdb" . }}
+  labels:
+    {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/deploy/helm/sumologic/templates/logs/common/service-headless.yaml
+++ b/deploy/helm/sumologic/templates/logs/common/service-headless.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ template "sumologic.metadata.name.logs.service-headless" . }}
   labels:
     app: {{ template "sumologic.labels.app.logs.service-headless" . }}
+    {{- include "sumologic.labels.common" . | nindent 4 }}
     {{- include "sumologic.labels.logs" . | nindent 4 }}
 {{- if .Values.metadata.serviceLabels }}
 {{ toYaml .Values.metadata.serviceLabels | indent 4 }}

--- a/deploy/helm/sumologic/templates/metrics/common/pdb.yaml
+++ b/deploy/helm/sumologic/templates/metrics/common/pdb.yaml
@@ -4,6 +4,8 @@ apiVersion: {{ include "apiVersion.podDisruptionBudget" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "sumologic.metadata.name.metrics.pdb" . }}
+  labels:
+    {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/deploy/helm/sumologic/templates/metrics/common/service-headless.yaml
+++ b/deploy/helm/sumologic/templates/metrics/common/service-headless.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ template "sumologic.metadata.name.metrics.service-headless" . }}
   labels:
     app: {{ template "sumologic.labels.app.metrics.service-headless" . }}
+    {{- include "sumologic.labels.common" . | nindent 4 }}
     {{- include "sumologic.labels.metrics" . | nindent 4 }}
 {{- if .Values.metadata.serviceLabels }}
 {{ toYaml .Values.metadata.serviceLabels | indent 4 }}

--- a/deploy/helm/sumologic/templates/priorityclass.yaml
+++ b/deploy/helm/sumologic/templates/priorityclass.yaml
@@ -2,6 +2,8 @@ apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: {{ template "sumologic.metadata.name.priorityclass" . }}
+  labels:
+    {{- include "sumologic.labels.common" . | nindent 4 }}
 value: 1000000
 globalDefault: false
 description: "This PriorityClass will be used for OTel Distro agents running as Daemonsets"

--- a/tests/helm/common_test.go
+++ b/tests/helm/common_test.go
@@ -1,0 +1,102 @@
+package helm
+
+import (
+	"fmt"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestBuiltinLabels(t *testing.T) {
+	valuesFilePath := path.Join(testDataDirectory, "everything-enabled.yaml")
+	chartVersion, err := GetChartVersion()
+	require.NoError(t, err)
+	renderedYamlString := RenderTemplate(
+		t,
+		&helm.Options{
+			ValuesFiles: []string{valuesFilePath},
+			SetStrValues: map[string]string{
+				"sumologic.accessId":  "accessId",
+				"sumologic.accessKey": "accessKey",
+			},
+			Logger: logger.Discard, // the log output is noisy and doesn't help much
+		},
+		chartDirectory,
+		releaseName,
+		[]string{},
+		true,
+		"--namespace",
+		defaultNamespace,
+	)
+
+	// split the rendered Yaml into individual documents and unmarshal them into K8s objects
+	// we could use the yaml decoder directly, but we'd have to implement our own unmarshaling logic then
+	renderedYamlDocuments := strings.Split(renderedYamlString, "---")
+	cleanedYamlDocuments := []string{}
+	for _, yamlDoc := range renderedYamlDocuments {
+		if len(strings.TrimSpace(yamlDoc)) > 0 {
+			cleanedYamlDocuments = append(cleanedYamlDocuments, yamlDoc)
+		}
+	}
+	renderedObjects := make([]unstructured.Unstructured, len(cleanedYamlDocuments))
+	for i, yamlDoc := range cleanedYamlDocuments {
+		helm.UnmarshalK8SYaml(t, yamlDoc, &renderedObjects[i])
+	}
+
+	for _, renderedObject := range renderedObjects {
+		if !isSubchartObject(&renderedObject) && renderedObject.GetKind() != "List" {
+			object := renderedObject
+			objectName := fmt.Sprintf("%s/%s", object.GetKind(), object.GetName())
+			t.Run(objectName, func(t *testing.T) {
+				checkBuiltinLabels(t, &object, chartVersion)
+			})
+		}
+	}
+}
+
+// check the built-in labels added to all K8s objects created by the chart
+func checkBuiltinLabels(t *testing.T, object metav1.Object, chartVersion string) {
+	labels := object.GetLabels()
+	require.Contains(t, labels, "chart")
+	require.Contains(t, labels, "heritage")
+	require.Contains(t, labels, "release")
+	assert.Equal(t, fmt.Sprintf("%s-%s", chartName, chartVersion), labels["chart"])
+	assert.Equal(t, releaseName, labels["release"])
+	assert.Equal(t, "Helm", labels["heritage"])
+}
+
+// isSubchartObject checks if the K8s object was created by a subchart
+func isSubchartObject(object metav1.Object) bool {
+	var chartLabel string
+	var ok bool
+	labels := object.GetLabels()
+	chartLabel, ok = labels["chart"]
+	if !ok {
+		chartLabel, ok = labels["helm.sh/chart"]
+		if !ok {
+			// if we don't have a chart label, we do a final check for subchart name in the object name
+			// unfortunately some charts don't set this for some resources so this is the next best thing
+			objectName := object.GetName()
+			for _, subChartName := range subChartNames {
+				if strings.Contains(objectName, subChartName) {
+					return true
+				}
+			}
+			return false
+		}
+	}
+	for _, subChartName := range subChartNames {
+		if strings.Contains(chartLabel, subChartName) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/tests/helm/const.go
+++ b/tests/helm/const.go
@@ -1,9 +1,21 @@
 package helm
 
 const (
-	configFileName   = "config.sh"
-	yamlDirectory    = "static"
-	chartDirectory   = "../../deploy/helm/sumologic"
-	releaseName      = "collection-test"
-	defaultNamespace = "sumologic"
+	configFileName    = "config.sh"
+	yamlDirectory     = "static"
+	chartDirectory    = "../../deploy/helm/sumologic"
+	chartName         = "sumologic"
+	releaseName       = "collection-test"
+	defaultNamespace  = "sumologic"
+	testDataDirectory = "./testdata"
 )
+
+var subChartNames []string = []string{
+	"prometheus",
+	"kube-state-metrics",
+	"fluent-bit",
+	"metrics-server",
+	"telegraf-operator",
+	"tailing-sidecar",
+	"falco",
+}

--- a/tests/helm/template_test.go
+++ b/tests/helm/template_test.go
@@ -33,7 +33,6 @@ func TestAllTemplates(t *testing.T) {
 		}
 	}
 
-	setupDependencies(t)
 	for _, templateDir := range templateDirectories {
 		// get template path from config script
 		configPath := path.Join(templateDir, configFileName)
@@ -42,7 +41,7 @@ func TestAllTemplates(t *testing.T) {
 		if _, err := os.Stat(configPath); errors.Is(err, os.ErrNotExist) {
 			continue
 		}
-		
+
 		templatePath, err := getTemplatePathFromConfigScript(configPath)
 		require.NoError(t, err)
 		yamlDirectoryPath := path.Join(templateDir, yamlDirectory)
@@ -97,25 +96,6 @@ func runTemplateTest(t *testing.T, templatePath string, valuesFileName string, o
 	require.NoError(t, err)
 
 	require.Equal(t, expected, rendered)
-}
-
-// setupDependencies adds the repos for chart dependencies and then updates them
-// ideally this should be run once per test execution on a fresh machine
-func setupDependencies(t *testing.T) {
-	repos := map[string]string{
-		"fluent":          "https://fluent.github.io/helm-charts",
-		"prometheus":      "https://prometheus-community.github.io/helm-charts",
-		"falco":           "https://falcosecurity.github.io/charts",
-		"bitnami":         "https://charts.bitnami.com/bitnami",
-		"influxdata":      "https://helm.influxdata.com/",
-		"tailing-sidecar": "https://sumologic.github.io/tailing-sidecar",
-		"opentelemetry":   "https://open-telemetry.github.io/opentelemetry-helm-charts",
-	}
-	for name, url := range repos {
-		helm.AddRepo(t, &helm.Options{}, name, url)
-	}
-	output, err := helm.RunHelmCommandAndGetOutputE(t, &helm.Options{}, "dependency", "update", chartDirectory)
-	require.NoError(t, err, output)
 }
 
 // getTemplatePathFromConfigScript extracts the template path from a config.sh script that

--- a/tests/helm/template_test.go
+++ b/tests/helm/template_test.go
@@ -1,6 +1,7 @@
 package helm
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -36,6 +37,12 @@ func TestAllTemplates(t *testing.T) {
 	for _, templateDir := range templateDirectories {
 		// get template path from config script
 		configPath := path.Join(templateDir, configFileName)
+
+		// if no config script, skip this directory
+		if _, err := os.Stat(configPath); errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		
 		templatePath, err := getTemplatePathFromConfigScript(configPath)
 		require.NoError(t, err)
 		yamlDirectoryPath := path.Join(templateDir, yamlDirectory)

--- a/tests/helm/testdata/everything-enabled.yaml
+++ b/tests/helm/testdata/everything-enabled.yaml
@@ -1,0 +1,19 @@
+sumologic:
+  logs:
+    collector:
+      allowSideBySide: true
+
+metrics-server:
+  enabled: true
+
+telegraf-operator:
+  enabled: true
+
+falco:
+  enabled: true
+
+fluent-bit:
+  enabled: true
+
+tailing-sidecar-operator:
+  enabled: true


### PR DESCRIPTION
Add a test for basic builtin labels that covers all manifests generated by the chart. This isn't too exciting by itself, but it shows how you can write a test like this, which we can leverage to greater effect in the future.

The test caught a couple resources with missing labels, added those.

A decent amount of effort in this test is spent filtering out resources from subcharts, which don't and shouldn't have the labels. I'm not sure if what I've done is the best way of achieving this, would appreciate feedback.