### PR TITLE
feat(instrumentation): scrape label added and updated

### DIFF
--- a/.changelog/2875.fixed.txt
+++ b/.changelog/2875.fixed.txt
@@ -1,0 +1,5 @@
+feat(instrumentation): scrape label added and updated
+
+Fixed [#2875] Scrape label value changed and added to the otelagent service.
+
+[#2875]: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2875

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 <!-- towncrier release notes start -->
 
+## [Unreleased]
+
+### Released TBA
+
+### Changed
+
+- feat(instrumentation): scrape label added and updated [#2875]
+
+[#2875]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2875
+[Unreleased]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v3.1.0...main
+
 ## [v3.1.0]
 
 ### Released 2023-02-09

--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -683,8 +683,8 @@ sumologic.com/app: otelcol-events
 sumologic.com/component: events
 {{- end -}}
 
-{{- define "sumologic.labels.traces.component" -}}
-sumologic.com/component: traces
+{{- define "sumologic.labels.instrumentation.component" -}}
+sumologic.com/component: instrumentation
 {{- end -}}
 
 {{- define "sumologic.labels.logs.collector" -}}
@@ -713,7 +713,7 @@ sumologic.com/scrape: "true"
 
 {{- define "sumologic.labels.scrape.instrumentation" -}}
 {{ template "sumologic.label.scrape" . }}
-{{ template "sumologic.labels.traces.component" . }}
+{{ template "sumologic.labels.instrumentation.component" . }}
 {{- end -}}
 
 {{- define "sumologic.labels.scrape.logs.collector" -}}

--- a/deploy/helm/sumologic/templates/instrumentation/otelcol-instrumentation/service-otelagent.yaml
+++ b/deploy/helm/sumologic/templates/instrumentation/otelcol-instrumentation/service-otelagent.yaml
@@ -8,6 +8,7 @@ metadata:
   name: {{ template "sumologic.metadata.name.instrumentation.otelagent.service" . }}
   labels:
     app: {{ template "sumologic.labels.app.otelcolinstrumentation.service" . }}
+    {{- include "sumologic.labels.scrape.instrumentation" . | nindent 4 }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   selector:


### PR DESCRIPTION
PR adds scrape labels to service related to `otelcol-instrumentation`. Label value changed from `traces` -> `instrumentation`.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features
