### PR TITLE
chore: drop support for k8s 1.22

### DIFF
--- a/.changelog/3081.changed.txt
+++ b/.changelog/3081.changed.txt
@@ -1,0 +1,1 @@
+chore: drop support for k8s 1.22

--- a/docs/README.md
+++ b/docs/README.md
@@ -84,16 +84,16 @@ The diagrams below illustrate the components of the Kubernetes collection soluti
 
 The following table displays the tested Kubernetes and Helm versions.
 
-| Name                   | Version                                  |
-| ---------------------- | ---------------------------------------- |
-| K8s with EKS           | 1.22<br/>1.23<br/>1.24<br/>1.25<br/>1.26 |
-| K8s with EKS (fargate) | 1.24<br/>1.25<br/>1.26                   |
-| K8s with Kops          | 1.22<br/>1.23<br/>1.24<br/>1.25<br/>1.26 |
-| K8s with GKE           | 1.23<br/>1.24<br/>1.25<br/>1.26          |
-| K8s with AKS           | 1.24<br/>1.25<br/>1.26                   |
-| OpenShift              | 4.10<br/>4.11<br/>4.12                   |
-| Helm                   | 3.8.2 (Linux)                            |
-| kubectl                | 1.23.6                                   |
+| Name                   | Version                         |
+| ---------------------- | ------------------------------- |
+| K8s with EKS           | 1.23<br/>1.24<br/>1.25<br/>1.26 |
+| K8s with EKS (fargate) | 1.24<br/>1.25<br/>1.26          |
+| K8s with Kops          | 1.23<br/>1.24<br/>1.25<br/>1.26 |
+| K8s with GKE           | 1.23<br/>1.24<br/>1.25<br/>1.26 |
+| K8s with AKS           | 1.24<br/>1.25<br/>1.26          |
+| OpenShift              | 4.10<br/>4.11<br/>4.12          |
+| Helm                   | 3.8.2 (Linux)                   |
+| kubectl                | 1.23.6                          |
 
 The following table displays the currently used software versions for our Helm chart.
 

--- a/tests/helm/const.go
+++ b/tests/helm/const.go
@@ -7,7 +7,7 @@ const (
 	chartName                = "sumologic"
 	releaseName              = "collection-test"
 	defaultNamespace         = "sumologic"
-	defaultK8sVersion        = "1.22.0"
+	defaultK8sVersion        = "1.23.0"
 	testDataDirectory        = "./testdata"
 	otelConfigFileName       = "config.yaml"
 	otelImageFIPSSuffix      = "-fips"

--- a/tests/integration/kind_images.json
+++ b/tests/integration/kind_images.json
@@ -3,8 +3,7 @@
     "kindest/node:v1.26.3",
     "kindest/node:v1.25.8",
     "kindest/node:v1.24.12",
-    "kindest/node:v1.23.17",
-    "kindest/node:v1.22.17"
+    "kindest/node:v1.23.17"
   ],
   "default": "kindest/node:v1.26.3"
 }

--- a/tests/integration/values/values_common.yaml
+++ b/tests/integration/values/values_common.yaml
@@ -34,18 +34,6 @@ kube-prometheus-stack:
     service:
       targetPort: 2381
 
-  # starting with K8s 1.23, the scheduler uses a secure port for metrics
-  # kube-prometheus-stack sets the default port based on the version
-  # however, kind uses kubeadm, which uses the secure port for 1.21 and 1.22 as well
-  # TODO: delete this after we drop support for 1.22
-  kubeScheduler:
-    service:
-      port: 10259
-      targetPort: 10259
-    serviceMonitor:
-      https: true
-      insecureSkipVerify: true
-
 # Request less resources so that this fits on Github actions runners environment
 metadata:
   persistence:

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -18,7 +18,7 @@ apt-get --yes install apt-transport-https jq make npm yamllint
 
 echo "export EDITOR=vim" >> /home/vagrant/.bashrc
 
-snap install microk8s --classic --channel=1.22/stable
+snap install microk8s --classic --channel=1.23/stable
 microk8s.status --wait-ready
 ufw allow in on cbr0
 ufw allow out on cbr0


### PR DESCRIPTION
EKS 1.22 is out of support since 04.06.2023 as per https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar. This was the last 1.22 version we supported, alongside KOPS.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [X] Changelog updated or skip changelog label added
- [X] Documentation updated
