### PR TITLE
chore: add support for EKS 1.26 and GKE 1.26

### DIFF
--- a/.changelog/3047.added.0.txt
+++ b/.changelog/3047.added.0.txt
@@ -1,0 +1,1 @@
+chore: add support for GKE 1.26

--- a/.changelog/3047.added.1.txt
+++ b/.changelog/3047.added.1.txt
@@ -1,0 +1,1 @@
+chore: add support for EKS 1.26

--- a/docs/README.md
+++ b/docs/README.md
@@ -86,9 +86,9 @@ The following table displays the tested Kubernetes and Helm versions.
 
 | Name          | Version                                  |
 | ------------- | ---------------------------------------- |
-| K8s with EKS  | 1.22<br/>1.23<br/>1.24<br/>1.25          |
+| K8s with EKS  | 1.22<br/>1.23<br/>1.24<br/>1.25<br/>1.26 |
 | K8s with Kops | 1.22<br/>1.23<br/>1.24<br/>1.25<br/>1.26 |
-| K8s with GKE  | 1.23<br/>1.24<br/>1.25                   |
+| K8s with GKE  | 1.23<br/>1.24<br/>1.25<br/>1.26          |
 | K8s with AKS  | 1.24<br/>1.25<br/>1.26                   |
 | OpenShift     | 4.10<br/>4.11<br/>4.12                   |
 | Helm          | 3.8.2 (Linux)                            |


### PR DESCRIPTION
E2E tests now pass for these versions.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [X] Changelog updated or skip changelog label added
- [X] Documentation updated
