### PR TITLE
chore: update support for v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Sumo Logic Helm Chart Version
 | [v3.2](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v3.2/docs/README.md)     | deprecated / supported until 2023-09-01 |
 | [v3.1](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v3.1/docs/README.md)     | deprecated / supported until 2023-08-09 |
 | [v3.0](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v3.0/docs/README.md)     | deprecated / supported until 2023-07-20 |
-| [v2.19](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v2.19/deploy/README.md) | deprecated / supported until 2023-05-24 |
+| [v2.19](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v2.19/deploy/README.md) | deprecated / supported until 2023-07-20 |
 | [v2.18](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v2.18/deploy/README.md) | deprecated / unsupported                |
 | [v2.17](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v2.17/deploy/README.md) | deprecated / unsupported                |
 | [v2.16](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v2.16/deploy/README.md) | deprecated / unsupported                |


### PR DESCRIPTION
This is quite tricky as 2.19 is going to be supported to `2023-07-20` only because it is the latest v2 version. Not sure how to handle it clear