### PR TITLE
chore: upgrade yq to 4.30.8

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -67,7 +67,7 @@ jobs:
   shellcheck:
     runs-on: ubuntu-20.04
     env:
-      YQ_VERSION: 3.4.1
+      YQ_VERSION: 4.30.8
     steps:
       - uses: actions/checkout@v3
       - name: install shellcheck
@@ -76,7 +76,7 @@ jobs:
             sudo cp shellcheck-v0.7.1/shellcheck /usr/local/bin && rm -rf shellcheck-v0.7.1
       - name: install yq
         run: |
-            curl --retry 10 --retry-max-time 120 --retry-delay 5 -L -o /tmp/yq https://github.com/mikefarah/yq/releases/download/${{ env.YQ_VERSION }}/yq_linux_amd64
+            curl --retry 10 --retry-max-time 120 --retry-delay 5 -L -o /tmp/yq https://github.com/mikefarah/yq/releases/download/v${{ env.YQ_VERSION }}/yq_linux_amd64
             chmod +x /tmp/yq
             sudo mv /tmp/yq /usr/local/bin/yq
       - name: shellcheck

--- a/ci/shellcheck.sh
+++ b/ci/shellcheck.sh
@@ -14,26 +14,26 @@ find . -path '*tests/helm/terraform/static/*.output.yaml' -type 'f' -print |
     while read -r file; do
         # Run tests in their own context
         echo "Checking ${file} (setup.sh) with shellcheck"
-        yq r "${file}" "data[setup.sh]" | shellcheck --enable all --external-sources --exclude SC2155 -
+        yq '.data."setup.sh"' "${file}" | shellcheck --enable all --external-sources --exclude SC2155 -
     done
 
 find . -path '*tests/helm/terraform/static/*.output.yaml' -type 'f' -print |
     while read -r file; do
         # Run tests in their own context
         echo "Checking ${file} (monitors.sh) with shellcheck"
-        yq r "${file}" "data[monitors.sh]" | shellcheck --enable all --external-sources --exclude SC2155 -
+        yq '.data."monitors.sh"' "${file}" | shellcheck --enable all --external-sources --exclude SC2155 -
     done
 
 find . -path '*tests/helm/terraform/static/*.output.yaml' -type 'f' -print |
     while read -r file; do
         # Run tests in their own context
         echo "Checking ${file} (dashboards.sh) with shellcheck"
-        yq r "${file}" "data[dashboards.sh]" | shellcheck --enable all --external-sources --exclude SC2155 -
+        yq '.data."dashboards.sh"' "${file}" | shellcheck --enable all --external-sources --exclude SC2155 -
     done
 
 find . -path '*tests/helm/terraform_custom/static/*.output.yaml' ! -path "./tests/helm/terraform_custom/static/empty.output.yaml" -type 'f' -print |
     while read -r file; do
         # Run tests in their own context
         echo "Checking ${file} (custom_setup.sh) with shellcheck"
-        yq r "${file}" "data[custom_setup.sh]" | shellcheck --enable all --external-sources --exclude SC2155 -
+        yq '.data."custom_setup.sh"' "${file}" | shellcheck --enable all --external-sources --exclude SC2155 -
     done

--- a/vagrant/Makefile
+++ b/vagrant/Makefile
@@ -69,9 +69,7 @@ clean-local-values-yaml:
 	rm ${local_values_file}
 
 _apply-avalanche-remote-write-to-local-values: generate-local-config
-	yq w -s ${vagrant_scripts_dir}/yq/update_remote_write_for_avalanche.yaml ${helm_path}/values.yaml | \
-	yq r - 'prometheus-operator.prometheus.prometheusSpec.remoteWrite' | \
-	yq prefix - 'prometheus-operator.prometheus.prometheusSpec.remoteWrite' > ${local_values_file}
+	yq -i '. *= load("${vagrant_scripts_dir}/yq/avalanche-remote-write.yaml")' ${local_values_file}
 
 # Make sure avalanche remote write rule is applied in prometheus by running
 # 'apply-avalanche-remote-write' target and verifying it in prometheus itself:

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -2,6 +2,8 @@
 
 set -x
 
+YQ_VERSION=4.30.8
+
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get --yes upgrade
@@ -55,9 +57,9 @@ ln -s /usr/bin/helm3 /usr/bin/helm
 usermod -a -G microk8s vagrant
 
 # install yq with access to file structure
-curl https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64 -L -o /usr/local/bin/yq-3.4.1
-chmod +x /usr/local/bin/yq-3.4.1
-ln -s /usr/local/bin/yq-3.4.1 /usr/local/bin/yq
+curl "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -L -o /usr/local/bin/yq-"${YQ_VERSION}"
+chmod +x /usr/local/bin/yq-"${YQ_VERSION}"
+ln -s /usr/local/bin/yq-"${YQ_VERSION}" /usr/local/bin/yq
 
 # Install docker
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -

--- a/vagrant/scripts/yq/avalanche-remote-write.yaml
+++ b/vagrant/scripts/yq/avalanche-remote-write.yaml
@@ -1,0 +1,9 @@
+kube-prometheus-stack:
+  prometheus:
+    prometheusSpec:
+      additionalRemoteWrite:
+        - url: http://$(FLUENTD_METRICS_SVC).$(NAMESPACE).svc.cluster.local.:9888/prometheus.metrics.avalanche
+          writeRelabelConfigs:
+          - action: keep
+            regex: avalanche.*
+            sourceLabels: [__name__]

--- a/vagrant/scripts/yq/update_remote_write_for_avalanche.yaml
+++ b/vagrant/scripts/yq/update_remote_write_for_avalanche.yaml
@@ -1,8 +1,0 @@
-- command: update
-  path: prometheus-operator.prometheus.prometheusSpec.remoteWrite[+]
-  value:
-    url: http://$(FLUENTD_METRICS_SVC).$(NAMESPACE).svc.cluster.local.:9888/prometheus.metrics.avalanche
-    writeRelabelConfigs:
-    - action: keep
-      regex: avalanche.*
-      sourceLabels: [__name__]


### PR DESCRIPTION
There are some instructions in the documentation that still use `yq` version 3, but those also explicitly say to install that version, so they're not blocking this change.