### PR TITLE
fix(logs): systemd logs with otel and Fluent Bit

### DIFF
--- a/.changelog/3042.fixed.txt
+++ b/.changelog/3042.fixed.txt
@@ -1,0 +1,1 @@
+fix(logs): systemd logs with otel and Fluent Bit

--- a/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
@@ -557,8 +557,6 @@ service:
         - groupbyattrs/systemd
         - resource/add_cluster
         - source/kubelet
-        - transform/remove_attributes
-        - transform/flatten
         - transform/add_timestamp
         - batch
       receivers:
@@ -581,8 +579,6 @@ service:
         - groupbyattrs/systemd
         - resource/add_cluster
         - source/systemd
-        - transform/remove_attributes
-        - transform/flatten
         - transform/add_timestamp
         - batch
       receivers:


### PR DESCRIPTION
When using Fluent Bit as the log collector and otel for metadata enrichment, systemd logs would arrive empty in Sumo. The reason for this is that Fluent Bit actually puts the systemd attributes in the equivalent of record attributes, while the otel log collector puts them in the body. The pipelines were the same, which caused the issue.

I've removed the unnecessary processors from the Fluent Bit pipeline.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [X] Changelog updated or skip changelog label added
