### PR TITLE
chore: downgrade Fluent Bit to v1.6.10-sumo-3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- chore: upgrade Fluent Bit to v2.0.6 [#2694]
+- chore: upgrade Fluent Bit to v1.6.10-sumo-3 [#2712]
 - added imagePullSecrets field in otel events and sumologic-setup template [#2689]
 - chore: upgrade otelcol to 0.66.0-sumo-0 [#2686] [#2687] [#2692] [#2693]
 
-[#2694]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2694
 [#2689]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2689
 [#2686]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2686
 [#2687]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2687
 [#2693]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2693
 [#2692]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2692
+[#2712]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2712
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v3.0.0-beta.0...main
 
 ## [v3.0.0-beta.0]

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1031,7 +1031,7 @@ fluent-bit:
   #   - name: "image-pull-secret"
   image:
     repository: public.ecr.aws/sumologic/fluent-bit
-    tag: 2.0.6
+    tag: 1.6.10-sumo-3
     pullPolicy: IfNotPresent
 
   ## Resource limits for fluent-bit


### PR DESCRIPTION
Fluent Bit v2.0.6 (introduced in #2694) is not passing our e2e tests.

Changes in v1.6.10-sumo-3 vs. v1.6.10-sumo-2:
- remove vulnerabilities by upgrading base Docker image to latest Debian 11 https://github.com/SumoLogic/fluent-bit-docker-image/pull/5