### PR TITLE
fix(logs): reduce the queue size of the logs collector

### DIFF
--- a/.changelog/2923.fixed.txt
+++ b/.changelog/2923.fixed.txt
@@ -1,0 +1,1 @@
+fix(logs): reduce the queue size of the logs collector

--- a/deploy/helm/sumologic/conf/logs/collector/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/collector/otelcol/config.yaml
@@ -264,6 +264,8 @@ receivers:
 exporters:
   otlphttp:
     endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local.:4318
+    sending_queue:
+      queue_size: 10
 processors:
   batch:
     send_batch_size: 1000

--- a/tests/helm/testdata/goldenfile/logs_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc/basic.output.yaml
@@ -14,6 +14,8 @@ data:
     exporters:
       otlphttp:
         endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local.:4318
+        sending_queue:
+          queue_size: 10
     extensions:
       file_storage:
         compaction:

--- a/tests/helm/testdata/goldenfile/logs_otc/options.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc/options.output.yaml
@@ -14,6 +14,8 @@ data:
     exporters:
       otlphttp:
         endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local.:4318
+        sending_queue:
+          queue_size: 10
     extensions:
       file_storage:
         compaction:


### PR DESCRIPTION
By default, the sending queue has a size of 5000 for otlp exporter. This is way too much for us with our batches of 1000 records. I've set it to 10, which is roughly in line with the 5 MB limit we have set for Fluent Bit.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [X] Changelog updated or skip changelog label added
