### PR TITLE
chore(metrics): remove deprecated apiserver metrics

### DIFF
--- a/.changelog/2898.changed.txt
+++ b/.changelog/2898.changed.txt
@@ -1,0 +1,1 @@
+chore(metrics): remove deprecated apiserver metrics

--- a/ci/add-changelog-entry.sh
+++ b/ci/add-changelog-entry.sh
@@ -34,7 +34,7 @@ function get_default_pr_number() {
     fi
 
     local latest_pr_number
-    latest_pr_number=$(curl -s "https://api.github.com/repos/SumoLogic/sumologic-kubernetes-collection/issues?per_page=1" | jq '.[0].number')
+    latest_pr_number=$(curl -s "https://api.github.com/repos/SumoLogic/sumologic-kubernetes-collection/issues?state=all&per_page=1" | jq '.[0].number')
     echo "$((latest_pr_number + 1))"
 }
 

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1590,17 +1590,12 @@ kube-prometheus-stack:
       ## see docs/scraped_metrics.md
       ## apiserver_request_count
       ## apiserver_request_total
-      ## apiserver_request_duration_seconds_count
       ## apiserver_request_duration_seconds_bucket
+      ## apiserver_request_duration_seconds_count
       ## apiserver_request_duration_seconds_sum
-      ## apiserver_request_latencies_count
-      ## apiserver_request_latencies_sum
-      ## apiserver_request_latencies_summary
-      ## apiserver_request_latencies_summary_count
-      ## apiserver_request_latencies_summary_sum
       metricRelabelings:
         - action: keep
-          regex: (?:apiserver_request_(?:count|total)|apiserver_request_(?:duration_seconds|latencies)_(?:count|sum)|apiserver_request_latencies_summary(?:|_count|_sum)|apiserver_request_duration_seconds_bucket)
+          regex: (?:apiserver_request_(?:count|total)|apiserver_request_(?:duration_seconds)_(?:count|sum|bucket))
           sourceLabels: [__name__]
   kubelet:
     serviceMonitor:
@@ -2127,13 +2122,9 @@ kube-prometheus-stack:
         ## api server metrics:
         ## apiserver_request_count
         ## apiserver_request_total
+        ## apiserver_request_duration_seconds_bucket
         ## apiserver_request_duration_seconds_count
         ## apiserver_request_duration_seconds_sum
-        ## apiserver_request_latencies_count
-        ## apiserver_request_latencies_sum
-        ## apiserver_request_latencies_summary
-        ## apiserver_request_latencies_summary_count
-        ## apiserver_request_latencies_summary_sum
         ## etcd_request_cache_get_duration_seconds_count
         ## etcd_request_cache_get_duration_seconds_sum
         ## etcd_request_cache_add_duration_seconds_count
@@ -2150,7 +2141,7 @@ kube-prometheus-stack:
           remoteTimeout: 5s
           writeRelabelConfigs:
             - action: keep
-              regex: apiserver;(?:apiserver_request_(?:count|total)|apiserver_request_(?:duration_seconds|latencies)_(?:count|sum)|apiserver_request_latencies_summary(?:|_count|_sum)|etcd_request_cache_(?:add|get)_(?:duration_seconds|latencies_summary)_(?:count|sum)|etcd_helper_cache_(?:hit|miss)_(?:count|total))
+              regex: apiserver;(?:apiserver_request_(?:count|total)|apiserver_request_(?:duration_seconds)_(?:count|sum|bucket)|etcd_helper_cache_(?:hit|miss)_(?:count|total))
               sourceLabels: [job, __name__]
         ## kubelet metrics:
         ## kubelet_docker_operations_errors

--- a/tests/integration/internal/constants.go
+++ b/tests/integration/internal/constants.go
@@ -106,17 +106,7 @@ var (
 		"apiserver_request_total",
 		"apiserver_request_duration_seconds_count",
 		"apiserver_request_duration_seconds_sum",
-		// We have the following metrics in our values.yaml, but they've been deprecated for a while
-		// Kubernetes 1.14 deprecation notice:
-		// https://github.com/kubernetes/kubernetes/blob/8ac5d4d6a92d59bba70844fbd6e5de2383a08c96/CHANGELOG/CHANGELOG-1.14.md#deprecated-metrics
-		// Kubernetes 1.17 disablement notice:
-		// https://github.com/kubernetes/kubernetes/blob/ea0764452222146c47ec826977f49d7001b0ea8c/CHANGELOG/CHANGELOG-1.17.md#deprecatedchanged-metrics
-		// TODO: Remove these from values.yaml and replace them with non-deprecated equivalents
-		// "apiserver_request_latencies_count",
-		// "apiserver_request_latencies_sum",
-		// "apiserver_request_latencies_summary",
-		// "apiserver_request_latencies_summary_count",
-		// "apiserver_request_latencies_summary_sum",
+		"apiserver_request_duration_seconds_bucket",
 	}
 	KubeEtcdMetrics = []string{
 		// Deprecated in etcd v3: https://github.com/kubernetes/kubernetes/pull/79520


### PR DESCRIPTION
`apiserver_request_latencies_*` metrics were deprecated in 1.14 and disabled in 1.17. The current replacement are `apiserver_request_duration_*`. Enable checking these in integration tests.

Fix another small issue in the changelog generation script as well.

### Checklist

- [X] Changelog updated or skip changelog label added
- [X] Integration tests added or modified for major features
