### PR TITLE
ci: only check links in changed md files in PRs

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -9,6 +9,18 @@ on:
       - 'release-v[0-9]+.[0-9]+'
 
 jobs:
+
+  markdown-link-check:
+    runs-on: ubuntu-20.04
+    needs: [docs-changed]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        if: needs.docs-changed.outputs.any_changed == 'true'
+        with:
+          config-file: '.markdown_link_check.json'
+          use-quiet-mode: yes
+
   push-helm-chart:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -111,9 +111,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
-        if: needs.docs-changed.outputs.any_changed == 'true'
         with:
           config-file: '.markdown_link_check.json'
+          use-quiet-mode: yes
+          check-modified-files-only: yes
+          base-branch: main
 
   md-links-lint:
     runs-on: ubuntu-20.04

--- a/ci/markdown_link_check.sh
+++ b/ci/markdown_link_check.sh
@@ -6,7 +6,12 @@ if ! markdown-link-check --help >/dev/null 2>&1 ; then
 fi
 
 # Get all markdown files
-readonly FILES=$(find . -type f -name '*.md')
+readonly ALL_FILES
+ALL_FILES=$(find . -type f -name '*.md')
+
+
+# Use the files passed as command line arguments if provided, otherwise all of them
+readonly FILES=${*:-${ALL_FILES}}
 
 for file in ${FILES}; do
     markdown-link-check --progress --verbose --retry \


### PR DESCRIPTION
In PRs, only check links in modified Markdown files. We still check all of them on pushes to main in case a link expires.