### PR TITLE
ci: fix markdown link check in dev builds

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -12,7 +12,6 @@ jobs:
 
   markdown-link-check:
     runs-on: ubuntu-20.04
-    needs: [docs-changed]
     steps:
       - uses: actions/checkout@v3
       - uses: gaurav-nelson/github-action-markdown-link-check@v1


### PR DESCRIPTION
#2714 broke the dev builds by adding an incorrect configuration to the workflow. This fixes it.
