### PR TITLE
chore: backport support for EKS and GKE 1.24 to v3.0

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -78,9 +78,9 @@ The following table displays the tested Kubernetes and Helm versions.
 
 | Name          | Version                         |
 |---------------|---------------------------------|
-| K8s with EKS  | 1.21<br/>1.22<br/>1.23          |
+| K8s with EKS  | 1.21<br/>1.22<br/>1.23<br/>1.24 |
 | K8s with Kops | 1.21<br/>1.22<br/>1.23<br/>1.24 |
-| K8s with GKE  | 1.21<br/>1.22<br/>1.23          |
+| K8s with GKE  | 1.21<br/>1.22<br/>1.23<br/>1.24 |
 | K8s with AKS  | 1.23<br/>1.24                   |
 | OpenShift     | 4.8<br/>4.9<br/>4.10            |
 | Helm          | 3.8.2 (Linux)                   |


### PR DESCRIPTION
I skip changelog on purpose because:
* I don't think we should release a patch release for this
* I don't want to add the "unreleased" section in the v3.0 docs
* I don't want to change the changelog for the already released version