### PR TITLE
docs(fluent): change max request size to 1 MB

### DIFF
--- a/docs/fluent/best-practices.md
+++ b/docs/fluent/best-practices.md
@@ -595,8 +595,8 @@ fluentd:
         retry_timeout 72h
         ## do not limit number of requests
         retry_max_times 0
-        ## set maximum request size to 16m to avoid timeouts
-        max_request_size 16m
+        ## set maximum request size to 1m to avoid timeouts
+        max_request_size 1m
   metrics:
     extraOutputConf: |-
       ## use plugin's retry mechanisms, which uses exponential algorithm


### PR DESCRIPTION
This is to align with the docs on the HTTP Source
https://help.sumologic.com/docs/send-data/hosted-collectors/http-source/logs-metrics/

> We recommend that the data payload of a POST request have a size, before compression, of 100KB to 1MB.