### PR TITLE
chore: reorganize root Makefile

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -154,7 +154,26 @@ jobs:
           python -m pip install pyyaml
       - run: |
           make check-configuration-keys
-
+  
+  lint-template-tests:
+    name: Lint template tests
+    runs-on: ubuntu-latest
+    needs: [chart-changed]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        if: needs.chart-changed.outputs.any_changed == 'true'
+        with:
+          go-version: '1.18'
+      - name: golangci-lint
+        if: needs.chart-changed.outputs.any_changed == 'true'
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.49
+          working-directory: ./tests/helm/
+          # Optional: golangci-lint command line arguments.
+          args: --timeout=10m --verbose
+  
   test:
     runs-on: ubuntu-20.04
     needs:

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -63,7 +63,7 @@ jobs:
         run: npm install -g markdownlint-cli
       - name: markdownlint check
         if: needs.docs-changed.outputs.any_changed == 'true'
-        run: make markdownlint
+        run: make markdown-lint
 
   shellcheck:
     runs-on: ubuntu-20.04
@@ -93,7 +93,7 @@ jobs:
         run: pip install yamllint
       - name: yamllint
         if: needs.chart-changed.outputs.any_changed == 'true'
-        run: make yamllint
+        run: make yaml-lint
 
   helmlint:
     runs-on: ubuntu-20.04

--- a/tests/helm/events_test.go
+++ b/tests/helm/events_test.go
@@ -51,4 +51,3 @@ otelevents:
 	expected := map[string]string{"key": "value"}
 	require.Equal(t, expected, otelConfig)
 }
-

--- a/tests/helm/goldenfile_test.go
+++ b/tests/helm/goldenfile_test.go
@@ -87,8 +87,10 @@ func runGoldenFileTest(t *testing.T, valuesFileName string, outputFileName strin
 		if expectedObject.GetKind() == "ConfigMap" {
 			var expectedConfigMap corev1.ConfigMap
 			var actualConfigMap corev1.ConfigMap
-			runtime.DefaultUnstructuredConverter.FromUnstructured(expectedObject.UnstructuredContent(), &expectedConfigMap)
-			runtime.DefaultUnstructuredConverter.FromUnstructured(actualObject.UnstructuredContent(), &actualConfigMap)
+			err = runtime.DefaultUnstructuredConverter.FromUnstructured(expectedObject.UnstructuredContent(), &expectedConfigMap)
+			require.NoError(t, err)
+			err = runtime.DefaultUnstructuredConverter.FromUnstructured(actualObject.UnstructuredContent(), &actualConfigMap)
+			require.NoError(t, err)
 			requireConfigMapsEqual(t, expectedConfigMap, actualConfigMap)
 		}
 


### PR DESCRIPTION
Split the Makefile into sections for:
* linters
* formatters
* tests
* utilities
* vagrant

Make the make target names consistent and add aggregate targets for each section.

Finally, add linting template tests to PR checks.

### Checklist

<!---
Remove items which don't apply to your PR.
-->

- [X] Changelog updated or skip changelog label added
