### PR TITLE
fix(logs): use longer fingerprint only on K8s <1.24

### DIFF
--- a/.changelog/3070.fixed.txt
+++ b/.changelog/3070.fixed.txt
@@ -1,0 +1,1 @@
+fix(logs): use longer fingerprint only on K8s <1.24

--- a/deploy/helm/sumologic/conf/logs/collector/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/collector/otelcol/config.yaml
@@ -59,9 +59,12 @@ receivers:
 {{- if .Values.sumologic.logs.container.enabled }}
   ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/receiver/filelogreceiver
   filelog/containers:
+{{ if lt (int .Capabilities.KubeVersion.Minor) 24 }}
     ## sets fingerprint_size to 17kb in order to match the longest possible docker line (which by default is 16kb)
     ## we want to include timestamp, which is at the end of the line
+    ## Not necessary in 1.24 and later, as docker-shim is not present anymore
     fingerprint_size: 17408
+{{ end }}
     include:
       - /var/log/pods/*/*/*.log
     include_file_name: false

--- a/tests/helm/const.go
+++ b/tests/helm/const.go
@@ -7,6 +7,7 @@ const (
 	chartName                = "sumologic"
 	releaseName              = "collection-test"
 	defaultNamespace         = "sumologic"
+	defaultK8sVersion        = "1.22.0"
 	testDataDirectory        = "./testdata"
 	otelConfigFileName       = "config.yaml"
 	otelImageFIPSSuffix      = "-fips"

--- a/tests/helm/goldenfile_test.go
+++ b/tests/helm/goldenfile_test.go
@@ -56,6 +56,8 @@ func runGoldenFileTest(t *testing.T, valuesFileName string, outputFileName strin
 		true,
 		"--namespace",
 		defaultNamespace,
+		"--kube-version",
+		defaultK8sVersion,
 	)
 
 	// render the actual and expected yaml strings and fix them up


### PR DESCRIPTION
Only use the longer file fingerprint for log file identification on K8s versions which still have docker-shim. This is not necessary with containerd.

Fixes #2916

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [X] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [X] Template tests added for new features
- [ ] Integration tests added or modified for major features
