### PR TITLE
chore: drop support for EOLd platforms

### DIFF
--- a/.changelog/3043.changed.0.txt
+++ b/.changelog/3043.changed.0.txt
@@ -1,0 +1,1 @@
+chore: drop support for GKE 1.22

--- a/.changelog/3043.changed.1.txt
+++ b/.changelog/3043.changed.1.txt
@@ -1,0 +1,1 @@
+chore: drop support for OpenShift 4.8 and 4.9

--- a/docs/README.md
+++ b/docs/README.md
@@ -88,7 +88,7 @@ The following table displays the tested Kubernetes and Helm versions.
 | ------------- | ---------------------------------------- |
 | K8s with EKS  | 1.22<br/>1.23<br/>1.24<br/>1.25          |
 | K8s with Kops | 1.22<br/>1.23<br/>1.24<br/>1.25<br/>1.26 |
-| K8s with GKE  | 1.22<br/>1.23<br/>1.24<br/>1.25          |
+| K8s with GKE  | 1.23<br/>1.24<br/>1.25                   |
 | K8s with AKS  | 1.24<br/>1.25<br/>1.26                   |
 | OpenShift     | 4.8<br/>4.9<br/>4.10<br/>4.11<br/>4.12   |
 | Helm          | 3.8.2 (Linux)                            |

--- a/docs/README.md
+++ b/docs/README.md
@@ -90,7 +90,7 @@ The following table displays the tested Kubernetes and Helm versions.
 | K8s with Kops | 1.22<br/>1.23<br/>1.24<br/>1.25<br/>1.26 |
 | K8s with GKE  | 1.23<br/>1.24<br/>1.25                   |
 | K8s with AKS  | 1.24<br/>1.25<br/>1.26                   |
-| OpenShift     | 4.8<br/>4.9<br/>4.10<br/>4.11<br/>4.12   |
+| OpenShift     | 4.10<br/>4.11<br/>4.12                   |
 | Helm          | 3.8.2 (Linux)                            |
 | kubectl       | 1.23.6                                   |
 


### PR DESCRIPTION
OpenShift 4.8 and 4.9 are no longer supported: https://access.redhat.com/support/policy/updates/openshift#dates
GKE 1.22 is also no longer supported: https://cloud.google.com/kubernetes-engine/docs/release-schedule

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [X] Changelog updated or skip changelog label added
- [X] Documentation updated
