### PR TITLE
fix: obey proxy settings in otelcol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - chore: upgrade otelcol to 0.66.0-sumo-0 [#2686] [#2687] [#2692] [#2693]
 - fix(openshift): changed allowed fsgroups in SecurityContextConstraints [#2717]
 - fix(openshift): set securityContexts for otelcol-logs-collector [#2717]
+- fix: obey proxy settings in otelcol [#2719]
 
 [#2689]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2689
 [#2686]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2686
@@ -22,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2692]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2692
 [#2712]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2712
 [#2717]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2717
+[#2719]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2719
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v3.0.0-beta.0...main
 
 ## [v3.0.0-beta.0]

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -1526,3 +1526,26 @@ Example Usage:
 {{- define "opentelemetry-operator.controller.manager.metrics.service.url" -}}
 http://opentelemetry-operator-controller-manager-metrics-service.{{ .Release.Namespace }}:8080/metrics
 {{- end -}}
+
+
+{{/*
+Environment variables used to configure the HTTP proxy for programs using
+Go's net/http. See: https://pkg.go.dev/net/http#RoundTripper
+
+Example Usage:
+'{{ include "proxy-env-variables" . }}'
+*/}}
+{{- define "proxy-env-variables" -}}
+{{- if .Values.sumologic.httpProxy -}}
+- name: HTTP_PROXY
+  value: {{ .Values.sumologic.httpProxy }}
+{{- end -}}
+{{- if .Values.sumologic.httpsProxy -}}
+- name: HTTPS_PROXY
+  value: {{ .Values.sumologic.httpsProxy }}
+{{- end -}}
+{{- if .Values.sumologic.noProxy -}}
+- name: NO_PROXY
+  value: {{ .Values.sumologic.noProxy }}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/sumologic/templates/events/otelcol/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/events/otelcol/statefulset.yaml
@@ -149,6 +149,7 @@ spec:
         env:
 {{- $ctx := .Values -}}
 {{- include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "events") -}}
+{{- include "proxy-env-variables" . | nindent 8 -}}
         {{- if .Values.otelevents.statefulset.extraEnvVars }}
 {{ toYaml .Values.otelevents.statefulset.extraEnvVars | nindent 8 }}
         {{- end }}

--- a/deploy/helm/sumologic/templates/instrumentation/traces-gateway/deployment.yaml
+++ b/deploy/helm/sumologic/templates/instrumentation/traces-gateway/deployment.yaml
@@ -71,6 +71,7 @@ spec:
 {{- $ctx := .Values -}}
 {{- include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "traces") -}}
 {{- include "kubernetes.sources.env" (dict "Context" $ctx "Type" "metrics" "Name" "default" ) | nindent 8 }}
+{{- include "proxy-env-variables" . | nindent 8 -}}
 {{- if $tracesGateway.deployment.extraEnvVars }}
 {{- toYaml $tracesGateway.deployment.extraEnvVars | nindent 8 }}
 {{- end }}

--- a/deploy/helm/sumologic/templates/instrumentation/traces-sampler/deployment.yaml
+++ b/deploy/helm/sumologic/templates/instrumentation/traces-sampler/deployment.yaml
@@ -64,6 +64,7 @@ spec:
           value: "80"
 {{- $ctx := .Values -}}
 {{- include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "traces") -}}
+{{- include "proxy-env-variables" . | nindent 8 -}}
 {{- if $tracesSampler.deployment.extraEnvVars }}
 {{- toYaml $tracesSampler.deployment.extraEnvVars | nindent 8 }}
 {{- end }}

--- a/deploy/helm/sumologic/templates/logs/otelcol/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/logs/otelcol/statefulset.yaml
@@ -160,6 +160,7 @@ spec:
         env:
 {{- $ctx := .Values -}}
 {{- include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "logs") -}}
+{{- include "proxy-env-variables" . | nindent 8 -}}
 {{- if .Values.metadata.logs.statefulset.extraEnvVars }}
 {{- toYaml .Values.metadata.logs.statefulset.extraEnvVars | nindent 8 }}
 {{- end }}

--- a/deploy/helm/sumologic/templates/metrics/otelcol/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics/otelcol/statefulset.yaml
@@ -156,6 +156,7 @@ spec:
         env:
 {{- $ctx := .Values -}}
 {{- include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "metrics") -}}
+{{- include "proxy-env-variables" . | nindent 8 -}}
         {{- if .Values.metadata.metrics.statefulset.extraEnvVars }}
 {{ toYaml .Values.metadata.metrics.statefulset.extraEnvVars | nindent 8 }}
         {{- end }}

--- a/deploy/helm/sumologic/templates/setup/job.yaml
+++ b/deploy/helm/sumologic/templates/setup/job.yaml
@@ -68,12 +68,7 @@ spec:
         env:
         - name: SUMOLOGIC_BASE_URL
           value: {{ .Values.sumologic.endpoint }}
-        - name: HTTP_PROXY
-          value: {{ .Values.sumologic.httpProxy }}
-        - name: HTTPS_PROXY
-          value: {{ .Values.sumologic.httpsProxy }}
-        - name: NO_PROXY
-          value: {{ .Values.sumologic.noProxy }}
+        {{- include "proxy-env-variables" . | nindent 8 -}}
 {{- if .Values.sumologic.setup.debug }}
         - name: DEBUG_MODE
           value: "true"

--- a/tests/helm/events_otc_statefulset/static/annotations_labels.output.yaml
+++ b/tests/helm/events_otc_statefulset/static/annotations_labels.output.yaml
@@ -108,6 +108,8 @@ spec:
             secretKeyRef:
               name: sumologic
               key: endpoint-events
+        - name: NO_PROXY
+          value: kubernetes.default.svc
   volumeClaimTemplates:
   - metadata:
       name: file-storage

--- a/tests/helm/events_otc_statefulset/static/basic.output.yaml
+++ b/tests/helm/events_otc_statefulset/static/basic.output.yaml
@@ -120,7 +120,8 @@ spec:
             secretKeyRef:
               name: sumologic
               key: endpoint-events
-
+        - name: NO_PROXY
+          value: kubernetes.default.svc
         - name: VALUE_FROM_SECRET
           valueFrom:
             secretKeyRef:

--- a/tests/helm/metadata_logs_otc_statefulset/static/basic.output.yaml
+++ b/tests/helm/metadata_logs_otc_statefulset/static/basic.output.yaml
@@ -126,6 +126,8 @@ spec:
             secretKeyRef:
               name: sumologic
               key: endpoint-logs
+        - name: NO_PROXY
+          value: kubernetes.default.svc
         - name: VALUE_FROM_SECRET
           valueFrom:
             secretKeyRef:

--- a/tests/helm/metadata_metrics_otc_statefulset/static/basic.output.yaml
+++ b/tests/helm/metadata_metrics_otc_statefulset/static/basic.output.yaml
@@ -158,7 +158,8 @@ spec:
             secretKeyRef:
               name: sumologic
               key: endpoint-metrics-kube-state
-
+        - name: NO_PROXY
+          value: kubernetes.default.svc
         - name: VALUE_FROM_SECRET
           valueFrom:
             secretKeyRef:

--- a/tests/helm/setup/basic.output.yaml
+++ b/tests/helm/setup/basic.output.yaml
@@ -1,0 +1,60 @@
+---
+# Source: sumologic/templates/setup/job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: RELEASE-NAME-sumologic-setup
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "3"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  labels:
+    app: RELEASE-NAME-sumologic
+    chart: "sumologic-%CURRENT_CHART_VERSION%"
+    release: "RELEASE-NAME"
+    heritage: "Helm"
+spec:
+  template:
+    metadata:
+      annotations:
+      labels:
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: RELEASE-NAME-sumologic-setup
+      volumes:
+      - name: setup
+        configMap:
+          name: RELEASE-NAME-sumologic-setup
+          defaultMode: 0777
+      - name: custom
+        configMap:
+          name: RELEASE-NAME-sumologic-setup-custom
+          defaultMode: 0777
+      containers:
+      - name: setup
+        image: public.ecr.aws/sumologic/kubernetes-setup:3.4.0
+        imagePullSecrets:
+        imagePullPolicy: IfNotPresent
+        command: ["/etc/terraform/setup.sh"]
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 256Mi
+          requests:
+            cpu: 200m
+            memory: 64Mi
+        volumeMounts:
+        - name: setup
+          mountPath: /etc/terraform
+        - name: custom
+          mountPath: /customer-scripts
+        envFrom:
+        - secretRef:
+            name: RELEASE-NAME-sumologic-setup
+        env:
+        - name: SUMOLOGIC_BASE_URL
+          value:
+        - name: NO_PROXY
+          value: kubernetes.default.svc
+      securityContext:
+        runAsUser: 999


### PR DESCRIPTION
Otelcol instances sending data to Sumo weren't using the global proxy settings. Fix this by adding the right environment variables, as per https://opentelemetry.io/docs/collector/configuration/#proxy-support.