### PR TITLE
chore: automatically add skip-changelog to dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    
+    labels:
+      - skip-changelog
 
   - package-ecosystem: "gomod"
     directory: "/tests/integration/"
     schedule:
       interval: "daily"
+    
+    labels:
+      - skip-changelog


### PR DESCRIPTION
### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
