### PR TITLE
docs: reorder upgrade docs to put most recent and the top

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -41,18 +41,18 @@ Documentation links:
 
 - Upgrades
 
-  - [Upgrade from v0.17 to v1.0][migration-doc-v1]
-  - [Upgrade from v1.3 to v2.0][migration-doc-v2]
   - [Upgrade from v2 to v3][migration-doc-v3]
+  - [Upgrade from v1.3 to v2.0][migration-doc-v2]
+  - [Upgrade from v0.17 to v1.0][migration-doc-v1]
+  - [Migrate from `SumoLogic/fluentd-kubernetes-sumologic`][migration-steps]
 
-- [Migration steps from `SumoLogic/fluentd-kubernetes-sumologic`][migration-steps]
 - [Troubleshooting Collection](/docs/troubleshoot-collection.md)
 - [Monitoring the Monitoring](/docs/monitoring-lag.md)
 - [Dev Releases](/docs/dev.md)
 
-[migration-doc-v1]: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/release-v2/deploy/docs/v1_migration_doc.md
-[migration-doc-v2]: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/release-v2/deploy/docs/v2_migration_doc.md
 [migration-doc-v3]: ./v3-migration-doc.md
+[migration-doc-v2]: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/release-v2/deploy/docs/v2_migration_doc.md
+[migration-doc-v1]: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/release-v2/deploy/docs/v1_migration_doc.md
 [migration-steps]: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/release-v2/deploy/docs/Migration_Steps.md
 
 ## Solution overview


### PR DESCRIPTION
This change reorders the upgrade docs in reverse-chronological order. I believe it makes much more sense to put most recent upgrades at the top. Other examples of reverse-chronological order for upgrade docs:
- https://kubernetes.io/docs/reference/using-api/deprecation-guide/
- https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/
- https://guides.rubyonrails.org/upgrading_ruby_on_rails.html

Builds upon #2929.