### PR TITLE
test(integration): fix image archive creation on MacOS

### DIFF
--- a/tests/integration/create-image-archive.sh
+++ b/tests/integration/create-image-archive.sh
@@ -36,4 +36,4 @@ do
 done <"${IMAGES_TEMPFILE}"
 
 echo "Saving archive"
-xargs -x -a "${IMAGES_TEMPFILE}" docker save -o "${IMAGE_ARCHIVE}"
+xargs -x -n 50 docker save -o "${IMAGE_ARCHIVE}" <"${IMAGES_TEMPFILE}"


### PR DESCRIPTION
In MacOS' antiquated userspace, `xargs` doesn't have a `-a` argument, and it requires an explicit argument limit for `-x` to work. I've set the limit to 50 arbitrarily, doubt we'll ever have that many images in there.