### PR TITLE
feat: use timestamp as message time if exists

### DIFF
--- a/.changelog/3039.changed.txt
+++ b/.changelog/3039.changed.txt
@@ -1,0 +1,1 @@
+feat: use timestamp as message time if exists

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -188,17 +188,26 @@ sumologic:
         default:
           name: logs
           config-name: endpoint-logs
-
           ## Properties can be used to extend default settings, such as processing rules, fields etc
-          # properties:
-          #  filters:
-          #    - name: "Test Exclude Debug"
-          #      filter_type: "Exclude"
-          #      regexp: ".*DEBUG.*"
+          properties:
+            default_date_formats:
+              ## Ensures that timestamp key has precedence over timestamp auto discovery
+              - format: epoch
+                locator: '\"timestamp\":(\\d+)'
+
+          # filters:
+          #   - name: "Test Exclude Debug"
+          #     filter_type: "Exclude"
+          #     regexp: ".*DEBUG.*"
       events:
         default:
           name: events
           config-name: endpoint-events
+          properties:
+            default_date_formats:
+              ## Ensures that timestamp key has precedence over timestamp auto discovery
+              - format: epoch
+                locator: '\"timestamp\":(\\d+)'
       traces:
         default:
           name: traces

--- a/tests/helm/testdata/goldenfile/terraform/all_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/all_fields.output.yaml
@@ -468,11 +468,19 @@ data:
     resource "sumologic_http_source" "default_events_source" {
         name         = local.default_events_source
         collector_id = sumologic_collector.collector.id
+        default_date_formats {
+          format  = "epoch"
+          locator = "\"timestamp\":(\\d+)"
+        }
     }
 
     resource "sumologic_http_source" "default_logs_source" {
         name         = local.default_logs_source
         collector_id = sumologic_collector.collector.id
+        default_date_formats {
+          format  = "epoch"
+          locator = "\"timestamp\":(\\d+)"
+        }
     }
 
     resource "sumologic_http_source" "apiserver_metrics_source" {

--- a/tests/helm/testdata/goldenfile/terraform/collector_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/collector_fields.output.yaml
@@ -469,11 +469,19 @@ data:
     resource "sumologic_http_source" "default_events_source" {
         name         = local.default_events_source
         collector_id = sumologic_collector.collector.id
+        default_date_formats {
+          format  = "epoch"
+          locator = "\"timestamp\":(\\d+)"
+        }
     }
 
     resource "sumologic_http_source" "default_logs_source" {
         name         = local.default_logs_source
         collector_id = sumologic_collector.collector.id
+        default_date_formats {
+          format  = "epoch"
+          locator = "\"timestamp\":(\\d+)"
+        }
     }
 
     resource "sumologic_http_source" "apiserver_metrics_source" {

--- a/tests/helm/testdata/goldenfile/terraform/default.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/default.output.yaml
@@ -467,11 +467,19 @@ data:
     resource "sumologic_http_source" "default_events_source" {
         name         = local.default_events_source
         collector_id = sumologic_collector.collector.id
+        default_date_formats {
+          format  = "epoch"
+          locator = "\"timestamp\":(\\d+)"
+        }
     }
 
     resource "sumologic_http_source" "default_logs_source" {
         name         = local.default_logs_source
         collector_id = sumologic_collector.collector.id
+        default_date_formats {
+          format  = "epoch"
+          locator = "\"timestamp\":(\\d+)"
+        }
     }
 
     resource "sumologic_http_source" "apiserver_metrics_source" {

--- a/tests/helm/testdata/goldenfile/terraform/disable_default_metrics.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disable_default_metrics.output.yaml
@@ -466,11 +466,19 @@ data:
     resource "sumologic_http_source" "default_events_source" {
         name         = local.default_events_source
         collector_id = sumologic_collector.collector.id
+        default_date_formats {
+          format  = "epoch"
+          locator = "\"timestamp\":(\\d+)"
+        }
     }
 
     resource "sumologic_http_source" "default_logs_source" {
         name         = local.default_logs_source
         collector_id = sumologic_collector.collector.id
+        default_date_formats {
+          format  = "epoch"
+          locator = "\"timestamp\":(\\d+)"
+        }
     }
 
     resource "sumologic_http_source" "apiserver_metrics_source" {

--- a/tests/helm/testdata/goldenfile/terraform/disabled_dashboards.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disabled_dashboards.output.yaml
@@ -467,11 +467,19 @@ data:
     resource "sumologic_http_source" "default_events_source" {
         name         = local.default_events_source
         collector_id = sumologic_collector.collector.id
+        default_date_formats {
+          format  = "epoch"
+          locator = "\"timestamp\":(\\d+)"
+        }
     }
 
     resource "sumologic_http_source" "default_logs_source" {
         name         = local.default_logs_source
         collector_id = sumologic_collector.collector.id
+        default_date_formats {
+          format  = "epoch"
+          locator = "\"timestamp\":(\\d+)"
+        }
     }
 
     resource "sumologic_http_source" "apiserver_metrics_source" {

--- a/tests/helm/testdata/goldenfile/terraform/disabled_monitors.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disabled_monitors.output.yaml
@@ -467,11 +467,19 @@ data:
     resource "sumologic_http_source" "default_events_source" {
         name         = local.default_events_source
         collector_id = sumologic_collector.collector.id
+        default_date_formats {
+          format  = "epoch"
+          locator = "\"timestamp\":(\\d+)"
+        }
     }
 
     resource "sumologic_http_source" "default_logs_source" {
         name         = local.default_logs_source
         collector_id = sumologic_collector.collector.id
+        default_date_formats {
+          format  = "epoch"
+          locator = "\"timestamp\":(\\d+)"
+        }
     }
 
     resource "sumologic_http_source" "apiserver_metrics_source" {

--- a/tests/helm/testdata/goldenfile/terraform/monitors_with_email_notifications.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/monitors_with_email_notifications.output.yaml
@@ -473,11 +473,19 @@ data:
     resource "sumologic_http_source" "default_events_source" {
         name         = local.default_events_source
         collector_id = sumologic_collector.collector.id
+        default_date_formats {
+          format  = "epoch"
+          locator = "\"timestamp\":(\\d+)"
+        }
     }
 
     resource "sumologic_http_source" "default_logs_source" {
         name         = local.default_logs_source
         collector_id = sumologic_collector.collector.id
+        default_date_formats {
+          format  = "epoch"
+          locator = "\"timestamp\":(\\d+)"
+        }
     }
 
     resource "sumologic_http_source" "apiserver_metrics_source" {

--- a/tests/helm/testdata/goldenfile/terraform/monitors_with_single_email.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/monitors_with_single_email.output.yaml
@@ -473,11 +473,19 @@ data:
     resource "sumologic_http_source" "default_events_source" {
         name         = local.default_events_source
         collector_id = sumologic_collector.collector.id
+        default_date_formats {
+          format  = "epoch"
+          locator = "\"timestamp\":(\\d+)"
+        }
     }
 
     resource "sumologic_http_source" "default_logs_source" {
         name         = local.default_logs_source
         collector_id = sumologic_collector.collector.id
+        default_date_formats {
+          format  = "epoch"
+          locator = "\"timestamp\":(\\d+)"
+        }
     }
 
     resource "sumologic_http_source" "apiserver_metrics_source" {

--- a/tests/helm/testdata/goldenfile/terraform/strip_extrapolation.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/strip_extrapolation.output.yaml
@@ -468,11 +468,19 @@ data:
     resource "sumologic_http_source" "default_events_source" {
         name         = local.default_events_source
         collector_id = sumologic_collector.collector.id
+        default_date_formats {
+          format  = "epoch"
+          locator = "\"timestamp\":(\\d+)"
+        }
     }
 
     resource "sumologic_http_source" "default_logs_source" {
         name         = local.default_logs_source
         collector_id = sumologic_collector.collector.id
+        default_date_formats {
+          format  = "epoch"
+          locator = "\"timestamp\":(\\d+)"
+        }
     }
 
     resource "sumologic_http_source" "apiserver_metrics_source" {

--- a/tests/helm/testdata/goldenfile/terraform/tracing-metrics-disabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/tracing-metrics-disabled.output.yaml
@@ -467,11 +467,19 @@ data:
     resource "sumologic_http_source" "default_events_source" {
         name         = local.default_events_source
         collector_id = sumologic_collector.collector.id
+        default_date_formats {
+          format  = "epoch"
+          locator = "\"timestamp\":(\\d+)"
+        }
     }
 
     resource "sumologic_http_source" "default_logs_source" {
         name         = local.default_logs_source
         collector_id = sumologic_collector.collector.id
+        default_date_formats {
+          format  = "epoch"
+          locator = "\"timestamp\":(\\d+)"
+        }
     }
 
     resource "sumologic_http_source" "apiserver_metrics_source" {


### PR DESCRIPTION
Instructs Sumo Logic to use `timestamp` key if it exists. It will ensure that the `timestamp` extraction is consistent. Auto-detection is fallback, so no behavior change is expected in case `timestamp` is not added to the log

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [ ] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features
