### PR TITLE
fix: json_merge where message bodies are only sometimes json

### DIFF
--- a/.changelog/3050.added.txt
+++ b/.changelog/3050.added.txt
@@ -1,0 +1,1 @@
+fix: otelcol logs json_merge where message bodies are only sometimes json

--- a/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
@@ -462,10 +462,11 @@ processors:
   ## We always parse json earlier in the pipeline though, so this is safe
   ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/transformprocessor
   transform/flatten:
+    error_mode: ignore
     log_statements:
       - context: log
         statements:
-          - merge_maps(attributes, body, "insert")
+          - merge_maps(attributes, body, "insert") where IsMatch(body, "^{") == true
           - set(body, "") where IsMatch(body, "^{") == true
 
   ## Remove all attributes, so body won't by nested by SumoLogic receiver in case of using otlp format

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/otel.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/otel.output.yaml
@@ -298,10 +298,11 @@ data:
           statements:
           - set(attributes["timestamp"], Int(time_unix_nano / 1000000))
       transform/flatten:
+        error_mode: ignore
         log_statements:
         - context: log
           statements:
-          - merge_maps(attributes, body, "insert")
+          - merge_maps(attributes, body, "insert") where IsMatch(body, "^{") == true
           - set(body, "") where IsMatch(body, "^{") == true
       transform/remove_attributes:
         log_statements:

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/templates.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/templates.output.yaml
@@ -298,10 +298,11 @@ data:
           statements:
           - set(attributes["timestamp"], Int(time_unix_nano / 1000000))
       transform/flatten:
+        error_mode: ignore
         log_statements:
         - context: log
           statements:
-          - merge_maps(attributes, body, "insert")
+          - merge_maps(attributes, body, "insert") where IsMatch(body, "^{") == true
           - set(body, "") where IsMatch(body, "^{") == true
       transform/remove_attributes:
         log_statements:


### PR DESCRIPTION
The [json_merge](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/release-v3.6/docs/collecting-container-logs.md#json_merge-log-format) log configuration has problems if log bodies are only _sometimes_ JSON. Some of our pods output JSON logs, others don't, and we got lots of these errors:

```
2023-05-11T19:41:15.418Z	error	logstransformprocessor@v0.76.3/processor.go:203	processor encountered an issue with next consumer	{"kind": "processor", "name": "logstransform/containers_parse_json", "pipeline": "logs/otlp/containers", "error": "failed to execute statement: merge_maps(attributes, body, \"insert\"), expected pcommon.Map but got string"}
```

We should check whether a log line seems like JSON, and don't attempt to `merge_maps` if not.

### Checklist

- [x] Changelog updated or skip changelog label added