### PR TITLE
ci: don't run unnecessary integration tests

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -279,7 +279,7 @@ jobs:
             ${{ runner.os }}-go-integration-
       - name: Run integration test - ${{ matrix.test_name }}
         working-directory: ./tests/integration/
-        run: make test TEST_NAME=${{matrix.test_name}} KIND_NODE_IMAGE=${{matrix.kind_image}}
+        run: make test TEST_NAME=^${{matrix.test_name}}$ KIND_NODE_IMAGE=${{matrix.kind_image}}
 
   integration-test-status:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Passing TEST_NAME to the integration test runner just passes that value verbatim to go test. The value in go test is a regular expression though , so if we have a test whose name is a prefix of another test, both will be run.

We were running the FIPS test alongside the default test every time because of this.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [X] Changelog updated or skip changelog label added
