### PR TITLE
docs: remove non-existent link

### DIFF
--- a/deploy/docs/additional_prometheus_configuration.md
+++ b/deploy/docs/additional_prometheus_configuration.md
@@ -1,3 +1,3 @@
 # Additional Prometheus Configuration
 
-Moved to [/docs/additional-prometheus-configuration.md](/docs/additional-prometheus-configuration.md)
+Moved to [/docs/collecting-application-metrics.md](/docs/collecting-application-metrics.md)

--- a/docs/fluent/best-practices.md
+++ b/docs/fluent/best-practices.md
@@ -645,9 +645,7 @@ fluentd:
 
 ## Excluding Metrics
 
-You can filter out metrics directly in promethus using [this documentation](/docs/additional-prometheus-configuration.md#filter-metrics).
-
-You can also exclude metrics by any tag in Fluentd.
+You can exclude metrics by any tag in Fluentd.
 For example to filter out metrics from `sumologic` namespace, you can use following configuration:
 
 ```yaml


### PR DESCRIPTION
We don't have any docs on removing metrics in Prometheus.

This non-existent link managed to get through the markdown-link-check because we now only check modified files,
so when a file is deleted or renamed,
links to it in other files are not checked.