### PR TITLE
docs(readme): fix link to v3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Sumo Logic Helm Chart Version
 
 | version                                                                                                   | status                                  |
 |-----------------------------------------------------------------------------------------------------------|-----------------------------------------|
-| [v3.0](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v3.0/deploy/README.md)   | current / supported                     |
+| [v3.0](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v3.0/docs/README.md)     | current / supported                     |
 | [v2.19](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v2.19/deploy/README.md) | deprecated / supported until 2023-05-24 |
 | [v2.18](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v2.18/deploy/README.md) | deprecated / supported until 2023-04-21 |
 | [v2.17](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v2.17/deploy/README.md) | deprecated / supported until 2023-04-20 |


### PR DESCRIPTION
/deploy/README.md does not exist in release-v3 branch, it's /docs/README.md instead.