### PR TITLE
fix: collect the right kube-scheduler metrics

### DIFF
--- a/.changelog/2896.fixed.txt
+++ b/.changelog/2896.fixed.txt
@@ -1,0 +1,1 @@
+fix: collect the right kube-scheduler metrics

--- a/ci/add-changelog-entry.sh
+++ b/ci/add-changelog-entry.sh
@@ -28,7 +28,7 @@ function get_default_pr_number() {
     local commit_hash
     commit_hash=$(git show -s --format=%h)
     existing_pr_number=$(curl -s "https://api.github.com/repos/SumoLogic/sumologic-kubernetes-collection/commits/${commit_hash}/pulls?per_page=1" | jq '.[0].number' 2>/dev/null)
-    if [[ -n "${existing_pr_number}" ]]; then
+    if [[ -n "${existing_pr_number}" && "${existing_pr_number}" != "null" ]]; then
         echo "${existing_pr_number}"
         return
     fi

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1752,6 +1752,7 @@ kube-prometheus-stack:
       ## scheduler_scheduling_attempt_duration_seconds_bucket
       ## scheduler_scheduling_attempt_duration_seconds_count
       ## scheduler_scheduling_attempt_duration_seconds_sum
+      ##
       ## scheduler_framework_extension_point_duration_seconds_bucket
       ## scheduler_framework_extension_point_duration_seconds_count
       ## scheduler_framework_extension_point_duration_seconds_sum

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1742,13 +1742,16 @@ kube-prometheus-stack:
       ## Scrape interval. If not set, the Prometheus default scrape interval is used.
       interval:
       ## see docs/scraped_metrics.md
-      ## scheduler metrics_latency_microseconds
+      ##
+      ## scheduler_e2e_* is present for K8s <1.23
       ## scheduler_e2e_scheduling_duration_seconds_bucket
       ## scheduler_e2e_scheduling_duration_seconds_count
       ## scheduler_e2e_scheduling_duration_seconds_sum
-      ## scheduler_binding_duration_seconds_bucket
-      ## scheduler_binding_duration_seconds_count
-      ## scheduler_binding_duration_seconds_sum
+      ##
+      ## scheduler_scheduling_attempt_duration_seconds is present for K8s >=1.23
+      ## scheduler_scheduling_attempt_duration_seconds_bucket
+      ## scheduler_scheduling_attempt_duration_seconds_count
+      ## scheduler_scheduling_attempt_duration_seconds_sum
       ## scheduler_framework_extension_point_duration_seconds_bucket
       ## scheduler_framework_extension_point_duration_seconds_count
       ## scheduler_framework_extension_point_duration_seconds_sum
@@ -1757,7 +1760,7 @@ kube-prometheus-stack:
       ## scheduler_scheduling_algorithm_duration_seconds_sum
       metricRelabelings:
         - action: keep
-          regex: (?:scheduler_(?:e2e_scheduling|binding|framework_extension_point|scheduling_algorithm)_duration_seconds.*)
+          regex: (?:scheduler_(?:e2e_scheduling|scheduling_attempt|framework_extension_point|scheduling_algorithm)_duration_seconds.*)
           sourceLabels: [__name__]
   kubeStateMetrics:
     serviceMonitor:
@@ -2097,13 +2100,17 @@ kube-prometheus-stack:
             - action: keep
               regex: kubelet;cloudprovider_.*_api_request_duration_seconds.*
               sourceLabels: [job, __name__]
-        ## scheduler metrics_latency_microseconds
+        ## scheduler metrics
+        ##
+        ## scheduler_e2e_* is present for K8s <1.23
         ## scheduler_e2e_scheduling_duration_seconds_bucket
         ## scheduler_e2e_scheduling_duration_seconds_count
         ## scheduler_e2e_scheduling_duration_seconds_sum
-        ## scheduler_binding_duration_seconds_bucket
-        ## scheduler_binding_duration_seconds_count
-        ## scheduler_binding_duration_seconds_sum
+        ##
+        ## scheduler_scheduling_attempt_duration_seconds is present for K8s >=1.23
+        ## scheduler_scheduling_attempt_duration_seconds_bucket
+        ## scheduler_scheduling_attempt_duration_seconds_count
+        ## scheduler_scheduling_attempt_duration_seconds_sum
         ## scheduler_framework_extension_point_duration_seconds_bucket
         ## scheduler_framework_extension_point_duration_seconds_count
         ## scheduler_framework_extension_point_duration_seconds_sum
@@ -2114,7 +2121,7 @@ kube-prometheus-stack:
           remoteTimeout: 5s
           writeRelabelConfigs:
             - action: keep
-              regex: kube-scheduler;scheduler_(?:e2e_scheduling|binding|framework_extension_point|scheduling_algorithm)_duration_seconds.*
+              regex: kube-scheduler;scheduler_(?:e2e_scheduling|scheduling_attempt|framework_extension_point|scheduling_algorithm)_duration_seconds.*
               sourceLabels: [job, __name__]
         ## api server metrics:
         ## apiserver_request_count

--- a/tests/integration/internal/constants.go
+++ b/tests/integration/internal/constants.go
@@ -86,15 +86,21 @@ var (
 		"kubelet_running_pods",
 	}
 	KubeSchedulerMetrics = []string{
-		"scheduler_e2e_scheduling_duration_seconds_count",
-		"scheduler_e2e_scheduling_duration_seconds_sum",
-		"scheduler_e2e_scheduling_duration_seconds_bucket",
+		// TODO: check different metrics depending on K8s version
+		// scheduler_scheduling_duration_seconds is present for K8s <1.23
+		// scheduler_scheduling_attempt_duration_seconds is present for K8s >=1.23
+		// "scheduler_e2e_scheduling_duration_seconds_count",
+		// "scheduler_e2e_scheduling_duration_seconds_sum",
+		// "scheduler_e2e_scheduling_duration_seconds_bucket",
+		// "scheduler_scheduling_attempt_duration_seconds_count",
+		// "scheduler_scheduling_attempt_duration_seconds_sum",
+		// "scheduler_scheduling_attempt_duration_seconds_bucket",
 		"scheduler_scheduling_algorithm_duration_seconds_count",
 		"scheduler_scheduling_algorithm_duration_seconds_sum",
 		"scheduler_scheduling_algorithm_duration_seconds_bucket",
-		// Deprecated in Kubernetes 1.21: https://github.com/kubernetes/kubernetes/pull/96447
-		// TODO: Remove this and the values.yaml settings after we drop support for 1.20
-		// "scheduler_binding_duration_seconds",
+		"scheduler_framework_extension_point_duration_seconds_bucket",
+		"scheduler_framework_extension_point_duration_seconds_count",
+		"scheduler_framework_extension_point_duration_seconds_sum",
 	}
 	KubeApiServerMetrics = []string{
 		"apiserver_request_total",
@@ -202,7 +208,7 @@ var (
 		KubeletMetrics,
 		// See: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2079
 		// TODO: Enable this again after the above issue is resolved
-		// KubeSchedulerMetrics,
+		KubeSchedulerMetrics,
 		KubeApiServerMetrics,
 		KubeEtcdMetrics,
 		// Need to upgrade kube-prometheus stack to use the secure metrics endpoint for controller metrics

--- a/tests/integration/values/values_common.yaml
+++ b/tests/integration/values/values_common.yaml
@@ -34,6 +34,18 @@ kube-prometheus-stack:
     service:
       targetPort: 2381
 
+  # starting with K8s 1.23, the scheduler uses a secure port for metrics
+  # kube-prometheus-stack sets the default port based on the version
+  # however, kind uses kubeadm, which uses the secure port for 1.21 and 1.22 as well
+  # TODO: delete this after we drop support for 1.22
+  kubeScheduler:
+    service:
+      port: 10259
+      targetPort: 10259
+    serviceMonitor:
+      https: true
+      insecureSkipVerify: true
+
 # Request less resources so that this fits on Github actions runners environment
 metadata:
   persistence:

--- a/tests/integration/yamls/cluster.yaml
+++ b/tests/integration/yamls/cluster.yaml
@@ -11,7 +11,6 @@ nodes:
         scheduler:
             extraArgs:
               bind-address: 0.0.0.0
-              secure-port: "10251"
         controllerManager:
             extraArgs:
               bind-address: 0.0.0.0


### PR DESCRIPTION
Some of the kube-scheduler metrics we've been collecting have been removed in Kubernetes 1.23. Collect the replacement metric as well. I've also re-added checking scheduler metrics in integration tests.

Also fixed an issue with the changelog entry script.

This also fixes https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2079

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [X] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [X] Integration tests added or modified for major features
