### PR TITLE
ci: fix dev Helm Chart pruning

### DIFF
--- a/ci/_build_functions.sh
+++ b/ci/_build_functions.sh
@@ -88,7 +88,7 @@ function prune_helm_releases() {
   last_pruned_commit="$(git rev-list HEAD --min-age "${max_age_timestamp}" -n 1)"
   root_commit="$(git rev-list --max-parents=0 HEAD)"
   for filename in $(git diff --name-only "${root_commit}" "${last_pruned_commit}" "${chart_dir}/"); do
-    if [[ -f "${filename}" && ${filename} == ${file_prefix}* ]]; then
+    if [[ -f "${filename}" && ${chart_dir}/${filename} = ${file_prefix}* ]]; then
       git rm "${filename}"
     fi
   done


### PR DESCRIPTION
There was an error in the pattern being matched.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [X] Changelog updated or skip changelog label added
