### PR TITLE
feat: collect metrics from otelcol event collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - chore: upgrade otelcol to 0.68.0-sumo-0 [#2755]
 - chore: remove support for AKS 1.22 [#2756]
 - feat(logs): add daemonset and statefulset to default fields [#2766]
+- feat: collect metrics from otelcol event collector [#2754]
 
 ### Fixed
 
@@ -30,7 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2755]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2755
 [#2756]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2756
 [#2761]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2761
-[#2766]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/123
+[#2766]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2766
+[#2754]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2754
 [v1.15.3-sumo-0]: https://github.com/SumoLogic/sumologic-kubernetes-fluentd/releases/tag/v1.15.3-sumo-0
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v3.0.0-beta.0...main
 

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -675,7 +675,11 @@ sumologic.com/component: metrics
 {{- end -}}
 
 {{- define "sumologic.labels.events" -}}
+{{- if eq .Values.sumologic.events.provider "fluentd" -}}
 sumologic.com/app: fluentd-events
+{{- else -}}
+sumologic.com/app: otelcol-events
+{{- end }}
 sumologic.com/component: events
 {{- end -}}
 

--- a/deploy/helm/sumologic/templates/events/otelcol/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/events/otelcol/statefulset.yaml
@@ -25,6 +25,7 @@ spec:
 {{- end }}
       labels:
         app: {{ template "sumologic.labels.app.events.pod" . }}
+        {{- include "sumologic.labels.scrape.events" . | nindent 8 }}
         {{- include "sumologic.labels.common" . | nindent 8 }}
 {{- if .Values.sumologic.podLabels }}
 {{ toYaml .Values.sumologic.podLabels | indent 8 }}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -522,6 +522,18 @@ sumologic:
           matchLabels:
             sumologic.com/app: otelcol-logs-collector
             sumologic.com/scrape: "true"
+      - name: collection-sumologic-otelcol-events
+        additionalLabels:
+          sumologic.com/app: otelcol-events
+        endpoints:
+          - port: otelcol-metrics
+        namespaceSelector:
+          matchNames:
+            - $(NAMESPACE)
+        selector:
+          matchLabels:
+            sumologic.com/app: otelcol-events
+            sumologic.com/scrape: "true"
       - name: collection-sumologic-otelcol-traces
         additionalLabels:
           sumologic.com/app: otelcol

--- a/tests/helm/events_otc_statefulset/static/annotations_labels.output.yaml
+++ b/tests/helm/events_otc_statefulset/static/annotations_labels.output.yaml
@@ -28,6 +28,9 @@ spec:
         release: "RELEASE-NAME"
         heritage: "Helm"
         sumoLabel: sumoValue
+        sumologic.com/app: otelcol-events
+        sumologic.com/component: events
+        sumologic.com/scrape: "true"
         statefulsetLabel: statefulsetValue
     spec:
       serviceAccountName: RELEASE-NAME-sumologic

--- a/tests/helm/events_otc_statefulset/static/basic.output.yaml
+++ b/tests/helm/events_otc_statefulset/static/basic.output.yaml
@@ -27,6 +27,9 @@ spec:
         release: "RELEASE-NAME"
         heritage: "Helm"
         someLabel: someValue
+        sumologic.com/app: otelcol-events
+        sumologic.com/component: events
+        sumologic.com/scrape: "true"
     spec:
       serviceAccountName: RELEASE-NAME-sumologic
       nodeSelector:

--- a/tests/helm/kube-prometheus-stack/servicemonitors/basic-sumo.output.yaml
+++ b/tests/helm/kube-prometheus-stack/servicemonitors/basic-sumo.output.yaml
@@ -189,6 +189,32 @@ items:
   - apiVersion: monitoring.coreos.com/v1
     kind: ServiceMonitor
     metadata:
+      name: collection-sumologic-otelcol-events
+      namespace: sumologic
+      labels:
+        app: sumologic-prometheus
+        
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/version: "%CURRENT_CHART_VERSION%"
+        app.kubernetes.io/part-of: sumologic
+        chart: sumologic-%CURRENT_CHART_VERSION%
+        release: "RELEASE-NAME"
+        heritage: "Helm"
+        sumologic.com/app: otelcol-events
+    spec:
+      endpoints:
+        - port: otelcol-metrics
+      namespaceSelector:
+        matchNames:
+        - $(NAMESPACE)
+      selector:
+        matchLabels:
+          sumologic.com/app: otelcol-events
+          sumologic.com/scrape: "true"
+  - apiVersion: monitoring.coreos.com/v1
+    kind: ServiceMonitor
+    metadata:
       name: collection-sumologic-otelcol-traces
       namespace: sumologic
       labels:

--- a/tests/helm/prometheus_test.go
+++ b/tests/helm/prometheus_test.go
@@ -46,6 +46,7 @@ kube-prometheus-stack:
 				"collection-sumologic-fluentd-events",
 				"collection-fluent-bit",
 				"collection-sumologic-otelcol-logs-collector",
+				"collection-sumologic-otelcol-events",
 				"collection-sumologic-otelcol-traces",
 				"collection-sumologic-prometheus",
 				"collection-sumologic-fluentd-logs-test",
@@ -80,7 +81,7 @@ sumologic:
 			TemplatePaths: allTemplatePaths,
 		},
 		{
-			Name: "default",
+			Name:       "default",
 			ValuesYaml: "",
 			ExpectedNames: []string{
 				"collection-sumologic-fluentd-logs",
@@ -90,6 +91,7 @@ sumologic:
 				"collection-sumologic-fluentd-events",
 				"collection-fluent-bit",
 				"collection-sumologic-otelcol-logs-collector",
+				"collection-sumologic-otelcol-events",
 				"collection-sumologic-otelcol-traces",
 				"collection-sumologic-prometheus",
 			},


### PR DESCRIPTION
Ensure the otelcol event collector Service and Pods have the right labels, and add a ServiceMonitor to collect metrics from the Pod.

This resolves #1549 