### PR TITLE
ci(changelog): fix changelog check

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -18,9 +18,11 @@ jobs:
       PR_NUMBER: ${{ github.event.number }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 50
       - name: Add PR base ref
         run: |
-          git fetch origin ${{ github.base_ref }} --depth=1
+          git fetch origin ${{ github.base_ref }} --depth=50
       - name: install towncrier
         run: pip install towncrier==${{ env.TOWNCRIER_VERSION }}
       - name: Check if new CHANGELOG entries added
@@ -28,4 +30,4 @@ jobs:
           make check-changelog
       - name: Check if new CHANGELOG entries reference the correct PR
         run: |
-          git diff --name-only ${{ github.base_ref }} HEAD .changelog | grep ${PR_NUMBER}
+          git diff --name-only origin/${{ github.base_ref }} HEAD .changelog | grep ${PR_NUMBER}


### PR DESCRIPTION
Fixing an issue with #2850. Towncrier actually uses a proper diff for the check, so we need history between the PR branch and `main`. I've set the depth to 50 to avoid cloning the entire thing.

Also fixed the check for the PR number.

### Checklist
- [X] Changelog updated or skip changelog label added
