### PR TITLE
chore: fix local markdown link check script

### DIFF
--- a/ci/markdown_link_check.sh
+++ b/ci/markdown_link_check.sh
@@ -6,9 +6,8 @@ if ! markdown-link-check --help >/dev/null 2>&1 ; then
 fi
 
 # Get all markdown files
-readonly ALL_FILES
 ALL_FILES=$(find . -type f -name '*.md')
-
+readonly ALL_FILES
 
 # Use the files passed as command line arguments if provided, otherwise all of them
 readonly FILES=${*:-${ALL_FILES}}


### PR DESCRIPTION
The script was not doing anything, because apparently the `ALL_FILES` variable was empty, because it was read-only and couldn't be modified.

```console
$ ./ci/markdown_link_check.sh
./ci/markdown_link_check.sh: line 10: ALL_FILES: readonly variable
$ echo $?
0
```

It's interesting that:
1. The script was returning 0, no error
2. Shellcheck was not highlighting this issue
3. We don't use this script in CI, only locally