### PR TITLE
fix(logs): fix metadata for pods with more than one container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- fix(logs): fix container attribute [#2863]
+
+[#2863]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2863
+[Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v3.1.0...main
+
 ## [v3.1.0]
 
 ### Released 2023-02-09

--- a/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
@@ -181,7 +181,6 @@ processors:
     extract:
       metadata:
         ## extract the following well-known metadata fields
-        - containerName
         - daemonSetName
         - deploymentName
         - hostName

--- a/tests/helm/metadata_logs_otc/static/otel.output.yaml
+++ b/tests/helm/metadata_logs_otc/static/otel.output.yaml
@@ -208,7 +208,6 @@ data:
           - key: '*'
             tag_name: pod_labels_%s
           metadata:
-          - containerName
           - daemonSetName
           - deploymentName
           - hostName

--- a/tests/helm/metadata_logs_otc/static/templates.output.yaml
+++ b/tests/helm/metadata_logs_otc/static/templates.output.yaml
@@ -208,7 +208,6 @@ data:
           - key: '*'
             tag_name: pod_labels_%s
           metadata:
-          - containerName
           - daemonSetName
           - deploymentName
           - hostName


### PR DESCRIPTION
Fixes #2862
The `containerName` metadata extraction gives incorrect results for pods with more than one containers.
We don't need this extraction anyway, because container logs already have the `k8s.container.name` attribute from log file name.
