### PR TITLE
ci: fix dev Helm Chart pruning

### DIFF
--- a/ci/_build_functions.sh
+++ b/ci/_build_functions.sh
@@ -74,7 +74,7 @@ function push_helm_chart() {
 function prune_helm_releases() {
   local chart_dir="$1"
   local max_age_timestamp="$2"
-  local major_version_number="${3}"
+  local major_version_number="$3"
   local remote="origin"
   local file_prefix="sumologic-${major_version_number}"
 


### PR DESCRIPTION
Definitively fix dev Chart pruning :face_exhaling: . When passing arguments to a bash function or script `$3` and `${3}` are in fact different values.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [X] Changelog updated or skip changelog label added
