### PR TITLE
fix(busybox): do not use latest tag img

### DIFF
--- a/.changelog/2893.fixed.txt
+++ b/.changelog/2893.fixed.txt
@@ -1,1 +1,1 @@
-fix(busybox): use exact version of busybox img"
+fix(busybox): use exact version of busybox img

--- a/.changelog/2893.fixed.txt
+++ b/.changelog/2893.fixed.txt
@@ -1,0 +1,1 @@
+fix(busybox): use exact version of busybox img"

--- a/deploy/helm/sumologic/templates/logs/collector/otelcol/daemonset.yaml
+++ b/deploy/helm/sumologic/templates/logs/collector/otelcol/daemonset.yaml
@@ -124,7 +124,9 @@ spec:
           protocol: TCP
       initContainers: # ensure the host path is owned by the otel user group
       - name: changeowner
-        image: public.ecr.aws/docker/library/busybox:latest
+        # yamllint disable-line rule:line-length
+        image: {{ $.Values.otellogs.daemonset.initContainers.changeowner.image.repository }}:{{ $.Values.otellogs.daemonset.initContainers.changeowner.image.tag }}
+        imagePullPolicy: {{ $.Values.otellogs.daemonset.initContainers.changeowner.image.pullPolicy }}
         securityContext:
           {{- toYaml $.Values.otellogs.daemonset.initContainers.changeowner.securityContext | nindent 10 }}
         command:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -4306,9 +4306,13 @@ otellogs:
             drop:
               - ALL
 
-    ## Set securityContext for initContainers running in pods in log collector daemonset
+    ## Set securityContext and image for initContainers running in pods in log collector daemonset
     initContainers:
       changeowner:
+        image:
+          repository: "public.ecr.aws/docker/library/busybox"
+          tag: "1.36.0"
+          pullPolicy: IfNotPresent
         securityContext:
           capabilities:
             drop:
@@ -4411,7 +4415,7 @@ falco:
     initContainers:
       ## Add initContainer to wait until kernel-devel is installed on host
       - name: init-falco
-        image: public.ecr.aws/docker/library/busybox:latest
+        image: public.ecr.aws/docker/library/busybox:1.36.0
         command:
           - "sh"
           - "-c"

--- a/tests/helm/logs_otc_daemonset/static/additional.output.yaml
+++ b/tests/helm/logs_otc_daemonset/static/additional.output.yaml
@@ -95,7 +95,8 @@ spec:
               protocol: TCP
       initContainers: # ensure the host path is owned by the otel user group
         - name: changeowner
-          image: public.ecr.aws/docker/library/busybox:latest
+          image: public.ecr.aws/docker/library/busybox:1.36.0
+          imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
               drop:
@@ -228,7 +229,8 @@ spec:
               protocol: TCP
       initContainers: # ensure the host path is owned by the otel user group
         - name: changeowner
-          image: public.ecr.aws/docker/library/busybox:latest
+          image: public.ecr.aws/docker/library/busybox:1.36.0
+          imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
               drop:

--- a/tests/helm/logs_otc_daemonset/static/basic.output.yaml
+++ b/tests/helm/logs_otc_daemonset/static/basic.output.yaml
@@ -87,7 +87,8 @@ spec:
               protocol: TCP
       initContainers: # ensure the host path is owned by the otel user group
         - name: changeowner
-          image: public.ecr.aws/docker/library/busybox:latest
+          image: public.ecr.aws/docker/library/busybox:1.36.0
+          imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
               drop:

--- a/tests/helm/logs_otc_daemonset/static/complex.output.yaml
+++ b/tests/helm/logs_otc_daemonset/static/complex.output.yaml
@@ -109,7 +109,8 @@ spec:
               protocol: TCP
       initContainers: # ensure the host path is owned by the otel user group
         - name: changeowner
-          image: public.ecr.aws/docker/library/busybox:latest
+          image: public.ecr.aws/docker/library/busybox:1.36.0
+          imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
               drop:

--- a/tests/integration/yamls/multiline-logs-generator.yaml
+++ b/tests/integration/yamls/multiline-logs-generator.yaml
@@ -39,7 +39,7 @@ metadata:
 spec:
   containers:
     - name: example-container-multiline-logs-long-lines
-      image: public.ecr.aws/docker/library/busybox:latest
+      image: public.ecr.aws/docker/library/busybox:1.36.0
       args:
         - /bin/sh
         - /multiline-logs-generator/multiline-generator.sh


### PR DESCRIPTION
PR changes the tag from `latest` to specific version for busybox img.

PR fixes https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2763

### Checklist

- [ ] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features
