### PR TITLE
chore: use Towncrier for changelog generation

### DIFF
--- a/.changelog/2863.fixed.txt
+++ b/.changelog/2863.fixed.txt
@@ -1,0 +1,5 @@
+fix(logs): fix container attribute
+
+Fixes [#2862] Logs from two different containers of one pod show up in Sumo as coming from one of the containers
+
+[#2862]: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2862

--- a/.changelog/2866.fixed.txt
+++ b/.changelog/2866.fixed.txt
@@ -1,0 +1,5 @@
+fix(setup): fix error when creating fields
+
+Fixes [#2865] Setup job fails trying to create fields that already exist
+
+[#2865]: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865

--- a/.changelog/changelog_template.jinja
+++ b/.changelog/changelog_template.jinja
@@ -7,7 +7,9 @@
 ### {{ definitions[category]['name'] }}
 
 {% for text, values in sections[""][category].items() %}
-- {{ text }} {{ values|join(', ') }}
+{%- set lines = text.split('\n') -%}
+- {{ lines[0] }} {{ values|join(', ') }}
+{{ lines[1:] | join('\n') }}
 {% endfor %}
 
 {% endfor %}
@@ -28,4 +30,5 @@ No significant changes.
 {%- for value in all_values | unique %}
 {{ value }}: https://github.com/SumoLogic/sumologic-kubernetes-collection/pulls/{{ value | trim('[]#') }}
 {% endfor %}
-[v{{ versiondata.version }}]: https://github.com/SumoLogic/sumologic-kubernetes-collection/releases/v{{ versiondata.version }}
+[v{{ versiondata.version }}]: https://github.com/SumoLogic/sumologic-kubernetes-collection/releases/v{{
+versiondata.version }}

--- a/.changelog/changelog_template.jinja
+++ b/.changelog/changelog_template.jinja
@@ -1,0 +1,31 @@
+{% if sections[""] -%}
+
+### Released {{ versiondata.date }}
+
+{% for category, val in definitions.items() if category in sections[""] -%}
+
+### {{ definitions[category]['name'] }}
+
+{% for text, values in sections[""][category].items() %}
+- {{ text }} {{ values|join(', ') }}
+{% endfor %}
+
+{% endfor %}
+{% else %}
+No significant changes.
+
+
+{% endif %}
+
+{%- set all_values = [] %}
+{%- for category, val in definitions.items() if category in sections[""] %}
+{% for text, values in sections[""][category].items() %}
+{% for value in values %}
+{{ all_values.append(value) or "" -}}
+{% endfor %}
+{% endfor %}
+{% endfor %}
+{%- for value in all_values | unique %}
+{{ value }}: https://github.com/SumoLogic/sumologic-kubernetes-collection/pulls/{{ value | trim('[]#') }}
+{% endfor %}
+[v{{ versiondata.version }}]: https://github.com/SumoLogic/sumologic-kubernetes-collection/releases/v{{ versiondata.version }}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,9 @@ Describe your PR here
 
 <!---
 Remove items which don't apply to your PR.
+
+You can add a changelog entry by running `make add-changelog-entry`
+See [/docs/dev.md] for more details
 -->
 
 - [ ] Changelog updated or skip changelog label added

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -13,21 +13,16 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-changelog')"
-
+    env:
+      TOWNCRIER_VERSION: 22.12.0
     steps:
       - uses: actions/checkout@v3
-
+      - name: install towncrier
+        run: pip install towncrier==${{ env.TOWNCRIER_VERSION }}
       - name: Check for CHANGELOG changes
         run: |
           # Only the latest commit of the feature branch is available
           # automatically. To diff with the base branch, we need to
           # fetch that too (and we only need its latest commit).
           git fetch origin ${{ github.base_ref }} --depth=1
-          if [[ $(git diff --name-only FETCH_HEAD | grep CHANGELOG) ]]
-          then
-            echo "A CHANGELOG was modified. Looks good!"
-          else
-            echo "No CHANGELOG was modified."
-            echo "Please add a CHANGELOG entry, or add the \"skip-changelog\" label if not required."
-            false
-          fi
+          make check-changelog

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -15,14 +15,17 @@ jobs:
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-changelog')"
     env:
       TOWNCRIER_VERSION: 22.12.0
+      PR_NUMBER: ${{ github.event.number }}
     steps:
       - uses: actions/checkout@v3
+      - name: Add PR base ref
+        run: |
+          git fetch origin ${{ github.base_ref }} --depth=1
       - name: install towncrier
         run: pip install towncrier==${{ env.TOWNCRIER_VERSION }}
-      - name: Check for CHANGELOG changes
+      - name: Check if new CHANGELOG entries added
         run: |
-          # Only the latest commit of the feature branch is available
-          # automatically. To diff with the base branch, we need to
-          # fetch that too (and we only need its latest commit).
-          git fetch origin ${{ github.base_ref }} --depth=1
           make check-changelog
+      - name: Check if new CHANGELOG entries reference the correct PR
+        run: |
+          git diff --name-only ${{ github.base_ref }} HEAD .changelog | grep ${PR_NUMBER}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,24 +7,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 <!-- towncrier release notes start -->
 
-## [Unreleased]
-
-### Fixed
-
-- fix(logs): fix container attribute [#2863]
-
-  Fixes [#2862] Logs from two different containers of one pod show up in Sumo as coming from one of the containers
-
-- fix(setup): fix error when creating fields [#2866]
-
-  Fixes [#2865] Setup job fails trying to create fields that already exist
-
-[#2863]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2863
-[#2862]: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2862
-[#2866]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2866
-[#2865]: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-[Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v3.1.0...main
-
 ## [v3.1.0]
 
 ### Released 2023-02-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+<!-- towncrier release notes start -->
+
 ## [Unreleased]
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -94,14 +94,10 @@ make test-integration:
 # Changelog management
 ## We use Towncrier (https://towncrier.readthedocs.io) for changelog management
 
-ENTRY_TEXT ?= 'Use [Semantic Versioning](https://semver.org/spec/v2.0.0.html) for your changelog entry'
-CHANGE_ID ?= 9999
-CHANGE_TYPE ?= changed
-
-## Usage: make add-changelog-entry CHANGE_TYPE=changed
+## Usage: make add-changelog-entry
 .PHONY: add-changelog-entry
 add-changelog-entry:
-	towncrier create -c "$(ENTRY_TEXT)" "(CHANGE_ID).(CHANGE_TYPE).txt"
+	./ci/add-changelog-entry.sh
 
 ## Consume the files in .changelog and update CHANGELOG.md
 ## We also format it afterwards to make sure it's consistent with our style

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,35 @@ make test-integration:
 	make -C ./tests/integration test
 
 
+# Changelog management
+## We use Towncrier (https://towncrier.readthedocs.io) for changelog management
+
+ENTRY_TEXT ?= 'Use [Semantic Versioning](https://semver.org/spec/v2.0.0.html) for your changelog entry'
+CHANGE_ID ?= 9999
+CHANGE_TYPE ?= changed
+
+## Usage: make add-changelog-entry CHANGE_TYPE=changed
+.PHONY: add-changelog-entry
+add-changelog-entry:
+	towncrier create -c "$(ENTRY_TEXT)" "(CHANGE_ID).(CHANGE_TYPE).txt"
+
+## Consume the files in .changelog and update CHANGELOG.md
+## We also format it afterwards to make sure it's consistent with our style
+## Usage: make update-changelog VERSION=x.x.x
+.PHONY: update-changelog
+update-changelog:
+ifndef VERSION
+	$(error Usage: make update-changelog VERSION=x.x.x)
+endif
+	towncrier build --yes --version $(VERSION)
+	prettier -w CHANGELOG.md
+	git add CHANGELOG.md
+
+## Check if the branch relative to main adds a changelog entry
+.PHONY: check-changelog
+check-changelog:
+	towncrier check
+
 # Various utilities
 .PHONY: push-helm-chart
 push-helm-chart:

--- a/ci/add-changelog-entry.sh
+++ b/ci/add-changelog-entry.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# This is a simple interactive script for adding changelog entries.
+
+set -euo pipefail
+
+function get_default_change_type() {
+    local text
+    readonly text="${1}"
+    readonly commit_type="${text%[(:]*}"
+
+    local change_type
+    case "${commit_type}" in
+    fix )
+        change_type="fixed"
+        ;;
+    feat )
+        change_type="added"
+        ;;
+    * )
+        change_type="changed"
+    esac
+    echo "${change_type}"
+}
+
+function get_default_pr_number() {
+    local existing_pr_number
+    local commit_hash
+    commit_hash=$(git show -s --format=%h)
+    existing_pr_number=$(curl -s "https://api.github.com/repos/SumoLogic/sumologic-kubernetes-collection/commits/${commit_hash}/pulls?per_page=1" | jq '.[0].number' 2>/dev/null)
+    if [[ -n "${existing_pr_number}" ]]; then
+        echo "${existing_pr_number}"
+        return
+    fi
+
+    local latest_pr_number
+    latest_pr_number=$(curl -s "https://api.github.com/repos/SumoLogic/sumologic-kubernetes-collection/issues?per_page=1" | jq '.[0].number')
+    echo "$((latest_pr_number + 1))"
+}
+
+DEFAULT_TEXT="$(git show -s --format=%s || true)"
+DEFAULT_CHANGE_TYPE="$(get_default_change_type "${DEFAULT_TEXT}")"
+DEFAULT_PR_NUMBER="$(get_default_pr_number)"
+
+echo -e "Generating changelog entry"
+
+echo -e "Enter the ID of your Pull Request."
+read -rp "Leave blank to use default (${DEFAULT_PR_NUMBER}) " PR_ID
+PR_NUMBER="${PR_ID###}"  # this removes a leading # if present
+PR_NUMBER="${PR_NUMBER:-${DEFAULT_PR_NUMBER}}"
+
+echo -e "Enter the type of your change. Available types are: breaking, changed, added, fixed"
+read -rp "Leave blank to use default (${DEFAULT_CHANGE_TYPE}) " CHANGE_TYPE
+CHANGE_TYPE="${CHANGE_TYPE:-${DEFAULT_CHANGE_TYPE}}"
+
+echo -e "Enter the text for your changelog entry."
+read -rp "Leave blank to use default (\"${DEFAULT_TEXT}\") " ENTRY_TEXT
+ENTRY_TEXT="${ENTRY_TEXT:-${DEFAULT_TEXT}}"
+
+towncrier create -c "${ENTRY_TEXT}" "${PR_NUMBER}.${CHANGE_TYPE}.txt"
+

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -2,6 +2,50 @@
 
 This document contains information helpful for developers.
 
+## Changelog management
+
+We use [Towncrier](https://towncrier.readthedocs.io) for changelog management. We keep the changelog entries for currently unreleased
+changed in the [.changelog] directory. The contents of this directory are consumed when the changelog is updated prior to a release.
+
+### Adding a changelog entry
+
+If you want to add a changelog entry for your PR, run:
+
+```bash
+make add-changelog-entry
+```
+
+You can also just create the file manually. The filename format is `<PR NUMBER>.<CHANGE TYPE>(.<FRAGMENT NUMBER>).txt`, and the content is
+the entry text.
+
+### My change doesn't need a changelog entry
+
+Add a `Skip Changelog` label to your Pull Request.
+
+### How do I update the changelog while releasing?
+
+```bash
+make update-changelog VERSION=x.x.x
+```
+
+### How do I add multiple entries for the same PR?
+
+Add a counter to your entry file names. For example, if you wanted to have three entries for PR `#123`, which is a fix, you'd create the
+following files in [.changelog]:
+
+```text
+123.fixed.0.txt
+123.fixed.1.txt
+123.fixed.2.txt
+```
+
+Unfortunately, the `towncrier create` command doesn't have support for this [yet](https://github.com/twisted/towncrier/issues/474), so you
+need to create the files manually.
+
+### How do I add an entry with multiple PR links?
+
+Just add an entry with the same text for each PR, they will be grouped together.
+
 ## Installation of non-official Helm charts
 
 | DISCLAIMER                                                                                                                                                                 |

--- a/docs/release.md
+++ b/docs/release.md
@@ -6,7 +6,7 @@ Perform the following steps in order to release new verions of helm chart.
 
 1. Prepare and merge PR with the following changes:
 
-   - update [changelog][changelog]
+   - update [changelog][changelog] by running `make update-changelog`
    - update [chart][chart]
    - update [README.md][documentation]
      - add link to minor version, if created

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,0 +1,28 @@
+[tool.towncrier]
+directory = ".changelog"
+filename = "CHANGELOG.md"
+start_string = "<!-- towncrier release notes start -->\n"
+underlines = ["", "", ""]
+template = ".changelog/changelog_template.jinja"
+title_format = "## [v{version}]"
+issue_format = "[#{issue}]"
+
+[[tool.towncrier.type]]
+directory = "breaking"
+name = "Breaking Changes"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "added"
+name = "Added"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "changed"
+name = "Changed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "fixed"
+name = "Fixed"
+showcontent = true


### PR DESCRIPTION
Use [Towncrier](https://towncrier.readthedocs.io/en/latest/index.html) for automatic changelog generation from entry files kept in `.changelog`. The specifics are described in the documentation updates.

For the current changelog, this is the block added to CHANGELOG.md after running `make update-changelog VERSION=3.1.0`:

```markdown
## [v3.1.0]

### Released 2023-02-08

### Changed

- chore: add support for EKS 1.24 [#2831]
- chore: add support for GKE 1.24 [#2832]
- feat(otelcol): add max size in batch processors [#2839]
- chore: add support for GKE 1.25 [#2848]
- chore: remove support for KOPS 1.21 [#2848]
- chore: add support for AKS 1.25 [#2848]
- chore: add support for Openshift 4.11 [#2848]
- chore: add support for KOPS 1.25 [#2848]

[#2831]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pulls/2831
[#2832]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pulls/2832
[#2839]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pulls/2839
[#2848]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pulls/2848
[v3.1.0]: https://github.com/SumoLogic/sumologic-kubernetes-collection/releases/v3.1.0
```

One difference between this generated changelog and our current manual process, is that I couldn't get Towncrier to output a github compare link, as it has no concept of a "previous version". We could fix this separately, but I'm not sure it's worth the trouble. Thoughts?

### Checklist

<!---
Remove items which don't apply to your PR.
-->

- [x] Changelog updated or skip changelog label added
- [x] Documentation updated
