### PR TITLE
feat(logs): parse JSON logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: collect metrics from otelcol event collector [#2754]
 - feat: add option to specify additionalEndpoints for metrics [#2788]
 - chore: upgrade kubernetes-setup to v3.5.0 [#2785]
+- feat(logs): parse JSON logs [#2773]
 
 ### Fixed
 
@@ -43,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2788]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2788
 [#2785]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2785
 [#2791]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2791
+[#2773]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2773
 [v1.15.3-sumo-0]: https://github.com/SumoLogic/sumologic-kubernetes-fluentd/releases/tag/v1.15.3-sumo-0
 [Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v3.0.0-beta.0...main
 

--- a/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
@@ -205,6 +205,14 @@ processors:
     container_annotations:
       enabled: {{ .Values.sumologic.logs.container.perContainerAnnotationsEnabled }}
       prefixes: {{ toJson .Values.sumologic.logs.container.perContainerAnnotationPrefixes }}
+  ## logstransformprocessor is experimental, but the same functionality in transformprocessor doesn't offer robust enough error handling
+  ## TODO: use transformprocessor here after https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16519 is closed
+  logstransform/containers_parse_json:
+    operators:
+      - type: json_parser
+        parse_from: body
+        parse_to: body
+        if: body matches "^{.*"
 {{ end }}
 {{ if .Values.sumologic.logs.systemd.enabled }}
   ## Systemd related processors
@@ -421,6 +429,7 @@ service:
         - k8s_tagger
         - resource/add_cluster
         - source/containers
+        - logstransform/containers_parse_json
         - resource/remove_k8s_pod_pod_name
         - resource/drop_annotations
         - resource/containers_copy_node_to_host

--- a/tests/helm/metadata_logs_otc/static/otel.output.yaml
+++ b/tests/helm/metadata_logs_otc/static/otel.output.yaml
@@ -222,6 +222,12 @@ data:
         passthrough: false
         pod_association:
         - from: build_hostname
+      logstransform/containers_parse_json:
+        operators:
+        - if: body matches "^{.*"
+          parse_from: body
+          parse_to: body
+          type: json_parser
       memory_limiter:
         check_interval: 5s
         limit_percentage: 75
@@ -305,6 +311,7 @@ data:
           - k8s_tagger
           - resource/add_cluster
           - source/containers
+          - logstransform/containers_parse_json
           - resource/remove_k8s_pod_pod_name
           - resource/drop_annotations
           - resource/containers_copy_node_to_host

--- a/tests/helm/metadata_logs_otc/static/templates.output.yaml
+++ b/tests/helm/metadata_logs_otc/static/templates.output.yaml
@@ -222,6 +222,12 @@ data:
         passthrough: false
         pod_association:
         - from: build_hostname
+      logstransform/containers_parse_json:
+        operators:
+        - if: body matches "^{.*"
+          parse_from: body
+          parse_to: body
+          type: json_parser
       memory_limiter:
         check_interval: 5s
         limit_percentage: 75
@@ -305,6 +311,7 @@ data:
           - k8s_tagger
           - resource/add_cluster
           - source/containers
+          - logstransform/containers_parse_json
           - resource/remove_k8s_pod_pod_name
           - resource/drop_annotations
           - resource/containers_copy_node_to_host


### PR DESCRIPTION
Parse JSON logs bodies into OTLP data structures. As a result, Sumo renders the JSON correctly. Without this change, JSON log bodies are just escaped strings.

This change is somewhat dangerous, and I'm wondering if we shouldn't make it possible to disable. The problem is that currently, if the JSON parsing returns an error, it'll result in a 500 returned to the collector, and potentially block the whole batch from being processed indefinitely. Discussion is ongoing in [otel upstream](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16519
) about how the errors should be handled, but right now there doesn't seem to be a way to just ignore parse errors.

I've switched to logstransform processor, and this actually lets the malformed data through while logging an error. It seems to be buggy in `0.68.0` though, and fine in `0.69.0`, so this PR shouldn't be merged until we upgrade to the latter.