### PR TITLE
docs(fluentd): change max request size to 1 MB

### DIFF
--- a/deploy/docs/Best_Practices.md
+++ b/deploy/docs/Best_Practices.md
@@ -703,8 +703,8 @@ fluentd:
         retry_timeout 72h
         ## do not limit number of requests
         retry_max_times 0
-        ## set maximum request size to 16m to avoid timeouts
-        max_request_size 16m
+        ## set maximum request size to 1m to avoid timeouts
+        max_request_size 1m
   metrics:
     extraOutputConf: |-
       ## use plugin's retry mechanisms, which uses exponential algorithm


### PR DESCRIPTION
Backports #2944

This is to align with the docs on the HTTP Source
https://help.sumologic.com/docs/send-data/hosted-collectors/http-source/logs-metrics/

> We recommend that the data payload of a POST request have a size, before compression, of 100KB to 1MB.