### PR TITLE
fix(logs): make `excludeHostRegex` consistent between Otelcol and Fluentd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     See [v1.15.3-sumo-0] for more.
 - chore: remove support for AKS 1.22 [#2757]
 
+### Fixed
+
+- fix(logs): make `excludeHostRegex` consistent between Otelcol and Fluentd [#2772]
+  - The `fluentd.logs.container.excludeHostRegex` should filter on the Kubernetes node name
+    when the metadata provider is Otelcol, to be consistent with Fluentd.
+
 [#2747]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2747
 [v1.15.3-sumo-0]: https://github.com/SumoLogic/sumologic-kubernetes-fluentd/releases/tag/v1.15.3-sumo-0
 [#2757]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2757
+[#2772]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2772
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.19.1...release-v2
 
 ## [v2.19.1]

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -4338,7 +4338,7 @@ metadata:
             k8s.namespace.name: '{{ include "fluentd.excludeNamespaces" . }}'
             k8s.pod.name: '{{ .Values.fluentd.logs.containers.excludePodRegex | quote }}'
             k8s.container.name: '{{ .Values.fluentd.logs.containers.excludeContainerRegex | quote }}'
-            k8s.pod.hostname: '{{ .Values.fluentd.logs.containers.excludeHostRegex | quote }}'
+            k8s.node.name: '{{ .Values.fluentd.logs.containers.excludeHostRegex | quote }}'
           annotation_prefix: "pod_annotations_"
           pod_template_hash_key: "pod_labels_pod-template-hash"
           pod_name_key: "k8s.pod.pod_name"

--- a/tests/helm/metadata_logs_otc/static/basic.output.yaml
+++ b/tests/helm/metadata_logs_otc/static/basic.output.yaml
@@ -259,7 +259,7 @@ data:
         exclude:
           k8s.container.name: ""
           k8s.namespace.name: ""
-          k8s.pod.hostname: ""
+          k8s.node.name: ""
           k8s.pod.name: ""
         pod_key: k8s.pod.name
         pod_name_key: k8s.pod.pod_name

--- a/tests/helm/metadata_logs_otc/static/templates.output.yaml
+++ b/tests/helm/metadata_logs_otc/static/templates.output.yaml
@@ -259,7 +259,7 @@ data:
         exclude:
           k8s.container.name: "my_containers_excludeContainerRegex"
           k8s.namespace.name: "my_containers_excludeNamespaceRegex"
-          k8s.pod.hostname: "my_containers_excludeHostRegex"
+          k8s.node.name: "my_containers_excludeHostRegex"
           k8s.pod.name: "my_containers_excludePodRegex"
         pod_key: k8s.pod.name
         pod_name_key: k8s.pod.pod_name


### PR DESCRIPTION
Backports the change from https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2771.