### PR TITLE
ci: prune old dev releases separately for each major version

### DIFF
--- a/ci/_build_functions.sh
+++ b/ci/_build_functions.sh
@@ -74,7 +74,9 @@ function push_helm_chart() {
 function prune_helm_releases() {
   local chart_dir="$1"
   local max_age_timestamp="$2"
+  local major_version_number="${3}"
   local remote="origin"
+  local file_prefix="sumologic-${major_version_number}"
 
   echo "Pruning Helm Chart releases in ${chart_dir}"
 
@@ -86,7 +88,7 @@ function prune_helm_releases() {
   last_pruned_commit="$(git rev-list HEAD --min-age "${max_age_timestamp}" -n 1)"
   root_commit="$(git rev-list --max-parents=0 HEAD)"
   for filename in $(git diff --name-only "${root_commit}" "${last_pruned_commit}" "${chart_dir}/"); do
-    if [[ -f "${filename}" ]]; then
+    if [[ -f "${filename}" && ${filename} == ${file_prefix}* ]]; then
       git rm "${filename}"
     fi
   done

--- a/ci/push-helm-chart.sh
+++ b/ci/push-helm-chart.sh
@@ -24,7 +24,8 @@ push_helm_chart "${DEV_VERSION}" "./dev"
 
 echo "Pruning the dev Helm Chart releases older than one month"
 max_age_timestamp="$(date --date="-1 month" +"%s")"
-prune_helm_releases "./dev" "${max_age_timestamp}"
+major_version_number=$(echo "${DEV_VERSION}" | cut -dv -f2 | cut -d. -f1)
+prune_helm_releases "./dev" "${max_age_timestamp}" "${major_version_number}"
 
 # shellcheck disable=SC2310
 if is_checkout_on_tag; then


### PR DESCRIPTION
We want to prune our dev releases to only keep the ones from the past month, but we also don't want to prune the most recent dev release, as E2E tests still run on it.

Fix the above by pruning for each major version separately. As a result, v2 dev releases will only be pruned when a new v2 dev release is added, ensuring there will always be one.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [X] Changelog updated or skip changelog label added
