### PR TITLE
chore(logs): use transform processor for json parsing

### DIFF
--- a/.changelog/3063.fixed.txt
+++ b/.changelog/3063.fixed.txt
@@ -1,0 +1,1 @@
+fix(logs): parse json in fluent bit pipeline

--- a/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
@@ -519,6 +519,7 @@ service:
         - resource/containers_copy_node_to_host
         - sumologic_schema
         - source/containers
+        - transform/containers_parse_json
 {{- if .Values.sumologic.logs.container.otelcol.extraProcessors }}
 {{- range $processor := .Values.sumologic.logs.container.otelcol.extraProcessors }}
 {{ printf "- %s" ( $processor | keys | first ) | indent 8 }}

--- a/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
@@ -326,15 +326,13 @@ processors:
 {{ end }}
 
 {{ if .Values.sumologic.logs.container.enabled }}
-  ## logstransformprocessor is experimental, but the same functionality in transformprocessor doesn't offer robust enough error handling
-  ## TODO: use transformprocessor here after https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16519 is closed
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/logstransformprocessor
-  logstransform/containers_parse_json:
-    operators:
-      - if: body matches "^{[\\s\\S]+"
-        parse_from: body
-        parse_to: body
-        type: json_parser
+  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/transformprocessor
+  transform/containers_parse_json:
+    error_mode: ignore
+    log_statements:
+      - context: log
+        statements:
+          - set(body, ParseJSON(body)) where IsMatch(body, "^{") == true
 {{ end }}
 
   ## ref: https://github.com/open-telemetry/opentelemetry-collector/tree/v0.76.1/processor/memorylimiterprocessor
@@ -605,7 +603,7 @@ service:
         - resource/containers_copy_node_to_host
         - sumologic_schema
         - source/containers
-        - logstransform/containers_parse_json
+        - transform/containers_parse_json
 {{- if .Values.sumologic.logs.container.otelcol.extraProcessors }}
 {{- range $processor := .Values.sumologic.logs.container.otelcol.extraProcessors }}
 {{ printf "- %s" ( $processor | keys | first ) | indent 8 }}

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/otel.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/otel.output.yaml
@@ -218,12 +218,6 @@ data:
         passthrough: false
         pod_association:
         - from: build_hostname
-      logstransform/containers_parse_json:
-        operators:
-        - if: body matches "^{[\\s\\S]+"
-          parse_from: body
-          parse_to: body
-          type: json_parser
       memory_limiter:
         check_interval: 5s
         limit_percentage: 75
@@ -297,6 +291,12 @@ data:
         - context: log
           statements:
           - set(attributes["timestamp"], Int(time_unix_nano / 1000000))
+      transform/containers_parse_json:
+        error_mode: ignore
+        log_statements:
+        - context: log
+          statements:
+          - set(body, ParseJSON(body)) where IsMatch(body, "^{") == true
       transform/flatten:
         log_statements:
         - context: log
@@ -332,7 +332,7 @@ data:
           - resource/containers_copy_node_to_host
           - sumologic_schema
           - source/containers
-          - logstransform/containers_parse_json
+          - transform/containers_parse_json
           - resource/remove_pod_name
           - resource/drop_annotations
           - transform/add_timestamp

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/templates.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/templates.output.yaml
@@ -218,12 +218,6 @@ data:
         passthrough: false
         pod_association:
         - from: build_hostname
-      logstransform/containers_parse_json:
-        operators:
-        - if: body matches "^{[\\s\\S]+"
-          parse_from: body
-          parse_to: body
-          type: json_parser
       memory_limiter:
         check_interval: 5s
         limit_percentage: 75
@@ -297,6 +291,12 @@ data:
         - context: log
           statements:
           - set(attributes["timestamp"], Int(time_unix_nano / 1000000))
+      transform/containers_parse_json:
+        error_mode: ignore
+        log_statements:
+        - context: log
+          statements:
+          - set(body, ParseJSON(body)) where IsMatch(body, "^{") == true
       transform/flatten:
         log_statements:
         - context: log
@@ -332,7 +332,7 @@ data:
           - resource/containers_copy_node_to_host
           - sumologic_schema
           - source/containers
-          - logstransform/containers_parse_json
+          - transform/containers_parse_json
           - resource/remove_pod_name
           - resource/drop_annotations
           - transform/add_timestamp


### PR DESCRIPTION
Use transform processor for JSON log parsing instead of the logstransform processor. The former is more stable and better supported, while the latter is slated for removal once OTTL has all the necessary features.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [X] Changelog updated or skip changelog label added