### PR TITLE
Reordering HPA spec.metrics to match HPA ordering

### DIFF
--- a/.changelog/3078.changed.txt
+++ b/.changelog/3078.changed.txt
@@ -1,0 +1,1 @@
+Reordering HPA metrics to match HPA ordering

--- a/deploy/helm/sumologic/templates/logs/common/hpa.yaml
+++ b/deploy/helm/sumologic/templates/logs/common/hpa.yaml
@@ -18,12 +18,6 @@ spec:
   minReplicas: {{ .Values.metadata.logs.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.metadata.logs.autoscaling.maxReplicas }}
   metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ .Values.metadata.logs.autoscaling.targetCPUUtilizationPercentage }}
 {{- if .Values.metadata.logs.autoscaling.targetMemoryUtilizationPercentage }}
   - type: Resource
     resource:
@@ -31,5 +25,11 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ .Values.metadata.logs.autoscaling.targetMemoryUtilizationPercentage }}
-{{- end -}}
+{{- end }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.metadata.logs.autoscaling.targetCPUUtilizationPercentage }}
 {{- end -}}

--- a/deploy/helm/sumologic/templates/logs/fluentd/hpa.yaml
+++ b/deploy/helm/sumologic/templates/logs/fluentd/hpa.yaml
@@ -18,12 +18,6 @@ spec:
   minReplicas: {{ .Values.fluentd.logs.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.fluentd.logs.autoscaling.maxReplicas }}
   metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ .Values.fluentd.logs.autoscaling.targetCPUUtilizationPercentage }}
 {{- if .Values.fluentd.logs.autoscaling.targetMemoryUtilizationPercentage }}
   - type: Resource
     resource:
@@ -32,4 +26,10 @@ spec:
         type: Utilization
         averageUtilization: {{ .Values.fluentd.logs.autoscaling.targetMemoryUtilizationPercentage }}
 {{- end -}}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.fluentd.logs.autoscaling.targetCPUUtilizationPercentage }}
 {{- end -}}

--- a/deploy/helm/sumologic/templates/metrics/common/hpa.yaml
+++ b/deploy/helm/sumologic/templates/metrics/common/hpa.yaml
@@ -18,12 +18,6 @@ spec:
   minReplicas: {{ .Values.metadata.metrics.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.metadata.metrics.autoscaling.maxReplicas }}
   metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ .Values.metadata.metrics.autoscaling.targetCPUUtilizationPercentage }}
 {{- if .Values.metadata.metrics.autoscaling.targetMemoryUtilizationPercentage }}
   - type: Resource
     resource:
@@ -31,5 +25,11 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ .Values.metadata.metrics.autoscaling.targetMemoryUtilizationPercentage }}
-{{- end -}}
+{{- end }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.metadata.metrics.autoscaling.targetCPUUtilizationPercentage }}
 {{- end -}}

--- a/deploy/helm/sumologic/templates/metrics/fluentd/hpa.yaml
+++ b/deploy/helm/sumologic/templates/metrics/fluentd/hpa.yaml
@@ -18,12 +18,6 @@ spec:
   minReplicas: {{ .Values.fluentd.metrics.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.fluentd.metrics.autoscaling.maxReplicas }}
   metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ .Values.fluentd.metrics.autoscaling.targetCPUUtilizationPercentage }}
 {{- if .Values.fluentd.metrics.autoscaling.targetMemoryUtilizationPercentage }}
   - type: Resource
     resource:
@@ -32,4 +26,10 @@ spec:
         type: Utilization
         averageUtilization: {{ .Values.fluentd.metrics.autoscaling.targetMemoryUtilizationPercentage }}
 {{- end -}}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.fluentd.metrics.autoscaling.targetCPUUtilizationPercentage }}
 {{- end -}}


### PR DESCRIPTION
This addresses an issue when using ArgoCD (and maybe other GitOps operators) where Kubernetes reorders the objects under the spec.metrics key thus causing Sync issues with ArgoCD.

Originally reported to the ArgoCD project here:
https://github.com/argoproj/argo-cd/issues/1079

Originally reported to the Kubernetes project here: https://github.com/kubernetes/kubernetes/issues/74099

Other projects and companies have also addressed this by simply reordering the metrics section:

* https://github.com/kubernetes/ingress-nginx/pull/10043
* https://github.com/nginxinc/kubernetes-ingress/pull/3773
* https://github.com/grafana/helm-charts/pull/758
* https://github.com/open-telemetry/opentelemetry-helm-charts/pull/103
* https://github.com/Nextdoor/k8s-charts/pull/102

<!---
Describe your PR here
-->

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [ ] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features
