### PR TITLE
docs: change OTC properties to lowercase

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -239,8 +239,8 @@ sumologic:
                 match_type: strict
                 ## Metadata to match for exclusion
                 resource_attributes:
-                  - Key: k8s.namespace.name
-                    Value: sumologic
+                  - key: k8s.namespace.name
+                    value: sumologic
 ```
 
 To exclude all metrics starting with `kube_`, you can use the following configuration:

--- a/docs/collecting-application-metrics.md
+++ b/docs/collecting-application-metrics.md
@@ -248,8 +248,8 @@ sumologic:
                   - prefix_.*
                 ## Metadata to match for inclusion
                 resource_attributes:
-                  - Key: container.name
-                    Value: app_container_1
+                  - key: container.name
+                    value: app_container_1
               ## Definition of exclusion
               exclude:
                 ## Match type, can be regexp or strict
@@ -260,8 +260,8 @@ sumologic:
                   - hello/world
                 ## Metadata to match for exclusion
                 resource_attributes:
-                  - Key: container.name
-                    Value: app_container_7
+                  - key: container.name
+                    value: app_container_7
 ```
 
 [filterprocessor]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor

--- a/docs/collecting-container-logs.md
+++ b/docs/collecting-container-logs.md
@@ -244,15 +244,15 @@ sumologic:
                 include:
                   match_type: strict
                   resource_attributes:
-                    - Key: host.name
-                      Value: just_this_one_hostname
+                    - key: host.name
+                      value: just_this_one_hostname
           - filter/include-logs-based-on-resource-attribute-regex:
               logs:
                 include:
                   match_type: regexp
                   resource_attributes:
-                    - Key: host.name
-                      Value: prefix.*
+                    - key: host.name
+                      value: prefix.*
           - filter/exclude-healthcheck-logs:
               logs:
                 exclude:

--- a/tests/helm/testdata/opentelemetry-metrics-extra-processors.yaml
+++ b/tests/helm/testdata/opentelemetry-metrics-extra-processors.yaml
@@ -9,8 +9,8 @@ sumologic:
                 metric_names:
                   - receiver_mock_.*
                 resource_attributes:
-                  - Key: k8s.pod.name
-                    Value: app.*
+                  - key: k8s.pod.name
+                    value: app.*
               exclude:
                 match_type: strict
                 metric_names:


### PR DESCRIPTION
The uppercase properties cause OTC crash in v0.71.0 and higher.