### PR TITLE
chore(tests/integration): update supported k8s versions

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -51,6 +51,7 @@ jobs:
             .github/*
             **/Makefile
             .*
+            tests/integration/kind_images.json
 
   markdownlint:
     runs-on: ubuntu-20.04

--- a/tests/integration/kind_images.json
+++ b/tests/integration/kind_images.json
@@ -1,9 +1,9 @@
 {
   "supported": [
+    "kindest/node:v1.24.0@sha256:0866296e693efe1fed79d5e6c7af8df71fc73ae45e3679af05342239cdc5bc8e",
+    "kindest/node:v1.23.6@sha256:b1fa224cc6c7ff32455e0b1fd9cbfd3d3bc87ecaa8fcb06961ed1afb3db0f9ae",
     "kindest/node:v1.22.9@sha256:8135260b959dfe320206eb36b3aeda9cffcb262f4b44cda6b33f7bb73f453105",
-    "kindest/node:v1.21.12@sha256:f316b33dd88f8196379f38feb80545ef3ed44d9197dca1bfd48bcb1583210207",
-    "kindest/node:v1.20.15@sha256:6f2d011dffe182bad80b85f6c00e8ca9d86b5b8922cdf433d53575c4c5212248",
-    "kindest/node:v1.19.16@sha256:d9c819e8668de8d5030708e484a9fdff44d95ec4675d136ef0a0a584e587f65c"
+    "kindest/node:v1.21.12@sha256:f316b33dd88f8196379f38feb80545ef3ed44d9197dca1bfd48bcb1583210207"
   ],
-  "default": "kindest/node:v1.22.9@sha256:8135260b959dfe320206eb36b3aeda9cffcb262f4b44cda6b33f7bb73f453105"
+  "default": "kindest/node:v1.24.0@sha256:0866296e693efe1fed79d5e6c7af8df71fc73ae45e3679af05342239cdc5bc8e"
 }

--- a/tests/integration/yamls/cluster.yaml
+++ b/tests/integration/yamls/cluster.yaml
@@ -11,7 +11,7 @@ nodes:
     scheduler:
         extraArgs:
           bind-address: 0.0.0.0
-          port: "10251"
+          secure-port: "10251"
     controllerManager:
         extraArgs:
           bind-address: 0.0.0.0


### PR DESCRIPTION
1.19 and 1.20 are no longer supported, so they have been removed from tests. 
1.23 and 1.24 are now supported, so they have been added to the tests.

