### PR TITLE
docs: change "gathering" to "collecting"

### DIFF
--- a/docs/collecting-kubernetes-metrics.md
+++ b/docs/collecting-kubernetes-metrics.md
@@ -74,4 +74,4 @@ See the relevant section in [Collecting application metrics](/docs/collecting-ap
 
 For investigation you may want to look at the
 [Collecting application metrics](/docs/collecting-application-metrics.md#metrics-modifications) and
-[Troubleshooting Collection document](/docs/troubleshoot-collection.md#gathering-metrics)
+[Troubleshooting Collection document](/docs/troubleshoot-collection.md#collecting-metrics)

--- a/docs/fluent/troubleshoot-collection.md
+++ b/docs/fluent/troubleshoot-collection.md
@@ -5,12 +5,12 @@
 - [`helm install` hanging](#helm-install-hanging)
 - [Installation fails with error `function "dig" not defined`](#installation-fails-with-error-function-dig-not-defined)
 - [Namespace configuration](#namespace-configuration)
-- [Gathering logs](#gathering-logs)
+- [Collecting logs](#collecting-logs)
   - [Check Fluentd autoscaling](#check-fluentd-autoscaling)
   - [Fluentd Logs](#fluentd-logs)
   - [Send data to Fluentd stdout instead of to Sumo](#send-data-to-fluentd-stdout-instead-of-to-sumo)
   - [Send data to Fluent Bit stdout](#send-data-to-fluent-bit-stdout)
-- [Gathering metrics](#gathering-metrics)
+- [Collecting metrics](#collecting-metrics)
   - [Check Fluentd autoscaling](#check-fluentd-autoscaling-1)
   - [Check FluentBit and Fluentd output metrics](#check-fluentbit-and-fluentd-output-metrics)
 - [Common Issues](#common-issues)
@@ -67,7 +67,7 @@ To set your namespace context more permanently, you can run
 kubectl config set-context $(kubectl config current-context) --namespace=sumologic
 ```
 
-## Gathering logs
+## Collecting logs
 
 If you cannot see logs in Sumo that you expect to be there, here are the things to check.
 
@@ -174,7 +174,7 @@ fluent-bit:
           Match *
 ```
 
-## Gathering metrics
+## Collecting metrics
 
 ### Check Fluentd autoscaling
 

--- a/docs/troubleshoot-collection.md
+++ b/docs/troubleshoot-collection.md
@@ -4,13 +4,13 @@
 
 - [Troubleshooting Installation](#troubleshooting-installation)
 - [Namespace configuration](#namespace-configuration)
-- [Gathering logs](#gathering-logs)
+- [Collecting logs](#collecting-logs)
   - [Check log throttling](#check-log-throttling)
   - [Check ingest budget limits](#check-ingest-budget-limits)
   - [Check if collection pods are in a healthy state](#check-if-collection-pods-are-in-a-healthy-state)
   - [Prometheus Logs](#prometheus-logs)
   - [OpenTelemetry Logs Collector is being CPU throttled](#opentelemetry-logs-collector-is-being-cpu-throttled)
-- [Gathering metrics](#gathering-metrics)
+- [Collecting metrics](#collecting-metrics)
   - [Check the `/metrics` endpoint](#check-the-metrics-endpoint)
   - [Check the `/metrics` endpoint for Kubernetes services](#check-the-metrics-endpoint-for-kubernetes-services)
   - [Check the Prometheus UI](#check-the-prometheus-ui)
@@ -49,7 +49,7 @@ To set your namespace context more permanently, you can run
 kubectl config set-context $(kubectl config current-context) --namespace=sumologic
 ```
 
-## Gathering logs
+## Collecting logs
 
 If you cannot see logs in Sumo that you expect to be there, here are the things to check.
 
@@ -158,7 +158,7 @@ For more information look at the `Setting different resources on different nodes
 [Advanced Configuration / Best Practices](/docs/best-practices.md#setting-different-resources-on-different-nodes-for-logs-collector)
 document.
 
-## Gathering metrics
+## Collecting metrics
 
 ### Check the `/metrics` endpoint
 


### PR DESCRIPTION
"Gathering" is an uncommon word in this context.
We usually talk about "collecting" logs/metrics/traces.

I've checked the [sumologic-documentation](https://github.com/SumoLogic/sumologic-documentation/) repo and did not find any references.