### PR TITLE
chore: remove reference comments from otel config

### DIFF
--- a/deploy/helm/sumologic/conf/events/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/events/otelcol/config.yaml
@@ -1,5 +1,4 @@
 exporters:
-  ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/exporter/sumologicexporter
   sumologic:
     endpoint: ${SUMO_ENDPOINT_DEFAULT_EVENTS_SOURCE}
     json_logs:
@@ -14,51 +13,36 @@ exporters:
 
 extensions:
 {{- if .Values.sumologic.events.persistence.enabled }}
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/extension/storage/filestorage
   file_storage:
     directory: {{ .Values.sumologic.events.persistence.persistentVolume.path }}
     timeout: 10s
 {{- end }}
-
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/extension/healthcheckextension
   health_check: {}
-
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/extension/pprofextension
   pprof: {}
 
 processors:
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector/tree/v0.76.1/processor/batchprocessor
   batch:
     send_batch_max_size: 2_048
     send_batch_size: 1024
     timeout: 1s
-
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector/tree/v0.76.1/processor/memorylimiterprocessor
   memory_limiter:
     check_interval: 1s
     limit_percentage: 70
     spike_limit_percentage: 20
-
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/resourceprocessor
   resource/add_cluster:
     attributes:
       - action: upsert
         key: cluster
         value: {{ .Values.sumologic.clusterName | quote }}
-
-  ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/processor/sourceprocessor
   source:
     collector: {{ .Values.sumologic.collectorName | default .Values.sumologic.clusterName | quote }}
     source_category: {{ .Values.sumologic.events.sourceCategory | default (printf "%s/%s"  (include "sumologic.clusterNameReplaceSpaceWithDash" .) (.Values.fluentd.events.sourceName )) | quote}}
     source_category_prefix: ""
     source_name: {{ .Values.sumologic.events.sourceName | quote}}
-
-  ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/processor/sumologicschemaprocessor
   sumologic_schema:
     add_cloud_namespace: false
 
 receivers:
-  ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/receiver/rawk8seventsreceiver
   raw_k8s_events: {}
 
 service:

--- a/deploy/helm/sumologic/conf/logs/collector/otelcloudwatch/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/collector/otelcloudwatch/config.yaml
@@ -1,27 +1,20 @@
 exporters:
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector/tree/v0.73.0/exporter/otlphttpexporter
   otlphttp:
     endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local.:4318
     sending_queue:
       queue_size: 10
 
 extensions:
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.73.0/extension/storage/filestorage
   file_storage:
     compaction:
       directory: /var/lib/storage/otc
       on_rebound: true
     directory: /var/lib/storage/otc
     timeout: 10s
-
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.73.0/extension/healthcheckextension
   health_check: {}
-
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.73.0/extension/pprofextension
   pprof: {}
 
 processors:
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector/tree/v0.73.0/processor/batchprocessor
   batch:
     send_batch_max_size: 2000
     send_batch_size: 1000

--- a/deploy/helm/sumologic/conf/logs/collector/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/collector/otelcol/config.yaml
@@ -1,27 +1,20 @@
 exporters:
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector/tree/v0.76.1/exporter/otlphttpexporter
   otlphttp:
     endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local.:4318
     sending_queue:
       queue_size: 10
 
 extensions:
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/extension/storage/filestorage
   file_storage:
     compaction:
       directory: /var/lib/storage/otc
       on_rebound: true
     directory: /var/lib/storage/otc
     timeout: 10s
-
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/extension/healthcheckextension
   health_check: {}
-
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/extension/pprofextension
   pprof: {}
 
 processors:
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector/tree/v0.76.1/processor/batchprocessor
   batch:
     send_batch_max_size: 2000
     send_batch_size: 1000
@@ -31,7 +24,6 @@ processors:
   ## copy _SYSTEMD_UNIT, SYSLOG_FACILITY, _HOSTNAME and PRIORITY from body to attributes
   ## so they can be used by metadata processors same way like for fluentd
   ## build fluent.tag attribute as `host.{_SYSTEMD_UNIT}`
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/logstransformprocessor
   logstransform/systemd:
     operators:
       - from: body._SYSTEMD_UNIT
@@ -57,7 +49,6 @@ processors:
 
 receivers:
 {{- if .Values.sumologic.logs.container.enabled }}
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/receiver/filelogreceiver
   filelog/containers:
 {{ if lt (int .Capabilities.KubeVersion.Minor) 24 }}
     ## sets fingerprint_size to 17kb in order to match the longest possible docker line (which by default is 16kb)
@@ -239,7 +230,6 @@ receivers:
 {{- end }}
 
 {{- if .Values.sumologic.logs.systemd.enabled }}
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/receiver/journaldreceiver
   journald:
     directory: /var/log/journal
     ## This is not a full equivalent of fluent-bit filtering as fluent-bit filters by `_SYSTEMD_UNIT`

--- a/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
@@ -2,7 +2,6 @@ extensions:
   health_check: {}
 {{ if .Values.metadata.persistence.enabled }}
   ## Configuration for File Storage extension
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/release/v0.37.x/extension/storage/filestorage
   file_storage:
     directory: /var/lib/storage/otc
     timeout: 10s
@@ -13,7 +12,6 @@ extensions:
   pprof: {}
 exporters:
 {{ if .Values.sumologic.logs.container.enabled }}
-  ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/exporter/sumologicexporter
   sumologic/containers:
     endpoint: ${SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE}
     json_logs:
@@ -29,7 +27,6 @@ exporters:
 {{ end }}
 
 {{ if .Values.sumologic.logs.systemd.enabled }}
-  ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/exporter/sumologicexporter
   sumologic/systemd:
     endpoint: ${SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE}
     json_logs:
@@ -46,7 +43,6 @@ exporters:
 
 extensions:
 {{ if .Values.metadata.persistence.enabled }}
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/extension/storage/filestorage
   file_storage:
     compaction:
       directory: /tmp
@@ -54,16 +50,11 @@ extensions:
     directory: /var/lib/storage/otc
     timeout: 10s
 {{ end }}
-
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/extension/healthcheckextension
   health_check: {}
-
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/extension/pprofextension
   pprof: {}
 
 processors:
 {{ if .Values.sumologic.logs.systemd.enabled }}
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/attributesprocessor
   attributes/extract_systemd_source_fields:
     actions:
       - action: extract
@@ -75,7 +66,6 @@ processors:
 {{ end }}
 
 {{ if .Values.sumologic.logs.container.enabled }}
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/attributesprocessor
   attributes/fluent_containers:
     actions:
       - action: extract
@@ -102,15 +92,12 @@ processors:
       - action: delete
         key: k8s_container_name
 {{ end }}
-
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/attributesprocessor
   attributes/remove_fluent_tag:
     actions:
       - action: delete
         key: fluent.tag
 
   ## The batch processor accepts spans and places them into batches grouped by node and resource
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector/tree/v0.76.1/processor/batchprocessor
   batch:
     ## Maximum number of spans sent at once
     send_batch_max_size: 2_048
@@ -120,7 +107,6 @@ processors:
     timeout: 1s
 
 {{ if .Values.sumologic.logs.systemd.enabled }}
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/filterprocessor
   filter/exclude_kubelet:
     logs:
       exclude:
@@ -131,7 +117,6 @@ processors:
 {{ end }}
 
 {{ if .Values.sumologic.logs.systemd.enabled }}
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/filterprocessor
   filter/exclude_kubelet_hostname:
     logs:
       exclude:
@@ -142,7 +127,6 @@ processors:
 {{ end }}
 
 {{ if .Values.sumologic.logs.systemd.enabled }}
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/filterprocessor
   filter/exclude_kubelet_priority:
     logs:
       exclude:
@@ -153,7 +137,6 @@ processors:
 {{ end }}
 
 {{ if .Values.sumologic.logs.systemd.enabled }}
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/filterprocessor
   filter/exclude_kubelet_syslog:
     logs:
       exclude:
@@ -164,7 +147,6 @@ processors:
 {{ end }}
 
 {{ if .Values.sumologic.logs.systemd.enabled }}
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/filterprocessor
   filter/exclude_kubelet_unit:
     logs:
       exclude:
@@ -175,7 +157,6 @@ processors:
 {{ end }}
 
 {{ if .Values.sumologic.logs.systemd.enabled }}
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/filterprocessor
   filter/exclude_systemd_hostname:
     logs:
       exclude:
@@ -186,7 +167,6 @@ processors:
 {{ end }}
 
 {{ if .Values.sumologic.logs.systemd.enabled }}
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/filterprocessor
   filter/exclude_systemd_priority:
     logs:
       exclude:
@@ -197,7 +177,6 @@ processors:
 {{ end }}
 
 {{ if .Values.sumologic.logs.systemd.enabled }}
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/filterprocessor
   filter/exclude_systemd_syslog:
     logs:
       exclude:
@@ -208,7 +187,6 @@ processors:
 {{ end }}
 
 {{ if .Values.sumologic.logs.systemd.enabled }}
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/filterprocessor
   filter/exclude_systemd_unit:
     logs:
       exclude:
@@ -219,7 +197,6 @@ processors:
 {{ end }}
 
 {{ if .Values.sumologic.logs.container.enabled }}
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/filterprocessor
   filter/include_containers:
     logs:
       include:
@@ -230,7 +207,6 @@ processors:
 {{ end }}
 
 {{ if .Values.sumologic.logs.container.enabled }}
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/filterprocessor
   filter/include_fluent_tag_containers:
     logs:
       include:
@@ -241,7 +217,6 @@ processors:
 {{ end }}
 
 {{ if .Values.sumologic.logs.systemd.enabled }}
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/filterprocessor
   filter/include_fluent_tag_host:
     logs:
       include:
@@ -252,7 +227,6 @@ processors:
 {{ end }}
 
 {{ if .Values.sumologic.logs.systemd.enabled }}
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/filterprocessor
   filter/include_kubelet:
     logs:
       include:
@@ -263,7 +237,6 @@ processors:
 {{ end }}
 
 {{ if .Values.sumologic.logs.systemd.enabled }}
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/filterprocessor
   filter/include_systemd:
     logs:
       include:
@@ -274,7 +247,6 @@ processors:
 {{ end }}
 
 {{ if .Values.sumologic.logs.container.enabled }}
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/groupbyattrsprocessor
   groupbyattrs/containers:
     keys:
       - k8s.container.id
@@ -285,7 +257,6 @@ processors:
 {{ end }}
 
 {{ if .Values.sumologic.logs.systemd.enabled }}
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/groupbyattrsprocessor
   groupbyattrs/systemd:
     keys:
       - _sourceName
@@ -294,7 +265,6 @@ processors:
 {{ end }}
 
 {{ if .Values.sumologic.logs.container.enabled }}
-  ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/processor/k8sprocessor
   k8s_tagger:
     extract:
       annotations:
@@ -326,7 +296,6 @@ processors:
 {{ end }}
 
 {{ if .Values.sumologic.logs.container.enabled }}
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/transformprocessor
   transform/containers_parse_json:
     error_mode: ignore
     log_statements:
@@ -334,8 +303,6 @@ processors:
         statements:
           - set(body, ParseJSON(body)) where IsMatch(body, "^{") == true
 {{ end }}
-
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector/tree/v0.76.1/processor/memorylimiterprocessor
   memory_limiter:
     ## check_interval is the time between measurements of memory usage for the
     ## purposes of avoiding going over the limits. Defaults to zero, so no
@@ -346,8 +313,6 @@ processors:
     limit_percentage: 75
     ## Spike limit (calculated from available memory). Must be less than limit_percentage.
     spike_limit_percentage: 20
-
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/resourceprocessor
   resource/add_cluster:
     attributes:
       - action: upsert
@@ -355,7 +320,6 @@ processors:
         value: {{ .Values.sumologic.clusterName | quote }}
 
 {{ if .Values.sumologic.logs.container.enabled }}
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/resourceprocessor
   resource/containers_copy_node_to_host:
     attributes:
       - action: upsert
@@ -364,7 +328,6 @@ processors:
 {{ end }}
 
 {{ if .Values.sumologic.logs.container.enabled }}
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/resourceprocessor
   resource/drop_annotations:
     attributes:
       - action: delete
@@ -372,7 +335,6 @@ processors:
 {{ end }}
 
 {{ if .Values.sumologic.logs.container.enabled }}
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/resourceprocessor
   resource/remove_pod_name:
     attributes:
       - action: delete
@@ -382,7 +344,6 @@ processors:
 {{ if .Values.sumologic.logs.container.enabled }}
   # As sourceprocessor can't set these attributes to be empty, we do it here instead
   # If they're defined to be anything else in sourceprocessor, those values will overwrite these
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/resourceprocessor
   resource/set_empty_source_metadata:
     attributes:
     - action: insert
@@ -397,7 +358,6 @@ processors:
 {{ end }}
 
 {{ if .Values.sumologic.logs.container.enabled }}
-  ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/processor/sourceprocessor
   source/containers:
     annotation_prefix: "pod_annotations_"
     collector: {{ .Values.sumologic.collectorName | default .Values.sumologic.clusterName | quote }}
@@ -420,7 +380,6 @@ processors:
 {{ end }}
 
 {{ if .Values.sumologic.logs.systemd.enabled }}
-  ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/processor/sourceprocessor
   source/kubelet:
     collector: {{ .Values.sumologic.collectorName | default .Values.sumologic.clusterName | quote }}
     source_host: "%{_sourceHost}"
@@ -431,7 +390,6 @@ processors:
 {{ end }}
 
 {{ if .Values.sumologic.logs.systemd.enabled }}
-  ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/processor/sourceprocessor
   source/systemd:
     collector: {{ .Values.sumologic.collectorName | default .Values.sumologic.clusterName | quote }}
     source_category: {{ .Values.sumologic.logs.systemd.sourceCategory | quote }}
@@ -442,13 +400,11 @@ processors:
 {{ end }}
 
 {{ if .Values.sumologic.logs.container.enabled }}
-  ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/processor/sumologicschemaprocessor
   sumologic_schema:
     add_cloud_namespace: false
 {{ end }}
 
   ## Add timestamp to attributes
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/transformprocessor
   transform/add_timestamp:
     log_statements:
       - context: log
@@ -458,7 +414,6 @@ processors:
   ## Move attributes from the body to the record and drop the body if it's a map
   ## The map check isn't perfect, as there's no way to check for this explicitly in OTTL
   ## We always parse json earlier in the pipeline though, so this is safe
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/transformprocessor
   transform/flatten:
     error_mode: ignore
     log_statements:
@@ -468,7 +423,6 @@ processors:
           - set(body, "") where IsMatch(body, "^{") == true
 
   ## Remove all attributes, so body won't by nested by SumoLogic receiver in case of using otlp format
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/transformprocessor
   transform/remove_attributes:
     log_statements:
       - context: log
@@ -483,13 +437,11 @@ processors:
 
 receivers:
 {{ if eq (include "logs.collector.fluentbit.enabled" .) "true" }}
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/receiver/fluentforwardreceiver
   fluentforward:
     endpoint: 0.0.0.0:24321
 {{ end }}
 
 {{ if or .Values.sumologic.logs.collector.otelcol.enabled .Values.sumologic.logs.collector.otelcloudwatch.enabled }}
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector/tree/v0.76.1/receiver/otlpreceiver
   otlp:
     protocols:
       http:

--- a/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
@@ -5,7 +5,6 @@ extensions:
   health_check: {}
 {{ if .Values.metadata.persistence.enabled }}
   ## Configuration for File Storage extension
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/release/v0.37.x/extension/storage/filestorage
   file_storage:
     directory: /var/lib/storage/otc
     timeout: 10s

--- a/deploy/helm/sumologic/conf/metrics/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/metrics/otelcol/config.yaml
@@ -4,7 +4,6 @@ exporters:
 extensions:
 {{ if .Values.metadata.persistence.enabled }}
   ## Configuration for File Storage extension
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/extension/storage/filestorage
   file_storage:
     compaction:
       directory: /tmp
@@ -12,11 +11,7 @@ extensions:
     directory: /var/lib/storage/otc
     timeout: 10s
 {{ end }}
-
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/extension/healthcheckextension
   health_check: {}
-
-  ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/extension/pprofextension
   pprof: {}
 
 processors:
@@ -24,7 +19,6 @@ processors:
 
 receivers:
   ## Configuration for Telegraf Receiver
-  ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/receiver/telegrafreceiver
   telegraf:
     agent_config: |
       [agent]

--- a/deploy/helm/sumologic/conf/metrics/otelcol/exporters.yaml
+++ b/deploy/helm/sumologic/conf/metrics/otelcol/exporters.yaml
@@ -1,4 +1,3 @@
-## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/exporter/sumologicexporter
 sumologic/apiserver:
   endpoint: ${SUMO_ENDPOINT_APISERVER_METRICS_SOURCE}
   max_request_body_size: 16_777_216  # 16 MB before compression
@@ -12,8 +11,6 @@ sumologic/apiserver:
 {{- end }}
   ## set timeout to 30s due to big requests
   timeout: 30s
-
-## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/exporter/sumologicexporter
 sumologic/control_plane:
   endpoint: ${SUMO_ENDPOINT_CONTROL_PLANE_METRICS_SOURCE}
   max_request_body_size: 16_777_216  # 16 MB before compression
@@ -27,8 +24,6 @@ sumologic/control_plane:
 {{- end }}
   ## set timeout to 30s due to big requests
   timeout: 30s
-
-## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/exporter/sumologicexporter
 sumologic/controller:
   endpoint: ${SUMO_ENDPOINT_CONTROLLER_METRICS_SOURCE}
   max_request_body_size: 16_777_216  # 16 MB before compression
@@ -42,8 +37,6 @@ sumologic/controller:
 {{- end }}
   ## set timeout to 30s due to big requests
   timeout: 30s
-
-## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/exporter/sumologicexporter
 sumologic/default:
   endpoint: ${SUMO_ENDPOINT_DEFAULT_METRICS_SOURCE}
   max_request_body_size: 16_777_216  # 16 MB before compression
@@ -59,8 +52,6 @@ sumologic/default:
 {{- end }}
   ## set timeout to 30s due to big requests
   timeout: 30s
-
-## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/exporter/sumologicexporter
 sumologic/kubelet:
   endpoint: ${SUMO_ENDPOINT_KUBELET_METRICS_SOURCE}
   max_request_body_size: 16_777_216  # 16 MB before compression
@@ -74,8 +65,6 @@ sumologic/kubelet:
 {{- end }}
   ## set timeout to 30s due to big requests
   timeout: 30s
-
-## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/exporter/sumologicexporter
 sumologic/node:
   endpoint: ${SUMO_ENDPOINT_NODE_METRICS_SOURCE}
   max_request_body_size: 16_777_216  # 16 MB before compression
@@ -89,8 +78,6 @@ sumologic/node:
 {{- end }}
   ## set timeout to 30s due to big requests
   timeout: 30s
-
-## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/exporter/sumologicexporter
 sumologic/scheduler:
   endpoint: ${SUMO_ENDPOINT_SCHEDULER_METRICS_SOURCE}
   max_request_body_size: 16_777_216  # 16 MB before compression
@@ -104,8 +91,6 @@ sumologic/scheduler:
 {{- end }}
   ## set timeout to 30s due to big requests
   timeout: 30s
-
-## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/exporter/sumologicexporter
 sumologic/state:
   endpoint: ${SUMO_ENDPOINT_STATE_METRICS_SOURCE}
   max_request_body_size: 16_777_216  # 16 MB before compression

--- a/deploy/helm/sumologic/conf/metrics/otelcol/processors.yaml
+++ b/deploy/helm/sumologic/conf/metrics/otelcol/processors.yaml
@@ -1,6 +1,5 @@
 ## Configuration for Batch Processor
 ## The batch processor accepts spans and places them into batches grouped by node and resource
-## ref: https://github.com/open-telemetry/opentelemetry-collector/tree/v0.76.1/processor/batchprocessor
 batch:
   ## Maximum number of spans sent at once
   send_batch_max_size: 2_048
@@ -18,7 +17,6 @@ groupbyattrs:
     - service
 
 ## The Kubernetes sprocessor automatically tags logs, metrics and traces with Kubernetes metadata like pod name, namespace name etc.
-## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/processor/k8sprocessor
 k8s_tagger:
   extract:
     delimiter: "_"
@@ -41,7 +39,6 @@ k8s_tagger:
 
 ## Configuration for Memory Limiter Processor
 ## The memory_limiter processor is used to prevent out of memory situations on the collector.
-## ref: https://github.com/open-telemetry/opentelemetry-collector/tree/v0.76.1/processor/memorylimiter
 memory_limiter:
   ## check_interval is the time between measurements of memory usage for the
   ## purposes of avoiding going over the limits. Defaults to zero, so no
@@ -54,7 +51,6 @@ memory_limiter:
   spike_limit_percentage: 20
 
 ## Configuration for Metrics Transform Processor
-## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/metricstransformprocessor
 metricstransform:
   transforms:
     ## rename all prometheus_remote_write_$name metrics to $name
@@ -64,7 +60,6 @@ metricstransform:
     new_name: $$1
 
 ## Configuration for Resource Processor
-## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/resourceprocessor
 resource:
   attributes:
     - action: upsert
@@ -102,8 +97,6 @@ resource:
 ## NOTE: Drop these for now and and when proper configuration options
 ## are exposed and source processor is configured then send them
 ## as headers.
-## ref: https://github.com/SumoLogic/sumologic-otel-collector/issues/265
-## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/resourceprocessor
 resource/delete_source_metadata:
   attributes:
     - action: delete
@@ -112,8 +105,6 @@ resource/delete_source_metadata:
       key: _sourceHost
     - action: delete
       key: _sourceName
-
-## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/resourceprocessor
 resource/remove_k8s_pod_pod_name:
   attributes:
     - action: delete
@@ -122,7 +113,6 @@ resource/remove_k8s_pod_pod_name:
 ## NOTE: below listed rules could be simplified if routingprocessor
 ## supports regex matching. At this point we could group route entries
 ## going to the same set of exporters.
-## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/routingprocessor
 routing:
   attribute_source: resource
   default_exporters:
@@ -168,13 +158,11 @@ routing:
 
 ## Configuration for Source Processor
 ## Source processor adds Sumo Logic related metadata
-## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/processor/sourceprocessor
 source:
   collector: {{ .Values.sumologic.collectorName | default .Values.sumologic.clusterName | quote }}
 
 ## The Sumo Logic Schema processor modifies the metadata on logs, metrics and traces sent to Sumo Logic
 ## so that the Sumo Logic apps can make full use of the ingested data.
-## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/processor/sumologicschemaprocessor
 sumologic_schema:
   add_cloud_namespace: false
 

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
@@ -93,7 +93,6 @@ spec:
             storage: 10Gi
   config: |
     exporters:
-      ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/exporter/sumologicexporter
       sumologic/apiserver:
         endpoint: ${SUMO_ENDPOINT_APISERVER_METRICS_SOURCE}
         max_request_body_size: 16_777_216  # 16 MB before compression
@@ -105,8 +104,6 @@ spec:
           storage: file_storage
         ## set timeout to 30s due to big requests
         timeout: 30s
-      
-      ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/exporter/sumologicexporter
       sumologic/control_plane:
         endpoint: ${SUMO_ENDPOINT_CONTROL_PLANE_METRICS_SOURCE}
         max_request_body_size: 16_777_216  # 16 MB before compression
@@ -118,8 +115,6 @@ spec:
           storage: file_storage
         ## set timeout to 30s due to big requests
         timeout: 30s
-      
-      ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/exporter/sumologicexporter
       sumologic/controller:
         endpoint: ${SUMO_ENDPOINT_CONTROLLER_METRICS_SOURCE}
         max_request_body_size: 16_777_216  # 16 MB before compression
@@ -131,8 +126,6 @@ spec:
           storage: file_storage
         ## set timeout to 30s due to big requests
         timeout: 30s
-      
-      ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/exporter/sumologicexporter
       sumologic/default:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_METRICS_SOURCE}
         max_request_body_size: 16_777_216  # 16 MB before compression
@@ -146,8 +139,6 @@ spec:
           storage: file_storage
         ## set timeout to 30s due to big requests
         timeout: 30s
-      
-      ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/exporter/sumologicexporter
       sumologic/kubelet:
         endpoint: ${SUMO_ENDPOINT_KUBELET_METRICS_SOURCE}
         max_request_body_size: 16_777_216  # 16 MB before compression
@@ -159,8 +150,6 @@ spec:
           storage: file_storage
         ## set timeout to 30s due to big requests
         timeout: 30s
-      
-      ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/exporter/sumologicexporter
       sumologic/node:
         endpoint: ${SUMO_ENDPOINT_NODE_METRICS_SOURCE}
         max_request_body_size: 16_777_216  # 16 MB before compression
@@ -172,8 +161,6 @@ spec:
           storage: file_storage
         ## set timeout to 30s due to big requests
         timeout: 30s
-      
-      ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/exporter/sumologicexporter
       sumologic/scheduler:
         endpoint: ${SUMO_ENDPOINT_SCHEDULER_METRICS_SOURCE}
         max_request_body_size: 16_777_216  # 16 MB before compression
@@ -185,8 +172,6 @@ spec:
           storage: file_storage
         ## set timeout to 30s due to big requests
         timeout: 30s
-      
-      ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/exporter/sumologicexporter
       sumologic/state:
         endpoint: ${SUMO_ENDPOINT_STATE_METRICS_SOURCE}
         max_request_body_size: 16_777_216  # 16 MB before compression
@@ -204,7 +189,6 @@ spec:
       health_check: {}
 
       ## Configuration for File Storage extension
-      ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/release/v0.37.x/extension/storage/filestorage
       file_storage:
         directory: /var/lib/storage/otc
         timeout: 10s
@@ -217,7 +201,6 @@ spec:
     processors:
       ## Configuration for Batch Processor
       ## The batch processor accepts spans and places them into batches grouped by node and resource
-      ## ref: https://github.com/open-telemetry/opentelemetry-collector/tree/v0.76.1/processor/batchprocessor
       batch:
         ## Maximum number of spans sent at once
         send_batch_max_size: 2_048
@@ -235,7 +218,6 @@ spec:
           - service
       
       ## The Kubernetes sprocessor automatically tags logs, metrics and traces with Kubernetes metadata like pod name, namespace name etc.
-      ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/processor/k8sprocessor
       k8s_tagger:
         extract:
           delimiter: "_"
@@ -258,7 +240,6 @@ spec:
       
       ## Configuration for Memory Limiter Processor
       ## The memory_limiter processor is used to prevent out of memory situations on the collector.
-      ## ref: https://github.com/open-telemetry/opentelemetry-collector/tree/v0.76.1/processor/memorylimiter
       memory_limiter:
         ## check_interval is the time between measurements of memory usage for the
         ## purposes of avoiding going over the limits. Defaults to zero, so no
@@ -271,7 +252,6 @@ spec:
         spike_limit_percentage: 20
       
       ## Configuration for Metrics Transform Processor
-      ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/metricstransformprocessor
       metricstransform:
         transforms:
           ## rename all prometheus_remote_write_$name metrics to $name
@@ -281,7 +261,6 @@ spec:
           new_name: $$1
       
       ## Configuration for Resource Processor
-      ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/resourceprocessor
       resource:
         attributes:
           - action: upsert
@@ -319,8 +298,6 @@ spec:
       ## NOTE: Drop these for now and and when proper configuration options
       ## are exposed and source processor is configured then send them
       ## as headers.
-      ## ref: https://github.com/SumoLogic/sumologic-otel-collector/issues/265
-      ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/resourceprocessor
       resource/delete_source_metadata:
         attributes:
           - action: delete
@@ -329,8 +306,6 @@ spec:
             key: _sourceHost
           - action: delete
             key: _sourceName
-      
-      ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/resourceprocessor
       resource/remove_k8s_pod_pod_name:
         attributes:
           - action: delete
@@ -339,7 +314,6 @@ spec:
       ## NOTE: below listed rules could be simplified if routingprocessor
       ## supports regex matching. At this point we could group route entries
       ## going to the same set of exporters.
-      ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/routingprocessor
       routing:
         attribute_source: resource
         default_exporters:
@@ -385,13 +359,11 @@ spec:
       
       ## Configuration for Source Processor
       ## Source processor adds Sumo Logic related metadata
-      ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/processor/sourceprocessor
       source:
         collector: "kubernetes"
       
       ## The Sumo Logic Schema processor modifies the metadata on logs, metrics and traces sent to Sumo Logic
       ## so that the Sumo Logic apps can make full use of the ingested data.
-      ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/processor/sumologicschemaprocessor
       sumologic_schema:
         add_cloud_namespace: false
       

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
@@ -98,7 +98,6 @@ spec:
             storage: 10Gi
   config: |
     exporters:
-      ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/exporter/sumologicexporter
       sumologic/apiserver:
         endpoint: ${SUMO_ENDPOINT_APISERVER_METRICS_SOURCE}
         max_request_body_size: 16_777_216  # 16 MB before compression
@@ -110,8 +109,6 @@ spec:
           storage: file_storage
         ## set timeout to 30s due to big requests
         timeout: 30s
-      
-      ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/exporter/sumologicexporter
       sumologic/control_plane:
         endpoint: ${SUMO_ENDPOINT_CONTROL_PLANE_METRICS_SOURCE}
         max_request_body_size: 16_777_216  # 16 MB before compression
@@ -123,8 +120,6 @@ spec:
           storage: file_storage
         ## set timeout to 30s due to big requests
         timeout: 30s
-      
-      ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/exporter/sumologicexporter
       sumologic/controller:
         endpoint: ${SUMO_ENDPOINT_CONTROLLER_METRICS_SOURCE}
         max_request_body_size: 16_777_216  # 16 MB before compression
@@ -136,8 +131,6 @@ spec:
           storage: file_storage
         ## set timeout to 30s due to big requests
         timeout: 30s
-      
-      ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/exporter/sumologicexporter
       sumologic/default:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_METRICS_SOURCE}
         max_request_body_size: 16_777_216  # 16 MB before compression
@@ -151,8 +144,6 @@ spec:
           storage: file_storage
         ## set timeout to 30s due to big requests
         timeout: 30s
-      
-      ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/exporter/sumologicexporter
       sumologic/kubelet:
         endpoint: ${SUMO_ENDPOINT_KUBELET_METRICS_SOURCE}
         max_request_body_size: 16_777_216  # 16 MB before compression
@@ -164,8 +155,6 @@ spec:
           storage: file_storage
         ## set timeout to 30s due to big requests
         timeout: 30s
-      
-      ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/exporter/sumologicexporter
       sumologic/node:
         endpoint: ${SUMO_ENDPOINT_NODE_METRICS_SOURCE}
         max_request_body_size: 16_777_216  # 16 MB before compression
@@ -177,8 +166,6 @@ spec:
           storage: file_storage
         ## set timeout to 30s due to big requests
         timeout: 30s
-      
-      ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/exporter/sumologicexporter
       sumologic/scheduler:
         endpoint: ${SUMO_ENDPOINT_SCHEDULER_METRICS_SOURCE}
         max_request_body_size: 16_777_216  # 16 MB before compression
@@ -190,8 +177,6 @@ spec:
           storage: file_storage
         ## set timeout to 30s due to big requests
         timeout: 30s
-      
-      ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/exporter/sumologicexporter
       sumologic/state:
         endpoint: ${SUMO_ENDPOINT_STATE_METRICS_SOURCE}
         max_request_body_size: 16_777_216  # 16 MB before compression
@@ -209,7 +194,6 @@ spec:
       health_check: {}
 
       ## Configuration for File Storage extension
-      ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/release/v0.37.x/extension/storage/filestorage
       file_storage:
         directory: /var/lib/storage/otc
         timeout: 10s
@@ -222,7 +206,6 @@ spec:
     processors:
       ## Configuration for Batch Processor
       ## The batch processor accepts spans and places them into batches grouped by node and resource
-      ## ref: https://github.com/open-telemetry/opentelemetry-collector/tree/v0.76.1/processor/batchprocessor
       batch:
         ## Maximum number of spans sent at once
         send_batch_max_size: 2_048
@@ -240,7 +223,6 @@ spec:
           - service
       
       ## The Kubernetes sprocessor automatically tags logs, metrics and traces with Kubernetes metadata like pod name, namespace name etc.
-      ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/processor/k8sprocessor
       k8s_tagger:
         extract:
           delimiter: "_"
@@ -263,7 +245,6 @@ spec:
       
       ## Configuration for Memory Limiter Processor
       ## The memory_limiter processor is used to prevent out of memory situations on the collector.
-      ## ref: https://github.com/open-telemetry/opentelemetry-collector/tree/v0.76.1/processor/memorylimiter
       memory_limiter:
         ## check_interval is the time between measurements of memory usage for the
         ## purposes of avoiding going over the limits. Defaults to zero, so no
@@ -276,7 +257,6 @@ spec:
         spike_limit_percentage: 20
       
       ## Configuration for Metrics Transform Processor
-      ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/metricstransformprocessor
       metricstransform:
         transforms:
           ## rename all prometheus_remote_write_$name metrics to $name
@@ -286,7 +266,6 @@ spec:
           new_name: $$1
       
       ## Configuration for Resource Processor
-      ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/resourceprocessor
       resource:
         attributes:
           - action: upsert
@@ -324,8 +303,6 @@ spec:
       ## NOTE: Drop these for now and and when proper configuration options
       ## are exposed and source processor is configured then send them
       ## as headers.
-      ## ref: https://github.com/SumoLogic/sumologic-otel-collector/issues/265
-      ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/resourceprocessor
       resource/delete_source_metadata:
         attributes:
           - action: delete
@@ -334,8 +311,6 @@ spec:
             key: _sourceHost
           - action: delete
             key: _sourceName
-      
-      ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/resourceprocessor
       resource/remove_k8s_pod_pod_name:
         attributes:
           - action: delete
@@ -344,7 +319,6 @@ spec:
       ## NOTE: below listed rules could be simplified if routingprocessor
       ## supports regex matching. At this point we could group route entries
       ## going to the same set of exporters.
-      ## ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.76.1/processor/routingprocessor
       routing:
         attribute_source: resource
         default_exporters:
@@ -390,13 +364,11 @@ spec:
       
       ## Configuration for Source Processor
       ## Source processor adds Sumo Logic related metadata
-      ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/processor/sourceprocessor
       source:
         collector: "kubernetes"
       
       ## The Sumo Logic Schema processor modifies the metadata on logs, metrics and traces sent to Sumo Logic
       ## so that the Sumo Logic apps can make full use of the ingested data.
-      ## ref: https://github.com/SumoLogic/sumologic-otel-collector/tree/main/pkg/processor/sumologicschemaprocessor
       sumologic_schema:
         add_cloud_namespace: false
       


### PR DESCRIPTION
The references are a holdover from when the whole configuration was exposed to the user. We don't need them anymore, and updating them is annoying, see #3087 .

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [X] Changelog updated or skip changelog label added

