### PR TITLE
chore(docs): update brew commands for vagrant instalation

### DIFF
--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -11,8 +11,8 @@ Please install the following:
 ### MacOS
 
 ```bash
-brew cask install virtualbox
-brew cask install vagrant
+brew install --cask virtualbox
+brew install --cask vagrant
 vagrant plugin install vagrant-disksize
 ```
 


### PR DESCRIPTION
##### Description

While using freshly installed `brew`, I got the following message after using suggested commands for vagrant instalation:
```
Error: `brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead.
```

Technically, for me it worked to just use it without the flag, eg. `brew install virtualbox`, but let's follow the suggestion and use `brew install --cask virtualbox`.

