### PR TITLE
test(helm): refactor template tests

### DIFF
--- a/deploy/helm/sumologic/conf/instrumentation/otelcol.instrumentation.conf.yaml
+++ b/deploy/helm/sumologic/conf/instrumentation/otelcol.instrumentation.conf.yaml
@@ -1,1 +1,1 @@
-{{ tpl (toYaml .Values.otelcolInstrumentation.config | replace ": '{{" ": {{" | replace "}}'" "}}") . | nindent 2 }}
+{{- tpl (toYaml .Values.otelcolInstrumentation.config | replace ": '{{" ": {{" | replace "}}'" "}}") . | nindent 2 }}

--- a/deploy/helm/sumologic/conf/instrumentation/traces.gateway.conf.yaml
+++ b/deploy/helm/sumologic/conf/instrumentation/traces.gateway.conf.yaml
@@ -1,1 +1,1 @@
-{{ tpl (toYaml .Values.tracesGateway.config | replace ": '{{" ": {{" | replace "}}'" "}}") . | nindent 2 }}
+{{- tpl (toYaml .Values.tracesGateway.config | replace ": '{{" ": {{" | replace "}}'" "}}") . | nindent 2 }}

--- a/deploy/helm/sumologic/conf/opentelemetry-operator/instrumentation.cr.yaml
+++ b/deploy/helm/sumologic/conf/opentelemetry-operator/instrumentation.cr.yaml
@@ -1,9 +1,9 @@
 {{- $ctx := . -}}
-{{ $instrumentationNamespaces := index .Values "opentelemetry-operator" }}
-{{- if eq ( get $instrumentationNamespaces "instrumentationNamespaces" ) "" }}
+{{- $instrumentationNamespaces := index .Values "opentelemetry-operator" -}}
+{{- if eq ( get $instrumentationNamespaces "instrumentationNamespaces" ) "" -}}
 {{ fail "No value for \"opentelemetry-operator.instrumentationNamespaces\".Value is comma separated namespaces e.g. \"ns1\\,ns2\"" }}
-{{ else }}
-{{- range $ns := splitList "," ( index .Values "opentelemetry-operator" "instrumentationNamespaces" ) }}
+{{- else -}}
+{{- range $ns := splitList "," ( index .Values "opentelemetry-operator" "instrumentationNamespaces" ) -}}
 ---
 apiVersion: opentelemetry.io/v1alpha1
 kind: Instrumentation
@@ -64,5 +64,5 @@ spec:
         value: http/protobuf
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://{{- include "sumologic.opentelemetry.operator.instrumentation.collector.endpoint" $ctx }}:4318
-{{- end -}}
+{{ end -}}
 {{- end -}}

--- a/deploy/helm/sumologic/templates/instrumentation/traces-gateway/configmap.yaml
+++ b/deploy/helm/sumologic/templates/instrumentation/traces-gateway/configmap.yaml
@@ -1,6 +1,6 @@
 {{ $tracesGatewayEnabled := .Values.tracesGateway.enabled }}
 {{ $tracesEnabled := .Values.sumologic.traces.enabled }}
-{{- if and $tracesEnabled $tracesGatewayEnabled }}
+{{- if and $tracesEnabled $tracesGatewayEnabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/deploy/helm/sumologic/templates/opentelemetry-operator/configmap-instrumentation-cr.yaml
+++ b/deploy/helm/sumologic/templates/opentelemetry-operator/configmap-instrumentation-cr.yaml
@@ -5,7 +5,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name:  {{ template "sumologic.metadata.name.opentelemetry.operator.instrumentation.configmap" . }}
+  name: {{ template "sumologic.metadata.name.opentelemetry.operator.instrumentation.configmap" . }}
   labels:
     app: {{ template "sumologic.labels.app.opentelemetry.operator.instrumentation.configmap" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}

--- a/tests/helm/common_test.go
+++ b/tests/helm/common_test.go
@@ -38,17 +38,7 @@ func TestBuiltinLabels(t *testing.T) {
 
 	// split the rendered Yaml into individual documents and unmarshal them into K8s objects
 	// we could use the yaml decoder directly, but we'd have to implement our own unmarshaling logic then
-	renderedYamlDocuments := strings.Split(renderedYamlString, "---")
-	cleanedYamlDocuments := []string{}
-	for _, yamlDoc := range renderedYamlDocuments {
-		if len(strings.TrimSpace(yamlDoc)) > 0 {
-			cleanedYamlDocuments = append(cleanedYamlDocuments, yamlDoc)
-		}
-	}
-	renderedObjects := make([]unstructured.Unstructured, len(cleanedYamlDocuments))
-	for i, yamlDoc := range cleanedYamlDocuments {
-		helm.UnmarshalK8SYaml(t, yamlDoc, &renderedObjects[i])
-	}
+	renderedObjects := UnmarshalMultipleFromYaml[unstructured.Unstructured](t, renderedYamlString)
 
 	for _, renderedObject := range renderedObjects {
 		if !isSubchartObject(&renderedObject) && renderedObject.GetKind() != "List" {

--- a/tests/helm/go.mod
+++ b/tests/helm/go.mod
@@ -3,6 +3,7 @@ module github.com/SumoLogic/sumologic-kubernetes-collection/tests/helm
 go 1.19
 
 require (
+	github.com/bmatcuk/doublestar/v4 v4.4.0
 	github.com/gruntwork-io/go-commons v0.8.0
 	github.com/gruntwork-io/terratest v0.41.3
 	github.com/stretchr/testify v1.8.1

--- a/tests/helm/go.sum
+++ b/tests/helm/go.sum
@@ -56,6 +56,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/aws/aws-sdk-go v1.40.56 h1:FM2yjR0UUYFzDTMx+mH9Vyw1k1EUUxsAFzk+BjkzANA=
 github.com/aws/aws-sdk-go v1.40.56/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/bmatcuk/doublestar/v4 v4.4.0 h1:LmAwNwhjEbYtyVLzjcP/XeVw4nhuScHGkF/XWXnvIic=
+github.com/bmatcuk/doublestar/v4 v4.4.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/tests/helm/opentelemetry_operator_instrumentation_cr_configmap/static/instrumentation.output.yaml
+++ b/tests/helm/opentelemetry_operator_instrumentation_cr_configmap/static/instrumentation.output.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name:  RELEASE-NAME-sumologic-ot-operator-instr-cm
+  name: RELEASE-NAME-sumologic-ot-operator-instr-cm
   labels:
     app: RELEASE-NAME-sumologic-ot-operator-instr-cm
     chart: "sumologic-%CURRENT_CHART_VERSION%"
@@ -11,7 +11,6 @@ metadata:
     heritage: "Helm"
 data:
   instrumentation.cr.yaml: |
-    
     ---
     apiVersion: opentelemetry.io/v1alpha1
     kind: Instrumentation

--- a/tests/helm/otelcol-instrumentation-config/static/traces-gateway-disabled.output.yaml
+++ b/tests/helm/otelcol-instrumentation-config/static/traces-gateway-disabled.output.yaml
@@ -11,7 +11,6 @@ metadata:
     heritage: "Helm"
 data:
   otelcol.instrumentation.conf.yaml: |
-    
     exporters:
       otlphttp/traces:
         endpoint: http://RELEASE-NAME-sumologic-traces-sampler.sumologic:4318

--- a/tests/helm/otelcol-instrumentation-config/static/traces-gateway-enabled.output.yaml
+++ b/tests/helm/otelcol-instrumentation-config/static/traces-gateway-enabled.output.yaml
@@ -11,7 +11,6 @@ metadata:
     heritage: "Helm"
 data:
   otelcol.instrumentation.conf.yaml: |
-    
     exporters:
       otlphttp/traces:
         endpoint: http://RELEASE-NAME-sumologic-traces-gateway.sumologic:4318

--- a/tests/helm/template_test.go
+++ b/tests/helm/template_test.go
@@ -1,15 +1,12 @@
 package helm
 
 import (
-	"errors"
-	"fmt"
 	"os"
-	"path"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
 
+	doublestar "github.com/bmatcuk/doublestar/v4"
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/stretchr/testify/require"
@@ -18,52 +15,28 @@ import (
 )
 
 func TestAllTemplates(t *testing.T) {
-	var templateDirectories []string
 	var err error
 
 	chartVersion, err := GetChartVersion()
 	require.NoError(t, err)
 
 	// get the template directories
-	dirEntries, err := os.ReadDir(".")
+	inputFileNames, err := doublestar.FilepathGlob("**/*.input.yaml")
 	require.NoError(t, err)
-	for _, dirEntry := range dirEntries {
-		if dirEntry.IsDir() {
-			templateDirectories = append(templateDirectories, dirEntry.Name())
-		}
-	}
-
-	for _, templateDir := range templateDirectories {
-		// get template path from config script
-		configPath := path.Join(templateDir, configFileName)
-
-		// if no config script, skip this directory
-		if _, err := os.Stat(configPath); errors.Is(err, os.ErrNotExist) {
-			continue
-		}
-
-		templatePath, err := getTemplatePathFromConfigScript(configPath)
-		require.NoError(t, err)
-		yamlDirectoryPath := path.Join(templateDir, yamlDirectory)
-
-		// get the input file names
-		inputFileNames, err := filepath.Glob(path.Join(yamlDirectoryPath, "*.input.yaml"))
-		require.NoError(t, err)
-		require.NotEmpty(t, inputFileNames)
-		for _, inputFileName := range inputFileNames { // for each input file name, run the test
-			inputFileName := inputFileName
-			outputFileName := strings.TrimSuffix(inputFileName, ".input.yaml") + ".output.yaml"
-			t.Run(inputFileName, func(t *testing.T) {
-				t.Parallel()
-				runTemplateTest(t, templatePath, inputFileName, outputFileName, chartVersion)
-			})
-		}
+	require.NotEmpty(t, inputFileNames)
+	for _, inputFileName := range inputFileNames { // for each input file name, run the test
+		inputFileName := inputFileName
+		outputFileName := strings.TrimSuffix(inputFileName, ".input.yaml") + ".output.yaml"
+		t.Run(inputFileName, func(t *testing.T) {
+			t.Parallel()
+			runTemplateTest(t, inputFileName, outputFileName, chartVersion)
+		})
 	}
 }
 
 // runTemplateTest renders the template using the given values file and compares it to the contents
 // of the output file
-func runTemplateTest(t *testing.T, templatePath string, valuesFileName string, outputFileName string, chartVersion string) {
+func runTemplateTest(t *testing.T, valuesFileName string, outputFileName string, chartVersion string) {
 	renderedYamlString := RenderTemplate(
 		t,
 		&helm.Options{
@@ -76,7 +49,7 @@ func runTemplateTest(t *testing.T, templatePath string, valuesFileName string, o
 		},
 		chartDirectory,
 		releaseName,
-		[]string{templatePath},
+		[]string{},
 		true,
 		"--namespace",
 		defaultNamespace,
@@ -86,31 +59,28 @@ func runTemplateTest(t *testing.T, templatePath string, valuesFileName string, o
 	renderedYamlString = fixupRenderedYaml(renderedYamlString, chartVersion)
 	expectedYamlBytes, err := os.ReadFile(outputFileName)
 	expectedYamlString := string(expectedYamlBytes)
-	expectedYamlString = fixupExpectedYaml(expectedYamlString)
+	// expectedYamlString = fixupExpectedYaml(expectedYamlString)
 	require.NoError(t, err)
 
-	var expected, rendered unstructured.Unstructured
-	helm.UnmarshalK8SYaml(t, expectedYamlString, &expected)
+	var expectedObject unstructured.Unstructured
+	var renderedObjects []unstructured.Unstructured
+	helm.UnmarshalK8SYaml(t, expectedYamlString, &expectedObject)
 	require.NoError(t, err)
-	helm.UnmarshalK8SYaml(t, renderedYamlString, &rendered)
+	renderedObjects = UnmarshalMultipleFromYaml[unstructured.Unstructured](t, renderedYamlString)
 	require.NoError(t, err)
 
-	require.Equal(t, expected, rendered)
-}
-
-// getTemplatePathFromConfigScript extracts the template path from a config.sh script that
-// the previous test framework used to set the template for the test
-func getTemplatePathFromConfigScript(configPath string) (string, error) {
-	configScript, err := os.ReadFile(configPath)
-	if err != nil {
-		return "", err
+	// find the object we expect
+	var actualObject *unstructured.Unstructured = nil
+	for _, renderedObject := range renderedObjects {
+		if renderedObject.GetName() == expectedObject.GetName() &&
+			renderedObject.GetKind() == expectedObject.GetKind() {
+			actualObject = &renderedObject
+			break
+		}
 	}
-	regex := regexp.MustCompile("TEST_TEMPLATE=\"([^)]+)\"")
-	matches := regex.FindStringSubmatch(string(configScript))
-	if len(matches) != 2 {
-		return "", fmt.Errorf("expected to get one match, got %v", matches)
-	}
-	return matches[1], nil
+	require.NotNilf(t, actualObject, "Couldn't find object %s/%s in output", expectedObject.GetKind(), expectedObject.GetName())
+
+	require.Equal(t, expectedObject, *actualObject)
 }
 
 // fixupRenderedYaml replaces certain highly variable properties with fixed ones used in the
@@ -122,11 +92,5 @@ func fixupRenderedYaml(yaml string, chartVersion string) string {
 	output = strings.ReplaceAll(output, chartVersion, "%CURRENT_CHART_VERSION%")
 	output = checksumRegex.ReplaceAllLiteralString(output, "checksum/config: '%CONFIG_CHECKSUM%'")
 	output = strings.TrimSuffix(output, "\n")
-	return output
-}
-
-// fixupExpectedYaml removes some unnecessary newlines from the expected templates
-func fixupExpectedYaml(yaml string) string {
-	output := strings.TrimSuffix(yaml, "\n")
 	return output
 }

--- a/tests/helm/template_test.go
+++ b/tests/helm/template_test.go
@@ -59,7 +59,6 @@ func runTemplateTest(t *testing.T, valuesFileName string, outputFileName string,
 	renderedYamlString = fixupRenderedYaml(renderedYamlString, chartVersion)
 	expectedYamlBytes, err := os.ReadFile(outputFileName)
 	expectedYamlString := string(expectedYamlBytes)
-	// expectedYamlString = fixupExpectedYaml(expectedYamlString)
 	require.NoError(t, err)
 
 	var expectedObject unstructured.Unstructured

--- a/tests/helm/traces-gateway-loadbalancing/static/traces-gateway-true.output.yaml
+++ b/tests/helm/traces-gateway-loadbalancing/static/traces-gateway-true.output.yaml
@@ -11,7 +11,6 @@ metadata:
     heritage: "Helm"
 data:
   traces.gateway.conf.yaml: |
-    
     exporters:
       loadbalancing:
         protocol:


### PR DESCRIPTION
Refactor the template tests to stop relying on `config.sh` files from the old test framework. These used to be necessary to know which template we are testing, but we can instead just render all the objects and then pick the one we want based on its name and kind. This will allow us to reorganize the template test files easily.

I also fixed some newline issues with tracing configmaps.