### PR TITLE
chore: move changelog entry to the right release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - chore: upgrade Fluent Bit to v2.0.6 [#2694]
+- chore: upgrade otelcol to 0.66.0-sumo-0 [#2686] [#2687] [#2692] [#2693]
 
 [#2694]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2694
+[#2686]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2686
+[#2687]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2687
+[#2693]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2693
+[#2692]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2692
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v3.0.0-beta.0...main
 
 ## [v3.0.0-beta.0]
@@ -99,7 +104,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- chore: upgrade otelcol to 0.66.0-sumo-0 [#2686] [#2687] [#2692] [#2693]
 - chore: upgrade nginx to 1.23.1 [#2544] [#2554]
 - feat: enable remote write proxy by default [#2483]
 - chore: update kubernetes-tools to 2.13.0 [#2515]
@@ -171,10 +175,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2647]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2647
 [#2664]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2664
 [#2653]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2653
-[#2686]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2686
-[#2687]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2687
-[#2693]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2693
-[#2692]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2692
 [v3.0.0-beta.0]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.17.0...v3.0.0-beta.0
 [telegraf_operator_comapare_1.3.5_and_1.3.10]: https://github.com/influxdata/helm-charts/compare/telegraf-operator-1.3.5...telegraf-operator-1.3.10
 [cert-manager-1.4]: https://github.com/cert-manager/cert-manager/releases/tag/v1.4.0


### PR DESCRIPTION
It was put under the first beta release by mistake.
