### PR TITLE
docs: gather all prometheus installation scenarios in one document

### DIFF
--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -178,8 +178,8 @@ Now, build Kube Prometheus Stack configuration for Sumo Logic:
   kube-prometheus-stack:
     prometheus-node-exporter:
       service:
-          port: 9200
-          targetPort: 9200
+        port: 9200
+        targetPort: 9200
   ```
 
   > __NOTE:__ Change port to other value if Prometheus Node Exporter Pods are in Pending state and you see the following warning in Events:
@@ -200,8 +200,8 @@ kube-prometheus-stack:
       releaseNamespace: true
   prometheus-node-exporter:
     service:
-        port: 9200
-        targetPort: 9200
+      port: 9200
+      targetPort: 9200
 ```
 
 Prometheus configuration is ready and now you can proceed with installation.

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -27,7 +27,7 @@ __NOTE:__ In this document we assume that `${NAMESPACE}` represents namespace in
 ## No Prometheus in the cluster
 
 If you don't have Prometheus or Kube Prometheus Stack installed in your cluster
-there is not much you can worry about.
+there is not much you need to worry about.
 There is no special configuration required, unless you want to have
 [Custom Application Metrics](/docs/collecting-application-metrics.md) or
 [Custom Kubernetes Metrics](/docs/collecting-kubernetes-metrics.md),

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -54,7 +54,7 @@ In that situation we support three scenarios:
 
 ### Custom Resource Definition compatibility
 
-CRD versions required by Sumo Logic Collection is `v0.59.2` or newer. If you are using newer version in your cluster, you probably don't have to do anything.
+Sumo Logic collection requires CRD version of `v0.59.2` or newer. If you are using a newer version in your cluster, you probably don't have to do anything.
 Otherwise, ensure that the Custom Resource Definitions won't break your existing Prometheus Operators and then apply them using the following commands:
 
 ```yaml

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -56,7 +56,7 @@ In that situation we support three scenarios:
 ### Custom Resource Definition compatibility
 
 CRD versions required by Sumo Logic Collection is `v0.59.2` or newer. If you are using newer version in your cluster, you probably don't have to do anything.
-Otherwise, ensure that the Custom Resource Definitions won't break your existing Prometheus Operators and apply them using the following commands:
+Otherwise, ensure that the Custom Resource Definitions won't break your existing Prometheus Operators and then apply them using the following commands:
 
 ```yaml
 kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.2/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -164,13 +164,13 @@ kube-prometheus-stack:
     enabled: false
 ```
 
-After that, please follow to [Prepare Sumo Logic Configuration to work with existing Operator](#prepare-sumo-logic-configuration-to-work-with-existing-operator)
+Next, please follow to [Prepare Sumo Logic Configuration to work with existing Operator](#prepare-sumo-logic-configuration-to-work-with-existing-operator)
 
 ### Prepare Sumo Logic Configuration to work with existing Operator
 
 :construction: Describe how to use node-exporter from different operators
 
-Now it's time to build Kube Prometheus Stack configuration for Sumo Logic:
+Now, build Kube Prometheus Stack configuration for Sumo Logic:
 
 - Change Node Exporter port to avoid conflicts with other Prometheuses
 
@@ -191,7 +191,7 @@ Now it's time to build Kube Prometheus Stack configuration for Sumo Logic:
   >   Warning  FailedScheduling  13m (x249 over 4h25m)  default-scheduler  0/3 nodes are available: 1 node(s) didn't have free ports for the requested pod ports, 2 node(s) didn't match Pod's node affinity/selector.
   > ```
 
-To sum up, the configuration for `user-values.yaml` should look like the following:
+Gathering all together, the configuration for `user-values.yaml` should look like the following:
 
 ```yaml
 kube-prometheus-stack:
@@ -311,7 +311,7 @@ You need to ensure that the following values are correctly added to your Kube Pr
     value: ${NAMESPACE}
     ```
 
-After all of this changes, your Kube Prometheus Stack should looks like the following:
+After all of the changes, your Kube Prometheus Stack should looks like the following:
 
 ```yaml
 prometheus:

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -310,7 +310,7 @@ You need to ensure that the following values are correctly added to your Kube Pr
     value: ${NAMESPACE}
     ```
 
-After all of the changes, your Kube Prometheus Stack should looks like the following:
+After all of the changes, your Kube Prometheus Stack should look like the following:
 
 ```yaml
 prometheus:

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -39,18 +39,19 @@ If you already have Prometheus operator in your cluster, the necessary changes d
 
 In that situation we support three scenarios:
 
-- Installing Sumo Logic Prometheus Operator side by side with existing Operator
+1. Installing Sumo Logic Prometheus Operator side by side with existing Operator
 
-  __NOTE:__ This is possible if Custom Resource Definitions in the cluster are compatible with those required by Sumo Logic,
-  or there is possibility to install Custom Resource Definition which will be accepted by all
-  Prometheus Operators
-- Using existing Operator to create Sumo Logic Prometheus instance
+   __NOTE:__ This is possible if Custom Resource Definitions in the cluster are compatible with those required by Sumo Logic,
+   or there is possibility to install Custom Resource Definition which will be accepted by all
+   Prometheus Operators
 
-  __NOTE:__ This is possible if Custom Resource Definitions in the cluster are compatible with those required by Sumo Logic,
-  or there is possibility to install Custom Resource Definition which will be accepted by all
-  Prometheus Operators
+1. Using existing Operator to create Sumo Logic Prometheus instance
 
-- Using existing Kube Prometheus Stack
+   __NOTE:__ This is possible if Custom Resource Definitions in the cluster are compatible with those required by Sumo Logic,
+   or there is possibility to install Custom Resource Definition which will be accepted by all
+   Prometheus Operators
+
+1. Using existing Kube Prometheus Stack
 
 ### Custom Resource Definition compatibility
 

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -35,8 +35,7 @@ but these steps can be performed after initial installation.
 
 ## Prometheus Operator in the cluster
 
-If you already have Prometheus operator in your cluster, the things can be less or more complicated.
-It depends on compatibility of Prometheus Operator used in your cluster and Prometheus Operator used by Sumo Logic Kubernetes Collection.
+If you already have Prometheus operator in your cluster, the necessary changes depend on the compatibility between Prometheus Operator used in your cluster and Prometheus Operator used by Sumo Logic Kubernetes Collection.
 
 In that situation we support three scenarios:
 

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -81,7 +81,7 @@ Required Custom Resource Definitions are listed in [Kube Prometheus Stack reposi
 
 ### Installing Sumo Logic Prometheus Operator side by side with existing Operator
 
-You can have multiple Prometheus Operators in the cluster, but you need to ensure that they do not observe the same namespace.
+You can have multiple Prometheus Operators in the cluster, but you need to ensure that they do not observe the same namespace(s).
 __Every__ Operator should have `${NAMESPACE}` as part of `--deny-namespaces` argument or shouldn't have it as part of `--namespaces` argument,
 for example:
 

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -1,6 +1,6 @@
 # Prometheus
 
-Prometheus is crucial part of the metrics pipeline. It is also complicated and powerful tool.
+Prometheus is crucial part of the metrics pipeline. It is also a complicated and powerful tool. In Kubernetes specifically, it's also often managed by Prometheus Operator and a set of custom resources.
 There are multiple scenarios of having it in the cluster and this document describes how to deal with the different situations.
 
 __NOTE:__ In this document we assume that `${NAMESPACE}` represents namespace in which the Sumo Logic Kubernetes Collection is going to be installed.

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -190,7 +190,7 @@ Now, build Kube Prometheus Stack configuration for Sumo Logic:
   >   Warning  FailedScheduling  13m (x249 over 4h25m)  default-scheduler  0/3 nodes are available: 1 node(s) didn't have free ports for the requested pod ports, 2 node(s) didn't match Pod's node affinity/selector.
   > ```
 
-Gathering all together, the configuration for `user-values.yaml` should look like the following:
+ln total, the configuration for `user-values.yaml` should look like the following:
 
 ```yaml
 kube-prometheus-stack:

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -127,7 +127,7 @@ After that, please follow to [Prepare Sumo Logic Configuration to work with exis
 Ensure that the `${NAMESPACE}` is being watched by your operator.
 For exactly one operator it should be part of `--namespaces` argument or shouldn't be part of `--deny-namespaces` argument.
 
-In the following example both of operators are going to watch `${NAMESPACE}` (which is incorrect, but shows two ways to observe the namespace):
+In the following example both operators are going to watch `${NAMESPACE}` (which is incorrect, but shows two ways to observe the namespace):
 
 ```shell
 $ kubectl get deployment -l app=kube-prometheus-stack-operator -oyaml -A

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -1,0 +1,330 @@
+# Prometheus
+
+Prometheus is crucial part of the metrics pipeline. It is also complicated and powerful tool.
+There are multiple scenarios of having it in the cluster and this document describes how to deal with the different situations.
+
+__NOTE:__ In this document we assume that `${NAMESPACE}` represents namespace in which the Sumo Logic Kubernetes Collection is going to be installed.
+
+- [No Prometheus in the cluster](#no-prometheus-in-the-cluster)
+- [Prometheus Operator in the cluster](#prometheus-operator-in-the-cluster)
+
+  - [Custom Resource Definition compatibility](#custom-resource-definition-compatibility)
+
+  - [Installing Sumo Logic Prometheus Operator side by side with existing Operator](#installing-sumo-logic-prometheus-operator-side-by-side-with-existing-operator)
+
+    - [Set Sumo Logic Prometheus Operator to observe installation namespace](#set-sumo-logic-prometheus-operator-to-observe-installation-namespace)
+
+  - [Using existing Operator to create Sumo Logic Prometheus instance](#using-existing-operator-to-create-sumo-logic-prometheus-instance)
+
+    - [Disable Sumo Logic Prometheus Operator](#disable-sumo-logic-prometheus-operator)
+
+  - [Prepare Sumo Logic Configuration to work with existing Operator](#prepare-sumo-logic-configuration-to-work-with-existing-operator)
+
+  - [Using existing Kube Prometheus Stack](#using-existing-kube-prometheus-stack)
+
+    - [Build Prometheus Configuration](#build-prometheus-configuration)
+
+## No Prometheus in the cluster
+
+If you don't have Prometheus or Kube Prometheus Stack installed in your cluster
+there is not much you can worry about.
+There is no special configuration required, unless you want to have
+[Custom Application Metrics](/docs/collecting-application-metrics.md) or
+[Custom Kubernetes Metrics](/docs/collecting-kubernetes-metrics.md),
+but these steps can be performed after initial installation.
+
+## Prometheus Operator in the cluster
+
+If you already have Prometheus operator in your cluster, the things can be less or more complicated.
+It depends on compatibility of Prometheus Operator used in your cluster and Prometheus Operator used by Sumo Logic Kubernetes Collection.
+
+In that situation we support three scenarios:
+
+- Installing Sumo Logic Prometheus Operator side by side with existing Operator
+
+  __NOTE:__ This is possible if Custom Resource Definitions in the cluster are compatible with those required by Sumo Logic,
+  or there is possibility to install Custom Resource Definition which will be accepted by all
+  Prometheus Operators
+- Using existing Operator to create Sumo Logic Prometheus instance
+
+  __NOTE:__ This is possible if Custom Resource Definitions in the cluster are compatible with those required by Sumo Logic,
+  or there is possibility to install Custom Resource Definition which will be accepted by all
+  Prometheus Operators
+
+- Using existing Kube Prometheus Stack
+
+### Custom Resource Definition compatibility
+
+CRD versions required by Sumo Logic Collection is `v0.59.2` or newer. If you are using newer version in your cluster, you probably don't have to do anything.
+Otherwise, ensure that the Custom Resource Definitions won't break your existing Prometheus Operators and apply them using the following commands:
+
+```yaml
+kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.2/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.2/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.2/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.2/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
+kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.2/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.2/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
+kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.2/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.59.2/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+```
+
+Unfortunately there is no easy way to check which Custom Resource Definition is applied on the cluster.
+The only symptom is failing installation with the following or similar error (containing `com.coreos.monitoring.v1`).
+
+```text
+Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Prometheus.spec): unknown field "hostNetwork" in com.coreos.monitoring.v1.Prometheus.spec
+```
+
+Required Custom Resource Definitions are listed in [Kube Prometheus Stack repository][kube-prometheus-stack-repo]
+
+[kube-prometheus-stack-repo]: https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#upgrading-an-existing-release-to-a-new-major-version
+
+### Installing Sumo Logic Prometheus Operator side by side with existing Operator
+
+You can have multiple Prometheus Operators in the cluster, but you need to ensure that they do not observe the same namespace.
+__Every__ Operator should have `${NAMESPACE}` as part of `--deny-namespaces` argument or shouldn't have it as part of `--namespaces` argument,
+for example:
+
+```shell
+$ kubectl get deployment -l app=kube-prometheus-stack-operator -oyaml -A
+apiVersion: v1
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+...
+      spec:
+        containers:
+        - args:
+...
+          - --deny-namespaces=${NAMESPACE},some-namespace
+...
+- apiVersion: apps/v1
+  kind: Deployment
+...
+      spec:
+        containers:
+        - args:
+...
+          - --namespaces=some-namespace
+...
+```
+
+#### Set Sumo Logic Prometheus Operator to observe installation namespace
+
+Limit observed namespaces to `${NAMESPACE}` in `user-values.yaml`
+
+```yaml
+kube-prometheus-stack:
+  prometheusOperator:
+    namespaces:
+      releaseNamespace: true
+```
+
+After that, please follow to [Prepare Sumo Logic Configuration to work with existing Operator](#prepare-sumo-logic-configuration-to-work-with-existing-operator)
+
+### Using existing Operator to create Sumo Logic Prometheus instance
+
+Ensure that the `${NAMESPACE}` is being watched by your operator.
+For exactly one operator it should be part of `--namespaces` argument or shouldn't be part of `--deny-namespaces` argument.
+
+In the following example both of operators are going to watch `${NAMESPACE}` (which is incorrect, but shows two ways to observe the namespace):
+
+```shell
+$ kubectl get deployment -l app=kube-prometheus-stack-operator -oyaml -A
+apiVersion: v1
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+...
+      spec:
+        containers:
+        - args:
+...
+          - --deny-namespaces=some-namespace
+...
+- apiVersion: apps/v1
+  kind: Deployment
+...
+      spec:
+        containers:
+        - args:
+...
+          - --namespaces=${NAMESPACE},other-namespace
+...
+```
+
+#### Disable Sumo Logic Prometheus Operator
+
+If the Sumo Logic Prometheus should be managed by external Operator, you need to disable installation of Sumo Logic Operator by merging the following configuration to your `user-values.yaml`.
+
+```yaml
+kube-prometheus-stack:
+  prometheusOperator:
+    enabled: false
+```
+
+After that, please follow to [Prepare Sumo Logic Configuration to work with existing Operator](#prepare-sumo-logic-configuration-to-work-with-existing-operator)
+
+### Prepare Sumo Logic Configuration to work with existing Operator
+
+:construction: Describe how to use node-exporter from different operators
+
+Now it's time to build Kube Prometheus Stack configuration for Sumo Logic:
+
+- Change Node Exporter port to avoid conflicts with other Prometheuses
+
+  ```yaml
+  kube-prometheus-stack:
+    prometheus-node-exporter:
+      service:
+          port: 9200
+          targetPort: 9200
+  ```
+
+  > __NOTE:__ Change port to other value if Prometheus Node Exporter Pods are in Pending state and you see the following warning in Events:
+  >
+  > ```txt
+  > Events:
+  >   Type     Reason            Age                    From               Message
+  >   ----     ------            ----                   ----               -------
+  >   Warning  FailedScheduling  13m (x249 over 4h25m)  default-scheduler  0/3 nodes are available: 1 node(s) didn't have free ports for the requested pod ports, 2 node(s) didn't match Pod's node affinity/selector.
+  > ```
+
+To sum up, the configuration for `user-values.yaml` should look like the following:
+
+```yaml
+kube-prometheus-stack:
+  prometheusOperator:
+    namespaces:
+      releaseNamespace: true
+  prometheus-node-exporter:
+    service:
+        port: 9200
+        targetPort: 9200
+```
+
+Prometheus configuration is ready and now you can proceed with installation.
+
+### Using existing Kube Prometheus Stack
+
+We recommend to install Sumo Logic Kubernetes Collection before configuring Prometheus,
+but you need to disable Kube Prometheus Stack used by Sumo Logic Collection first.
+
+```yaml
+kube-prometheus-stack:
+  enabled: false
+```
+
+#### Build Prometheus Configuration
+
+If there is no common CRDs for Prometheus Operators or you want to use only one instance of Prometheus (which is not the instance used by Sumo Logic),
+you should merge our configuration with the configuration used in your Operator.
+You need to ensure that the following values are correctly added to your Kube Prometheus Stack configuration:
+
+- ServiceMonitors configuration:
+
+  - `sumologic.metrics.ServiceMonitors` to `prometheus.additionalServiceMonitors`
+
+- RemoteWrite configuration:
+
+  - `kube-prometheus-stack.prometheus.prometheusSpec.remoteWrite` to `prometheus.prometheusSpec.remoteWrite` or `prometheus.prometheusSpec.additionalRemoteWrite`
+  - `kube-prometheus-stack.prometheus.prometheusSpec.additionalRemoteWrite` to `prometheus.prometheusSpec.remoteWrite` or `prometheus.prometheusSpec.additionalRemoteWrite`
+
+  __Note:__ `kube-prometheus-stack.prometheus.prometheusSpec.remoteWrite` and `kube-prometheus-stack.prometheus.prometheusSpec.additionalRemoteWrite`
+  are being use to generate list of endpoints in Metadata Pod, so ensure that:
+
+  - they are always in sync with the current configuration and endpoints starts with.
+  - url is always starting with `http://$(METADATA_METRICS_SVC).$(NAMESPACE).svc.cluster.local.:9888`
+
+  Alternatively, you can list endpoints in `metadata.metrics.config.additionalEndpoints`:
+
+  ```yaml
+  metadata:
+    metrics:
+      config:
+        additionalEndpoints:
+          - /prometheus.metrics.state
+          - /prometheus.metrics.controller-manager
+          # - ...
+  ```
+
+- Env Variables configuration:
+
+  - `kube-prometheus-stack.prometheus.prometheusSpec.initContainers` to `prometheus.prometheusSpec.initContainers`
+  - `kube-prometheus-stack.prometheus.prometheusSpec.containers` to `prometheus.prometheusSpec.containers`
+
+  with the following modification:
+
+  - replace
+
+    ```yaml
+    valueFrom:
+      configMapKeyRef:
+        name: sumologic-configmap
+        key: metadataMetrics
+    ```
+
+    with
+
+    ```yaml
+    value: ${METADATA}
+    ```
+
+    where `${METADATA}` is content of `metadataMetrics` key from `sumologic-configmap` Config Map within `${NAMESPACE}`:
+
+    ```yaml
+    apiVersion: v1
+    data:
+      metadataLogs: collection-sumologic-metadata-logs
+      metadataMetrics: collection-sumologic-remote-write-proxy
+      metadataNamespace: sumologic
+    kind: ConfigMap
+    metadata:
+      annotations:
+        meta.helm.sh/release-name: collection
+        meta.helm.sh/release-namespace: sumologic
+      creationTimestamp: "2023-01-11T15:05:57Z"
+      labels:
+        app.kubernetes.io/managed-by: Helm
+        chart: sumologic-3.0.0-beta.1
+        heritage: Helm
+        release: collection
+      name: sumologic-configmap
+      namespace: sumologic
+      resourceVersion: "509256"
+      uid: 1a916815-84ab-48a4-82d1-91e4df29daae
+    ```
+
+  - replace
+
+    ```yaml
+    valueFrom:
+      configMapKeyRef:
+        name: sumologic-configmap
+        key: metadataNamespace
+    ```
+
+    with
+
+    ```yaml
+    value: ${NAMESPACE}
+    ```
+
+After all of this changes, your Kube Prometheus Stack should looks like the following:
+
+```yaml
+prometheus:
+  additionalServiceMonitors:
+    # values copied from sumologic.metrics.ServiceMonitors
+  prometheusSpec:
+    initContainers:
+      # values copied from kube-prometheus-stack.prometheus.prometheusSpec.initContainers
+    containers:
+      # values copied from kube-prometheus-stack.prometheus.prometheusSpec.containers
+    additionalRemoteWrite:
+      # values copied from kube-prometheus-stack.prometheus.prometheusSpec.remoteWrite
+      # values copied from kube-prometheus-stack.prometheus.prometheusSpec.additionalRemoteWrite
+```
+
+Prometheus configuration is ready. Apply the changes on the cluster.

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -1,7 +1,7 @@
 # Prometheus
 
 Prometheus is crucial part of the metrics pipeline. It is also a complicated and powerful tool. In Kubernetes specifically, it's also often managed by Prometheus Operator and a set of custom resources.
-There are multiple scenarios of having it in the cluster and this document describes how to deal with the different situations.
+It's possible that you already have some part of the K8s Prometheus stack already installed, and would like to make use of it. This document describes how to deal with all the possible cases.
 
 __NOTE:__ In this document we assume that `${NAMESPACE}` represents namespace in which the Sumo Logic Kubernetes Collection is going to be installed.
 


### PR DESCRIPTION
I'm going to rewrite installation to externally point to this document. Until that I would like to left old documentation as well