### PR TITLE
test(integration): add otel and fluent bit logs test

### DIFF
--- a/tests/integration/helm_ot_fluentbit_logs_test.go
+++ b/tests/integration/helm_ot_fluentbit_logs_test.go
@@ -1,0 +1,236 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	log "k8s.io/klog/v2"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	terrak8s "github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/stretchr/testify/require"
+
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal"
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/ctxopts"
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/stepfuncs"
+)
+
+func Test_Helm_OT_FluentBit_Logs(t *testing.T) {
+	const (
+		tickDuration            = 3 * time.Second
+		waitDuration            = 5 * time.Minute
+		logsGeneratorCount uint = 1000
+	)
+
+	featInstall := features.New("installation").
+		Assess("sumologic secret is created with endpoints",
+			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
+				terrak8s.WaitUntilSecretAvailable(t, ctxopts.KubectlOptions(ctx), "sumologic", 60, tickDuration)
+				secret := terrak8s.GetSecret(t, ctxopts.KubectlOptions(ctx), "sumologic")
+				require.Len(t, secret.Data, 1, "Secret has incorrect number of endpoints")
+				return ctx
+			}).
+		Assess("otelcol logs statefulset is ready",
+			stepfuncs.WaitUntilStatefulSetIsReady(
+				waitDuration,
+				tickDuration,
+				stepfuncs.WithNameF(
+					stepfuncs.ReleaseFormatter("%s-sumologic-otelcol-logs"),
+				),
+				stepfuncs.WithLabelsF(
+					stepfuncs.LabelFormatterKV{
+						K: "app",
+						V: stepfuncs.ReleaseFormatter("%s-sumologic-otelcol-logs"),
+					},
+				),
+			),
+		).
+		Assess("otelcol logs buffers PVCs are created and bound",
+			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
+				res := envConf.Client().Resources(ctxopts.Namespace(ctx))
+				pvcs := corev1.PersistentVolumeClaimList{}
+				cond := conditions.
+					New(res).
+					ResourceListMatchN(&pvcs, 1,
+						func(object k8s.Object) bool {
+							pvc := object.(*corev1.PersistentVolumeClaim)
+							if pvc.Status.Phase != corev1.ClaimBound {
+								log.V(0).Infof("PVC %q not bound yet", pvc.Name)
+								return false
+							}
+							return true
+						},
+						resources.WithLabelSelector(
+							fmt.Sprintf("app=%s-sumologic-otelcol-logs", ctxopts.HelmRelease(ctx)),
+						),
+					)
+				require.NoError(t,
+					wait.For(cond,
+						wait.WithTimeout(waitDuration),
+						wait.WithInterval(tickDuration),
+					),
+				)
+				return ctx
+			}).
+		Assess("fluent-bit daemonset is running",
+			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
+				var daemonsets []appsv1.DaemonSet
+				require.Eventually(t, func() bool {
+					daemonsets = terrak8s.ListDaemonSets(t, ctxopts.KubectlOptions(ctx), v1.ListOptions{
+						LabelSelector: "app.kubernetes.io/name=fluent-bit",
+					})
+
+					return len(daemonsets) == 1
+				}, waitDuration, tickDuration)
+
+				require.EqualValues(t, 0, daemonsets[0].Status.NumberUnavailable)
+				return ctx
+			}).
+		Feature()
+
+	featLogs := features.New("logs").
+		Setup(stepfuncs.GenerateLogs(
+			stepfuncs.LogsGeneratorDeployment,
+			logsGeneratorCount,
+			internal.LogsGeneratorName,
+			internal.LogsGeneratorNamespace,
+			internal.LogsGeneratorImage,
+		)).
+		Setup(stepfuncs.GenerateLogs(
+			stepfuncs.LogsGeneratorDaemonSet,
+			logsGeneratorCount,
+			internal.LogsGeneratorName,
+			internal.LogsGeneratorNamespace,
+			internal.LogsGeneratorImage,
+		)).
+		Assess("logs from log generator deployment present", stepfuncs.WaitUntilExpectedLogsPresent(
+			logsGeneratorCount,
+			map[string]string{
+				"namespace":      internal.LogsGeneratorName,
+				"pod_labels_app": internal.LogsGeneratorName,
+				"deployment":     internal.LogsGeneratorName,
+			},
+			internal.ReceiverMockNamespace,
+			internal.ReceiverMockServiceName,
+			internal.ReceiverMockServicePort,
+			waitDuration,
+			tickDuration,
+		)).
+		Assess("logs from log generator daemonset present", stepfuncs.WaitUntilExpectedLogsPresent(
+			logsGeneratorCount,
+			map[string]string{
+				"namespace":      internal.LogsGeneratorName,
+				"pod_labels_app": internal.LogsGeneratorName,
+				"daemonset":      internal.LogsGeneratorName,
+			},
+			internal.ReceiverMockNamespace,
+			internal.ReceiverMockServiceName,
+			internal.ReceiverMockServicePort,
+			waitDuration,
+			tickDuration,
+		)).
+		Assess("expected container log metadata is present for log generator deployment", stepfuncs.WaitUntilExpectedLogsPresent(
+			logsGeneratorCount,
+			map[string]string{
+				"cluster":          "kubernetes",
+				"_collector":       "kubernetes",
+				"namespace":        internal.LogsGeneratorName,
+				"pod_labels_app":   internal.LogsGeneratorName,
+				"container":        internal.LogsGeneratorName,
+				"deployment":       internal.LogsGeneratorName,
+				"replicaset":       "",
+				"pod":              "",
+				"k8s.pod.id":       "",
+				"k8s.pod.pod_name": "",
+				"host":             "",
+				"node":             "",
+				"_sourceName":      "",
+				"_sourceCategory":  "",
+				"_sourceHost":      "",
+			},
+			internal.ReceiverMockNamespace,
+			internal.ReceiverMockServiceName,
+			internal.ReceiverMockServicePort,
+			waitDuration,
+			tickDuration,
+		)).
+		Assess("expected container log metadata is present for log generator daemonset", stepfuncs.WaitUntilExpectedLogsPresent(
+			logsGeneratorCount,
+			map[string]string{
+				"_collector":       "kubernetes",
+				"namespace":        internal.LogsGeneratorName,
+				"pod_labels_app":   internal.LogsGeneratorName,
+				"container":        internal.LogsGeneratorName,
+				"daemonset":        internal.LogsGeneratorName,
+				"pod":              "",
+				"k8s.pod.id":       "",
+				"k8s.pod.pod_name": "",
+				"host":             "",
+				"node":             "",
+				"_sourceName":      "",
+				"_sourceCategory":  "",
+				"_sourceHost":      "",
+			},
+			internal.ReceiverMockNamespace,
+			internal.ReceiverMockServiceName,
+			internal.ReceiverMockServicePort,
+			waitDuration,
+			tickDuration,
+		)).
+		Assess("logs from node systemd present", stepfuncs.WaitUntilExpectedLogsPresent(
+			10, // we don't really control this, just want to check if the logs show up
+			map[string]string{
+				"cluster":         "kubernetes",
+				"_sourceName":     "(?!undefined$).*",
+				"_sourceCategory": "kubernetes/system",
+				"_sourceHost":     "(?!undefined$).*",
+			},
+			internal.ReceiverMockNamespace,
+			internal.ReceiverMockServiceName,
+			internal.ReceiverMockServicePort,
+			waitDuration,
+			tickDuration,
+		)).
+		Assess("logs from kubelet present", stepfuncs.WaitUntilExpectedLogsPresent(
+			1, // we don't really control this, just want to check if the logs show up
+			map[string]string{
+				"cluster":         "kubernetes",
+				"_sourceName":     "k8s_kubelet",
+				"_sourceCategory": "kubernetes/kubelet",
+				"_sourceHost":     "(?!undefined$).*",
+			},
+			internal.ReceiverMockNamespace,
+			internal.ReceiverMockServiceName,
+			internal.ReceiverMockServicePort,
+			waitDuration,
+			tickDuration,
+		)).
+		Teardown(
+			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
+				opts := *ctxopts.KubectlOptions(ctx)
+				opts.Namespace = internal.LogsGeneratorNamespace
+				terrak8s.RunKubectl(t, &opts, "delete", "deployment", internal.LogsGeneratorName)
+				return ctx
+			}).
+		Teardown(
+			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
+				opts := *ctxopts.KubectlOptions(ctx)
+				opts.Namespace = internal.LogsGeneratorNamespace
+				terrak8s.RunKubectl(t, &opts, "delete", "daemonset", internal.LogsGeneratorName)
+				return ctx
+			}).
+		Teardown(stepfuncs.KubectlDeleteNamespaceOpt(internal.LogsGeneratorNamespace)).
+		Feature()
+
+	testenv.Test(t, featInstall, featLogs)
+}

--- a/tests/integration/values/values_common.yaml
+++ b/tests/integration/values/values_common.yaml
@@ -135,13 +135,81 @@ otelcolInstrumentation:
 fluent-bit:
   enabled: false
 
-  # Prevent snowball effect by filtering out receiver mock logs
   config:
+    # use the containerd parser, we have docker-shim by default
+    inputs: |
+      [INPUT]
+          Name                tail
+          Path                /var/log/containers/*.log
+          Parser              containerd
+          Tag                 containers.*
+          Refresh_Interval    1
+          Rotate_Wait         60
+          Mem_Buf_Limit       5MB
+          Skip_Long_Lines     On
+          DB                  /tail-db/tail-containers-pods-state-sumo.db
+          DB.Sync             Normal
+      [INPUT]
+          Name            systemd
+          Tag             host.*
+          DB              /tail-db/systemd-state-sumo.db
+          Systemd_Filter  _SYSTEMD_UNIT=addon-config.service
+          Systemd_Filter  _SYSTEMD_UNIT=addon-run.service
+          Systemd_Filter  _SYSTEMD_UNIT=cfn-etcd-environment.service
+          Systemd_Filter  _SYSTEMD_UNIT=cfn-signal.service
+          Systemd_Filter  _SYSTEMD_UNIT=clean-ca-certificates.service
+          Systemd_Filter  _SYSTEMD_UNIT=containerd.service
+          Systemd_Filter  _SYSTEMD_UNIT=coreos-metadata.service
+          Systemd_Filter  _SYSTEMD_UNIT=coreos-setup-environment.service
+          Systemd_Filter  _SYSTEMD_UNIT=coreos-tmpfiles.service
+          Systemd_Filter  _SYSTEMD_UNIT=dbus.service
+          Systemd_Filter  _SYSTEMD_UNIT=docker.service
+          Systemd_Filter  _SYSTEMD_UNIT=efs.service
+          Systemd_Filter  _SYSTEMD_UNIT=etcd-member.service
+          Systemd_Filter  _SYSTEMD_UNIT=etcd.service
+          Systemd_Filter  _SYSTEMD_UNIT=etcd2.service
+          Systemd_Filter  _SYSTEMD_UNIT=etcd3.service
+          Systemd_Filter  _SYSTEMD_UNIT=etcdadm-check.service
+          Systemd_Filter  _SYSTEMD_UNIT=etcdadm-reconfigure.service
+          Systemd_Filter  _SYSTEMD_UNIT=etcdadm-save.service
+          Systemd_Filter  _SYSTEMD_UNIT=etcdadm-update-status.service
+          Systemd_Filter  _SYSTEMD_UNIT=flanneld.service
+          Systemd_Filter  _SYSTEMD_UNIT=format-etcd2-volume.service
+          Systemd_Filter  _SYSTEMD_UNIT=kube-node-taint-and-uncordon.service
+          Systemd_Filter  _SYSTEMD_UNIT=kubelet.service
+          Systemd_Filter  _SYSTEMD_UNIT=snap.microk8s.daemon-kubelite.service
+          Systemd_Filter  _SYSTEMD_UNIT=ldconfig.service
+          Systemd_Filter  _SYSTEMD_UNIT=locksmithd.service
+          Systemd_Filter  _SYSTEMD_UNIT=logrotate.service
+          Systemd_Filter  _SYSTEMD_UNIT=lvm2-monitor.service
+          Systemd_Filter  _SYSTEMD_UNIT=mdmon.service
+          Systemd_Filter  _SYSTEMD_UNIT=nfs-idmapd.service
+          Systemd_Filter  _SYSTEMD_UNIT=nfs-mountd.service
+          Systemd_Filter  _SYSTEMD_UNIT=nfs-server.service
+          Systemd_Filter  _SYSTEMD_UNIT=nfs-utils.service
+          Systemd_Filter  _SYSTEMD_UNIT=node-problem-detector.service
+          Systemd_Filter  _SYSTEMD_UNIT=ntp.service
+          Systemd_Filter  _SYSTEMD_UNIT=oem-cloudinit.service
+          Systemd_Filter  _SYSTEMD_UNIT=rkt-gc.service
+          Systemd_Filter  _SYSTEMD_UNIT=rkt-metadata.service
+          Systemd_Filter  _SYSTEMD_UNIT=rpc-idmapd.service
+          Systemd_Filter  _SYSTEMD_UNIT=rpc-mountd.service
+          Systemd_Filter  _SYSTEMD_UNIT=rpc-statd.service
+          Systemd_Filter  _SYSTEMD_UNIT=rpcbind.service
+          Systemd_Filter  _SYSTEMD_UNIT=set-aws-environment.service
+          Systemd_Filter  _SYSTEMD_UNIT=system-cloudinit.service
+          Systemd_Filter  _SYSTEMD_UNIT=systemd-timesyncd.service
+          Systemd_Filter  _SYSTEMD_UNIT=update-ca-certificates.service
+          Systemd_Filter  _SYSTEMD_UNIT=user-cloudinit.service
+          Systemd_Filter  _SYSTEMD_UNIT=var-lib-etcd2.service
+          Max_Entries     1000
+          Read_From_Tail  true
+    # Prevent snowball effect by filtering out receiver mock logs
     filters: |
       [FILTER]
           Name    grep
           Match   containers.var.log.containers.receiver-mock*
-          Exclude log .*
+          Exclude logtag .*
   extraVolumeMounts:
     - mountPath: /tail-db
       name: tail-db

--- a/tests/integration/values/values_helm_ot_fluentbit_logs.yaml
+++ b/tests/integration/values/values_helm_ot_fluentbit_logs.yaml
@@ -1,0 +1,14 @@
+sumologic:
+  events:
+    enabled: false
+  logs:
+    collector:
+      otelcol:
+        enabled: false
+  metrics:
+    enabled: false
+  traces:
+    enabled: false
+
+fluent-bit:
+  enabled: true


### PR DESCRIPTION
We were missing this configuration in tests, and we do support it.