### PR TITLE
docs: refactor the v3 upgrade guide

### DIFF
--- a/docs/v3-migration-doc.md
+++ b/docs/v3-migration-doc.md
@@ -15,6 +15,7 @@
   - [Logs migration](#logs-migration)
     - [Replacing Fluent Bit with OpenTelemetry Collector](#replacing-fluent-bit-with-opentelemetry-collector)
     - [Otelcol StatefulSet](#otelcol-statefulset)
+    - [Custom logs filtering and processing](#custom-logs-filtering-and-processing)
   - [Tracing migration](#tracing-migration)
     - [Replace special configuration values marked by 'replace' suffix](#replace-special-configuration-values-marked-by-replace-suffix)
   - [Running the helm upgrade](#running-the-helm-upgrade)
@@ -189,7 +190,7 @@ you have to remove all Sumo Logic related service monitors from the list, becaus
 **When?**: If you added extra configuration to Fluentd metrics
 
 If you're adding extra configuration to fluentd metrics,
-you will likely want to do analogical modifications in OpenTelemetry.
+you will likely want to do analogous modifications in OpenTelemetry.
 
 Please look at the [Metrics modifications](./collecting-application-metrics.md#metrics-modifications) doc.
 
@@ -213,7 +214,7 @@ side by side, enable the following setting:
 sumologic:
   logs:
     collector:
-      allowSideBySide: false
+      allowSideBySide: true
 fluent-bit:
   enabled: true
 ```
@@ -229,6 +230,15 @@ Run the following command to manually delete StatefulSets in helm chart v2 befor
   ```
   kubectl delete sts --namespace=${NAMESPACE} --cascade=orphan -lapp=${HELM_RELEASE_NAME}-sumologic-otelcol-logs
   ```
+
+#### Custom logs filtering and processing
+
+**When?**: If you added extra configuration to Fluentd logs
+
+If you're adding extra configuration to Fluentd logss,
+you will likely want to do analogous modifications in OpenTelemetry.
+
+Please look at the [Logs modifications](./collecting-container-logs.md#modifying-log-records) doc.
 
 ### Tracing migration
 
@@ -287,6 +297,9 @@ Once you've taken care of any manual steps necessary for your configuration, run
 ```bash
 helm upgrade ${HELM_RELEASE_NAME} sumologic/sumologic --version=3.0.0 -f new-values.yaml
 ```
+
+After you're done, please review the [full list of changes](#full-list-of-changes), as some of them
+may impact you even if they don't require additional action.
 
 ### Known issues
 

--- a/docs/v3-migration-doc.md
+++ b/docs/v3-migration-doc.md
@@ -52,6 +52,13 @@ See the full list of changes [here](#full-list-of-changes).
 - `jq`
 - `docker`
 
+Set the following environment variables that our commands will make use of:
+
+```bash
+export NAMESPACE=...
+export HELM_RELEASE_NAME=...
+```
+
 ### Migrating the configuration
 
 We've made some breaking changes to our configuration file format, but most of them can be handled automatically by our migration tool.
@@ -59,7 +66,7 @@ We've made some breaking changes to our configuration file format, but most of t
 You can get your current configuration from the cluster by running:
 
 ```bash
-helm get values --output yaml <RELEASE-NAME> > user-values.yaml
+helm get values --output yaml "${HELM_RELEASE_NAME}" > user-values.yaml
 ```
 
 Afterwards, run the upgrade tool:
@@ -166,7 +173,7 @@ kubectl apply \
 Run the following command to manually delete StatefulSets in helm chart v2 before upgrade:
 
   ```
-  kubectl delete sts --namespace=my-namespace --cascade=false my-release-sumologic-otelcol-metrics
+  kubectl delete sts --namespace=${NAMESPACE} --cascade=orphan -lapp=${HELM_RELEASE_NAME}-sumologic-otelcol-metrics
   ```
 
 #### Additional Service Monitors
@@ -220,7 +227,7 @@ After the upgrade, once OpenTelemetry Collector is running, you can disable Flue
 Run the following command to manually delete StatefulSets in helm chart v2 before upgrade:
 
   ```
-  kubectl delete sts --namespace=my-namespace --cascade=false my-release-sumologic-otelcol-logs
+  kubectl delete sts --namespace=${NAMESPACE} --cascade=orphan -lapp=${HELM_RELEASE_NAME}-sumologic-otelcol-logs
   ```
 
 ### Tracing migration
@@ -251,8 +258,8 @@ Above special configuration values can be replaced either to direct values or be
   If you're using `otelagent` (`otelagent.enabled=true`), please run the following command to manually delete DamemonSet and ConfigMap in helm chart v2 before upgrade:
 
   ```
-  kubectl delete ds --namespace=my-namespace --cascade=false my-release-sumologic-otelagent
-  kubectl delete cm --namespace-my-namespace --cascade=false my-release-sumologic-otelagent
+  kubectl delete ds --namespace=${NAMESPACE} --cascade=orphan ${HELM_RELEASE_NAME}-sumologic-otelagent
+  kubectl delete cm --namespace=${NAMESPACE} --cascade=orphan ${HELM_RELEASE_NAME}-sumologic-otelagent
   ```
 
 - **Otelgateway Deployment**
@@ -260,8 +267,8 @@ Above special configuration values can be replaced either to direct values or be
   If you're using `otelgateway` (`otelgateway.enabled=true`), please run the following command to manually delete Deployment and ConfigMap in helm chart v2 before upgrade:
 
   ```
-  kubectl delete deployment --namespace=my-namespace --cascade=false my-release-sumologic-otelgateway
-  kubectl delete cm --namespace-my-namespace --cascade=false my-release-sumologic-otelgateway
+  kubectl delete deployment --namespace=${NAMESPACE} --cascade=orphan ${HELM_RELEASE_NAME}-sumologic-otelgateway
+  kubectl delete cm --namespace=${NAMESPACE} --cascade=orphan ${HELM_RELEASE_NAME}-sumologic-otelgateway
   ```
 
 - **Otelcol Deployment**
@@ -269,8 +276,8 @@ Above special configuration values can be replaced either to direct values or be
   Please run the following command to manually delete Deployment and ConfigMap in helm chart v2 before upgrade:
 
   ```
-  kubectl delete deployment --namespace=my-namespace --cascade=false my-release-sumologic-otelcol
-  kubectl delete cm --namespace-my-namespace --cascade=false my-release-sumologic-otelcol
+  kubectl delete deployment --namespace=${NAMESPACE} --cascade=orphan ${HELM_RELEASE_NAME}-sumologic-otelcol
+  kubectl delete cm --namespace=${NAMESPACE} --cascade=orphan ${HELM_RELEASE_NAME}-sumologic-otelcol
   ```
 
 ### Running the helm upgrade
@@ -278,7 +285,7 @@ Above special configuration values can be replaced either to direct values or be
 Once you've taken care of any manual steps necessary for your configuration, run the helm upgrade:
 
 ```bash
-helm upgrade <RELEASE-NAME> sumologic/sumologic --version=3.0.0 -f new-values.yaml
+helm upgrade ${HELM_RELEASE_NAME} sumologic/sumologic --version=3.0.0 -f new-values.yaml
 ```
 
 ### Known issues


### PR DESCRIPTION
I split the manual steps by signal type and made it clearer when the user needs to care about a specific step. To that end, I added a daisy chain of links they can use to go straight to the end if the steps don't apply to their usecase.

I'm planning to add more sections for other changes than may require user action or attention, this mostly sets up the new structure.