### PR TITLE
chore: upgrade Fluent Bit to v1.6.10-sumo-3 (backport)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.19.1]
+
+### Changed
+
+- chore: upgrade Fluent Bit to v1.6.10-sumo-3 [#2730]
+
+### Fixed
+
+- The repository for the metrics-server dependency was updated [#2730]
+
+[#2730]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2730
+
 ## [v2.19.0]
 
 ### Released 2022-11-24

--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     condition: falco.enabled
   - name: metrics-server
     version: 5.11.9
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: metrics-server.enabled
   - name: telegraf-operator
     version: 1.3.10

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1025,7 +1025,7 @@ fluent-bit:
   #   - name: "image-pull-secret"
   image:
     repository: public.ecr.aws/sumologic/fluent-bit
-    tag: 1.6.10-sumo-2
+    tag: 1.6.10-sumo-3
     pullPolicy: IfNotPresent
 
   ## Resource limits for fluent-bit


### PR DESCRIPTION
##### Description

Upgrade Fluent Bit to v1.6.10-sumo-3 (backport)

- remove vulnerabilities by upgrading base Docker image to latest Debian 11 https://github.com/SumoLogic/fluent-bit-docker-image/pull/5

- Also, updated the repository of the metrics-server based on the change to the bitnami/charts `index.yaml` retention policy 
   - https://github.com/bitnami/charts/issues/10539#issue-1257888825

---

##### Checklist

<!---
Remove items which don't apply to your PR.
-->

- [x] Changelog updated
