### PR TITLE
feat: disable otel storage compaction on start

### DIFF
--- a/.changelog/2870.changed.txt
+++ b/.changelog/2870.changed.txt
@@ -1,0 +1,1 @@
+feat: disable otel storage compaction on start

--- a/deploy/helm/sumologic/conf/logs/collector/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/collector/otelcol/config.yaml
@@ -4,7 +4,6 @@ extensions:
     directory: /var/lib/storage/otc
     timeout: 10s
     compaction:
-      on_start: true
       on_rebound: true
       # Can't be /tmp yet, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13449
       directory: /var/lib/storage/otc

--- a/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
@@ -18,7 +18,6 @@ extensions:
     directory: /var/lib/storage/otc
     timeout: 10s
     compaction:
-      on_start: true
       on_rebound: true
       # Can't be /tmp yet, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13449
       directory: /var/lib/storage/otc

--- a/deploy/helm/sumologic/conf/metrics/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/metrics/otelcol/config.yaml
@@ -26,7 +26,6 @@ extensions:
     directory: /var/lib/storage/otc
     timeout: 10s
     compaction:
-      on_start: true
       on_rebound: true
       # Can't be /tmp yet, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13449
       directory: /var/lib/storage/otc

--- a/tests/helm/logs_otc/static/basic.output.yaml
+++ b/tests/helm/logs_otc/static/basic.output.yaml
@@ -19,7 +19,6 @@ data:
         compaction:
           directory: /var/lib/storage/otc
           on_rebound: true
-          on_start: true
         directory: /var/lib/storage/otc
         timeout: 10s
       health_check: {}

--- a/tests/helm/logs_otc/static/options.output.yaml
+++ b/tests/helm/logs_otc/static/options.output.yaml
@@ -19,7 +19,6 @@ data:
         compaction:
           directory: /var/lib/storage/otc
           on_rebound: true
-          on_start: true
         directory: /var/lib/storage/otc
         timeout: 10s
       health_check: {}

--- a/tests/helm/metadata_logs_otc/static/otel.output.yaml
+++ b/tests/helm/metadata_logs_otc/static/otel.output.yaml
@@ -41,7 +41,6 @@ data:
         compaction:
           directory: /var/lib/storage/otc
           on_rebound: true
-          on_start: true
         directory: /var/lib/storage/otc
         timeout: 10s
       health_check: {}

--- a/tests/helm/metadata_logs_otc/static/templates.output.yaml
+++ b/tests/helm/metadata_logs_otc/static/templates.output.yaml
@@ -41,7 +41,6 @@ data:
         compaction:
           directory: /var/lib/storage/otc
           on_rebound: true
-          on_start: true
         directory: /var/lib/storage/otc
         timeout: 10s
       health_check: {}

--- a/tests/helm/metadata_metrics_otc/static/additional_endpoints.output.yaml
+++ b/tests/helm/metadata_metrics_otc/static/additional_endpoints.output.yaml
@@ -97,7 +97,6 @@ data:
         compaction:
           directory: /var/lib/storage/otc
           on_rebound: true
-          on_start: true
         directory: /var/lib/storage/otc
         timeout: 10s
       health_check: {}

--- a/tests/helm/metadata_metrics_otc/static/basic.output.yaml
+++ b/tests/helm/metadata_metrics_otc/static/basic.output.yaml
@@ -97,7 +97,6 @@ data:
         compaction:
           directory: /var/lib/storage/otc
           on_rebound: true
-          on_start: true
         directory: /var/lib/storage/otc
         timeout: 10s
       health_check: {}


### PR DESCRIPTION
With on_rebound compaction enabled, this isn't necessary anymore, and it causes long startup times when the queue is large.


### Checklist

- [X] Changelog updated or skip changelog label added