### PR TITLE
test(integration): speed up tracing tests

### DIFF
--- a/tests/integration/features.go
+++ b/tests/integration/features.go
@@ -37,8 +37,8 @@ const (
 	logRecords              = 4   // number of log records in single loop, see: tests/integration/yamls/pod_multiline_long_lines.yaml
 	logLoops                = 500 // number of loops in which logs are generated, see: tests/integration/yamls/pod_multiline_long_lines.yaml
 	multilineLogCount  uint = logRecords * logLoops
-	tracesPerExporter  uint = 10 // number of traces generated per exporter
-	spansPerTrace      uint = 5
+	tracesPerExporter  uint = 5 // number of traces generated per exporter
+	spansPerTrace      uint = 2
 )
 
 func GetMetricsFeature(expectedMetrics []string) features.Feature {

--- a/tests/integration/helm_opentelemetry_operator_enabled_test.go
+++ b/tests/integration/helm_opentelemetry_operator_enabled_test.go
@@ -27,6 +27,13 @@ func Test_Helm_OpenTelemetry_Operator_Enabled(t *testing.T) {
 		waitDuration = time.Minute * 2
 	)
 
+	installChecks := []featureCheck{
+		CheckSumologicSecret(2),
+		CheckTracesInstall,
+	}
+
+	featInstall := GetInstallFeature(installChecks)
+
 	// It is required to add v1alpha1 OT Operator Scheme to K8s Scheme
 	// https://github.com/open-telemetry/opentelemetry-operator/issues/772
 	if err := otoperatorappsv1.AddToScheme(scheme.Scheme); err != nil {
@@ -100,5 +107,5 @@ func Test_Helm_OpenTelemetry_Operator_Enabled(t *testing.T) {
 		}).
 		Feature()
 
-	testenv.Test(t, featTraces, featOpenTelemetryOperator)
+	testenv.Test(t, featInstall, featTraces, featOpenTelemetryOperator)
 }

--- a/tests/integration/values/values_helm_opentelemetry_operator_enabled.yaml
+++ b/tests/integration/values/values_helm_opentelemetry_operator_enabled.yaml
@@ -5,7 +5,7 @@ sumologic:
   logs:
     enabled: false
   metrics:
-    enabled: true
+    enabled: false
 
 opentelemetry-operator:
   enabled: true


### PR DESCRIPTION
Tracing tests are slow because the trace generator tool's [hardcoded behaviour](https://github.com/SumoLogic/sumologic-kubernetes-tools/blob/53b49ad1d4a8ccda5c3919b3d109d2492e137ad8/src/go/cmd/customer-trace-tester/main.go#L218) is to wait for an average of 0.5s between each span. I've reduced the number of spans per trace and the number of total traces to mitigate this, but in the longer term we should make this configurable in the tool.

I've also: 
- disabled metrics in the opentelemetry operator test, as they're not necessary
- added an install feature to the same test
