### PR TITLE
chore: drop EKS 1.20 support (EOL since Nov 2022)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -78,7 +78,7 @@ The following table displays the tested Kubernetes and Helm versions.
 
 | Name          | Version                         |
 |---------------|---------------------------------|
-| K8s with EKS  | 1.20<br/>1.21<br/>1.22<br/>1.23 |
+| K8s with EKS  | 1.21<br/>1.22<br/>1.23          |
 | K8s with Kops | 1.21<br/>1.22<br/>1.23<br/>1.24 |
 | K8s with GKE  | 1.21<br/>1.22<br/>1.23          |
 | K8s with AKS  | 1.23<br/>1.24                   |


### PR DESCRIPTION
EKS release calendar: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar