### PR TITLE
test(integration): only check tracing metrics if tracing is enabled

### DIFF
--- a/tests/integration/helm_ot_default_test.go
+++ b/tests/integration/helm_ot_default_test.go
@@ -9,6 +9,9 @@ import (
 func Test_Helm_Default_OT(t *testing.T) {
 
 	expectedMetrics := internal.DefaultExpectedMetrics
+	// we have tracing enabled, so check tracing-specific metrics
+	expectedMetrics = append(expectedMetrics, internal.TracingOtelcolMetrics...)
+
 	installChecks := []featureCheck{
 		CheckSumologicSecret(11),
 		CheckOtelcolMetadataLogsInstall,

--- a/tests/integration/helm_otc_fips_metadata_installation_test.go
+++ b/tests/integration/helm_otc_fips_metadata_installation_test.go
@@ -9,6 +9,8 @@ import (
 func Test_Helm_Default_OT_FIPS_Metadata(t *testing.T) {
 
 	expectedMetrics := internal.DefaultExpectedMetrics
+	// we have tracing enabled, so check tracing-specific metrics
+	expectedMetrics = append(expectedMetrics, internal.TracingOtelcolMetrics...)
 
 	installChecks := []featureCheck{
 		CheckSumologicSecret(11),

--- a/tests/integration/internal/constants.go
+++ b/tests/integration/internal/constants.go
@@ -160,7 +160,7 @@ var (
 		"node_load15",
 		"node_cpu_seconds_total",
 	}
-	OtelcolMetrics = []string{
+	DefaultOtelcolMetrics = []string{
 		"otelcol_exporter_enqueue_failed_log_records",
 		"otelcol_exporter_enqueue_failed_metric_points",
 		"otelcol_exporter_enqueue_failed_spans",
@@ -171,6 +171,8 @@ var (
 		"otelcol_process_runtime_total_alloc_bytes",
 		"otelcol_process_runtime_total_sys_memory_bytes",
 		"otelcol_process_uptime",
+	}
+	TracingOtelcolMetrics = []string{
 		"otelcol_loadbalancer_num_backend_updates",
 		"otelcol_loadbalancer_num_backends",
 		"otelcol_loadbalancer_num_resolutions",
@@ -225,7 +227,7 @@ func InitializeConstants() error {
 	}
 
 	DefaultExpectedMetrics = []string{}
-	metricsGroupsWithOtelcol := append(DefaultExpectedMetricsGroups, OtelcolMetrics)
+	metricsGroupsWithOtelcol := append(DefaultExpectedMetricsGroups, DefaultOtelcolMetrics)
 	for _, metrics := range metricsGroupsWithOtelcol {
 		DefaultExpectedMetrics = append(DefaultExpectedMetrics, metrics...)
 	}


### PR DESCRIPTION
We are checking for tracing-specific otelcol metrics in all tests. This worked because we don't have a metrics test where tracing isn't enabled, but I wanted to add one in #2949 and ran into this problem.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [X] Changelog updated or skip changelog label added
