### PR TITLE
ci: fix integration tests

### DIFF
--- a/.github/workflows/backport_bot.yaml
+++ b/.github/workflows/backport_bot.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   backport:
     if: github.event.pull_request.merged == true
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Backport
     steps:
       - name: Generate token

--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   markdown-link-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
@@ -20,7 +20,7 @@ jobs:
           use-quiet-mode: yes
 
   push-helm-chart:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Push dev helm chart
@@ -29,7 +29,7 @@ jobs:
   # Add this to dev builds as that's the only way for cache to be shared across branches.
   # https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
   setup-integration-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       kind_images: ${{ steps.set_kind_images.outputs.kind_images }}
       test_names: ${{ steps.set_test_names.outputs.test_names }}
@@ -52,7 +52,7 @@ jobs:
         run: echo "Test names ${{ steps.set_test_names.outputs.test_names }}"
 
   integration-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: IT - ${{ matrix.test_name }} - ${{ matrix.kind_image }}
     needs:
       - setup-integration-tests

--- a/.github/workflows/pr_labeler.yaml
+++ b/.github/workflows/pr_labeler.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   triage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/labeler@v4
         with:

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   docs-changed:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       any_changed: ${{ steps.changed-files.outputs.any_changed }}
     steps:
@@ -29,7 +29,7 @@ jobs:
             .*
 
   chart-changed:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       any_changed: ${{ steps.changed-files.outputs.any_changed }}
     steps:
@@ -54,7 +54,7 @@ jobs:
             tests/integration/kind_images.json
 
   markdownlint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [docs-changed]
     env:
       PRETTIER_VERSION: 2.8.4
@@ -68,7 +68,7 @@ jobs:
         run: make markdown-lint
 
   shellcheck:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       YQ_VERSION: 4.33.2
       SHELLCHECK_VERSION: 0.9.0
@@ -87,7 +87,7 @@ jobs:
         run: make shellcheck
 
   yamllint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [chart-changed]
     env:
       PRETTIER_VERSION: 2.8.4
@@ -101,7 +101,7 @@ jobs:
         run: make yaml-lint
 
   helmlint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [chart-changed]
     steps:
       - uses: actions/checkout@v3
@@ -112,7 +112,7 @@ jobs:
           make helm-lint
 
   markdown-link-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [docs-changed]
     steps:
       - uses: actions/checkout@v3
@@ -124,7 +124,7 @@ jobs:
           base-branch: ${{ github.base_ref }}
 
   md-links-lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [docs-changed]
     steps:
       - uses: actions/checkout@v3
@@ -134,7 +134,7 @@ jobs:
           make markdown-links-lint
 
   check-configuration-keys:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -166,7 +166,7 @@ jobs:
           args: --timeout=10m --verbose
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
       - helmlint
       - chart-changed
@@ -202,7 +202,7 @@ jobs:
   ##############################################################################
 
   setup-integration-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [chart-changed]
     if: needs.chart-changed.outputs.any_changed == 'true'
     outputs:
@@ -246,7 +246,7 @@ jobs:
           args: --timeout=10m --verbose
 
   integration-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: IT - ${{ matrix.test_name }} - ${{ matrix.kind_image }}
     needs:
       - setup-integration-tests
@@ -282,7 +282,7 @@ jobs:
         run: make test TEST_NAME=^${{matrix.test_name}}$ KIND_NODE_IMAGE=${{matrix.kind_image}}
 
   integration-test-status:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: ${{ always() }}
     needs:
       - integration-tests

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   push-helm-chart:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Push helm chart

--- a/tests/integration/kind_images.json
+++ b/tests/integration/kind_images.json
@@ -1,10 +1,10 @@
 {
   "supported": [
     "kindest/node:v1.26.3",
-    "kindest/node:v1.25.3",
-    "kindest/node:v1.24.0",
-    "kindest/node:v1.23.6",
-    "kindest/node:v1.22.9"
+    "kindest/node:v1.25.8",
+    "kindest/node:v1.24.12",
+    "kindest/node:v1.23.17",
+    "kindest/node:v1.22.17"
   ],
   "default": "kindest/node:v1.26.3"
 }

--- a/tests/integration/yamls/cluster.yaml
+++ b/tests/integration/yamls/cluster.yaml
@@ -19,6 +19,3 @@ nodes:
             dataDir: /tmp/etcd
             extraArgs:
               listen-metrics-urls: http://0.0.0.0:2381
-      - | ## https://github.com/kubernetes-sigs/kind/issues/3061
-        kind: KubeletConfiguration
-        cgroupDriver: systemd


### PR DESCRIPTION
The actual fix is the removal of the cgroupdriver workaround we added for MacOS in #2901 and the upgrade to ubuntu 22.04 for some unknown reason. I've also upgraded kind images in the process.

This is probably still broken on MacOS, but it's more important to unblock the CI right now.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [X] Changelog updated or skip changelog label added
