### PR TITLE
chore: upgrade fluent-bit chart to 0.25.0

### DIFF
--- a/.changelog/2968.changed.txt
+++ b/.changelog/2968.changed.txt
@@ -1,0 +1,1 @@
+chore: upgrade fluent-bit chart to 0.25.0

--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -13,7 +13,7 @@ sources:
   - https://github.com/SumoLogic/sumologic-kubernetes-collection
 dependencies:
   - name: fluent-bit
-    version: 0.21.3
+    version: 0.25.0
     repository: https://fluent.github.io/helm-charts
     condition: fluent-bit.enabled,sumologic.logs.enabled
   - name: kube-prometheus-stack


### PR DESCRIPTION
No breaking changes observed. The upstream was mostly increasing default image

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [ ] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features
