### PR TITLE
refactor: remove indentation from helpers

### DIFF
--- a/deploy/helm/sumologic/templates/_helpers.tpl
+++ b/deploy/helm/sumologic/templates/_helpers.tpl
@@ -1223,8 +1223,8 @@ Example:
 {{- $ctx := .Context -}}
 {{- $type := .Type -}}
 {{- range $name, $source := (index .Context.sumologic.collector.sources $type) -}}
-{{- include "kubernetes.sources.env" (dict "Context" $ctx "Type" $type  "Name" $name ) | nindent 8 -}}
-{{- end }}
+{{- include "kubernetes.sources.env" (dict "Context" $ctx "Type" $type  "Name" $name ) -}}
+{{- end -}}
 {{- end -}}
 
 {{/*
@@ -1234,7 +1234,7 @@ Example:
 
 {{ include "kubernetes.sources.env" (dict "Context" .Values "Type" "metrics" "Name" $name ) }}
 */}}
-{{- define "kubernetes.sources.env" -}}
+{{ define "kubernetes.sources.env" }}
 {{- $ctx := .Context -}}
 {{- $type := .Type -}}
 {{- $name := .Name -}}
@@ -1243,7 +1243,7 @@ Example:
     secretKeyRef:
       name: sumologic
       key: {{ template "terraform.sources.config-map-variable" (dict "Type" $type "Context" $ctx "Name" $name) }}
-{{- end -}}
+{{ end }}
 
 
 {{/*

--- a/deploy/helm/sumologic/templates/events/fluentd/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/events/fluentd/statefulset.yaml
@@ -106,7 +106,7 @@ spec:
           periodSeconds: 5
         env:
 {{- $ctx := .Values -}}
-{{- include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "events") -}}
+{{- include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "events") | nindent 8 -}}
 {{- if .Values.fluentd.events.extraEnvVars }}
 {{ toYaml .Values.fluentd.events.extraEnvVars | nindent 8 }}
 {{- end }}

--- a/deploy/helm/sumologic/templates/events/otelcol/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/events/otelcol/statefulset.yaml
@@ -145,7 +145,7 @@ spec:
 {{- end }}
         env:
 {{- $ctx := .Values -}}
-{{- include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "events") -}}
+{{- include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "events") | nindent 8 -}}
 {{- include "proxy-env-variables" . | nindent 8 -}}
         {{- if .Values.otelevents.statefulset.extraEnvVars }}
 {{ toYaml .Values.otelevents.statefulset.extraEnvVars | nindent 8 }}

--- a/deploy/helm/sumologic/templates/instrumentation/traces-gateway/deployment.yaml
+++ b/deploy/helm/sumologic/templates/instrumentation/traces-gateway/deployment.yaml
@@ -69,7 +69,7 @@ spec:
         - name: GOGC
           value: "80"
 {{- $ctx := .Values -}}
-{{- include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "traces") -}}
+{{- include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "traces") | nindent 8 -}}
 {{- include "kubernetes.sources.env" (dict "Context" $ctx "Type" "metrics" "Name" "default" ) | nindent 8 }}
 {{- include "proxy-env-variables" . | nindent 8 -}}
 {{- if $tracesGateway.deployment.extraEnvVars }}

--- a/deploy/helm/sumologic/templates/instrumentation/traces-sampler/deployment.yaml
+++ b/deploy/helm/sumologic/templates/instrumentation/traces-sampler/deployment.yaml
@@ -63,7 +63,7 @@ spec:
         - name: GOGC
           value: "80"
 {{- $ctx := .Values -}}
-{{- include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "traces") -}}
+{{- include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "traces") | nindent 8 -}}
 {{- include "proxy-env-variables" . | nindent 8 -}}
 {{- if $tracesSampler.deployment.extraEnvVars }}
 {{- toYaml $tracesSampler.deployment.extraEnvVars | nindent 8 }}

--- a/deploy/helm/sumologic/templates/logs/fluentd/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/logs/fluentd/statefulset.yaml
@@ -153,7 +153,7 @@ spec:
 {{- if or .Values.sumologic.collector.sources .Values.fluentd.logs.extraEnvVars }}
         env:
 {{- $ctx := .Values -}}
-{{- include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "logs") -}}
+{{- include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "logs") | nindent 8 -}}
         {{- if .Values.fluentd.logs.extraEnvVars }}
 {{ toYaml .Values.fluentd.logs.extraEnvVars | nindent 8 }}
         {{- end }}

--- a/deploy/helm/sumologic/templates/logs/otelcol/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/logs/otelcol/statefulset.yaml
@@ -166,7 +166,7 @@ spec:
 {{- if or .Values.sumologic.collector.sources .Values.metadata.logs.statefulset.extraEnvVars }}
         env:
 {{- $ctx := .Values -}}
-{{- include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "logs") -}}
+{{- include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "logs") | nindent 8 -}}
 {{- include "proxy-env-variables" . | nindent 8 -}}
 {{- if .Values.metadata.logs.statefulset.extraEnvVars }}
 {{- toYaml .Values.metadata.logs.statefulset.extraEnvVars | nindent 8 }}

--- a/deploy/helm/sumologic/templates/metrics/fluentd/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics/fluentd/statefulset.yaml
@@ -153,7 +153,7 @@ spec:
 {{- if or .Values.sumologic.collector.sources .Values.fluentd.metrics.extraEnvVars }}
         env:
 {{- $ctx := .Values -}}
-{{- include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "metrics") -}}
+{{- include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "metrics") | nindent 8 -}}
 {{- if .Values.fluentd.metrics.extraEnvVars }}
 {{ toYaml .Values.fluentd.metrics.extraEnvVars | nindent 8 }}
 {{- end }}

--- a/deploy/helm/sumologic/templates/metrics/otelcol/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics/otelcol/statefulset.yaml
@@ -159,7 +159,7 @@ spec:
 {{- end }}
         env:
 {{- $ctx := .Values -}}
-{{- include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "metrics") -}}
+{{- include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "metrics") | nindent 8 -}}
 {{- include "proxy-env-variables" . | nindent 8 -}}
         {{- if .Values.metadata.metrics.statefulset.extraEnvVars }}
 {{ toYaml .Values.metadata.metrics.statefulset.extraEnvVars | nindent 8 }}


### PR DESCRIPTION
The caller should always handle indentation, not helpers themselves.

This change will help with the Prometheus migration.

### Checklist

- [X] Changelog updated or skip changelog label added
