### PR TITLE
feat: use /tmp for otel storage compaction

### DIFF
--- a/.changelog/2873.changed.txt
+++ b/.changelog/2873.changed.txt
@@ -1,0 +1,1 @@
+feat: use /tmp for otel storage compaction

--- a/deploy/helm/sumologic/conf/logs/collector/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/collector/otelcol/config.yaml
@@ -5,7 +5,6 @@ extensions:
     timeout: 10s
     compaction:
       on_rebound: true
-      # Can't be /tmp yet, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13449
       directory: /var/lib/storage/otc
   pprof: {}
 service:

--- a/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
@@ -19,8 +19,7 @@ extensions:
     timeout: 10s
     compaction:
       on_rebound: true
-      # Can't be /tmp yet, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13449
-      directory: /var/lib/storage/otc
+      directory: /tmp
 {{ end }}
   pprof: {}
 exporters:

--- a/deploy/helm/sumologic/conf/metrics/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/metrics/otelcol/config.yaml
@@ -27,8 +27,7 @@ extensions:
     timeout: 10s
     compaction:
       on_rebound: true
-      # Can't be /tmp yet, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13449
-      directory: /var/lib/storage/otc
+      directory: /tmp
 {{ end }}
   pprof: {}
 exporters:

--- a/deploy/helm/sumologic/templates/logs/otelcol/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/logs/otelcol/statefulset.yaml
@@ -97,6 +97,8 @@ spec:
       - name: config-volume
         configMap:
           name: {{ template "sumologic.metadata.name.logs.configmap" . }}
+      - name: tmp
+        emptyDir: {}
 {{- if .Values.metadata.logs.statefulset.extraVolumes }}
 {{ toYaml .Values.metadata.logs.statefulset.extraVolumes | indent 6 }}
 {{- end }}
@@ -149,6 +151,8 @@ spec:
         - name: config-volume
           mountPath: /etc/otel/config.yaml
           subPath: config.yaml
+        - name: tmp
+          mountPath: /tmp
 {{- if .Values.metadata.persistence.enabled }}
         - name: file-storage
           mountPath: /var/lib/storage/otc

--- a/deploy/helm/sumologic/templates/metrics/otelcol/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics/otelcol/statefulset.yaml
@@ -97,6 +97,8 @@ spec:
       - name: config-volume
         configMap:
           name: {{ template "sumologic.metadata.name.metrics.configmap" . }}
+      - name: tmp
+        emptyDir: {}
 {{- if .Values.metadata.metrics.statefulset.extraVolumes }}
 {{ toYaml .Values.metadata.metrics.statefulset.extraVolumes | indent 6 }}
 {{- end }}
@@ -146,6 +148,8 @@ spec:
         - name: config-volume
           mountPath: /etc/otel/config.yaml
           subPath: config.yaml
+        - name: tmp
+          mountPath: /tmp
 {{- if .Values.metadata.persistence.enabled }}
         - name: file-storage
           mountPath: /var/lib/storage/otc

--- a/tests/helm/metadata_logs_otc/static/otel.output.yaml
+++ b/tests/helm/metadata_logs_otc/static/otel.output.yaml
@@ -39,7 +39,7 @@ data:
     extensions:
       file_storage:
         compaction:
-          directory: /var/lib/storage/otc
+          directory: /tmp
           on_rebound: true
         directory: /var/lib/storage/otc
         timeout: 10s

--- a/tests/helm/metadata_logs_otc/static/templates.output.yaml
+++ b/tests/helm/metadata_logs_otc/static/templates.output.yaml
@@ -39,7 +39,7 @@ data:
     extensions:
       file_storage:
         compaction:
-          directory: /var/lib/storage/otc
+          directory: /tmp
           on_rebound: true
         directory: /var/lib/storage/otc
         timeout: 10s

--- a/tests/helm/metadata_logs_otc_statefulset/static/basic.output.yaml
+++ b/tests/helm/metadata_logs_otc_statefulset/static/basic.output.yaml
@@ -56,6 +56,8 @@ spec:
         - name: config-volume
           configMap:
             name: RELEASE-NAME-sumologic-otelcol-logs
+        - name: tmp
+          emptyDir: {}
         - name: es-certs
           secret:
             defaultMode: 420
@@ -115,6 +117,8 @@ spec:
             - name: config-volume
               mountPath: /etc/otel/config.yaml
               subPath: config.yaml
+            - name: tmp
+              mountPath: /tmp
             - name: file-storage
               mountPath: /var/lib/storage/otc
             - mountPath: /certs

--- a/tests/helm/metadata_metrics_otc/static/additional_endpoints.output.yaml
+++ b/tests/helm/metadata_metrics_otc/static/additional_endpoints.output.yaml
@@ -95,7 +95,7 @@ data:
     extensions:
       file_storage:
         compaction:
-          directory: /var/lib/storage/otc
+          directory: /tmp
           on_rebound: true
         directory: /var/lib/storage/otc
         timeout: 10s

--- a/tests/helm/metadata_metrics_otc/static/basic.output.yaml
+++ b/tests/helm/metadata_metrics_otc/static/basic.output.yaml
@@ -95,7 +95,7 @@ data:
     extensions:
       file_storage:
         compaction:
-          directory: /var/lib/storage/otc
+          directory: /tmp
           on_rebound: true
         directory: /var/lib/storage/otc
         timeout: 10s

--- a/tests/helm/metadata_metrics_otc_statefulset/static/basic.output.yaml
+++ b/tests/helm/metadata_metrics_otc_statefulset/static/basic.output.yaml
@@ -56,6 +56,8 @@ spec:
         - name: config-volume
           configMap:
             name: RELEASE-NAME-sumologic-otelcol-metrics
+        - name: tmp
+          emptyDir: {}
         - name: es-certs
           secret:
             defaultMode: 420
@@ -112,6 +114,8 @@ spec:
             - name: config-volume
               mountPath: /etc/otel/config.yaml
               subPath: config.yaml
+            - name: tmp
+              mountPath: /tmp
             - name: file-storage
               mountPath: /var/lib/storage/otc
             - mountPath: /certs


### PR DESCRIPTION
It's now possible to put the compaction directory on a different filesystem. Do this for metadata file storage extensions. This required manually adding `emptyDir` volumes at `/tmp`, as distroless containers don't have it by default.

### Checklist

- [X] Changelog updated or skip changelog label added