### PR TITLE
docs(upgrading): add upgrade guide for v2.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ for differences between Telegraf Operator Helm Chart 1.3.5 and Telegraf Operator
 
 ### Released 2022-10-20
 
+See [Upgrading from v2.17 to v2.18][v2-18-migration].
+
 This release updates Opentelemetry Operator and disables by default creation of `Instrumentation` resource.
 `opentelemetry-operator.manager.env.WATCH_NAMESPACE` has no longer effect on creation of `Instrumentation` resource.
 To create `Instrumentation` resource it is required to set `opentelemetry-operator.createDefaultInstrumentation` to `true` and
@@ -71,9 +73,9 @@ This change affects you only if you have enabled opentelemetry-operator and trac
 
 ### Changed
 
-- chore: upgrade nginx to 1.23.1 [#2544] [#2554]
+- chore: upgrade nginx to 1.23.1 [#2544]
 - chore: remove support for GKE 1.20 [#2579]
-- chore(opentelemetry-operator): upgrade opentelemetry-operator subchart to 0.13.0 [#2577]
+- chore(opentelemetry-operator): upgrade opentelemetry-operator subchart to 0.13.0 [#2577] ([Upgrade guide][v2-18-migration])
 
 ### Fixed
 
@@ -84,6 +86,7 @@ This change affects you only if you have enabled opentelemetry-operator and trac
 [#2579]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2579
 [#2577]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2577
 [v2.18.0]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.17.0...v2.18.0
+[v2-18-migration]: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/release-v2/deploy/docs/v2-18-migration.md
 
 ## [v2.17.0]
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -37,6 +37,7 @@ Documentation links:
 - Upgrades
   - [Upgrade from v0.17 to v1.0](./docs/v1_migration_doc.md)
   - [Upgrade from v1.3 to v2.0](./docs/v2_migration_doc.md)
+  - [Upgrade from v2.17 to v2.18](./docs/v2-18-migration.md)
 
 - [Migration steps from `SumoLogic/fluentd-kubernetes-sumologic`](./docs/Migration_Steps.md)
 - [Troubleshooting Collection](./docs/Troubleshoot_Collection.md)

--- a/deploy/docs/v2-18-migration.md
+++ b/deploy/docs/v2-18-migration.md
@@ -1,0 +1,24 @@
+# Upgrading from v2.17 to v2.18
+
+## Upgrade OpenTelemetry Operator CRDs
+
+### Do I need to do this?
+
+You need to do this if you have the OpenTelemetry Operator subchart enabled with `opentelemetry-operator.enabled: true` in your values file.
+
+### What do I need to do?
+
+Run the following commands on the cluster before upgrading the chart:
+
+```shell
+kubectl apply --server-side --force-conflicts --filename https://raw.githubusercontent.com/open-telemetry/opentelemetry-helm-charts/opentelemetry-operator-0.24.0/charts/opentelemetry-operator/crds/crd-opentelemetrycollector.yaml
+kubectl apply --server-side --force-conflicts --filename https://raw.githubusercontent.com/open-telemetry/opentelemetry-helm-charts/opentelemetry-operator-0.24.0/charts/opentelemetry-operator/crds/crd-opentelemetryinstrumentation.yaml
+```
+
+### Why do I need to do this?
+
+The OpenTelemetry Operator subchart was upgraded from [v0.13.0][ot-operator-v0.13.0] to [v0.18.3][ot-operator-v0.18.3]. The new chart introduces a new feature in the Instrumentation CRD.
+If you do not upgrade the CRDs, the `release-name-ot-operator-instr` job will fail.
+
+[ot-operator-v0.13.0]: https://github.com/open-telemetry/opentelemetry-helm-charts/releases/opentelemetry-operator-0.13.0
+[ot-operator-v0.18.3]: https://github.com/open-telemetry/opentelemetry-helm-charts/releases/opentelemetry-operator-0.18.3


### PR DESCRIPTION
Upgrading to this release with the OpenTelemetry Operator enabled breaks unless you upgrade the operator's CRDs. This needs to be documented.

Ports change from #2931 to `release-v2.19` branch.