### PR TITLE
chore: upgrade shellcheck to 0.9.0

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -69,12 +69,13 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       YQ_VERSION: 4.30.8
+      SHELLCHECK_VERSION: 0.9.0
     steps:
       - uses: actions/checkout@v3
       - name: install shellcheck
         run: |
-            curl --retry 10 --retry-max-time 120 --retry-delay 5 -Lo- https://github.com/koalaman/shellcheck/releases/download/v0.7.1/shellcheck-v0.7.1.linux.x86_64.tar.xz | tar -xJf -
-            sudo cp shellcheck-v0.7.1/shellcheck /usr/local/bin && rm -rf shellcheck-v0.7.1
+            curl --retry 10 --retry-max-time 120 --retry-delay 5 -Lo- https://github.com/koalaman/shellcheck/releases/download/v${{ env.SHELLCHECK_VERSION }}/shellcheck-v${{ env.SHELLCHECK_VERSION }}.linux.x86_64.tar.xz | tar -xJf -
+            sudo cp shellcheck-v${{ env.SHELLCHECK_VERSION }}/shellcheck /usr/local/bin && rm -rf shellcheck-v${{ env.SHELLCHECK_VERSION }}
       - name: install yq
         run: |
             curl --retry 10 --retry-max-time 120 --retry-delay 5 -L -o /tmp/yq https://github.com/mikefarah/yq/releases/download/v${{ env.YQ_VERSION }}/yq_linux_amd64

--- a/ci/_build_functions.sh
+++ b/ci/_build_functions.sh
@@ -2,6 +2,8 @@
 
 # shellcheck disable=SC2154
 
+set -euo pipefail
+
 err_report() {
     echo "Script error on line $1"
     exit 1
@@ -9,8 +11,9 @@ err_report() {
 trap 'err_report $LINENO' ERR
 
 function helm() {
+  PWD="$(pwd)"
   docker run --rm \
-    -v "$(pwd):/chart" \
+    -v "${PWD}:/chart" \
     -w /chart \
     sumologic/kubernetes-tools:2.13.0 \
     helm "$@"
@@ -83,7 +86,8 @@ function fetch_current_branch() {
   # and we need to unshallow the repository because otherwise we'd get:
   # fatal: No tags can describe '<SHA>'.
   # Try --always, or create some tags.
-  if [[ "true" == "$(git rev-parse --is-shallow-repository)" ]]; then
+  IS_SHALLOW="$(git rev-parse --is-shallow-repository)"
+  if [[ "true" == "${IS_SHALLOW}" ]]; then
     git fetch -v --tags --unshallow origin "${BRANCH}"
   else
     git fetch -v --tags origin "${BRANCH}"

--- a/ci/markdown_links_lint.sh
+++ b/ci/markdown_links_lint.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 GREP="grep"
-if [[ "$(uname -s)" == "Darwin" ]]; then
+OS="$(uname -s)"
+if [[ "${OS}" == "Darwin" ]]; then
     GREP="ggrep"
 fi
 

--- a/ci/push-helm-chart.sh
+++ b/ci/push-helm-chart.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 ROOT_DIR="$(dirname "$(dirname "${0}")")"
 readonly ROOT_DIR="${ROOT_DIR}"
 
@@ -16,11 +18,13 @@ pushd "${ROOT_DIR}" || exit 1
 
 set_up_github
 
-echo "Pushing helm chart in: $(pwd) with version tag: ${DEV_VERSION} to the dev catalog"
+PWD=$(pwd)
+echo "Pushing helm chart in: ${PWD} with version tag: ${DEV_VERSION} to the dev catalog"
 push_helm_chart "${DEV_VERSION}" "./dev"
 
-if is_checkout_on_tag; then
-  echo "Pushing helm chart in: $(pwd) with version tag: ${RELEASE_VERSION} to the release catalog"
+IS_CHECKOUT_ON_TAG=$(is_checkout_on_tag)
+if ${IS_CHECKOUT_ON_TAG}; then
+  echo "Pushing helm chart in: ${PWD} with version tag: ${RELEASE_VERSION} to the release catalog"
   push_helm_chart "${RELEASE_VERSION}" "."
 fi
 

--- a/ci/shellcheck.sh
+++ b/ci/shellcheck.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
 echo "Checking the bash scripts with shellcheck..."
 find . ! -path '*deploy/helm/sumologic/conf/setup/setup.sh' ! -path '*deploy/helm/sumologic/conf/setup/monitors.sh' ! -path "*/tmp/*" -name '*.sh' -type 'f' -print |
@@ -21,7 +21,7 @@ find . -path '*tests/helm/terraform/static/*.output.yaml' -type 'f' -print |
     while read -r file; do
         # Run tests in their own context
         echo "Checking ${file} (monitors.sh) with shellcheck"
-        yq '.data."monitors.sh"' "${file}" | shellcheck --enable all --external-sources --exclude SC2155 -
+        yq '.data."monitors.sh"' "${file}" | shellcheck --enable all --external-sources --exclude SC2155 --exclude SC2312 -
     done
 
 find . -path '*tests/helm/terraform/static/*.output.yaml' -type 'f' -print |

--- a/deploy/helm/sumologic/conf/cleanup/cleanup.sh
+++ b/deploy/helm/sumologic/conf/cleanup/cleanup.sh
@@ -1,11 +1,13 @@
-#!/bin/sh
+#!/bin/bash
+
+set -euo pipefail
 
 # Fix URL to remove "v1" or "v1/"
-export SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL%v1*}
+export SUMOLOGIC_BASE_URL="${SUMOLOGIC_BASE_URL%v1*}"
 # Support proxy for Terraform
-export HTTP_PROXY=${HTTP_PROXY:=""}
-export HTTPS_PROXY=${HTTPS_PROXY:=""}
-export NO_PROXY=${NO_PROXY:=""}
+export HTTP_PROXY="${HTTP_PROXY:=''}"
+export HTTPS_PROXY="${HTTPS_PROXY:=''}"
+export NO_PROXY="${NO_PROXY:=''}"
 
 cp /etc/terraform/*.tf /terraform/
 cd /terraform || exit 1

--- a/deploy/helm/sumologic/conf/setup/custom.sh
+++ b/deploy/helm/sumologic/conf/setup/custom.sh
@@ -22,18 +22,24 @@
 #
 # shellcheck disable=SC2010
 # extract target directory names from the file names using _ as separator
+
+set -euo pipefail
+
 err_report() {
     echo "Custom script error on line $1"
     exit 1
 }
 trap 'err_report $LINENO' ERR
 
-for dir in $(ls -1 /customer-scripts | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq); do
+declare -a dirs
+ls -1 /customer-scripts 2>/dev/null | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq | read -ar dirs || true
+for dir in "${dirs[@]}"; do
   target="/scripts/${dir}"
   mkdir "${target}"
-  # shellcheck disable=SC2010
   # Get files for given directory and take only filename part (after first _)
-  for file in $(ls -1 "/customer-scripts/${dir}_"* | grep -oE '_.*' | sed 's/_//g'); do
+  declare -a files
+  ls -1 /customer-scripts 2>/dev/null | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq | read -ar files || true
+  for file in "${files[@]}"; do
     cp "/customer-scripts/${dir}_${file}" "${target}/${file}"
   done
 

--- a/deploy/helm/sumologic/conf/setup/dashboards.sh
+++ b/deploy/helm/sumologic/conf/setup/dashboards.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 SUMOLOGIC_ACCESSID=${SUMOLOGIC_ACCESSID:=""}
 readonly SUMOLOGIC_ACCESSID
 SUMOLOGIC_ACCESSKEY=${SUMOLOGIC_ACCESSKEY:=""}
@@ -21,7 +23,7 @@ function load_dashboards_folder_id() {
 
   local ADMIN_FOLDER_JOB_STATUS
   ADMIN_FOLDER_JOB_STATUS="InProgress"
-  while [ "${ADMIN_FOLDER_JOB_STATUS}" = "InProgress" ]; do
+  while [[ "${ADMIN_FOLDER_JOB_STATUS}" = "InProgress" ]]; do
     ADMIN_FOLDER_JOB_STATUS="$(curl -XGET -s \
           -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
           "${SUMOLOGIC_BASE_URL}"v2/content/folders/adminRecommended/"${ADMIN_FOLDER_JOB_ID}"/status | jq '.status' | tr -d '"' )"
@@ -29,7 +31,7 @@ function load_dashboards_folder_id() {
     sleep 1
   done
 
-  if [ "${ADMIN_FOLDER_JOB_STATUS}" != "Success" ]; then
+  if [[ "${ADMIN_FOLDER_JOB_STATUS}" != "Success" ]]; then
     echo "Could not fetch data from the \"Admin Recommended\" content folder. The K8s Dashboards won't be installed."
     echo "You can still install them manually:"
     echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
@@ -91,7 +93,7 @@ if [[ -z "${K8S_FOLDER_ID}" ]]; then
   readonly APP_INSTALL_JOB_ID
 
   APP_INSTALL_JOB_STATUS="InProgress"
-  while [ "${APP_INSTALL_JOB_STATUS}" = "InProgress" ]; do
+  while [[ "${APP_INSTALL_JOB_STATUS}" = "InProgress" ]]; do
     APP_INSTALL_JOB_STATUS="$(curl -XGET -s \
           -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
           "${SUMOLOGIC_BASE_URL}"v1/apps/install/"${APP_INSTALL_JOB_ID}"/status | jq '.status' | tr -d '"' )"
@@ -99,7 +101,7 @@ if [[ -z "${K8S_FOLDER_ID}" ]]; then
     sleep 1
   done
 
-  if [ "${APP_INSTALL_JOB_STATUS}" != "Success" ]; then
+  if [[ "${APP_INSTALL_JOB_STATUS}" != "Success" ]]; then
     ERROR_MSG="$(curl -XGET -s \
           -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
           "${SUMOLOGIC_BASE_URL}"v1/apps/install/"${APP_INSTALL_JOB_ID}"/status )"
@@ -125,7 +127,7 @@ if [[ -z "${K8S_FOLDER_ID}" ]]; then
       "${SUMOLOGIC_BASE_URL}"v2/content/"${K8S_FOLDER_ID}"/permissions/add | jq '.errors' )
     readonly PERMS_ERRORS
 
-    if [ "${PERMS_ERRORS}" != "null" ]; then
+    if [[ "${PERMS_ERRORS}" != "null" ]]; then
       echo "Setting permissions for the installed content failed."
       echo "${PERMS_ERRORS}"
     fi

--- a/deploy/helm/sumologic/conf/setup/setup.sh
+++ b/deploy/helm/sumologic/conf/setup/setup.sh
@@ -11,7 +11,8 @@ if [[ ${DEBUG_MODE,,} == "${DEBUG_MODE_ENABLED_FLAG}" ]]; then
 
     while true; do
         sleep 10
-        echo "$(date) Sleeping in the debug mode..."
+        DATE=$(date)
+        echo "${DATE} Sleeping in the debug mode..."
     done
 fi
 
@@ -23,6 +24,7 @@ function fix_sumo_base_url() {
     BASE_URL="https://api.sumologic.com/api/"
   fi
 
+  # shellcheck disable=SC2312
   OPTIONAL_REDIRECTION="$(curl -XGET -s -o /dev/null -D - \
           -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
           "${BASE_URL}"v1/collectors \
@@ -91,6 +93,7 @@ terraform init -input=false -get=false || terraform init -input=false -upgrade
 # Sumo Logic fields
 if should_create_fields ; then
     readonly CREATE_FIELDS=1
+    # shellcheck disable=SC2312
     FIELDS_RESPONSE="$(curl -XGET -s \
         -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
         "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"

--- a/tests/helm/README.md
+++ b/tests/helm/README.md
@@ -48,3 +48,25 @@ You'll need to modify the output files in the following ways:
 - replace all instances of the release name (`collection` by default) with `RELEASE-NAME`
 - replace all instances of the chart version with `%CURRENT_CHART_VERSION%`
 - replace all checksum annotation (`config/checksum`) values with `%CONFIG_CHECKSUM%`
+
+You can use the following snippet to regenerate the output templates in a single directory:
+
+```bash
+export PATH_TO_TEMPLATE=
+export CHART_VERSION=3.0.0
+
+for filename in *.input.yaml; do
+  test_name=${"${filename%%.input.yaml}"}
+  helm template ../../../../deploy/helm/sumologic/ \
+  --namespace sumologic \
+  --set sumologic.accessId='accessId' \
+  --set sumologic.accessKey='accessKey' \
+  -f ${test_name}.input.yaml \
+  -s ${PATH_TO_TEMPLATE} >${test_name}.output.yaml
+
+  sed -i "s/release-name/RELEASE-NAME/g" ${test_name}.output.yaml
+  sed -i "s/${CHART_VERSION}/%CURRENT_CHART_VERSION%/g" ${test_name}.output.yaml
+  sed -i "s#config/checksum: .*$#checksum: '%CONFIG_CHECKSUM%'#g" ${test_name}.output.yaml
+done
+
+```

--- a/tests/helm/goldenfile_test.go
+++ b/tests/helm/goldenfile_test.go
@@ -93,7 +93,6 @@ func runGoldenFileTest(t *testing.T, valuesFileName string, outputFileName strin
 			require.NoError(t, err)
 			requireConfigMapsEqual(t, expectedConfigMap, actualConfigMap)
 		}
-
 		require.Equal(t, expectedObject, *actualObject)
 	}
 

--- a/tests/helm/terraform/static/all_fields.output.yaml
+++ b/tests/helm/terraform/static/all_fields.output.yaml
@@ -39,18 +39,24 @@ data:
     #
     # shellcheck disable=SC2010
     # extract target directory names from the file names using _ as separator
+  
+    set -euo pipefail
+  
     err_report() {
         echo "Custom script error on line $1"
         exit 1
     }
     trap 'err_report $LINENO' ERR
   
-    for dir in $(ls -1 /customer-scripts | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq); do
+    declare -a dirs
+    ls -1 /customer-scripts 2>/dev/null | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq | read -ar dirs || true
+    for dir in "${dirs[@]}"; do
       target="/scripts/${dir}"
       mkdir "${target}"
-      # shellcheck disable=SC2010
       # Get files for given directory and take only filename part (after first _)
-      for file in $(ls -1 "/customer-scripts/${dir}_"* | grep -oE '_.*' | sed 's/_//g'); do
+      declare -a files
+      ls -1 /customer-scripts 2>/dev/null | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq | read -ar files || true
+      for file in "${files[@]}"; do
         cp "/customer-scripts/${dir}_${file}" "${target}/${file}"
       done
   
@@ -63,6 +69,8 @@ data:
     done
   dashboards.sh: |
     #!/bin/bash
+  
+    set -euo pipefail
   
     SUMOLOGIC_ACCESSID=${SUMOLOGIC_ACCESSID:=""}
     readonly SUMOLOGIC_ACCESSID
@@ -85,7 +93,7 @@ data:
   
       local ADMIN_FOLDER_JOB_STATUS
       ADMIN_FOLDER_JOB_STATUS="InProgress"
-      while [ "${ADMIN_FOLDER_JOB_STATUS}" = "InProgress" ]; do
+      while [[ "${ADMIN_FOLDER_JOB_STATUS}" = "InProgress" ]]; do
         ADMIN_FOLDER_JOB_STATUS="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v2/content/folders/adminRecommended/"${ADMIN_FOLDER_JOB_ID}"/status | jq '.status' | tr -d '"' )"
@@ -93,7 +101,7 @@ data:
         sleep 1
       done
   
-      if [ "${ADMIN_FOLDER_JOB_STATUS}" != "Success" ]; then
+      if [[ "${ADMIN_FOLDER_JOB_STATUS}" != "Success" ]]; then
         echo "Could not fetch data from the \"Admin Recommended\" content folder. The K8s Dashboards won't be installed."
         echo "You can still install them manually:"
         echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
@@ -155,7 +163,7 @@ data:
       readonly APP_INSTALL_JOB_ID
   
       APP_INSTALL_JOB_STATUS="InProgress"
-      while [ "${APP_INSTALL_JOB_STATUS}" = "InProgress" ]; do
+      while [[ "${APP_INSTALL_JOB_STATUS}" = "InProgress" ]]; do
         APP_INSTALL_JOB_STATUS="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v1/apps/install/"${APP_INSTALL_JOB_ID}"/status | jq '.status' | tr -d '"' )"
@@ -163,7 +171,7 @@ data:
         sleep 1
       done
   
-      if [ "${APP_INSTALL_JOB_STATUS}" != "Success" ]; then
+      if [[ "${APP_INSTALL_JOB_STATUS}" != "Success" ]]; then
         ERROR_MSG="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v1/apps/install/"${APP_INSTALL_JOB_ID}"/status )"
@@ -189,7 +197,7 @@ data:
           "${SUMOLOGIC_BASE_URL}"v2/content/"${K8S_FOLDER_ID}"/permissions/add | jq '.errors' )
         readonly PERMS_ERRORS
   
-        if [ "${PERMS_ERRORS}" != "null" ]; then
+        if [[ "${PERMS_ERRORS}" != "null" ]]; then
           echo "Setting permissions for the installed content failed."
           echo "${PERMS_ERRORS}"
         fi
@@ -535,7 +543,8 @@ data:
   
         while true; do
             sleep 10
-            echo "$(date) Sleeping in the debug mode..."
+            DATE=$(date)
+            echo "${DATE} Sleeping in the debug mode..."
         done
     fi
   
@@ -547,6 +556,7 @@ data:
         BASE_URL="https://api.sumologic.com/api/"
       fi
   
+      # shellcheck disable=SC2312
       OPTIONAL_REDIRECTION="$(curl -XGET -s -o /dev/null -D - \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${BASE_URL}"v1/collectors \
@@ -615,6 +625,7 @@ data:
     # Sumo Logic fields
     if should_create_fields ; then
         readonly CREATE_FIELDS=1
+        # shellcheck disable=SC2312
         FIELDS_RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"

--- a/tests/helm/terraform/static/collector_fields.output.yaml
+++ b/tests/helm/terraform/static/collector_fields.output.yaml
@@ -39,18 +39,24 @@ data:
     #
     # shellcheck disable=SC2010
     # extract target directory names from the file names using _ as separator
+  
+    set -euo pipefail
+  
     err_report() {
         echo "Custom script error on line $1"
         exit 1
     }
     trap 'err_report $LINENO' ERR
   
-    for dir in $(ls -1 /customer-scripts | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq); do
+    declare -a dirs
+    ls -1 /customer-scripts 2>/dev/null | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq | read -ar dirs || true
+    for dir in "${dirs[@]}"; do
       target="/scripts/${dir}"
       mkdir "${target}"
-      # shellcheck disable=SC2010
       # Get files for given directory and take only filename part (after first _)
-      for file in $(ls -1 "/customer-scripts/${dir}_"* | grep -oE '_.*' | sed 's/_//g'); do
+      declare -a files
+      ls -1 /customer-scripts 2>/dev/null | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq | read -ar files || true
+      for file in "${files[@]}"; do
         cp "/customer-scripts/${dir}_${file}" "${target}/${file}"
       done
   
@@ -63,6 +69,8 @@ data:
     done
   dashboards.sh: |
     #!/bin/bash
+  
+    set -euo pipefail
   
     SUMOLOGIC_ACCESSID=${SUMOLOGIC_ACCESSID:=""}
     readonly SUMOLOGIC_ACCESSID
@@ -85,7 +93,7 @@ data:
   
       local ADMIN_FOLDER_JOB_STATUS
       ADMIN_FOLDER_JOB_STATUS="InProgress"
-      while [ "${ADMIN_FOLDER_JOB_STATUS}" = "InProgress" ]; do
+      while [[ "${ADMIN_FOLDER_JOB_STATUS}" = "InProgress" ]]; do
         ADMIN_FOLDER_JOB_STATUS="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v2/content/folders/adminRecommended/"${ADMIN_FOLDER_JOB_ID}"/status | jq '.status' | tr -d '"' )"
@@ -93,7 +101,7 @@ data:
         sleep 1
       done
   
-      if [ "${ADMIN_FOLDER_JOB_STATUS}" != "Success" ]; then
+      if [[ "${ADMIN_FOLDER_JOB_STATUS}" != "Success" ]]; then
         echo "Could not fetch data from the \"Admin Recommended\" content folder. The K8s Dashboards won't be installed."
         echo "You can still install them manually:"
         echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
@@ -155,7 +163,7 @@ data:
       readonly APP_INSTALL_JOB_ID
   
       APP_INSTALL_JOB_STATUS="InProgress"
-      while [ "${APP_INSTALL_JOB_STATUS}" = "InProgress" ]; do
+      while [[ "${APP_INSTALL_JOB_STATUS}" = "InProgress" ]]; do
         APP_INSTALL_JOB_STATUS="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v1/apps/install/"${APP_INSTALL_JOB_ID}"/status | jq '.status' | tr -d '"' )"
@@ -163,7 +171,7 @@ data:
         sleep 1
       done
   
-      if [ "${APP_INSTALL_JOB_STATUS}" != "Success" ]; then
+      if [[ "${APP_INSTALL_JOB_STATUS}" != "Success" ]]; then
         ERROR_MSG="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v1/apps/install/"${APP_INSTALL_JOB_ID}"/status )"
@@ -189,7 +197,7 @@ data:
           "${SUMOLOGIC_BASE_URL}"v2/content/"${K8S_FOLDER_ID}"/permissions/add | jq '.errors' )
         readonly PERMS_ERRORS
   
-        if [ "${PERMS_ERRORS}" != "null" ]; then
+        if [[ "${PERMS_ERRORS}" != "null" ]]; then
           echo "Setting permissions for the installed content failed."
           echo "${PERMS_ERRORS}"
         fi
@@ -490,7 +498,8 @@ data:
   
         while true; do
             sleep 10
-            echo "$(date) Sleeping in the debug mode..."
+            DATE=$(date)
+            echo "${DATE} Sleeping in the debug mode..."
         done
     fi
   
@@ -502,6 +511,7 @@ data:
         BASE_URL="https://api.sumologic.com/api/"
       fi
   
+      # shellcheck disable=SC2312
       OPTIONAL_REDIRECTION="$(curl -XGET -s -o /dev/null -D - \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${BASE_URL}"v1/collectors \
@@ -570,6 +580,7 @@ data:
     # Sumo Logic fields
     if should_create_fields ; then
         readonly CREATE_FIELDS=1
+        # shellcheck disable=SC2312
         FIELDS_RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"

--- a/tests/helm/terraform/static/conditional_sources.output.yaml
+++ b/tests/helm/terraform/static/conditional_sources.output.yaml
@@ -39,18 +39,24 @@ data:
     #
     # shellcheck disable=SC2010
     # extract target directory names from the file names using _ as separator
+  
+    set -euo pipefail
+  
     err_report() {
         echo "Custom script error on line $1"
         exit 1
     }
     trap 'err_report $LINENO' ERR
   
-    for dir in $(ls -1 /customer-scripts | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq); do
+    declare -a dirs
+    ls -1 /customer-scripts 2>/dev/null | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq | read -ar dirs || true
+    for dir in "${dirs[@]}"; do
       target="/scripts/${dir}"
       mkdir "${target}"
-      # shellcheck disable=SC2010
       # Get files for given directory and take only filename part (after first _)
-      for file in $(ls -1 "/customer-scripts/${dir}_"* | grep -oE '_.*' | sed 's/_//g'); do
+      declare -a files
+      ls -1 /customer-scripts 2>/dev/null | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq | read -ar files || true
+      for file in "${files[@]}"; do
         cp "/customer-scripts/${dir}_${file}" "${target}/${file}"
       done
   
@@ -63,6 +69,8 @@ data:
     done
   dashboards.sh: |
     #!/bin/bash
+  
+    set -euo pipefail
   
     SUMOLOGIC_ACCESSID=${SUMOLOGIC_ACCESSID:=""}
     readonly SUMOLOGIC_ACCESSID
@@ -85,7 +93,7 @@ data:
   
       local ADMIN_FOLDER_JOB_STATUS
       ADMIN_FOLDER_JOB_STATUS="InProgress"
-      while [ "${ADMIN_FOLDER_JOB_STATUS}" = "InProgress" ]; do
+      while [[ "${ADMIN_FOLDER_JOB_STATUS}" = "InProgress" ]]; do
         ADMIN_FOLDER_JOB_STATUS="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v2/content/folders/adminRecommended/"${ADMIN_FOLDER_JOB_ID}"/status | jq '.status' | tr -d '"' )"
@@ -93,7 +101,7 @@ data:
         sleep 1
       done
   
-      if [ "${ADMIN_FOLDER_JOB_STATUS}" != "Success" ]; then
+      if [[ "${ADMIN_FOLDER_JOB_STATUS}" != "Success" ]]; then
         echo "Could not fetch data from the \"Admin Recommended\" content folder. The K8s Dashboards won't be installed."
         echo "You can still install them manually:"
         echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
@@ -155,7 +163,7 @@ data:
       readonly APP_INSTALL_JOB_ID
   
       APP_INSTALL_JOB_STATUS="InProgress"
-      while [ "${APP_INSTALL_JOB_STATUS}" = "InProgress" ]; do
+      while [[ "${APP_INSTALL_JOB_STATUS}" = "InProgress" ]]; do
         APP_INSTALL_JOB_STATUS="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v1/apps/install/"${APP_INSTALL_JOB_ID}"/status | jq '.status' | tr -d '"' )"
@@ -163,7 +171,7 @@ data:
         sleep 1
       done
   
-      if [ "${APP_INSTALL_JOB_STATUS}" != "Success" ]; then
+      if [[ "${APP_INSTALL_JOB_STATUS}" != "Success" ]]; then
         ERROR_MSG="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v1/apps/install/"${APP_INSTALL_JOB_ID}"/status )"
@@ -189,7 +197,7 @@ data:
           "${SUMOLOGIC_BASE_URL}"v2/content/"${K8S_FOLDER_ID}"/permissions/add | jq '.errors' )
         readonly PERMS_ERRORS
   
-        if [ "${PERMS_ERRORS}" != "null" ]; then
+        if [[ "${PERMS_ERRORS}" != "null" ]]; then
           echo "Setting permissions for the installed content failed."
           echo "${PERMS_ERRORS}"
         fi
@@ -410,7 +418,8 @@ data:
   
         while true; do
             sleep 10
-            echo "$(date) Sleeping in the debug mode..."
+            DATE=$(date)
+            echo "${DATE} Sleeping in the debug mode..."
         done
     fi
   
@@ -422,6 +431,7 @@ data:
         BASE_URL="https://api.sumologic.com/api/"
       fi
   
+      # shellcheck disable=SC2312
       OPTIONAL_REDIRECTION="$(curl -XGET -s -o /dev/null -D - \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${BASE_URL}"v1/collectors \
@@ -490,6 +500,7 @@ data:
     # Sumo Logic fields
     if should_create_fields ; then
         readonly CREATE_FIELDS=1
+        # shellcheck disable=SC2312
         FIELDS_RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"

--- a/tests/helm/terraform/static/custom.output.yaml
+++ b/tests/helm/terraform/static/custom.output.yaml
@@ -39,18 +39,24 @@ data:
     #
     # shellcheck disable=SC2010
     # extract target directory names from the file names using _ as separator
+  
+    set -euo pipefail
+  
     err_report() {
         echo "Custom script error on line $1"
         exit 1
     }
     trap 'err_report $LINENO' ERR
   
-    for dir in $(ls -1 /customer-scripts | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq); do
+    declare -a dirs
+    ls -1 /customer-scripts 2>/dev/null | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq | read -ar dirs || true
+    for dir in "${dirs[@]}"; do
       target="/scripts/${dir}"
       mkdir "${target}"
-      # shellcheck disable=SC2010
       # Get files for given directory and take only filename part (after first _)
-      for file in $(ls -1 "/customer-scripts/${dir}_"* | grep -oE '_.*' | sed 's/_//g'); do
+      declare -a files
+      ls -1 /customer-scripts 2>/dev/null | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq | read -ar files || true
+      for file in "${files[@]}"; do
         cp "/customer-scripts/${dir}_${file}" "${target}/${file}"
       done
   
@@ -63,6 +69,8 @@ data:
     done
   dashboards.sh: |
     #!/bin/bash
+  
+    set -euo pipefail
   
     SUMOLOGIC_ACCESSID=${SUMOLOGIC_ACCESSID:=""}
     readonly SUMOLOGIC_ACCESSID
@@ -85,7 +93,7 @@ data:
   
       local ADMIN_FOLDER_JOB_STATUS
       ADMIN_FOLDER_JOB_STATUS="InProgress"
-      while [ "${ADMIN_FOLDER_JOB_STATUS}" = "InProgress" ]; do
+      while [[ "${ADMIN_FOLDER_JOB_STATUS}" = "InProgress" ]]; do
         ADMIN_FOLDER_JOB_STATUS="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v2/content/folders/adminRecommended/"${ADMIN_FOLDER_JOB_ID}"/status | jq '.status' | tr -d '"' )"
@@ -93,7 +101,7 @@ data:
         sleep 1
       done
   
-      if [ "${ADMIN_FOLDER_JOB_STATUS}" != "Success" ]; then
+      if [[ "${ADMIN_FOLDER_JOB_STATUS}" != "Success" ]]; then
         echo "Could not fetch data from the \"Admin Recommended\" content folder. The K8s Dashboards won't be installed."
         echo "You can still install them manually:"
         echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
@@ -155,7 +163,7 @@ data:
       readonly APP_INSTALL_JOB_ID
   
       APP_INSTALL_JOB_STATUS="InProgress"
-      while [ "${APP_INSTALL_JOB_STATUS}" = "InProgress" ]; do
+      while [[ "${APP_INSTALL_JOB_STATUS}" = "InProgress" ]]; do
         APP_INSTALL_JOB_STATUS="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v1/apps/install/"${APP_INSTALL_JOB_ID}"/status | jq '.status' | tr -d '"' )"
@@ -163,7 +171,7 @@ data:
         sleep 1
       done
   
-      if [ "${APP_INSTALL_JOB_STATUS}" != "Success" ]; then
+      if [[ "${APP_INSTALL_JOB_STATUS}" != "Success" ]]; then
         ERROR_MSG="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v1/apps/install/"${APP_INSTALL_JOB_ID}"/status )"
@@ -189,7 +197,7 @@ data:
           "${SUMOLOGIC_BASE_URL}"v2/content/"${K8S_FOLDER_ID}"/permissions/add | jq '.errors' )
         readonly PERMS_ERRORS
   
-        if [ "${PERMS_ERRORS}" != "null" ]; then
+        if [[ "${PERMS_ERRORS}" != "null" ]]; then
           echo "Setting permissions for the installed content failed."
           echo "${PERMS_ERRORS}"
         fi
@@ -410,7 +418,8 @@ data:
   
         while true; do
             sleep 10
-            echo "$(date) Sleeping in the debug mode..."
+            DATE=$(date)
+            echo "${DATE} Sleeping in the debug mode..."
         done
     fi
   
@@ -422,6 +431,7 @@ data:
         BASE_URL="https://api.sumologic.com/api/"
       fi
   
+      # shellcheck disable=SC2312
       OPTIONAL_REDIRECTION="$(curl -XGET -s -o /dev/null -D - \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${BASE_URL}"v1/collectors \
@@ -490,6 +500,7 @@ data:
     # Sumo Logic fields
     if should_create_fields ; then
         readonly CREATE_FIELDS=1
+        # shellcheck disable=SC2312
         FIELDS_RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"

--- a/tests/helm/terraform/static/default.output.yaml
+++ b/tests/helm/terraform/static/default.output.yaml
@@ -39,18 +39,24 @@ data:
     #
     # shellcheck disable=SC2010
     # extract target directory names from the file names using _ as separator
+  
+    set -euo pipefail
+  
     err_report() {
         echo "Custom script error on line $1"
         exit 1
     }
     trap 'err_report $LINENO' ERR
   
-    for dir in $(ls -1 /customer-scripts | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq); do
+    declare -a dirs
+    ls -1 /customer-scripts 2>/dev/null | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq | read -ar dirs || true
+    for dir in "${dirs[@]}"; do
       target="/scripts/${dir}"
       mkdir "${target}"
-      # shellcheck disable=SC2010
       # Get files for given directory and take only filename part (after first _)
-      for file in $(ls -1 "/customer-scripts/${dir}_"* | grep -oE '_.*' | sed 's/_//g'); do
+      declare -a files
+      ls -1 /customer-scripts 2>/dev/null | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq | read -ar files || true
+      for file in "${files[@]}"; do
         cp "/customer-scripts/${dir}_${file}" "${target}/${file}"
       done
   
@@ -63,6 +69,8 @@ data:
     done
   dashboards.sh: |
     #!/bin/bash
+  
+    set -euo pipefail
   
     SUMOLOGIC_ACCESSID=${SUMOLOGIC_ACCESSID:=""}
     readonly SUMOLOGIC_ACCESSID
@@ -85,7 +93,7 @@ data:
   
       local ADMIN_FOLDER_JOB_STATUS
       ADMIN_FOLDER_JOB_STATUS="InProgress"
-      while [ "${ADMIN_FOLDER_JOB_STATUS}" = "InProgress" ]; do
+      while [[ "${ADMIN_FOLDER_JOB_STATUS}" = "InProgress" ]]; do
         ADMIN_FOLDER_JOB_STATUS="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v2/content/folders/adminRecommended/"${ADMIN_FOLDER_JOB_ID}"/status | jq '.status' | tr -d '"' )"
@@ -93,7 +101,7 @@ data:
         sleep 1
       done
   
-      if [ "${ADMIN_FOLDER_JOB_STATUS}" != "Success" ]; then
+      if [[ "${ADMIN_FOLDER_JOB_STATUS}" != "Success" ]]; then
         echo "Could not fetch data from the \"Admin Recommended\" content folder. The K8s Dashboards won't be installed."
         echo "You can still install them manually:"
         echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
@@ -155,7 +163,7 @@ data:
       readonly APP_INSTALL_JOB_ID
   
       APP_INSTALL_JOB_STATUS="InProgress"
-      while [ "${APP_INSTALL_JOB_STATUS}" = "InProgress" ]; do
+      while [[ "${APP_INSTALL_JOB_STATUS}" = "InProgress" ]]; do
         APP_INSTALL_JOB_STATUS="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v1/apps/install/"${APP_INSTALL_JOB_ID}"/status | jq '.status' | tr -d '"' )"
@@ -163,7 +171,7 @@ data:
         sleep 1
       done
   
-      if [ "${APP_INSTALL_JOB_STATUS}" != "Success" ]; then
+      if [[ "${APP_INSTALL_JOB_STATUS}" != "Success" ]]; then
         ERROR_MSG="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v1/apps/install/"${APP_INSTALL_JOB_ID}"/status )"
@@ -189,7 +197,7 @@ data:
           "${SUMOLOGIC_BASE_URL}"v2/content/"${K8S_FOLDER_ID}"/permissions/add | jq '.errors' )
         readonly PERMS_ERRORS
   
-        if [ "${PERMS_ERRORS}" != "null" ]; then
+        if [[ "${PERMS_ERRORS}" != "null" ]]; then
           echo "Setting permissions for the installed content failed."
           echo "${PERMS_ERRORS}"
         fi
@@ -488,7 +496,8 @@ data:
   
         while true; do
             sleep 10
-            echo "$(date) Sleeping in the debug mode..."
+            DATE=$(date)
+            echo "${DATE} Sleeping in the debug mode..."
         done
     fi
   
@@ -500,6 +509,7 @@ data:
         BASE_URL="https://api.sumologic.com/api/"
       fi
   
+      # shellcheck disable=SC2312
       OPTIONAL_REDIRECTION="$(curl -XGET -s -o /dev/null -D - \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${BASE_URL}"v1/collectors \
@@ -568,6 +578,7 @@ data:
     # Sumo Logic fields
     if should_create_fields ; then
         readonly CREATE_FIELDS=1
+        # shellcheck disable=SC2312
         FIELDS_RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"

--- a/tests/helm/terraform/static/disable_default_metrics.output.yaml
+++ b/tests/helm/terraform/static/disable_default_metrics.output.yaml
@@ -39,18 +39,24 @@ data:
     #
     # shellcheck disable=SC2010
     # extract target directory names from the file names using _ as separator
+  
+    set -euo pipefail
+  
     err_report() {
         echo "Custom script error on line $1"
         exit 1
     }
     trap 'err_report $LINENO' ERR
   
-    for dir in $(ls -1 /customer-scripts | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq); do
+    declare -a dirs
+    ls -1 /customer-scripts 2>/dev/null | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq | read -ar dirs || true
+    for dir in "${dirs[@]}"; do
       target="/scripts/${dir}"
       mkdir "${target}"
-      # shellcheck disable=SC2010
       # Get files for given directory and take only filename part (after first _)
-      for file in $(ls -1 "/customer-scripts/${dir}_"* | grep -oE '_.*' | sed 's/_//g'); do
+      declare -a files
+      ls -1 /customer-scripts 2>/dev/null | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq | read -ar files || true
+      for file in "${files[@]}"; do
         cp "/customer-scripts/${dir}_${file}" "${target}/${file}"
       done
   
@@ -63,6 +69,8 @@ data:
     done
   dashboards.sh: |
     #!/bin/bash
+  
+    set -euo pipefail
   
     SUMOLOGIC_ACCESSID=${SUMOLOGIC_ACCESSID:=""}
     readonly SUMOLOGIC_ACCESSID
@@ -85,7 +93,7 @@ data:
   
       local ADMIN_FOLDER_JOB_STATUS
       ADMIN_FOLDER_JOB_STATUS="InProgress"
-      while [ "${ADMIN_FOLDER_JOB_STATUS}" = "InProgress" ]; do
+      while [[ "${ADMIN_FOLDER_JOB_STATUS}" = "InProgress" ]]; do
         ADMIN_FOLDER_JOB_STATUS="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v2/content/folders/adminRecommended/"${ADMIN_FOLDER_JOB_ID}"/status | jq '.status' | tr -d '"' )"
@@ -93,7 +101,7 @@ data:
         sleep 1
       done
   
-      if [ "${ADMIN_FOLDER_JOB_STATUS}" != "Success" ]; then
+      if [[ "${ADMIN_FOLDER_JOB_STATUS}" != "Success" ]]; then
         echo "Could not fetch data from the \"Admin Recommended\" content folder. The K8s Dashboards won't be installed."
         echo "You can still install them manually:"
         echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
@@ -155,7 +163,7 @@ data:
       readonly APP_INSTALL_JOB_ID
   
       APP_INSTALL_JOB_STATUS="InProgress"
-      while [ "${APP_INSTALL_JOB_STATUS}" = "InProgress" ]; do
+      while [[ "${APP_INSTALL_JOB_STATUS}" = "InProgress" ]]; do
         APP_INSTALL_JOB_STATUS="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v1/apps/install/"${APP_INSTALL_JOB_ID}"/status | jq '.status' | tr -d '"' )"
@@ -163,7 +171,7 @@ data:
         sleep 1
       done
   
-      if [ "${APP_INSTALL_JOB_STATUS}" != "Success" ]; then
+      if [[ "${APP_INSTALL_JOB_STATUS}" != "Success" ]]; then
         ERROR_MSG="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v1/apps/install/"${APP_INSTALL_JOB_ID}"/status )"
@@ -189,7 +197,7 @@ data:
           "${SUMOLOGIC_BASE_URL}"v2/content/"${K8S_FOLDER_ID}"/permissions/add | jq '.errors' )
         readonly PERMS_ERRORS
   
-        if [ "${PERMS_ERRORS}" != "null" ]; then
+        if [[ "${PERMS_ERRORS}" != "null" ]]; then
           echo "Setting permissions for the installed content failed."
           echo "${PERMS_ERRORS}"
         fi
@@ -481,7 +489,8 @@ data:
   
         while true; do
             sleep 10
-            echo "$(date) Sleeping in the debug mode..."
+            DATE=$(date)
+            echo "${DATE} Sleeping in the debug mode..."
         done
     fi
   
@@ -493,6 +502,7 @@ data:
         BASE_URL="https://api.sumologic.com/api/"
       fi
   
+      # shellcheck disable=SC2312
       OPTIONAL_REDIRECTION="$(curl -XGET -s -o /dev/null -D - \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${BASE_URL}"v1/collectors \
@@ -561,6 +571,7 @@ data:
     # Sumo Logic fields
     if should_create_fields ; then
         readonly CREATE_FIELDS=1
+        # shellcheck disable=SC2312
         FIELDS_RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"

--- a/tests/helm/terraform/static/disabled_dashboards.output.yaml
+++ b/tests/helm/terraform/static/disabled_dashboards.output.yaml
@@ -39,18 +39,24 @@ data:
     #
     # shellcheck disable=SC2010
     # extract target directory names from the file names using _ as separator
+  
+    set -euo pipefail
+  
     err_report() {
         echo "Custom script error on line $1"
         exit 1
     }
     trap 'err_report $LINENO' ERR
   
-    for dir in $(ls -1 /customer-scripts | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq); do
+    declare -a dirs
+    ls -1 /customer-scripts 2>/dev/null | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq | read -ar dirs || true
+    for dir in "${dirs[@]}"; do
       target="/scripts/${dir}"
       mkdir "${target}"
-      # shellcheck disable=SC2010
       # Get files for given directory and take only filename part (after first _)
-      for file in $(ls -1 "/customer-scripts/${dir}_"* | grep -oE '_.*' | sed 's/_//g'); do
+      declare -a files
+      ls -1 /customer-scripts 2>/dev/null | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq | read -ar files || true
+      for file in "${files[@]}"; do
         cp "/customer-scripts/${dir}_${file}" "${target}/${file}"
       done
   
@@ -63,6 +69,8 @@ data:
     done
   dashboards.sh: |
     #!/bin/bash
+  
+    set -euo pipefail
   
     SUMOLOGIC_ACCESSID=${SUMOLOGIC_ACCESSID:=""}
     readonly SUMOLOGIC_ACCESSID
@@ -85,7 +93,7 @@ data:
   
       local ADMIN_FOLDER_JOB_STATUS
       ADMIN_FOLDER_JOB_STATUS="InProgress"
-      while [ "${ADMIN_FOLDER_JOB_STATUS}" = "InProgress" ]; do
+      while [[ "${ADMIN_FOLDER_JOB_STATUS}" = "InProgress" ]]; do
         ADMIN_FOLDER_JOB_STATUS="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v2/content/folders/adminRecommended/"${ADMIN_FOLDER_JOB_ID}"/status | jq '.status' | tr -d '"' )"
@@ -93,7 +101,7 @@ data:
         sleep 1
       done
   
-      if [ "${ADMIN_FOLDER_JOB_STATUS}" != "Success" ]; then
+      if [[ "${ADMIN_FOLDER_JOB_STATUS}" != "Success" ]]; then
         echo "Could not fetch data from the \"Admin Recommended\" content folder. The K8s Dashboards won't be installed."
         echo "You can still install them manually:"
         echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
@@ -155,7 +163,7 @@ data:
       readonly APP_INSTALL_JOB_ID
   
       APP_INSTALL_JOB_STATUS="InProgress"
-      while [ "${APP_INSTALL_JOB_STATUS}" = "InProgress" ]; do
+      while [[ "${APP_INSTALL_JOB_STATUS}" = "InProgress" ]]; do
         APP_INSTALL_JOB_STATUS="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v1/apps/install/"${APP_INSTALL_JOB_ID}"/status | jq '.status' | tr -d '"' )"
@@ -163,7 +171,7 @@ data:
         sleep 1
       done
   
-      if [ "${APP_INSTALL_JOB_STATUS}" != "Success" ]; then
+      if [[ "${APP_INSTALL_JOB_STATUS}" != "Success" ]]; then
         ERROR_MSG="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v1/apps/install/"${APP_INSTALL_JOB_ID}"/status )"
@@ -189,7 +197,7 @@ data:
           "${SUMOLOGIC_BASE_URL}"v2/content/"${K8S_FOLDER_ID}"/permissions/add | jq '.errors' )
         readonly PERMS_ERRORS
   
-        if [ "${PERMS_ERRORS}" != "null" ]; then
+        if [[ "${PERMS_ERRORS}" != "null" ]]; then
           echo "Setting permissions for the installed content failed."
           echo "${PERMS_ERRORS}"
         fi
@@ -488,7 +496,8 @@ data:
   
         while true; do
             sleep 10
-            echo "$(date) Sleeping in the debug mode..."
+            DATE=$(date)
+            echo "${DATE} Sleeping in the debug mode..."
         done
     fi
   
@@ -500,6 +509,7 @@ data:
         BASE_URL="https://api.sumologic.com/api/"
       fi
   
+      # shellcheck disable=SC2312
       OPTIONAL_REDIRECTION="$(curl -XGET -s -o /dev/null -D - \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${BASE_URL}"v1/collectors \
@@ -568,6 +578,7 @@ data:
     # Sumo Logic fields
     if should_create_fields ; then
         readonly CREATE_FIELDS=1
+        # shellcheck disable=SC2312
         FIELDS_RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"

--- a/tests/helm/terraform/static/disabled_monitors.output.yaml
+++ b/tests/helm/terraform/static/disabled_monitors.output.yaml
@@ -39,18 +39,24 @@ data:
     #
     # shellcheck disable=SC2010
     # extract target directory names from the file names using _ as separator
+  
+    set -euo pipefail
+  
     err_report() {
         echo "Custom script error on line $1"
         exit 1
     }
     trap 'err_report $LINENO' ERR
   
-    for dir in $(ls -1 /customer-scripts | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq); do
+    declare -a dirs
+    ls -1 /customer-scripts 2>/dev/null | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq | read -ar dirs || true
+    for dir in "${dirs[@]}"; do
       target="/scripts/${dir}"
       mkdir "${target}"
-      # shellcheck disable=SC2010
       # Get files for given directory and take only filename part (after first _)
-      for file in $(ls -1 "/customer-scripts/${dir}_"* | grep -oE '_.*' | sed 's/_//g'); do
+      declare -a files
+      ls -1 /customer-scripts 2>/dev/null | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq | read -ar files || true
+      for file in "${files[@]}"; do
         cp "/customer-scripts/${dir}_${file}" "${target}/${file}"
       done
   
@@ -63,6 +69,8 @@ data:
     done
   dashboards.sh: |
     #!/bin/bash
+  
+    set -euo pipefail
   
     SUMOLOGIC_ACCESSID=${SUMOLOGIC_ACCESSID:=""}
     readonly SUMOLOGIC_ACCESSID
@@ -85,7 +93,7 @@ data:
   
       local ADMIN_FOLDER_JOB_STATUS
       ADMIN_FOLDER_JOB_STATUS="InProgress"
-      while [ "${ADMIN_FOLDER_JOB_STATUS}" = "InProgress" ]; do
+      while [[ "${ADMIN_FOLDER_JOB_STATUS}" = "InProgress" ]]; do
         ADMIN_FOLDER_JOB_STATUS="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v2/content/folders/adminRecommended/"${ADMIN_FOLDER_JOB_ID}"/status | jq '.status' | tr -d '"' )"
@@ -93,7 +101,7 @@ data:
         sleep 1
       done
   
-      if [ "${ADMIN_FOLDER_JOB_STATUS}" != "Success" ]; then
+      if [[ "${ADMIN_FOLDER_JOB_STATUS}" != "Success" ]]; then
         echo "Could not fetch data from the \"Admin Recommended\" content folder. The K8s Dashboards won't be installed."
         echo "You can still install them manually:"
         echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
@@ -155,7 +163,7 @@ data:
       readonly APP_INSTALL_JOB_ID
   
       APP_INSTALL_JOB_STATUS="InProgress"
-      while [ "${APP_INSTALL_JOB_STATUS}" = "InProgress" ]; do
+      while [[ "${APP_INSTALL_JOB_STATUS}" = "InProgress" ]]; do
         APP_INSTALL_JOB_STATUS="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v1/apps/install/"${APP_INSTALL_JOB_ID}"/status | jq '.status' | tr -d '"' )"
@@ -163,7 +171,7 @@ data:
         sleep 1
       done
   
-      if [ "${APP_INSTALL_JOB_STATUS}" != "Success" ]; then
+      if [[ "${APP_INSTALL_JOB_STATUS}" != "Success" ]]; then
         ERROR_MSG="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v1/apps/install/"${APP_INSTALL_JOB_ID}"/status )"
@@ -189,7 +197,7 @@ data:
           "${SUMOLOGIC_BASE_URL}"v2/content/"${K8S_FOLDER_ID}"/permissions/add | jq '.errors' )
         readonly PERMS_ERRORS
   
-        if [ "${PERMS_ERRORS}" != "null" ]; then
+        if [[ "${PERMS_ERRORS}" != "null" ]]; then
           echo "Setting permissions for the installed content failed."
           echo "${PERMS_ERRORS}"
         fi
@@ -488,7 +496,8 @@ data:
   
         while true; do
             sleep 10
-            echo "$(date) Sleeping in the debug mode..."
+            DATE=$(date)
+            echo "${DATE} Sleeping in the debug mode..."
         done
     fi
   
@@ -500,6 +509,7 @@ data:
         BASE_URL="https://api.sumologic.com/api/"
       fi
   
+      # shellcheck disable=SC2312
       OPTIONAL_REDIRECTION="$(curl -XGET -s -o /dev/null -D - \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${BASE_URL}"v1/collectors \
@@ -568,6 +578,7 @@ data:
     # Sumo Logic fields
     if should_create_fields ; then
         readonly CREATE_FIELDS=1
+        # shellcheck disable=SC2312
         FIELDS_RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"

--- a/tests/helm/terraform/static/monitors_with_email_notifications.output.yaml
+++ b/tests/helm/terraform/static/monitors_with_email_notifications.output.yaml
@@ -39,18 +39,24 @@ data:
     #
     # shellcheck disable=SC2010
     # extract target directory names from the file names using _ as separator
+  
+    set -euo pipefail
+  
     err_report() {
         echo "Custom script error on line $1"
         exit 1
     }
     trap 'err_report $LINENO' ERR
   
-    for dir in $(ls -1 /customer-scripts | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq); do
+    declare -a dirs
+    ls -1 /customer-scripts 2>/dev/null | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq | read -ar dirs || true
+    for dir in "${dirs[@]}"; do
       target="/scripts/${dir}"
       mkdir "${target}"
-      # shellcheck disable=SC2010
       # Get files for given directory and take only filename part (after first _)
-      for file in $(ls -1 "/customer-scripts/${dir}_"* | grep -oE '_.*' | sed 's/_//g'); do
+      declare -a files
+      ls -1 /customer-scripts 2>/dev/null | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq | read -ar files || true
+      for file in "${files[@]}"; do
         cp "/customer-scripts/${dir}_${file}" "${target}/${file}"
       done
   
@@ -63,6 +69,8 @@ data:
     done
   dashboards.sh: |
     #!/bin/bash
+  
+    set -euo pipefail
   
     SUMOLOGIC_ACCESSID=${SUMOLOGIC_ACCESSID:=""}
     readonly SUMOLOGIC_ACCESSID
@@ -85,7 +93,7 @@ data:
   
       local ADMIN_FOLDER_JOB_STATUS
       ADMIN_FOLDER_JOB_STATUS="InProgress"
-      while [ "${ADMIN_FOLDER_JOB_STATUS}" = "InProgress" ]; do
+      while [[ "${ADMIN_FOLDER_JOB_STATUS}" = "InProgress" ]]; do
         ADMIN_FOLDER_JOB_STATUS="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v2/content/folders/adminRecommended/"${ADMIN_FOLDER_JOB_ID}"/status | jq '.status' | tr -d '"' )"
@@ -93,7 +101,7 @@ data:
         sleep 1
       done
   
-      if [ "${ADMIN_FOLDER_JOB_STATUS}" != "Success" ]; then
+      if [[ "${ADMIN_FOLDER_JOB_STATUS}" != "Success" ]]; then
         echo "Could not fetch data from the \"Admin Recommended\" content folder. The K8s Dashboards won't be installed."
         echo "You can still install them manually:"
         echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
@@ -155,7 +163,7 @@ data:
       readonly APP_INSTALL_JOB_ID
   
       APP_INSTALL_JOB_STATUS="InProgress"
-      while [ "${APP_INSTALL_JOB_STATUS}" = "InProgress" ]; do
+      while [[ "${APP_INSTALL_JOB_STATUS}" = "InProgress" ]]; do
         APP_INSTALL_JOB_STATUS="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v1/apps/install/"${APP_INSTALL_JOB_ID}"/status | jq '.status' | tr -d '"' )"
@@ -163,7 +171,7 @@ data:
         sleep 1
       done
   
-      if [ "${APP_INSTALL_JOB_STATUS}" != "Success" ]; then
+      if [[ "${APP_INSTALL_JOB_STATUS}" != "Success" ]]; then
         ERROR_MSG="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v1/apps/install/"${APP_INSTALL_JOB_ID}"/status )"
@@ -189,7 +197,7 @@ data:
           "${SUMOLOGIC_BASE_URL}"v2/content/"${K8S_FOLDER_ID}"/permissions/add | jq '.errors' )
         readonly PERMS_ERRORS
   
-        if [ "${PERMS_ERRORS}" != "null" ]; then
+        if [[ "${PERMS_ERRORS}" != "null" ]]; then
           echo "Setting permissions for the installed content failed."
           echo "${PERMS_ERRORS}"
         fi
@@ -494,7 +502,8 @@ data:
   
         while true; do
             sleep 10
-            echo "$(date) Sleeping in the debug mode..."
+            DATE=$(date)
+            echo "${DATE} Sleeping in the debug mode..."
         done
     fi
   
@@ -506,6 +515,7 @@ data:
         BASE_URL="https://api.sumologic.com/api/"
       fi
   
+      # shellcheck disable=SC2312
       OPTIONAL_REDIRECTION="$(curl -XGET -s -o /dev/null -D - \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${BASE_URL}"v1/collectors \
@@ -574,6 +584,7 @@ data:
     # Sumo Logic fields
     if should_create_fields ; then
         readonly CREATE_FIELDS=1
+        # shellcheck disable=SC2312
         FIELDS_RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"

--- a/tests/helm/terraform/static/monitors_with_single_email.output.yaml
+++ b/tests/helm/terraform/static/monitors_with_single_email.output.yaml
@@ -39,18 +39,24 @@ data:
     #
     # shellcheck disable=SC2010
     # extract target directory names from the file names using _ as separator
+  
+    set -euo pipefail
+  
     err_report() {
         echo "Custom script error on line $1"
         exit 1
     }
     trap 'err_report $LINENO' ERR
   
-    for dir in $(ls -1 /customer-scripts | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq); do
+    declare -a dirs
+    ls -1 /customer-scripts 2>/dev/null | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq | read -ar dirs || true
+    for dir in "${dirs[@]}"; do
       target="/scripts/${dir}"
       mkdir "${target}"
-      # shellcheck disable=SC2010
       # Get files for given directory and take only filename part (after first _)
-      for file in $(ls -1 "/customer-scripts/${dir}_"* | grep -oE '_.*' | sed 's/_//g'); do
+      declare -a files
+      ls -1 /customer-scripts 2>/dev/null | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq | read -ar files || true
+      for file in "${files[@]}"; do
         cp "/customer-scripts/${dir}_${file}" "${target}/${file}"
       done
   
@@ -63,6 +69,8 @@ data:
     done
   dashboards.sh: |
     #!/bin/bash
+  
+    set -euo pipefail
   
     SUMOLOGIC_ACCESSID=${SUMOLOGIC_ACCESSID:=""}
     readonly SUMOLOGIC_ACCESSID
@@ -85,7 +93,7 @@ data:
   
       local ADMIN_FOLDER_JOB_STATUS
       ADMIN_FOLDER_JOB_STATUS="InProgress"
-      while [ "${ADMIN_FOLDER_JOB_STATUS}" = "InProgress" ]; do
+      while [[ "${ADMIN_FOLDER_JOB_STATUS}" = "InProgress" ]]; do
         ADMIN_FOLDER_JOB_STATUS="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v2/content/folders/adminRecommended/"${ADMIN_FOLDER_JOB_ID}"/status | jq '.status' | tr -d '"' )"
@@ -93,7 +101,7 @@ data:
         sleep 1
       done
   
-      if [ "${ADMIN_FOLDER_JOB_STATUS}" != "Success" ]; then
+      if [[ "${ADMIN_FOLDER_JOB_STATUS}" != "Success" ]]; then
         echo "Could not fetch data from the \"Admin Recommended\" content folder. The K8s Dashboards won't be installed."
         echo "You can still install them manually:"
         echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
@@ -155,7 +163,7 @@ data:
       readonly APP_INSTALL_JOB_ID
   
       APP_INSTALL_JOB_STATUS="InProgress"
-      while [ "${APP_INSTALL_JOB_STATUS}" = "InProgress" ]; do
+      while [[ "${APP_INSTALL_JOB_STATUS}" = "InProgress" ]]; do
         APP_INSTALL_JOB_STATUS="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v1/apps/install/"${APP_INSTALL_JOB_ID}"/status | jq '.status' | tr -d '"' )"
@@ -163,7 +171,7 @@ data:
         sleep 1
       done
   
-      if [ "${APP_INSTALL_JOB_STATUS}" != "Success" ]; then
+      if [[ "${APP_INSTALL_JOB_STATUS}" != "Success" ]]; then
         ERROR_MSG="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v1/apps/install/"${APP_INSTALL_JOB_ID}"/status )"
@@ -189,7 +197,7 @@ data:
           "${SUMOLOGIC_BASE_URL}"v2/content/"${K8S_FOLDER_ID}"/permissions/add | jq '.errors' )
         readonly PERMS_ERRORS
   
-        if [ "${PERMS_ERRORS}" != "null" ]; then
+        if [[ "${PERMS_ERRORS}" != "null" ]]; then
           echo "Setting permissions for the installed content failed."
           echo "${PERMS_ERRORS}"
         fi
@@ -494,7 +502,8 @@ data:
   
         while true; do
             sleep 10
-            echo "$(date) Sleeping in the debug mode..."
+            DATE=$(date)
+            echo "${DATE} Sleeping in the debug mode..."
         done
     fi
   
@@ -506,6 +515,7 @@ data:
         BASE_URL="https://api.sumologic.com/api/"
       fi
   
+      # shellcheck disable=SC2312
       OPTIONAL_REDIRECTION="$(curl -XGET -s -o /dev/null -D - \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${BASE_URL}"v1/collectors \
@@ -574,6 +584,7 @@ data:
     # Sumo Logic fields
     if should_create_fields ; then
         readonly CREATE_FIELDS=1
+        # shellcheck disable=SC2312
         FIELDS_RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"

--- a/tests/helm/terraform/static/strip_extrapolation.output.yaml
+++ b/tests/helm/terraform/static/strip_extrapolation.output.yaml
@@ -39,18 +39,24 @@ data:
     #
     # shellcheck disable=SC2010
     # extract target directory names from the file names using _ as separator
+  
+    set -euo pipefail
+  
     err_report() {
         echo "Custom script error on line $1"
         exit 1
     }
     trap 'err_report $LINENO' ERR
   
-    for dir in $(ls -1 /customer-scripts | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq); do
+    declare -a dirs
+    ls -1 /customer-scripts 2>/dev/null | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq | read -ar dirs || true
+    for dir in "${dirs[@]}"; do
       target="/scripts/${dir}"
       mkdir "${target}"
-      # shellcheck disable=SC2010
       # Get files for given directory and take only filename part (after first _)
-      for file in $(ls -1 "/customer-scripts/${dir}_"* | grep -oE '_.*' | sed 's/_//g'); do
+      declare -a files
+      ls -1 /customer-scripts 2>/dev/null | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq | read -ar files || true
+      for file in "${files[@]}"; do
         cp "/customer-scripts/${dir}_${file}" "${target}/${file}"
       done
   
@@ -63,6 +69,8 @@ data:
     done
   dashboards.sh: |
     #!/bin/bash
+  
+    set -euo pipefail
   
     SUMOLOGIC_ACCESSID=${SUMOLOGIC_ACCESSID:=""}
     readonly SUMOLOGIC_ACCESSID
@@ -85,7 +93,7 @@ data:
   
       local ADMIN_FOLDER_JOB_STATUS
       ADMIN_FOLDER_JOB_STATUS="InProgress"
-      while [ "${ADMIN_FOLDER_JOB_STATUS}" = "InProgress" ]; do
+      while [[ "${ADMIN_FOLDER_JOB_STATUS}" = "InProgress" ]]; do
         ADMIN_FOLDER_JOB_STATUS="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v2/content/folders/adminRecommended/"${ADMIN_FOLDER_JOB_ID}"/status | jq '.status' | tr -d '"' )"
@@ -93,7 +101,7 @@ data:
         sleep 1
       done
   
-      if [ "${ADMIN_FOLDER_JOB_STATUS}" != "Success" ]; then
+      if [[ "${ADMIN_FOLDER_JOB_STATUS}" != "Success" ]]; then
         echo "Could not fetch data from the \"Admin Recommended\" content folder. The K8s Dashboards won't be installed."
         echo "You can still install them manually:"
         echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
@@ -155,7 +163,7 @@ data:
       readonly APP_INSTALL_JOB_ID
   
       APP_INSTALL_JOB_STATUS="InProgress"
-      while [ "${APP_INSTALL_JOB_STATUS}" = "InProgress" ]; do
+      while [[ "${APP_INSTALL_JOB_STATUS}" = "InProgress" ]]; do
         APP_INSTALL_JOB_STATUS="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v1/apps/install/"${APP_INSTALL_JOB_ID}"/status | jq '.status' | tr -d '"' )"
@@ -163,7 +171,7 @@ data:
         sleep 1
       done
   
-      if [ "${APP_INSTALL_JOB_STATUS}" != "Success" ]; then
+      if [[ "${APP_INSTALL_JOB_STATUS}" != "Success" ]]; then
         ERROR_MSG="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v1/apps/install/"${APP_INSTALL_JOB_ID}"/status )"
@@ -189,7 +197,7 @@ data:
           "${SUMOLOGIC_BASE_URL}"v2/content/"${K8S_FOLDER_ID}"/permissions/add | jq '.errors' )
         readonly PERMS_ERRORS
   
-        if [ "${PERMS_ERRORS}" != "null" ]; then
+        if [[ "${PERMS_ERRORS}" != "null" ]]; then
           echo "Setting permissions for the installed content failed."
           echo "${PERMS_ERRORS}"
         fi
@@ -489,7 +497,8 @@ data:
   
         while true; do
             sleep 10
-            echo "$(date) Sleeping in the debug mode..."
+            DATE=$(date)
+            echo "${DATE} Sleeping in the debug mode..."
         done
     fi
   
@@ -501,6 +510,7 @@ data:
         BASE_URL="https://api.sumologic.com/api/"
       fi
   
+      # shellcheck disable=SC2312
       OPTIONAL_REDIRECTION="$(curl -XGET -s -o /dev/null -D - \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${BASE_URL}"v1/collectors \
@@ -569,6 +579,7 @@ data:
     # Sumo Logic fields
     if should_create_fields ; then
         readonly CREATE_FIELDS=1
+        # shellcheck disable=SC2312
         FIELDS_RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"

--- a/tests/helm/terraform/static/traces.output.yaml
+++ b/tests/helm/terraform/static/traces.output.yaml
@@ -39,18 +39,24 @@ data:
     #
     # shellcheck disable=SC2010
     # extract target directory names from the file names using _ as separator
+  
+    set -euo pipefail
+  
     err_report() {
         echo "Custom script error on line $1"
         exit 1
     }
     trap 'err_report $LINENO' ERR
   
-    for dir in $(ls -1 /customer-scripts | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq); do
+    declare -a dirs
+    ls -1 /customer-scripts 2>/dev/null | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq | read -ar dirs || true
+    for dir in "${dirs[@]}"; do
       target="/scripts/${dir}"
       mkdir "${target}"
-      # shellcheck disable=SC2010
       # Get files for given directory and take only filename part (after first _)
-      for file in $(ls -1 "/customer-scripts/${dir}_"* | grep -oE '_.*' | sed 's/_//g'); do
+      declare -a files
+      ls -1 /customer-scripts 2>/dev/null | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq | read -ar files || true
+      for file in "${files[@]}"; do
         cp "/customer-scripts/${dir}_${file}" "${target}/${file}"
       done
   
@@ -63,6 +69,8 @@ data:
     done
   dashboards.sh: |
     #!/bin/bash
+  
+    set -euo pipefail
   
     SUMOLOGIC_ACCESSID=${SUMOLOGIC_ACCESSID:=""}
     readonly SUMOLOGIC_ACCESSID
@@ -85,7 +93,7 @@ data:
   
       local ADMIN_FOLDER_JOB_STATUS
       ADMIN_FOLDER_JOB_STATUS="InProgress"
-      while [ "${ADMIN_FOLDER_JOB_STATUS}" = "InProgress" ]; do
+      while [[ "${ADMIN_FOLDER_JOB_STATUS}" = "InProgress" ]]; do
         ADMIN_FOLDER_JOB_STATUS="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v2/content/folders/adminRecommended/"${ADMIN_FOLDER_JOB_ID}"/status | jq '.status' | tr -d '"' )"
@@ -93,7 +101,7 @@ data:
         sleep 1
       done
   
-      if [ "${ADMIN_FOLDER_JOB_STATUS}" != "Success" ]; then
+      if [[ "${ADMIN_FOLDER_JOB_STATUS}" != "Success" ]]; then
         echo "Could not fetch data from the \"Admin Recommended\" content folder. The K8s Dashboards won't be installed."
         echo "You can still install them manually:"
         echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
@@ -155,7 +163,7 @@ data:
       readonly APP_INSTALL_JOB_ID
   
       APP_INSTALL_JOB_STATUS="InProgress"
-      while [ "${APP_INSTALL_JOB_STATUS}" = "InProgress" ]; do
+      while [[ "${APP_INSTALL_JOB_STATUS}" = "InProgress" ]]; do
         APP_INSTALL_JOB_STATUS="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v1/apps/install/"${APP_INSTALL_JOB_ID}"/status | jq '.status' | tr -d '"' )"
@@ -163,7 +171,7 @@ data:
         sleep 1
       done
   
-      if [ "${APP_INSTALL_JOB_STATUS}" != "Success" ]; then
+      if [[ "${APP_INSTALL_JOB_STATUS}" != "Success" ]]; then
         ERROR_MSG="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v1/apps/install/"${APP_INSTALL_JOB_ID}"/status )"
@@ -189,7 +197,7 @@ data:
           "${SUMOLOGIC_BASE_URL}"v2/content/"${K8S_FOLDER_ID}"/permissions/add | jq '.errors' )
         readonly PERMS_ERRORS
   
-        if [ "${PERMS_ERRORS}" != "null" ]; then
+        if [[ "${PERMS_ERRORS}" != "null" ]]; then
           echo "Setting permissions for the installed content failed."
           echo "${PERMS_ERRORS}"
         fi
@@ -425,7 +433,8 @@ data:
   
         while true; do
             sleep 10
-            echo "$(date) Sleeping in the debug mode..."
+            DATE=$(date)
+            echo "${DATE} Sleeping in the debug mode..."
         done
     fi
   
@@ -437,6 +446,7 @@ data:
         BASE_URL="https://api.sumologic.com/api/"
       fi
   
+      # shellcheck disable=SC2312
       OPTIONAL_REDIRECTION="$(curl -XGET -s -o /dev/null -D - \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${BASE_URL}"v1/collectors \
@@ -505,6 +515,7 @@ data:
     # Sumo Logic fields
     if should_create_fields ; then
         readonly CREATE_FIELDS=1
+        # shellcheck disable=SC2312
         FIELDS_RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"

--- a/tests/helm/terraform/static/tracing-metrics-disabled.output.yaml
+++ b/tests/helm/terraform/static/tracing-metrics-disabled.output.yaml
@@ -39,18 +39,24 @@ data:
     #
     # shellcheck disable=SC2010
     # extract target directory names from the file names using _ as separator
+  
+    set -euo pipefail
+  
     err_report() {
         echo "Custom script error on line $1"
         exit 1
     }
     trap 'err_report $LINENO' ERR
   
-    for dir in $(ls -1 /customer-scripts | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq); do
+    declare -a dirs
+    ls -1 /customer-scripts 2>/dev/null | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq | read -ar dirs || true
+    for dir in "${dirs[@]}"; do
       target="/scripts/${dir}"
       mkdir "${target}"
-      # shellcheck disable=SC2010
       # Get files for given directory and take only filename part (after first _)
-      for file in $(ls -1 "/customer-scripts/${dir}_"* | grep -oE '_.*' | sed 's/_//g'); do
+      declare -a files
+      ls -1 /customer-scripts 2>/dev/null | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq | read -ar files || true
+      for file in "${files[@]}"; do
         cp "/customer-scripts/${dir}_${file}" "${target}/${file}"
       done
   
@@ -63,6 +69,8 @@ data:
     done
   dashboards.sh: |
     #!/bin/bash
+  
+    set -euo pipefail
   
     SUMOLOGIC_ACCESSID=${SUMOLOGIC_ACCESSID:=""}
     readonly SUMOLOGIC_ACCESSID
@@ -85,7 +93,7 @@ data:
   
       local ADMIN_FOLDER_JOB_STATUS
       ADMIN_FOLDER_JOB_STATUS="InProgress"
-      while [ "${ADMIN_FOLDER_JOB_STATUS}" = "InProgress" ]; do
+      while [[ "${ADMIN_FOLDER_JOB_STATUS}" = "InProgress" ]]; do
         ADMIN_FOLDER_JOB_STATUS="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v2/content/folders/adminRecommended/"${ADMIN_FOLDER_JOB_ID}"/status | jq '.status' | tr -d '"' )"
@@ -93,7 +101,7 @@ data:
         sleep 1
       done
   
-      if [ "${ADMIN_FOLDER_JOB_STATUS}" != "Success" ]; then
+      if [[ "${ADMIN_FOLDER_JOB_STATUS}" != "Success" ]]; then
         echo "Could not fetch data from the \"Admin Recommended\" content folder. The K8s Dashboards won't be installed."
         echo "You can still install them manually:"
         echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
@@ -155,7 +163,7 @@ data:
       readonly APP_INSTALL_JOB_ID
   
       APP_INSTALL_JOB_STATUS="InProgress"
-      while [ "${APP_INSTALL_JOB_STATUS}" = "InProgress" ]; do
+      while [[ "${APP_INSTALL_JOB_STATUS}" = "InProgress" ]]; do
         APP_INSTALL_JOB_STATUS="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v1/apps/install/"${APP_INSTALL_JOB_ID}"/status | jq '.status' | tr -d '"' )"
@@ -163,7 +171,7 @@ data:
         sleep 1
       done
   
-      if [ "${APP_INSTALL_JOB_STATUS}" != "Success" ]; then
+      if [[ "${APP_INSTALL_JOB_STATUS}" != "Success" ]]; then
         ERROR_MSG="$(curl -XGET -s \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${SUMOLOGIC_BASE_URL}"v1/apps/install/"${APP_INSTALL_JOB_ID}"/status )"
@@ -189,7 +197,7 @@ data:
           "${SUMOLOGIC_BASE_URL}"v2/content/"${K8S_FOLDER_ID}"/permissions/add | jq '.errors' )
         readonly PERMS_ERRORS
   
-        if [ "${PERMS_ERRORS}" != "null" ]; then
+        if [[ "${PERMS_ERRORS}" != "null" ]]; then
           echo "Setting permissions for the installed content failed."
           echo "${PERMS_ERRORS}"
         fi
@@ -488,7 +496,8 @@ data:
   
         while true; do
             sleep 10
-            echo "$(date) Sleeping in the debug mode..."
+            DATE=$(date)
+            echo "${DATE} Sleeping in the debug mode..."
         done
     fi
   
@@ -500,6 +509,7 @@ data:
         BASE_URL="https://api.sumologic.com/api/"
       fi
   
+      # shellcheck disable=SC2312
       OPTIONAL_REDIRECTION="$(curl -XGET -s -o /dev/null -D - \
               -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
               "${BASE_URL}"v1/collectors \
@@ -568,6 +578,7 @@ data:
     # Sumo Logic fields
     if should_create_fields ; then
         readonly CREATE_FIELDS=1
+        # shellcheck disable=SC2312
         FIELDS_RESPONSE="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"

--- a/tests/integration/create-image-archive.sh
+++ b/tests/integration/create-image-archive.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 # Create a docker image archive of all images used in test values files
 
 IMAGE_ARCHIVE=${IMAGE_ARCHIVE:-images.tar}

--- a/vagrant/forwarding/forward-dashboard.sh
+++ b/vagrant/forwarding/forward-dashboard.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 DASHBOARD_POD="$(kubectl get pods --all-namespaces | grep -i kubernetes-dashboard | awk '{print $2}')"
 
 kubectl -n kube-system port-forward "${DASHBOARD_POD}" --address 0.0.0.0 8443:8443

--- a/vagrant/forwarding/forward-prometheus.sh
+++ b/vagrant/forwarding/forward-prometheus.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 PROM_POD="$(kubectl get pods --all-namespaces | grep -i prometheus-0 | awk '{print $2}')"
 
 kubectl -n sumologic port-forward "${PROM_POD}" --address 0.0.0.0 9090:9090

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -x
+set -euo pipefail
 
 YQ_VERSION=4.30.8
 
@@ -62,10 +62,11 @@ chmod +x /usr/local/bin/yq-"${YQ_VERSION}"
 ln -s /usr/local/bin/yq-"${YQ_VERSION}" /usr/local/bin/yq
 
 # Install docker
+LSB_RELEASE="$(lsb_release -cs)"
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 add-apt-repository \
    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-   $(lsb_release -cs) \
+   ${LSB_RELEASE} \
    stable"
 apt-get install -y docker-ce docker-ce-cli containerd.io
 usermod -aG docker vagrant

--- a/vagrant/scripts/get-dashboard-token.sh
+++ b/vagrant/scripts/get-dashboard-token.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+set -euo pipefail
+
 kubectl -n kube-system describe secret default | awk '$1=="token:"{print $2}'

--- a/vagrant/scripts/get-kubeconfig.sh
+++ b/vagrant/scripts/get-kubeconfig.sh
@@ -30,7 +30,8 @@ vagrant ssh-config > "${SSH_CONFIG_PATH}"
 ssh -o StrictHostKeyChecking=no -F "${SSH_CONFIG_PATH}" default 'kubectl config view --raw' | \
 	sed "s/127.0.0.1/${VAGRANT_IP}/g" > "${CONFIG_PATH}"
 
-mv -v "${KUBECONFIG_PATH}" "${KUBECONFIG_PATH}.bkp.$(date +%s)"
+TODAY="$(date +%s)"
+mv -v "${KUBECONFIG_PATH}" "${KUBECONFIG_PATH}.bkp.${TODAY}"
 cp "${CONFIG_PATH}" "${KUBECONFIG_PATH}"
 
 clean_up

--- a/vagrant/scripts/perf-test.sh
+++ b/vagrant/scripts/perf-test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 # Exemplar script output
 # TEST_DURATION=300 TEST_WARMUP_DURATION=30 ./scripts/perf-test.sh
@@ -71,7 +71,8 @@ function run_test() {
     local DURATION_SECONDS="${2}"
     echo "Starting perf tests"
 
-    if [[ $(is_avalanche_running) -eq 0 ]]; then
+    IS_AVALANCHE_RUNNING="$(is_avalanche_running)"
+    if [[ ${IS_AVALANCHE_RUNNING} -eq 0 ]]; then
         echo "Avalanche is running, stop it, wait for the collection to cool down and then rerun the test"
         exit 1
     fi

--- a/vagrant/scripts/sumo-make-completion.sh
+++ b/vagrant/scripts/sumo-make-completion.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 targets=$(grep -oE '^\S*\:' /sumologic/vagrant/Makefile | sed 's/\:$//g')
 complete -W "${targets}" sumo-make


### PR DESCRIPTION
Upgrading shellcheck, really messy because of how we handle the setup scripts. I'm not 100% sure yet if adding error checking (`set -euo pipefail`) is correct for all of these scripts, I'm keeping this as draft until I verify.

### Checklist

<!---
Remove items which don't apply to your PR.
-->

- [X] Changelog updated or skip changelog label added
