### PR TITLE
chore: upgrade Fluent Bit to v2.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- chore: upgrade Fluent Bit to v2.0.6 [#2694]
+
+[#2694]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2694
+[Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v3.0.0-beta.0...main
+
 ## [v3.0.0-beta.0]
 
 ### Released 2022-12-02

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1031,7 +1031,7 @@ fluent-bit:
   #   - name: "image-pull-secret"
   image:
     repository: public.ecr.aws/sumologic/fluent-bit
-    tag: 1.6.10-sumo-2
+    tag: 2.0.6
     pullPolicy: IfNotPresent
 
   ## Resource limits for fluent-bit


### PR DESCRIPTION
The image for v1.6.10 has vulnerabilities that we'd rather not care about fixing.
Let's upgrade to the latest and see how it works.