### PR TITLE
chore: update support matrix

### DIFF
--- a/.changelog/2969.changed.txt
+++ b/.changelog/2969.changed.txt
@@ -1,0 +1,1 @@
+chore: add support for KOPS 1.26, EKS 1.25; remove support for GKE 1.21, EKS 1.21

--- a/.changelog/2969.changed.txt
+++ b/.changelog/2969.changed.txt
@@ -1,1 +1,1 @@
-chore: add support for KOPS 1.26, EKS 1.25, AKS 1.26; remove support for GKE 1.21, EKS 1.21, AKS 1.23
+chore: add support for KOPS 1.26, EKS 1.25, AKS 1.26, OpenShift 4.12; remove support for GKE 1.21, EKS 1.21, AKS 1.23

--- a/.changelog/2969.changed.txt
+++ b/.changelog/2969.changed.txt
@@ -1,1 +1,1 @@
-chore: add support for KOPS 1.26, EKS 1.25; remove support for GKE 1.21, EKS 1.21
+chore: add support for KOPS 1.26, EKS 1.25, AKS 1.26; remove support for GKE 1.21, EKS 1.21, AKS 1.23

--- a/deploy/helm/sumologic/templates/logs/common/hpa.yaml
+++ b/deploy/helm/sumologic/templates/logs/common/hpa.yaml
@@ -1,5 +1,9 @@
 {{- if and (eq (include "logs.otelcol.enabled" .) "true") (.Values.metadata.logs.autoscaling.enabled) }}
+{{- if and (eq .Capabilities.KubeVersion.Major "1") (lt (int (include "kubernetes.minor" .)) 26) }}
 apiVersion: autoscaling/v2beta2
+{{- else }}
+apiVersion: autoscaling/v2
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "sumologic.metadata.name.logs.hpa" . }}

--- a/deploy/helm/sumologic/templates/logs/fluentd/hpa.yaml
+++ b/deploy/helm/sumologic/templates/logs/fluentd/hpa.yaml
@@ -1,5 +1,9 @@
 {{- if and (eq (include "logs.fluentd.enabled" .) "true") (.Values.fluentd.logs.autoscaling.enabled) }}
+{{- if and (eq .Capabilities.KubeVersion.Major "1") (lt (int (include "kubernetes.minor" .)) 26) }}
 apiVersion: autoscaling/v2beta2
+{{- else }}
+apiVersion: autoscaling/v2
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "sumologic.metadata.name.logs.hpa" . }}

--- a/deploy/helm/sumologic/templates/metrics/common/hpa.yaml
+++ b/deploy/helm/sumologic/templates/metrics/common/hpa.yaml
@@ -1,5 +1,9 @@
 {{- if and (eq (include "metrics.otelcol.enabled" .) "true") ( .Values.metadata.metrics.autoscaling.enabled) }}
+{{- if and (eq .Capabilities.KubeVersion.Major "1") (lt (int (include "kubernetes.minor" .)) 26) }}
 apiVersion: autoscaling/v2beta2
+{{- else }}
+apiVersion: autoscaling/v2
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "sumologic.metadata.name.metrics.hpa" . }}

--- a/deploy/helm/sumologic/templates/metrics/fluentd/hpa.yaml
+++ b/deploy/helm/sumologic/templates/metrics/fluentd/hpa.yaml
@@ -1,5 +1,9 @@
 {{- if and (eq (include "metrics.fluentd.enabled" .) "true") ( .Values.fluentd.metrics.autoscaling.enabled) }}
+{{- if and (eq .Capabilities.KubeVersion.Major "1") (lt (int (include "kubernetes.minor" .)) 26) }}
 apiVersion: autoscaling/v2beta2
+{{- else }}
+apiVersion: autoscaling/v2
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "sumologic.metadata.name.metrics.hpa" . }}

--- a/docs/README.md
+++ b/docs/README.md
@@ -90,7 +90,7 @@ The following table displays the tested Kubernetes and Helm versions.
 | K8s with Kops | 1.22<br/>1.23<br/>1.24<br/>1.25<br/>1.26 |
 | K8s with GKE  | 1.22<br/>1.23<br/>1.24<br/>1.25          |
 | K8s with AKS  | 1.24<br/>1.25<br/>1.26                   |
-| OpenShift     | 4.8<br/>4.9<br/>4.10<br/>4.11            |
+| OpenShift     | 4.8<br/>4.9<br/>4.10<br/>4.11<br/>4.12   |
 | Helm          | 3.8.2 (Linux)                            |
 | kubectl       | 1.23.6                                   |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -89,7 +89,7 @@ The following table displays the tested Kubernetes and Helm versions.
 | K8s with EKS  | 1.22<br/>1.23<br/>1.24<br/>1.25          |
 | K8s with Kops | 1.22<br/>1.23<br/>1.24<br/>1.25<br/>1.26 |
 | K8s with GKE  | 1.22<br/>1.23<br/>1.24<br/>1.25          |
-| K8s with AKS  | 1.23<br/>1.24<br/>1.25                   |
+| K8s with AKS  | 1.24<br/>1.25<br/>1.26                   |
 | OpenShift     | 4.8<br/>4.9<br/>4.10<br/>4.11            |
 | Helm          | 3.8.2 (Linux)                            |
 | kubectl       | 1.23.6                                   |

--- a/docs/README.md
+++ b/docs/README.md
@@ -86,9 +86,9 @@ The following table displays the tested Kubernetes and Helm versions.
 
 | Name          | Version                                  |
 | ------------- | ---------------------------------------- |
-| K8s with EKS  | 1.21<br/>1.22<br/>1.23<br/>1.24          |
-| K8s with Kops | 1.22<br/>1.23<br/>1.24<br/>1.25          |
-| K8s with GKE  | 1.21<br/>1.22<br/>1.23<br/>1.24<br/>1.25 |
+| K8s with EKS  | 1.22<br/>1.23<br/>1.24<br/>1.25          |
+| K8s with Kops | 1.22<br/>1.23<br/>1.24<br/>1.25<br/>1.26 |
+| K8s with GKE  | 1.22<br/>1.23<br/>1.24<br/>1.25          |
 | K8s with AKS  | 1.23<br/>1.24<br/>1.25                   |
 | OpenShift     | 4.8<br/>4.9<br/>4.10<br/>4.11            |
 | Helm          | 3.8.2 (Linux)                            |

--- a/tests/integration/kind_images.json
+++ b/tests/integration/kind_images.json
@@ -1,10 +1,10 @@
 {
   "supported": [
+    "kindest/node:v1.26.3",
     "kindest/node:v1.25.3",
     "kindest/node:v1.24.0",
     "kindest/node:v1.23.6",
-    "kindest/node:v1.22.9",
-    "kindest/node:v1.21.12"
+    "kindest/node:v1.22.9"
   ],
-  "default": "kindest/node:v1.25.3"
+  "default": "kindest/node:v1.26.3"
 }


### PR DESCRIPTION
chore: add support for KOPS 1.26, EKS 1.25; remove support for GKE 1.21, EKS 1.21

Start supporting 1.26

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [ ] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features
