### PR TITLE
chore(metrics): remove deprecated coredns and etcd metrics

### DIFF
--- a/.changelog/2899.changed.txt
+++ b/.changelog/2899.changed.txt
@@ -1,0 +1,1 @@
+chore(metrics): remove deprecated coredns and etcd metrics

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1673,24 +1673,23 @@ kube-prometheus-stack:
       interval:
       ## see docs/scraped_metrics.md
       ## coredns:
-      ## coredns_cache_size
       ## coredns_cache_entries
       ## coredns_cache_hits_total
       ## coredns_cache_misses_total
       ## coredns_dns_request_duration_seconds_count
       ## coredns_dns_request_duration_seconds_sum
-      ## coredns_dns_request_count_total
       ## coredns_dns_requests_total
-      ## coredns_dns_response_rcode_count_total
       ## coredns_dns_responses_total
-      ## coredns_forward_request_count_total
       ## coredns_forward_requests_total
+      ## process_cpu_seconds_total
+      ## process_open_fds
+      ## process_resident_memory_bytes
       ## process_cpu_seconds_total
       ## process_open_fds
       ## process_resident_memory_bytes
       metricRelabelings:
         - action: keep
-          regex: (?:coredns_cache_(size|entries|(hits|misses)_total)|coredns_dns_request_duration_seconds_(count|sum)|coredns_(dns_request|dns_response_rcode|forward_request)_count_total|coredns_(forward_requests|dns_requests|dns_responses)_total|process_(cpu_seconds_total|open_fds|resident_memory_bytes))
+          regex: (?:coredns_cache_(entries|(hits|misses)_total)|coredns_dns_request_duration_seconds_(count|sum)|coredns_(forward_requests|dns_requests|dns_responses)_total|process_(cpu_seconds_total|open_fds|resident_memory_bytes))
           sourceLabels: [__name__]
   kubeEtcd:
     serviceMonitor:
@@ -2313,17 +2312,13 @@ kube-prometheus-stack:
               sourceLabels: [__name__]
         ## control plane metrics
         ## coredns:
-        ## coredns_cache_size
         ## coredns_cache_entries
         ## coredns_cache_hits_total
         ## coredns_cache_misses_total
         ## coredns_dns_request_duration_seconds_count
         ## coredns_dns_request_duration_seconds_sum
-        ## coredns_dns_request_count_total
         ## coredns_dns_requests_total
-        ## coredns_dns_response_rcode_count_total
         ## coredns_dns_responses_total
-        ## coredns_forward_request_count_total
         ## coredns_forward_requests_total
         ## process_cpu_seconds_total
         ## process_open_fds
@@ -2332,7 +2327,7 @@ kube-prometheus-stack:
           remoteTimeout: 5s
           writeRelabelConfigs:
             - action: keep
-              regex: coredns;(?:coredns_cache_(size|entries|(hits|misses)_total)|coredns_dns_request_duration_seconds_(count|sum)|coredns_(dns_request|dns_response_rcode|forward_request)_count_total|coredns_(forward_requests|dns_requests|dns_responses)_total|process_(cpu_seconds_total|open_fds|resident_memory_bytes))
+              regex: coredns;(?:coredns_cache_(entries|(hits|misses)_total)|coredns_dns_request_duration_seconds_(count|sum)|coredns_(forward_requests|dns_requests|dns_responses)_total|process_(cpu_seconds_total|open_fds|resident_memory_bytes))
               sourceLabels: [job, __name__]
         ## etcd server:
         ## etcd_mvcc_db_total_size_in_bytes

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1710,7 +1710,7 @@ kube-prometheus-stack:
       ## etcd_helper_cache_miss_count
       ## etcd_helper_cache_miss_total
       ## etcd server:
-      ## etcd_debugging_mvcc_db_total_size_in_bytes
+      ## etcd_mvcc_db_total_size_in_bytes
       ## etcd_debugging_store_expires_total
       ## etcd_debugging_store_watchers
       ## etcd_disk_backend_commit_duration_seconds_bucket
@@ -1730,7 +1730,7 @@ kube-prometheus-stack:
       ## process_resident_memory_bytes
       metricRelabelings:
         - action: keep
-          regex: (?:etcd_request_cache_(?:add|get)_(?:duration_seconds|latencies_summary)_(?:count|sum)|etcd_helper_cache_(?:hit|miss)_(?:count|total)|etcd_debugging_(mvcc_db_total_size_in_bytes|store_(expires_total|watchers))|etcd_disk_(backend_commit|wal_fsync)_duration_seconds_bucket|etcd_grpc_proxy_cache_(hits|misses)_total|etcd_network_client_grpc_(received|sent)_bytes_total|etcd_server_(has_leader|leader_changes_seen_total)|etcd_server_proposals_(pending|(applied|committed|failed)_total)|process_(cpu_seconds_total|open_fds|resident_memory_bytes))
+          regex: (?:etcd_request_cache_(?:add|get)_(?:duration_seconds|latencies_summary)_(?:count|sum)|etcd_helper_cache_(?:hit|miss)_(?:count|total)|etcd_mvcc_db_total_size_in_bytes|etcd_debugging_(store_(expires_total|watchers))|etcd_disk_(backend_commit|wal_fsync)_duration_seconds_bucket|etcd_grpc_proxy_cache_(hits|misses)_total|etcd_network_client_grpc_(received|sent)_bytes_total|etcd_server_(has_leader|leader_changes_seen_total)|etcd_server_proposals_(pending|(applied|committed|failed)_total)|process_(cpu_seconds_total|open_fds|resident_memory_bytes))
           sourceLabels: [__name__]
   kubeScheduler:
     serviceMonitor:
@@ -2335,7 +2335,7 @@ kube-prometheus-stack:
               regex: coredns;(?:coredns_cache_(size|entries|(hits|misses)_total)|coredns_dns_request_duration_seconds_(count|sum)|coredns_(dns_request|dns_response_rcode|forward_request)_count_total|coredns_(forward_requests|dns_requests|dns_responses)_total|process_(cpu_seconds_total|open_fds|resident_memory_bytes))
               sourceLabels: [job, __name__]
         ## etcd server:
-        ## etcd_debugging_mvcc_db_total_size_in_bytes
+        ## etcd_mvcc_db_total_size_in_bytes
         ## etcd_debugging_store_expires_total
         ## etcd_debugging_store_watchers
         ## etcd_disk_backend_commit_duration_seconds_bucket
@@ -2357,7 +2357,7 @@ kube-prometheus-stack:
           remoteTimeout: 5s
           writeRelabelConfigs:
             - action: keep
-              regex: kube-etcd;(?:etcd_debugging_(mvcc_db_total_size_in_bytes|store_(expires_total|watchers))|etcd_disk_(backend_commit|wal_fsync)_duration_seconds_bucket|etcd_grpc_proxy_cache_(hits|misses)_total|etcd_network_client_grpc_(received|sent)_bytes_total|etcd_server_(has_leader|leader_changes_seen_total)|etcd_server_proposals_(pending|(applied|committed|failed)_total)|process_(cpu_seconds_total|open_fds|resident_memory_bytes))
+              regex: kube-etcd;(?:etcd_debugging_(store_(expires_total|watchers))|etcd_mvcc_db_total_size_in_bytes|etcd_disk_(backend_commit|wal_fsync)_duration_seconds_bucket|etcd_grpc_proxy_cache_(hits|misses)_total|etcd_network_client_grpc_(received|sent)_bytes_total|etcd_server_(has_leader|leader_changes_seen_total)|etcd_server_proposals_(pending|(applied|committed|failed)_total)|process_(cpu_seconds_total|open_fds|resident_memory_bytes))
               sourceLabels: [job, __name__]
 
         ## Nginx ingress controller metrics

--- a/tests/integration/internal/constants.go
+++ b/tests/integration/internal/constants.go
@@ -145,9 +145,7 @@ var (
 		"process_resident_memory_bytes",
 	}
 	KubeControllerManagerMetrics = []string{
-		"cloudprovider_aws_api_request_duration_seconds_bucket",
-		"cloudprovider_aws_api_request_duration_seconds_count",
-		"cloudprovider_aws_api_request_duration_seconds_sum",
+		// we only collect AWS-specific metrics here
 	}
 	CoreDNSMetrics = []string{
 		"coredns_cache_entries",
@@ -212,13 +210,10 @@ var (
 		KubeNodeMetrics,
 		KubePodMetrics,
 		KubeletMetrics,
-		// See: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2079
-		// TODO: Enable this again after the above issue is resolved
 		KubeSchedulerMetrics,
 		KubeApiServerMetrics,
 		KubeEtcdMetrics,
-		// Need to upgrade kube-prometheus stack to use the secure metrics endpoint for controller metrics
-		// KubeControllerManagerMetrics,
+		KubeControllerManagerMetrics,
 		CoreDNSMetrics,
 		CAdvisorMetrics,
 		NodeExporterMetrics,

--- a/tests/integration/internal/constants.go
+++ b/tests/integration/internal/constants.go
@@ -110,22 +110,7 @@ var (
 		"apiserver_request_duration_seconds_bucket",
 	}
 	KubeEtcdMetrics = []string{
-		// Deprecated in etcd v3: https://github.com/kubernetes/kubernetes/pull/79520
-		// "etcd_request_cache_get_duration_seconds_count",
-		// "etcd_request_cache_get_duration_seconds_sum",
-		// "etcd_request_cache_add_duration_seconds_count",
-		// "etcd_request_cache_add_duration_seconds_sum",
-		// "etcd_request_cache_add_latencies_summary_count",
-		// "etcd_request_cache_add_latencies_summary_sum",
-		// "etcd_request_cache_get_latencies_summary_count",
-		// "etcd_request_cache_get_latencies_summary_sum",
-		// "etcd_helper_cache_hit_count",
-		// "etcd_helper_cache_hit_total",
-		// "etcd_helper_cache_miss_count",
-		// "etcd_helper_cache_miss_total",
-		// Deprecated in etcd 3.5: https://github.com/etcd-io/etcd/blob/e433d12656c5dbd41f4f6b085ced134647ffeb14/CHANGELOG-3.5.md#breaking-changes
-		// TODO: Replace with etcd_mvcc_db_total_size_in_bytes
-		//"etcd_debugging_mvcc_db_total_size_in_bytes",
+		"etcd_mvcc_db_total_size_in_bytes",
 		"etcd_debugging_store_expires_total",
 		"etcd_debugging_store_watchers",
 		"etcd_disk_backend_commit_duration_seconds_bucket",

--- a/tests/integration/internal/constants.go
+++ b/tests/integration/internal/constants.go
@@ -144,13 +144,6 @@ var (
 		"process_cpu_seconds_total",
 		"process_open_fds",
 		"process_resident_memory_bytes",
-		// Deprecated in https://coredns.io/2020/06/15/coredns-1.7.0-release/#metric-changes
-		// "coredns_cache_size",
-		// "coredns_dns_response_rcode_count_total",
-		// "coredns_forward_request_count_total",
-		// No idea where this came from, doesn't seem to exist
-		// TODO: confirm it doesn't exist and remove it from values.yaml
-		// "coredns_dns_request_count_total",
 	}
 	CAdvisorMetrics = []string{
 		"container_cpu_usage_seconds_total",


### PR DESCRIPTION
Final part of the control plane metrics cleanup. We now don't try to collect any deprecated metrics, and check everything we collect in integration tests.

### Checklist

- [X] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [X] Integration tests added or modified for major features
