### PR TITLE
docs: add link to upgrade guide for v2.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,7 +244,6 @@ please see [this][telegraf_operator_comapare_1.3.5_and_1.3.10].
 
 ### Breaking Changes
 
-- fix(setup):allow credentials to not be set if setup is disabled [#2572]
 - fix(logs): prevent Fluent Bit from doing metadata enrichment [#2512]
 - chore(kube-prometheus-stack): update kube-prometheus-stack chart to 42.1.0 [#2446] [#2651]
 - feat(metrics)!: disable Thanos by default [#2514]
@@ -313,7 +312,6 @@ please see [this][telegraf_operator_comapare_1.3.5_and_1.3.10].
 
 ### Changed
 
-- chore: upgrade nginx to 1.23.1 [#2544] [#2554]
 - feat: enable remote write proxy by default [#2483]
 - chore: update kubernetes-tools to 2.13.0 [#2515]
 - feat(metadata): upgrade otelcol to v0.57.2-sumo-1 [#2526]
@@ -333,7 +331,6 @@ please see [this][telegraf_operator_comapare_1.3.5_and_1.3.10].
 
 ### Fixed
 
-- fix(openshift): fix remote write proxy - use unprivileged NGINX [#2510], [#2510]
 - fix: default.metrics source is not imported when metrics are disabled and traces are enabled [#2547]
 - fix(cleanup): fix cleanup job [#2600]
 - fix(setup): add permission to modify secrets [#2653]
@@ -344,13 +341,9 @@ please see [this][telegraf_operator_comapare_1.3.5_and_1.3.10].
 [#2514]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2514
 [#2446]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2446
 [#2515]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2515
-[#2510]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2510
 [#2526]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2526
-[#2544]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2544
 [#2547]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2547
-[#2554]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2554
 [#2549]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2549
-[#2572]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2572
 [#2561]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2561
 [#2578]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2578
 [#2587]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2587
@@ -385,10 +378,91 @@ please see [this][telegraf_operator_comapare_1.3.5_and_1.3.10].
 [#2664]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2664
 [#2653]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2653
 [v3.0.0-beta.0]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.17.0...v3.0.0-beta.0
+
+## [v2.19.1]
+
+### Released 2022-12-29
+
+### Changed
+
+- chore: upgrade Fluent Bit to v1.6.10-sumo-3 [#2730]
+
+### Fixed
+
+- The repository for the metrics-server dependency was updated [#2730]
+
+[#2730]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2730
+[v2.19.1]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.19.0...v2.19.1
+
+## [v2.19.0]
+
+### Released 2022-11-24
+
+If you use custom configuration for Telegraf Operator Helm Chart with cert-manager enabled (`telegraf-operator.certManager.enable=true`)
+please note that in this release Telegraf Operator Helm Chart is changed to 1.3.10 which uses the cert-manager apiVersion
+`cert-manager.io/v1`, previous apiVersion `cert-manager.io/v1alpha2` was deprecated in cert-manager [1.4][cert-manager-1.4] and removed in
+cert-manager [1.6][cert-manager-1.6], for differences between Telegraf Operator Helm Chart 1.3.5 and Telegraf Operator Helm Chart 1.3.10
+please see [this][telegraf_operator_comapare_1.3.5_and_1.3.10].
+
+### Changed
+
+- chore: remove support for OpenShift 4.6 and OpenShift 4.7 [#2592]
+- chore: remove support for EKS 1.19 [#2592]
+- chore: remove support for kOps 1.20 [#2592]
+- chore(fluent-bit): update Fluent Bit Helm Chart to 0.20.9 [#2596]
+- chore(telegraf-operator): update Telegraf Operator Helm Chart to 1.3.10 [#2598]
+- feat: update opentelemetry-operator chart and fix progagators list in instrumentation resource [#2630]
+
+[#2592]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2592
+[#2596]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2596
+[#2598]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2598
+[#2630]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2630
+[v2.19.0]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.18.1...v2.19.0
 [telegraf_operator_comapare_1.3.5_and_1.3.10]:
   https://github.com/influxdata/helm-charts/compare/telegraf-operator-1.3.5...telegraf-operator-1.3.10
 [cert-manager-1.4]: https://github.com/cert-manager/cert-manager/releases/tag/v1.4.0
 [cert-manager-1.6]: https://github.com/cert-manager/cert-manager/releases/tag/v1.6.0
+
+## [v2.18.1]
+
+### Released 2022-10-21
+
+### Fixed
+
+- fix(setup):allow credentials to not be set if setup is disabled [#2572]
+
+[#2572]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2572
+[v2.18.1]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.18.0...v2.18.1
+
+## [v2.18.0]
+
+### Released 2022-10-20
+
+See [Upgrading from v2.17 to v2.18][v2-18-migration].
+
+This release updates Opentelemetry Operator and disables by default creation of `Instrumentation` resource.
+`opentelemetry-operator.manager.env.WATCH_NAMESPACE` has no longer effect on creation of `Instrumentation` resource. To create
+`Instrumentation` resource it is required to set `opentelemetry-operator.createDefaultInstrumentation` to `true` and
+`opentelemetry-operator.instrumentationNamespaces` to comma separated list of namespaces where `Instrumentation` resource will be created
+e.g. `"ns1\,ns2"`. This change affects you only if you have enabled opentelemetry-operator and traces with
+`opentelemetry-operator.enabled: true` and `sumologic.traces.enabled: true`.
+
+### Changed
+
+- chore: upgrade nginx to 1.23.1 [#2544]
+- chore: remove support for GKE 1.20 [#2579]
+- chore(opentelemetry-operator): upgrade opentelemetry-operator subchart to 0.13.0 [#2577] ([Upgrade guide][v2-18-migration])
+
+### Fixed
+
+- fix(openshift): fix remote write proxy - use unprivileged NGINX [#2510][#2510]
+
+[#2510]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2510
+[#2544]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2544
+[#2579]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2579
+[#2577]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2577
+[v2.18.0]: https://github.com/SumoLogic/sumologic-kubernetes-collection/compare/v2.17.0...v2.18.0
+[v2-18-migration]: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/release-v2/deploy/docs/v2-18-migration.md
 
 ## [v2.17.0]
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,7 @@ Documentation links:
 - Upgrades
 
   - [Upgrade from v2 to v3][migration-doc-v3]
+  - [Upgrade from v2.17 to v2.18][migration-doc-v2.18]
   - [Upgrade from v1.3 to v2.0][migration-doc-v2]
   - [Upgrade from v0.17 to v1.0][migration-doc-v1]
   - [Migrate from `SumoLogic/fluentd-kubernetes-sumologic`][migration-steps]
@@ -51,6 +52,7 @@ Documentation links:
 - [Dev Releases](/docs/dev.md)
 
 [migration-doc-v3]: ./v3-migration-doc.md
+[migration-doc-v2.18]: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/release-v2/deploy/docs/v2-18-migration.md
 [migration-doc-v2]: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/release-v2/deploy/docs/v2_migration_doc.md
 [migration-doc-v1]: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/release-v2/deploy/docs/v1_migration_doc.md
 [migration-steps]: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/release-v2/deploy/docs/Migration_Steps.md


### PR DESCRIPTION
Ports change from #2931 from `release-v2` branch.

Also adds missing releases to Changelog and cleans it up from duplicate entries :unamused: 