### PR TITLE
fix(openshift): add missing privileges for otelcol-logs-collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - chore: upgrade Fluent Bit to v1.6.10-sumo-3 [#2712]
 - added imagePullSecrets field in otel events and sumologic-setup template [#2689]
 - chore: upgrade otelcol to 0.66.0-sumo-0 [#2686] [#2687] [#2692] [#2693]
+- fix(openshift): changed allowed fsgroups in SecurityContextConstraints [#2717]
+- fix(openshift): set securityContexts for otelcol-logs-collector [#2717]
 
 [#2689]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2689
 [#2686]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2686
@@ -19,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2693]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2693
 [#2692]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2692
 [#2712]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2712
+[#2717]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2717
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v3.0.0-beta.0...main
 
 ## [v3.0.0-beta.0]

--- a/deploy/helm/sumologic/templates/logs/collector/otelcol/daemonset.yaml
+++ b/deploy/helm/sumologic/templates/logs/collector/otelcol/daemonset.yaml
@@ -107,6 +107,8 @@ spec:
       initContainers: # ensure the host path is owned by the otel user group
       - name: changeowner
         image: public.ecr.aws/docker/library/busybox:latest
+        securityContext:
+          {{- toYaml .Values.otellogs.daemonset.initContainers.changeowner.securityContext | nindent 10 }}
         command:
         - "sh"
         - "-c"

--- a/deploy/helm/sumologic/templates/scc.yaml
+++ b/deploy/helm/sumologic/templates/scc.yaml
@@ -18,7 +18,8 @@ allowHostPID: true
 allowHostPorts: true
 allowPrivilegeEscalation: true # fluent-bit
 allowPrivilegedContainer: true # fluent-bit
-allowedCapabilities: []
+allowedCapabilities:
+- CAP_CHOWN # otelcol-logs-collector
 allowedUnsafeSysctls: []
 defaultAddCapabilities: []
 fsGroup:
@@ -30,6 +31,8 @@ fsGroup:
       max: 1000 # prometheus
     - min: 2000 # prometheus
       max: 2000 # prometheus
+    - min: 0  # otelcol-logs-collector
+      max: 0  # otelcol-logs-collector
 groups:
 - system:serviceaccounts:{{ .Release.Namespace }}
 priority: 0

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -4197,7 +4197,20 @@ otellogs:
     ## Set securityContext for containers running in pods in log collector daemonset
     containers:
       otelcol:
-        securityContext: {}
+        securityContext:
+          capabilities:
+            drop:
+              - ALL
+
+    ## Set securityContext for initContainers running in pods in log collector daemonset
+    initContainers:
+      changeowner:
+        securityContext:
+          capabilities:
+            drop:
+              - ALL
+            add:
+              - CAP_CHOWN
 
     nodeSelector: {}
     tolerations: []

--- a/docs/existing-prometheus-doc.md
+++ b/docs/existing-prometheus-doc.md
@@ -126,9 +126,16 @@ sumologic:
 tailing-sidecar-operator:
   scc:
     create: true
-fluent-bit:
-  securityContext:
-    privileged: true
+otellogs:
+  daemonset:
+    containers:
+      otelcol:
+        securityContext:
+          privileged: true
+    initContainers:
+      changeowner:
+        securityContext:
+          privileged: true
 ```
 
 so, it should looks like the following way:
@@ -145,9 +152,16 @@ tailing-sidecar-operator:
     create: true
 kube-prometheus-stack:
   enabled: false
-fluent-bit:
-  securityContext:
-    privileged: true
+otellogs:
+  daemonset:
+    containers:
+      otelcol:
+        securityContext:
+          privileged: true
+    initContainers:
+      changeowner:
+        securityContext:
+          privileged: true
 ```
 
 and then upgrade it to apply configuration:

--- a/docs/installation-with-helm.md
+++ b/docs/installation-with-helm.md
@@ -4,6 +4,7 @@ Our Helm chart deploys Kubernetes resources for collecting Kubernetes logs, metr
 enriching them with deployment, pod, and service level metadata; and sends them to Sumo Logic.
 
 - [Requirements](#requirements)
+  - [Kubernetes version](#kubernetes-version)
 - [Prerequisite](#prerequisite)
 - [Installation Steps](#installation-steps)
   - [Authenticating with container registry](#authenticating-with-container-registry)
@@ -15,6 +16,8 @@ enriching them with deployment, pod, and service level metadata; and sends them 
 - [Customizing Installation](#customizing-installation)
 - [Upgrading Sumo Logic Collection](#upgrading-sumo-logic-collection)
 - [Uninstalling Sumo Logic Collection](#uninstalling-sumo-logic-collection)
+  - [Post installation cleanup](#post-installation-cleanup)
+  - [Removing the kubelet Service](#removing-the-kubelet-service)
 
 ## Requirements
 
@@ -172,9 +175,16 @@ you can add the following configuration to `user-values.yaml`:
 sumologic:
   scc:
     create: true
-fluent-bit:
-  securityContext:
-    privileged: true
+otellogs:
+  daemonset:
+    containers:
+      otelcol:
+        securityContext:
+          privileged: true
+    initContainers:
+      changeowner:
+        securityContext:
+          privileged: true
 kube-prometheus-stack:
   prometheus-node-exporter:
     service:
@@ -198,9 +208,16 @@ sumologic:
   clusterName: ${MY_CLUSTER_NAME}
   scc:
     create: true
-fluent-bit:
-  securityContext:
-    privileged: true
+otellogs:
+  daemonset:
+    containers:
+      otelcol:
+        securityContext:
+          privileged: true
+    initContainers:
+      changeowner:
+        securityContext:
+          privileged: true
 kube-prometheus-stack:
   prometheus-node-exporter:
     service:

--- a/docs/non-helm-installation.md
+++ b/docs/non-helm-installation.md
@@ -184,9 +184,16 @@ In order to enable it, please add the following to `user-values.yaml`:
 sumologic:
   scc:
     create: true
-fluent-bit:
-  securityContext:
-    privileged: true
+otellogs:
+  daemonset:
+    containers:
+      otelcol:
+        securityContext:
+          privileged: true
+    initContainers:
+      changeowner:
+        securityContext:
+          privileged: true
 kube-prometheus-stack:
   prometheus-node-exporter:
     service:
@@ -210,9 +217,16 @@ sumologic:
   clusterName: ${CLUSTER_NAME}
   scc:
     create: true
-fluent-bit:
-  securityContext:
-    privileged: true
+otellogs:
+  daemonset:
+    containers:
+      otelcol:
+        securityContext:
+          privileged: true
+    initContainers:
+      changeowner:
+        securityContext:
+          privileged: true
 kube-prometheus-stack:
   prometheus-node-exporter:
     service:

--- a/docs/side-by-side-prometheus.md
+++ b/docs/side-by-side-prometheus.md
@@ -169,9 +169,16 @@ If you are installing the Sumo Logic Kubernetes collection Helm Chart in Openshi
       service:
         port: 9200
         targetPort: 9200
-  fluent-bit:
-    securityContext:
-      privileged: true
+  otellogs:
+    daemonset:
+      containers:
+        otelcol:
+          securityContext:
+            privileged: true
+      initContainers:
+        changeowner:
+          securityContext:
+            privileged: true
   tailing-sidecar-operator:
     scc:
       create: true
@@ -195,9 +202,16 @@ If you are installing the Sumo Logic Kubernetes collection Helm Chart in Openshi
       service:
         port: 9200
         targetPort: 9200
-  fluent-bit:
-    securityContext:
-      privileged: true
+  otellogs:
+    daemonset:
+      containers:
+        otelcol:
+          securityContext:
+            privileged: true
+      initContainers:
+        changeowner:
+          securityContext:
+            privileged: true
   tailing-sidecar-operator:
     scc:
       create: true
@@ -226,9 +240,16 @@ If you are installing the Sumo Logic Kubernetes collection Helm Chart in Openshi
         targetPort: 9200
     prometheusOperator:
       enabled: false
-  fluent-bit:
-    securityContext:
-      privileged: true
+  otellogs:
+    daemonset:
+      containers:
+        otelcol:
+          securityContext:
+            privileged: true
+      initContainers:
+        changeowner:
+          securityContext:
+            privileged: true
   tailing-sidecar-operator:
     scc:
       create: true
@@ -250,9 +271,16 @@ If you are installing the Sumo Logic Kubernetes collection Helm Chart in Openshi
         targetPort: 9200
     prometheusOperator:
       enabled: false
-  fluent-bit:
-    securityContext:
-      privileged: true
+  otellogs:
+    daemonset:
+      containers:
+        otelcol:
+          securityContext:
+            privileged: true
+      initContainers:
+        changeowner:
+          securityContext:
+            privileged: true
   tailing-sidecar-operator:
     scc:
       create: true

--- a/docs/standalone-prometheus.md
+++ b/docs/standalone-prometheus.md
@@ -110,9 +110,16 @@ If you are installing the Helm chart in OpenShift platform, you can update `user
 sumologic:
   scc:
     create: true
-fluent-bit:
-  securityContext:
-    privileged: true
+otellogs:
+  daemonset:
+    containers:
+      otelcol:
+        securityContext:
+          privileged: true
+    initContainers:
+      changeowner:
+        securityContext:
+          privileged: true
 tailing-sidecar-operator:
   scc:
     create: true
@@ -125,13 +132,20 @@ sumologic:
   accessId: ${SUMO_ACCESS_ID}
   accessKey: ${SUMO_ACCESS_KEY}
   clusterName: ${MY_CLUSTER_NAME}
-kube-prometheus-stack:
-  enabled: false
   scc:
     create: true
-fluent-bit:
-  securityContext:
-    privileged: true
+kube-prometheus-stack:
+  enabled: false
+otellogs:
+  daemonset:
+    containers:
+      otelcol:
+        securityContext:
+          privileged: true
+    initContainers:
+      changeowner:
+        securityContext:
+          privileged: true
 tailing-sidecar-operator:
   scc:
     create: true

--- a/tests/helm/logs_otc_daemonset/static/basic.output.yaml
+++ b/tests/helm/logs_otc_daemonset/static/basic.output.yaml
@@ -74,7 +74,9 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         securityContext:
-          {}
+          capabilities:
+            drop:
+              - ALL
         ports:
         - name: pprof
           containerPort: 1777
@@ -85,6 +87,12 @@ spec:
       initContainers: # ensure the host path is owned by the otel user group
       - name: changeowner
         image: public.ecr.aws/docker/library/busybox:latest
+        securityContext:
+          capabilities:
+            drop:
+              - ALL
+            add:
+              - CAP_CHOWN
         command:
         - "sh"
         - "-c"

--- a/tests/helm/logs_otc_daemonset/static/complex.input.yaml
+++ b/tests/helm/logs_otc_daemonset/static/complex.input.yaml
@@ -38,8 +38,22 @@ otellogs:
     ## Set securityContext for containers running in pods in log collector daemonset
     containers:
       otelcol:
-        securityContext: {}
+        securityContext:
+          capabilities:
+            drop:
+              - ALL
+          privileged: true
 
+    ## Set securityContext for initContainers running in pods in log collector daemonset
+    initContainers:
+      changeowner:
+        securityContext:
+          capabilities:
+            drop:
+              - ALL
+            add:
+              - CAP_CHOWN
+          privileged: true
     nodeSelector:
       sumologic.com/kind: worker
 

--- a/tests/helm/logs_otc_daemonset/static/complex.output.yaml
+++ b/tests/helm/logs_otc_daemonset/static/complex.output.yaml
@@ -92,7 +92,10 @@ spec:
               key: secret_key
               name: secret_name
         securityContext:
-          {}
+          capabilities:
+            drop:
+              - ALL
+          privileged: true
         ports:
         - name: pprof
           containerPort: 1777
@@ -103,6 +106,13 @@ spec:
       initContainers: # ensure the host path is owned by the otel user group
       - name: changeowner
         image: public.ecr.aws/docker/library/busybox:latest
+        securityContext:
+          capabilities:
+            drop:
+              - ALL
+            add:
+              - CAP_CHOWN
+          privileged: true
         command:
         - "sh"
         - "-c"


### PR DESCRIPTION
##### Description

Fixes following errors:

```
kubectl describe  -n sumologic daemonset.apps/collection-sumologic-otelcol-logs-collector 
....
  Warning  FailedCreate  65s                daemonset-controller  Error creating: pods "collection1-sumologic-otelcol-logs-collector-" is forbidden: unable to validate against any security context constraint: [provider "anyuid": Forbidden: not usable by user or serviceaccount, provider "collection-sumologic-setup-scc": Forbidden: not usable by user or serviceaccount, provider restricted: .spec.securityContext.fsGroup: Invalid value: []int64{0}: 0 is not an allowed group, spec.volumes[1]: Invalid value: "hostPath": hostPath volumes are not allowed to be used, spec.volumes[2]: Invalid value: "hostPath": hostPath volumes are not allowed to be used, spec.volumes[3]: Invalid value: "hostPath": hostPath volumes are not allowed to be used, spec.volumes[4]: Invalid value: "hostPath": hostPath volumes are not allowed to be used, spec.initContainers[0].securityContext.runAsUser: Invalid value: 0: must be in the ranges: [1000660000, 1000669999], spec.containers[0].securityContext.runAsUser: Invalid value: 0: must be in the ranges: [1000660000, 1000669999], provider "nonroot": Forbidden: not usable by user or serviceaccount, provider "hostmount-anyuid": Forbidden: not usable by user or serviceaccount, provider "machine-api-termination-handler": Forbidden: not usable by user or serviceaccount, provider "hostnetwork": Forbidden: not usable by user or serviceaccount, provider "hostaccess": Forbidden: not usable by user or serviceaccount, provider "node-exporter": Forbidden: not usable by user or serviceaccount, provider "privileged": Forbidden: not usable by user or serviceaccount]
  Warning  FailedCreate  24s (x6 over 64s)  daemonset-controller  Error creating: pods "collection1-sumologic-otelcol-logs-collector-" is forbidden: unable to validate against any security context constraint: [provider "anyuid": Forbidden: not usable by user or serviceaccount, provider "collection-sumologic-setup-scc": Forbidden: not usable by user or serviceaccount, provider restricted: .spec.securityContext.fsGroup: Invalid value: []int64{0}: 0 is not an allowed group, spec.volumes[1]: Invalid value: "hostPath": hostPath volumes are not allowed to be used, spec.volumes[2]: Invalid value: "hostPath": hostPath volumes are not allowed to be used, spec.volumes[3]: Invalid value: "hostPath": hostPath volumes are not allowed to be used, spec.volumes[4]: Invalid value: "hostPath": hostPath volumes are not allowed to be used, spec.initContainers[0].securityContext.runAsUser: Invalid value: 0: must be in the ranges: [1000660000, 1000669999], spec.containers[0].securityContext.runAsUser: Invalid value: 0: must be in the ranges: [1000660000, 1000669999], provider "nonroot": Forbidden: not usable by user or serviceaccount, provider "hostmount-anyuid": Forbidden: not usable by user or serviceaccount, provider "machine-api-termination-handler": Forbidden: not usable by user or serviceaccount, provider "hostnetwork": Forbidden: not usable by user or serviceaccount, provider "hostaccess": Forbidden: not usable by user or serviceaccount, provider collection1-sumologic-scc: .spec.securityContext.fsGroup: Invalid value: []int64{0}: 0 is not an allowed group, provider "node-exporter": Forbidden: not usable by user or serviceaccount, provider "privileged": Forbidden: not usable by user or serviceaccount]
```

```
 % kubectl logs -n sumologic collection-sumologic-otelcol-logs-collector-rt52v changeowner
chown: /var/lib/storage/otc: Permission denied
chown: /var/lib/storage/otc: Permission denied
```

Note: without this part in configuration:
```
otellogs:
  daemonset:
    containers:
      otelcol:
        securityContext:
          privileged: true
```

there is following issue:
```
% kubectl logs -n sumologic collection-sumologic-otelcol-logs-collector-wmscj 
Defaulted container "otelcol" out of: otelcol, changeowner (init)
2022-12-20T11:33:20.569Z        info    service/telemetry.go:111        Setting up own telemetry...
2022-12-20T11:33:20.571Z        info    service/telemetry.go:141        Serving Prometheus metrics      {"address": ":8888", "level": "Basic"}
2022-12-20T11:33:20.572Z        info    components/components.go:30     Development component. May change in the future.        {"kind": "processor", "name": "logstransform/systemd", "pipeline": "logs/systemd", "stability": "Development"}
2022-12-20T11:33:20.576Z        info    service/service.go:89   Starting otelcol-sumo...        {"Version": "v0.66.0-sumo-0", "NumCPU": 4}
2022-12-20T11:33:20.576Z        info    extensions/extensions.go:41     Starting extensions...
2022-12-20T11:33:20.576Z        info    extensions/extensions.go:44     Extension is starting...        {"kind": "extension", "name": "file_storage"}
2022-12-20T11:33:20.576Z        info    extensions/extensions.go:48     Extension started.      {"kind": "extension", "name": "file_storage"}
2022-12-20T11:33:20.576Z        info    extensions/extensions.go:44     Extension is starting...        {"kind": "extension", "name": "pprof"}
2022-12-20T11:33:20.577Z        info    pprofextension@v0.66.0/pprofextension.go:71     Starting net/http/pprof server  {"kind": "extension", "name": "pprof", "config": {"ExtensionConfig":null,"TCPAddr":{"Endpoint":"localhost:1777"},"BlockProfileFraction":0,"MutexProfileFraction":0,"SaveToFile":""}}
2022-12-20T11:33:20.577Z        info    extensions/extensions.go:48     Extension started.      {"kind": "extension", "name": "pprof"}
2022-12-20T11:33:20.577Z        info    extensions/extensions.go:44     Extension is starting...        {"kind": "extension", "name": "health_check"}
2022-12-20T11:33:20.577Z        info    healthcheckextension@v0.66.0/healthcheckextension.go:44 Starting health_check extension {"kind": "extension", "name": "health_check", "config": {"ExtensionConfig":null,"Endpoint":"0.0.0.0:13133","TLSSetting":null,"CORS":null,"Auth":null,"MaxRequestBodySize":0,"IncludeMetadata":false,"Path":"/","CheckCollectorPipeline":{"Enabled":false,"Interval":"5m","ExporterFailureThreshold":5}}}
2022-12-20T11:33:20.577Z        warn    internal/warning.go:51  Using the 0.0.0.0 address exposes this server to every network interface, which may facilitate Denial of Service attacks    {"kind": "extension", "name": "health_check", "documentation": "https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security-best-practices.md#safeguards-against-denial-of-service-attacks"}
2022-12-20T11:33:20.577Z        info    extensions/extensions.go:48     Extension started.      {"kind": "extension", "name": "health_check"}
2022-12-20T11:33:20.577Z        info    pipelines/pipelines.go:74       Starting exporters...
2022-12-20T11:33:20.578Z        info    pipelines/pipelines.go:78       Exporter is starting... {"kind": "exporter", "data_type": "logs", "name": "otlphttp"}
2022-12-20T11:33:20.578Z        info    pipelines/pipelines.go:82       Exporter started.       {"kind": "exporter", "data_type": "logs", "name": "otlphttp"}
2022-12-20T11:33:20.578Z        info    pipelines/pipelines.go:86       Starting processors...
2022-12-20T11:33:20.578Z        info    pipelines/pipelines.go:90       Processor is starting...        {"kind": "processor", "name": "batch", "pipeline": "logs/systemd"}
2022-12-20T11:33:20.578Z        info    pipelines/pipelines.go:94       Processor started.      {"kind": "processor", "name": "batch", "pipeline": "logs/systemd"}
2022-12-20T11:33:20.578Z        info    pipelines/pipelines.go:90       Processor is starting...        {"kind": "processor", "name": "logstransform/systemd", "pipeline": "logs/systemd"}
2022-12-20T11:33:20.578Z        info    pipelines/pipelines.go:94       Processor started.      {"kind": "processor", "name": "logstransform/systemd", "pipeline": "logs/systemd"}
2022-12-20T11:33:20.578Z        info    pipelines/pipelines.go:90       Processor is starting...        {"kind": "processor", "name": "batch", "pipeline": "logs/containers"}
2022-12-20T11:33:20.578Z        info    pipelines/pipelines.go:94       Processor started.      {"kind": "processor", "name": "batch", "pipeline": "logs/containers"}
2022-12-20T11:33:20.578Z        info    pipelines/pipelines.go:98       Starting receivers...
2022-12-20T11:33:20.578Z        info    pipelines/pipelines.go:102      Receiver is starting... {"kind": "receiver", "name": "journald", "pipeline": "logs"}
2022-12-20T11:33:20.578Z        info    adapter/receiver.go:55  Starting stanza receiver        {"kind": "receiver", "name": "journald", "pipeline": "logs"}
2022-12-20T11:33:20.582Z        info    pipelines/pipelines.go:106      Receiver started.       {"kind": "receiver", "name": "journald", "pipeline": "logs"}
2022-12-20T11:33:20.582Z        info    pipelines/pipelines.go:102      Receiver is starting... {"kind": "receiver", "name": "filelog/containers", "pipeline": "logs"}
2022-12-20T11:33:20.582Z        info    adapter/receiver.go:55  Starting stanza receiver        {"kind": "receiver", "name": "filelog/containers", "pipeline": "logs"}
2022-12-20T11:33:20.582Z        info    service/service.go:115  Starting shutdown...
2022-12-20T11:33:20.582Z        info    healthcheck/handler.go:129      Health Check state change       {"kind": "extension", "name": "health_check", "status": "unavailable"}
2022-12-20T11:33:20.582Z        info    pipelines/pipelines.go:118      Stopping receivers...
2022-12-20T11:33:20.582Z        info    adapter/receiver.go:145 Stopping stanza receiver        {"kind": "receiver", "name": "journald", "pipeline": "logs"}
2022-12-20T11:33:20.585Z        info    adapter/receiver.go:145 Stopping stanza receiver        {"kind": "receiver", "name": "filelog/containers", "pipeline": "logs"}
2022-12-20T11:33:20.585Z        info    pipelines/pipelines.go:125      Stopping processors...
2022-12-20T11:33:20.585Z        info    logstransformprocessor@v0.66.0/processor.go:55  Stopping logs transform processor       {"kind": "processor", "name": "logstransform/systemd", "pipeline": "logs/systemd"}
2022-12-20T11:33:20.585Z        info    pipelines/pipelines.go:132      Stopping exporters...
2022-12-20T11:33:20.585Z        info    extensions/extensions.go:55     Stopping extensions...
2022-12-20T11:33:20.585Z        info    service/service.go:129  Shutdown complete.
Error: cannot start pipelines: storage client: open /var/lib/storage/otc/receiver_filelog_containers: permission denied
2022/12/20 11:33:20 collector server run finished with error: cannot start pipelines: storage client: open /var/lib/storage/otc/receiver_filelog_containers: permission denied
```
---
