### PR TITLE
feat(traces): add ability to use OTLP source

### DIFF
--- a/.changelog/3094.added.txt
+++ b/.changelog/3094.added.txt
@@ -1,0 +1,1 @@
+feat(traces): add ability to use OTLP source

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -221,6 +221,11 @@ sumologic:
           config-name: endpoint-traces
           properties:
             content_type: Zipkin
+        default-otlp:
+          name: traces-otlp
+          config-name: endpoint-traces-otlp
+          properties:
+            content_type: Otlp
 
   ### Global configuration for OpenTelemetry Collector
   otelcolImage:

--- a/docs/otlp-source.md
+++ b/docs/otlp-source.md
@@ -21,6 +21,18 @@ sumologic:
 
 **Note:** The source is automatically created during Chart installation. This setting simply makes the Chart start sending data to it.
 
+### Enabling the OTLP source for traces
+
+Add the following to your configuration:
+
+```yaml
+tracesSampler:
+  config:
+    exporters:
+      otlphttp:
+        traces_endpoint: ${SUMO_ENDPOINT_DEFAULT_OTLP_TRACES_SOURCE}
+```
+
 ## Benefits
 
 Sending data directly via OTLP is more efficient, as we skip the conversion step. OTLP is also a binary-encoded format, which improves the

--- a/tests/helm/testdata/goldenfile/terraform/all_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/all_fields.output.yaml
@@ -356,6 +356,7 @@ data:
       state_metrics_source                        = "kube-state-metrics"
       test_source_metrics_source                  = "(Test source)"
       default_traces_source                       = "traces"
+      default_otlp_traces_source                  = "traces-otlp"
     }
   main.tf: |
     terraform {
@@ -582,6 +583,12 @@ data:
         content_type = "Zipkin"
     }
 
+    resource "sumologic_http_source" "default_otlp_traces_source" {
+        name         = local.default_otlp_traces_source
+        collector_id = sumologic_collector.collector.id
+        content_type = "Otlp"
+    }
+
     resource "kubernetes_secret" "sumologic_collection_secret" {
       metadata {
         name = "sumologic"
@@ -602,6 +609,7 @@ data:
         endpoint-metrics-kube-state               = sumologic_http_source.state_metrics_source.url
         endpoint-test_source_metrics_source       = sumologic_http_source.test_source_metrics_source.url
         endpoint-traces                           = sumologic_http_source.default_traces_source.url
+        endpoint-traces-otlp                      = sumologic_http_source.default_otlp_traces_source.url
       }
 
       type = "Opaque"
@@ -746,6 +754,7 @@ data:
     terraform import sumologic_http_source.state_metrics_source "${COLLECTOR_NAME}/kube-state-metrics"
     terraform import sumologic_http_source.test_source_metrics_source "${COLLECTOR_NAME}/(Test source)"
     terraform import sumologic_http_source.default_traces_source "${COLLECTOR_NAME}/traces"
+    terraform import sumologic_http_source.default_otlp_traces_source "${COLLECTOR_NAME}/traces-otlp"
     fi
 
     # Kubernetes Secret

--- a/tests/helm/testdata/goldenfile/terraform/collector_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/collector_fields.output.yaml
@@ -355,6 +355,7 @@ data:
       scheduler_metrics_source                    = "kube-scheduler-metrics"
       state_metrics_source                        = "kube-state-metrics"
       default_traces_source                       = "traces"
+      default_otlp_traces_source                  = "traces-otlp"
     }
   main.tf: |
     terraform {
@@ -538,6 +539,12 @@ data:
         content_type = "Zipkin"
     }
 
+    resource "sumologic_http_source" "default_otlp_traces_source" {
+        name         = local.default_otlp_traces_source
+        collector_id = sumologic_collector.collector.id
+        content_type = "Otlp"
+    }
+
     resource "kubernetes_secret" "sumologic_collection_secret" {
       metadata {
         name = "sumologic"
@@ -557,6 +564,7 @@ data:
         endpoint-metrics-kube-scheduler           = sumologic_http_source.scheduler_metrics_source.url
         endpoint-metrics-kube-state               = sumologic_http_source.state_metrics_source.url
         endpoint-traces                           = sumologic_http_source.default_traces_source.url
+        endpoint-traces-otlp                      = sumologic_http_source.default_otlp_traces_source.url
       }
 
       type = "Opaque"
@@ -700,6 +708,7 @@ data:
     terraform import sumologic_http_source.scheduler_metrics_source "${COLLECTOR_NAME}/kube-scheduler-metrics"
     terraform import sumologic_http_source.state_metrics_source "${COLLECTOR_NAME}/kube-state-metrics"
     terraform import sumologic_http_source.default_traces_source "${COLLECTOR_NAME}/traces"
+    terraform import sumologic_http_source.default_otlp_traces_source "${COLLECTOR_NAME}/traces-otlp"
     fi
 
     # Kubernetes Secret

--- a/tests/helm/testdata/goldenfile/terraform/default.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/default.output.yaml
@@ -355,6 +355,7 @@ data:
       scheduler_metrics_source                    = "kube-scheduler-metrics"
       state_metrics_source                        = "kube-state-metrics"
       default_traces_source                       = "traces"
+      default_otlp_traces_source                  = "traces-otlp"
     }
   main.tf: |
     terraform {
@@ -536,6 +537,12 @@ data:
         content_type = "Zipkin"
     }
 
+    resource "sumologic_http_source" "default_otlp_traces_source" {
+        name         = local.default_otlp_traces_source
+        collector_id = sumologic_collector.collector.id
+        content_type = "Otlp"
+    }
+
     resource "kubernetes_secret" "sumologic_collection_secret" {
       metadata {
         name = "sumologic"
@@ -555,6 +562,7 @@ data:
         endpoint-metrics-kube-scheduler           = sumologic_http_source.scheduler_metrics_source.url
         endpoint-metrics-kube-state               = sumologic_http_source.state_metrics_source.url
         endpoint-traces                           = sumologic_http_source.default_traces_source.url
+        endpoint-traces-otlp                      = sumologic_http_source.default_otlp_traces_source.url
       }
 
       type = "Opaque"
@@ -698,6 +706,7 @@ data:
     terraform import sumologic_http_source.scheduler_metrics_source "${COLLECTOR_NAME}/kube-scheduler-metrics"
     terraform import sumologic_http_source.state_metrics_source "${COLLECTOR_NAME}/kube-state-metrics"
     terraform import sumologic_http_source.default_traces_source "${COLLECTOR_NAME}/traces"
+    terraform import sumologic_http_source.default_otlp_traces_source "${COLLECTOR_NAME}/traces-otlp"
     fi
 
     # Kubernetes Secret

--- a/tests/helm/testdata/goldenfile/terraform/disable_default_metrics.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disable_default_metrics.output.yaml
@@ -354,6 +354,7 @@ data:
       scheduler_metrics_source                    = "kube-scheduler-metrics"
       state_metrics_source                        = "kube-state-metrics"
       default_traces_source                       = "traces"
+      default_otlp_traces_source                  = "traces-otlp"
     }
   main.tf: |
     terraform {
@@ -530,6 +531,12 @@ data:
         content_type = "Zipkin"
     }
 
+    resource "sumologic_http_source" "default_otlp_traces_source" {
+        name         = local.default_otlp_traces_source
+        collector_id = sumologic_collector.collector.id
+        content_type = "Otlp"
+    }
+
     resource "kubernetes_secret" "sumologic_collection_secret" {
       metadata {
         name = "sumologic"
@@ -548,6 +555,7 @@ data:
         endpoint-metrics-kube-scheduler           = sumologic_http_source.scheduler_metrics_source.url
         endpoint-metrics-kube-state               = sumologic_http_source.state_metrics_source.url
         endpoint-traces                           = sumologic_http_source.default_traces_source.url
+        endpoint-traces-otlp                      = sumologic_http_source.default_otlp_traces_source.url
       }
 
       type = "Opaque"
@@ -690,6 +698,7 @@ data:
     terraform import sumologic_http_source.scheduler_metrics_source "${COLLECTOR_NAME}/kube-scheduler-metrics"
     terraform import sumologic_http_source.state_metrics_source "${COLLECTOR_NAME}/kube-state-metrics"
     terraform import sumologic_http_source.default_traces_source "${COLLECTOR_NAME}/traces"
+    terraform import sumologic_http_source.default_otlp_traces_source "${COLLECTOR_NAME}/traces-otlp"
     fi
 
     # Kubernetes Secret

--- a/tests/helm/testdata/goldenfile/terraform/disabled_dashboards.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disabled_dashboards.output.yaml
@@ -355,6 +355,7 @@ data:
       scheduler_metrics_source                    = "kube-scheduler-metrics"
       state_metrics_source                        = "kube-state-metrics"
       default_traces_source                       = "traces"
+      default_otlp_traces_source                  = "traces-otlp"
     }
   main.tf: |
     terraform {
@@ -536,6 +537,12 @@ data:
         content_type = "Zipkin"
     }
 
+    resource "sumologic_http_source" "default_otlp_traces_source" {
+        name         = local.default_otlp_traces_source
+        collector_id = sumologic_collector.collector.id
+        content_type = "Otlp"
+    }
+
     resource "kubernetes_secret" "sumologic_collection_secret" {
       metadata {
         name = "sumologic"
@@ -555,6 +562,7 @@ data:
         endpoint-metrics-kube-scheduler           = sumologic_http_source.scheduler_metrics_source.url
         endpoint-metrics-kube-state               = sumologic_http_source.state_metrics_source.url
         endpoint-traces                           = sumologic_http_source.default_traces_source.url
+        endpoint-traces-otlp                      = sumologic_http_source.default_otlp_traces_source.url
       }
 
       type = "Opaque"
@@ -698,6 +706,7 @@ data:
     terraform import sumologic_http_source.scheduler_metrics_source "${COLLECTOR_NAME}/kube-scheduler-metrics"
     terraform import sumologic_http_source.state_metrics_source "${COLLECTOR_NAME}/kube-state-metrics"
     terraform import sumologic_http_source.default_traces_source "${COLLECTOR_NAME}/traces"
+    terraform import sumologic_http_source.default_otlp_traces_source "${COLLECTOR_NAME}/traces-otlp"
     fi
 
     # Kubernetes Secret

--- a/tests/helm/testdata/goldenfile/terraform/disabled_monitors.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disabled_monitors.output.yaml
@@ -355,6 +355,7 @@ data:
       scheduler_metrics_source                    = "kube-scheduler-metrics"
       state_metrics_source                        = "kube-state-metrics"
       default_traces_source                       = "traces"
+      default_otlp_traces_source                  = "traces-otlp"
     }
   main.tf: |
     terraform {
@@ -536,6 +537,12 @@ data:
         content_type = "Zipkin"
     }
 
+    resource "sumologic_http_source" "default_otlp_traces_source" {
+        name         = local.default_otlp_traces_source
+        collector_id = sumologic_collector.collector.id
+        content_type = "Otlp"
+    }
+
     resource "kubernetes_secret" "sumologic_collection_secret" {
       metadata {
         name = "sumologic"
@@ -555,6 +562,7 @@ data:
         endpoint-metrics-kube-scheduler           = sumologic_http_source.scheduler_metrics_source.url
         endpoint-metrics-kube-state               = sumologic_http_source.state_metrics_source.url
         endpoint-traces                           = sumologic_http_source.default_traces_source.url
+        endpoint-traces-otlp                      = sumologic_http_source.default_otlp_traces_source.url
       }
 
       type = "Opaque"
@@ -698,6 +706,7 @@ data:
     terraform import sumologic_http_source.scheduler_metrics_source "${COLLECTOR_NAME}/kube-scheduler-metrics"
     terraform import sumologic_http_source.state_metrics_source "${COLLECTOR_NAME}/kube-state-metrics"
     terraform import sumologic_http_source.default_traces_source "${COLLECTOR_NAME}/traces"
+    terraform import sumologic_http_source.default_otlp_traces_source "${COLLECTOR_NAME}/traces-otlp"
     fi
 
     # Kubernetes Secret

--- a/tests/helm/testdata/goldenfile/terraform/monitors_with_email_notifications.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/monitors_with_email_notifications.output.yaml
@@ -355,6 +355,7 @@ data:
       scheduler_metrics_source                    = "kube-scheduler-metrics"
       state_metrics_source                        = "kube-state-metrics"
       default_traces_source                       = "traces"
+      default_otlp_traces_source                  = "traces-otlp"
     }
   main.tf: |
     terraform {
@@ -542,6 +543,12 @@ data:
         content_type = "Zipkin"
     }
 
+    resource "sumologic_http_source" "default_otlp_traces_source" {
+        name         = local.default_otlp_traces_source
+        collector_id = sumologic_collector.collector.id
+        content_type = "Otlp"
+    }
+
     resource "kubernetes_secret" "sumologic_collection_secret" {
       metadata {
         name = "sumologic"
@@ -561,6 +568,7 @@ data:
         endpoint-metrics-kube-scheduler           = sumologic_http_source.scheduler_metrics_source.url
         endpoint-metrics-kube-state               = sumologic_http_source.state_metrics_source.url
         endpoint-traces                           = sumologic_http_source.default_traces_source.url
+        endpoint-traces-otlp                      = sumologic_http_source.default_otlp_traces_source.url
       }
 
       type = "Opaque"
@@ -704,6 +712,7 @@ data:
     terraform import sumologic_http_source.scheduler_metrics_source "${COLLECTOR_NAME}/kube-scheduler-metrics"
     terraform import sumologic_http_source.state_metrics_source "${COLLECTOR_NAME}/kube-state-metrics"
     terraform import sumologic_http_source.default_traces_source "${COLLECTOR_NAME}/traces"
+    terraform import sumologic_http_source.default_otlp_traces_source "${COLLECTOR_NAME}/traces-otlp"
     fi
 
     # Kubernetes Secret

--- a/tests/helm/testdata/goldenfile/terraform/monitors_with_single_email.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/monitors_with_single_email.output.yaml
@@ -355,6 +355,7 @@ data:
       scheduler_metrics_source                    = "kube-scheduler-metrics"
       state_metrics_source                        = "kube-state-metrics"
       default_traces_source                       = "traces"
+      default_otlp_traces_source                  = "traces-otlp"
     }
   main.tf: |
     terraform {
@@ -542,6 +543,12 @@ data:
         content_type = "Zipkin"
     }
 
+    resource "sumologic_http_source" "default_otlp_traces_source" {
+        name         = local.default_otlp_traces_source
+        collector_id = sumologic_collector.collector.id
+        content_type = "Otlp"
+    }
+
     resource "kubernetes_secret" "sumologic_collection_secret" {
       metadata {
         name = "sumologic"
@@ -561,6 +568,7 @@ data:
         endpoint-metrics-kube-scheduler           = sumologic_http_source.scheduler_metrics_source.url
         endpoint-metrics-kube-state               = sumologic_http_source.state_metrics_source.url
         endpoint-traces                           = sumologic_http_source.default_traces_source.url
+        endpoint-traces-otlp                      = sumologic_http_source.default_otlp_traces_source.url
       }
 
       type = "Opaque"
@@ -704,6 +712,7 @@ data:
     terraform import sumologic_http_source.scheduler_metrics_source "${COLLECTOR_NAME}/kube-scheduler-metrics"
     terraform import sumologic_http_source.state_metrics_source "${COLLECTOR_NAME}/kube-state-metrics"
     terraform import sumologic_http_source.default_traces_source "${COLLECTOR_NAME}/traces"
+    terraform import sumologic_http_source.default_otlp_traces_source "${COLLECTOR_NAME}/traces-otlp"
     fi
 
     # Kubernetes Secret

--- a/tests/helm/testdata/goldenfile/terraform/strip_extrapolation.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/strip_extrapolation.output.yaml
@@ -355,6 +355,7 @@ data:
       scheduler_metrics_source                    = "kube-scheduler-metrics"
       state_metrics_source                        = "kube-state-metrics"
       default_traces_source                       = "traces"
+      default_otlp_traces_source                  = "traces-otlp"
     }
   main.tf: |
     terraform {
@@ -537,6 +538,12 @@ data:
         content_type = "Zipkin"
     }
 
+    resource "sumologic_http_source" "default_otlp_traces_source" {
+        name         = local.default_otlp_traces_source
+        collector_id = sumologic_collector.collector.id
+        content_type = "Otlp"
+    }
+
     resource "kubernetes_secret" "sumologic_collection_secret" {
       metadata {
         name = "sumologic"
@@ -556,6 +563,7 @@ data:
         endpoint-metrics-kube-scheduler           = sumologic_http_source.scheduler_metrics_source.url
         endpoint-metrics-kube-state               = sumologic_http_source.state_metrics_source.url
         endpoint-traces                           = sumologic_http_source.default_traces_source.url
+        endpoint-traces-otlp                      = sumologic_http_source.default_otlp_traces_source.url
       }
 
       type = "Opaque"
@@ -699,6 +707,7 @@ data:
     terraform import sumologic_http_source.scheduler_metrics_source "${COLLECTOR_NAME}/kube-scheduler-metrics"
     terraform import sumologic_http_source.state_metrics_source "${COLLECTOR_NAME}/kube-state-metrics"
     terraform import sumologic_http_source.default_traces_source "${COLLECTOR_NAME}/traces"
+    terraform import sumologic_http_source.default_otlp_traces_source "${COLLECTOR_NAME}/traces-otlp"
     fi
 
     # Kubernetes Secret

--- a/tests/helm/testdata/goldenfile/terraform/traces.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/traces.output.yaml
@@ -345,6 +345,7 @@ data:
     locals {
       default_metrics_source                      = "(default-metrics)"
       default_traces_source                       = "traces"
+      default_otlp_traces_source                  = "traces-otlp"
     }
   main.tf: |
     terraform {
@@ -467,6 +468,12 @@ data:
         content_type = "Zipkin"
     }
 
+    resource "sumologic_http_source" "default_otlp_traces_source" {
+        name         = local.default_otlp_traces_source
+        collector_id = sumologic_collector.collector.id
+        content_type = "Otlp"
+    }
+
     resource "kubernetes_secret" "sumologic_collection_secret" {
       metadata {
         name = "sumologic"
@@ -476,6 +483,7 @@ data:
       data = {
         endpoint-metrics                          = sumologic_http_source.default_metrics_source.url
         endpoint-traces                           = sumologic_http_source.default_traces_source.url
+        endpoint-traces-otlp                      = sumologic_http_source.default_otlp_traces_source.url
       }
 
       type = "Opaque"
@@ -609,6 +617,7 @@ data:
     true  # prevent to render empty if; then
     terraform import sumologic_http_source.default_metrics_source "${COLLECTOR_NAME}/(default-metrics)"
     terraform import sumologic_http_source.default_traces_source "${COLLECTOR_NAME}/traces"
+    terraform import sumologic_http_source.default_otlp_traces_source "${COLLECTOR_NAME}/traces-otlp"
     fi
 
     # Kubernetes Secret

--- a/tests/helm/testdata/goldenfile/terraform/tracing-metrics-disabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/tracing-metrics-disabled.output.yaml
@@ -355,6 +355,7 @@ data:
       scheduler_metrics_source                    = "kube-scheduler-metrics"
       state_metrics_source                        = "kube-state-metrics"
       default_traces_source                       = "traces"
+      default_otlp_traces_source                  = "traces-otlp"
     }
   main.tf: |
     terraform {
@@ -536,6 +537,12 @@ data:
         content_type = "Zipkin"
     }
 
+    resource "sumologic_http_source" "default_otlp_traces_source" {
+        name         = local.default_otlp_traces_source
+        collector_id = sumologic_collector.collector.id
+        content_type = "Otlp"
+    }
+
     resource "kubernetes_secret" "sumologic_collection_secret" {
       metadata {
         name = "sumologic"
@@ -555,6 +562,7 @@ data:
         endpoint-metrics-kube-scheduler           = sumologic_http_source.scheduler_metrics_source.url
         endpoint-metrics-kube-state               = sumologic_http_source.state_metrics_source.url
         endpoint-traces                           = sumologic_http_source.default_traces_source.url
+        endpoint-traces-otlp                      = sumologic_http_source.default_otlp_traces_source.url
       }
 
       type = "Opaque"
@@ -698,6 +706,7 @@ data:
     terraform import sumologic_http_source.scheduler_metrics_source "${COLLECTOR_NAME}/kube-scheduler-metrics"
     terraform import sumologic_http_source.state_metrics_source "${COLLECTOR_NAME}/kube-state-metrics"
     terraform import sumologic_http_source.default_traces_source "${COLLECTOR_NAME}/traces"
+    terraform import sumologic_http_source.default_otlp_traces_source "${COLLECTOR_NAME}/traces-otlp"
     fi
 
     # Kubernetes Secret

--- a/tests/helm/testdata/goldenfile/traces-gateway-deployment/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-gateway-deployment/basic.output.yaml
@@ -48,6 +48,11 @@ spec:
                 secretKeyRef:
                   name: sumologic
                   key: endpoint-traces
+            - name: SUMO_ENDPOINT_DEFAULT_OTLP_TRACES_SOURCE
+              valueFrom:
+                secretKeyRef:
+                  name: sumologic
+                  key: endpoint-traces-otlp
 
             - name: SUMO_ENDPOINT_DEFAULT_METRICS_SOURCE
               valueFrom:

--- a/tests/helm/testdata/goldenfile/traces-sampler-deployment/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-sampler-deployment/basic.output.yaml
@@ -42,6 +42,11 @@ spec:
                 secretKeyRef:
                   name: sumologic
                   key: endpoint-traces
+            - name: SUMO_ENDPOINT_DEFAULT_OTLP_TRACES_SOURCE
+              valueFrom:
+                secretKeyRef:
+                  name: sumologic
+                  key: endpoint-traces-otlp
 
             - name: NO_PROXY
               value: kubernetes.default.svc

--- a/tests/integration/helm_opentelemetry_operator_enabled_test.go
+++ b/tests/integration/helm_opentelemetry_operator_enabled_test.go
@@ -28,7 +28,7 @@ func Test_Helm_OpenTelemetry_Operator_Enabled(t *testing.T) {
 	)
 
 	installChecks := []featureCheck{
-		CheckSumologicSecret(2),
+		CheckSumologicSecret(3),
 		CheckTracesInstall,
 	}
 

--- a/tests/integration/helm_ot_default_namespaceoverride_test.go
+++ b/tests/integration/helm_ot_default_namespaceoverride_test.go
@@ -19,7 +19,7 @@ func Test_Helm_Default_OT_NamespaceOverride(t *testing.T) {
 	expectedMetrics = append(expectedMetrics, internal.TracingOtelcolMetrics...)
 
 	installChecks := []featureCheck{
-		CheckSumologicSecret(12),
+		CheckSumologicSecret(13),
 		CheckOtelcolMetadataLogsInstall,
 		CheckOtelcolMetadataMetricsInstall,
 		CheckOtelcolEventsInstall,

--- a/tests/integration/helm_ot_default_test.go
+++ b/tests/integration/helm_ot_default_test.go
@@ -13,7 +13,7 @@ func Test_Helm_Default_OT(t *testing.T) {
 	expectedMetrics = append(expectedMetrics, internal.TracingOtelcolMetrics...)
 
 	installChecks := []featureCheck{
-		CheckSumologicSecret(12),
+		CheckSumologicSecret(13),
 		CheckOtelcolMetadataLogsInstall,
 		CheckOtelcolMetadataMetricsInstall,
 		CheckOtelcolEventsInstall,

--- a/tests/integration/helm_otc_fips_metadata_installation_test.go
+++ b/tests/integration/helm_otc_fips_metadata_installation_test.go
@@ -13,7 +13,7 @@ func Test_Helm_Default_OT_FIPS(t *testing.T) {
 	expectedMetrics = append(expectedMetrics, internal.TracingOtelcolMetrics...)
 
 	installChecks := []featureCheck{
-		CheckSumologicSecret(12),
+		CheckSumologicSecret(13),
 		CheckOtelcolMetadataLogsInstall,
 		CheckOtelcolMetadataMetricsInstall,
 		CheckOtelcolEventsInstall,

--- a/tests/integration/helm_otlp_test.go
+++ b/tests/integration/helm_otlp_test.go
@@ -7,7 +7,7 @@ import (
 func Test_Helm_OTLP(t *testing.T) {
 
 	installChecks := []featureCheck{
-		CheckSumologicSecret(2),
+		CheckSumologicSecret(5),
 		CheckOtelcolMetadataLogsInstall,
 		CheckOtelcolLogsCollectorInstall,
 	}
@@ -16,5 +16,7 @@ func Test_Helm_OTLP(t *testing.T) {
 
 	featLogs := GetLogsFeature()
 
-	testenv.Test(t, featInstall, featLogs)
+	featTraces := GetTracesFeature()
+
+	testenv.Test(t, featInstall, featLogs, featTraces)
 }

--- a/tests/integration/values/values_common.yaml
+++ b/tests/integration/values/values_common.yaml
@@ -104,7 +104,7 @@ tracesSampler:
     # Default otlp pipeline from values.yaml is used.
     exporters:
       otlphttp:
-        traces_endpoint: http://receiver-mock.receiver-mock:3000/receiver/v1/traces
+        traces_endpoint: ${SUMO_ENDPOINT_DEFAULT_TRACES_SOURCE}/v1/traces
   deployment:
     replicas: 1
     resources:

--- a/tests/integration/values/values_helm_otlp.yaml
+++ b/tests/integration/values/values_helm_otlp.yaml
@@ -6,4 +6,10 @@ sumologic:
   logs:
     sourceType: otlp
   traces:
-    enabled: false
+    enabled: true
+
+tracesSampler:
+  config:
+    exporters:
+      otlphttp:
+        traces_endpoint: ${SUMO_ENDPOINT_DEFAULT_OTLP_TRACES_SOURCE}/v1/traces


### PR DESCRIPTION
#3093 but for traces. As tracing otel config is embedded in values.yaml, the user has to manually change the exporter endpoint to enable otlp source.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [X] Changelog updated or skip changelog label added
- [X] Documentation updated
- [X] Integration tests added or modified for major features
