### PR TITLE
Otel cloudwatch logs collector fixes

### DIFF
--- a/.changelog/3099.fixed.txt
+++ b/.changelog/3099.fixed.txt
@@ -1,0 +1,2 @@
+fix(otelcloudwatch): Fixing PVC name for the cloudwatch logs collector
+docs(otelcloudwatch): Correcting the name for EFS Access points

--- a/deploy/helm/sumologic/templates/_helpers/_logs.tpl
+++ b/deploy/helm/sumologic/templates/_helpers/_logs.tpl
@@ -228,6 +228,11 @@ Return the exporters for kubelet log pipeline.
 {{- template "sumologic.fullname" . }}-otelcloudwatch-logs-collector
 {{- end -}}
 
+{{- define "sumologic.labels.app.logs.cloudwatch.pvc" -}}
+{{- $namespace := printf "%s" ( include "sumologic.namespace" .  ) | quote -}}
+{{- printf "file-storage-%s-sumologic-otelcol-logs-0" $namespace -}}
+{{- end -}}
+
 {{- define "sumologic.labels.app.logs.pod" -}}
 {{- template "sumologic.labels.app.logs" . }}
 {{- end -}}

--- a/deploy/helm/sumologic/templates/_helpers/_logs.tpl
+++ b/deploy/helm/sumologic/templates/_helpers/_logs.tpl
@@ -229,8 +229,7 @@ Return the exporters for kubelet log pipeline.
 {{- end -}}
 
 {{- define "sumologic.labels.app.logs.cloudwatch.pvc" -}}
-{{- $namespace := printf "%s" ( include "sumologic.namespace" .  ) | quote -}}
-{{- printf "file-storage-%s-sumologic-otelcol-logs-0" $namespace -}}
+{{- printf "file-storage-%s-sumologic-otelcol-logs-0" .Release.Name -}}
 {{- end -}}
 
 {{- define "sumologic.labels.app.logs.pod" -}}

--- a/deploy/helm/sumologic/templates/logs/collector/otelcol-cloudwatch/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/logs/collector/otelcol-cloudwatch/statefulset.yaml
@@ -62,7 +62,7 @@ spec:
 {{- if .Values.sumologic.logs.collector.otelcloudwatch.persistence.enabled }}
       - name: file-storage
         persistentVolumeClaim:
-          claimName: file-storage-sumo-sumologic-otelcol-logs-0
+          claimName: {{ template "sumologic.labels.app.logs.cloudwatch.pvc" . }}
 {{- end }}
       securityContext:
         {{- toYaml .Values.metadata.securityContext | nindent 8 }}

--- a/docs/fargate.md
+++ b/docs/fargate.md
@@ -198,7 +198,7 @@ for (( counter=0; counter<"${LOG_PODS}"; counter++ )); do
     aws efs describe-access-points \
       --region "${AWS_REGION}" |
     jq ".AccessPoints[] |
-      select(.RootDirectory.Path == \"/sumologic/file-storage-${HELM_INSTALLATION_NAME}-sumologic-otelcol-log-${counter}\") |
+      select(.RootDirectory.Path == \"/sumologic/file-storage-${HELM_INSTALLATION_NAME}-sumologic-otelcol-logs-${counter}\") |
       .AccessPointId" \
       --raw-output)"
 
@@ -206,7 +206,7 @@ for (( counter=0; counter<"${LOG_PODS}"; counter++ )); do
     aws efs create-access-point \
         --file-system-id "${EFS_ID}" \
         --posix-user Uid=1000,Gid=1000 \
-        --root-directory "Path=/${NAMESPACE}/file-storage-${HELM_INSTALLATION_NAME}-sumologic-otelcol-log-${counter},CreationInfo={OwnerUid=1000,OwnerGid=1000,Permissions=777}" \
+        --root-directory "Path=/${NAMESPACE}/file-storage-${HELM_INSTALLATION_NAME}-sumologic-otelcol-logs-${counter},CreationInfo={OwnerUid=1000,OwnerGid=1000,Permissions=777}" \
         --region "${AWS_REGION}"
   fi
 done

--- a/tests/helm/testdata/goldenfile/logs_otc_cloudwatch/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_cloudwatch/basic.output.yaml
@@ -36,7 +36,7 @@ spec:
           name: otelcol-config
         - name: file-storage
           persistentVolumeClaim:
-            claimName: file-storage-sumo-sumologic-otelcol-logs-0
+            claimName: file-storage-RELEASE-NAME-sumologic-otelcol-logs-0
       securityContext:
         fsGroup: 999
       containers:

--- a/tests/helm/testdata/goldenfile/logs_otc_cloudwatch/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_cloudwatch/custom.output.yaml
@@ -36,7 +36,7 @@ spec:
           name: otelcol-config
         - name: file-storage
           persistentVolumeClaim:
-            claimName: file-storage-sumo-sumologic-otelcol-logs-0
+            claimName: file-storage-RELEASE-NAME-sumologic-otelcol-logs-0
       securityContext:
         fsGroup: 999
       containers:


### PR DESCRIPTION
- Fixing PVC name for the cloudwatch logs collector - to not hardcode the release name
- Correct the name of the EFS access points

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [x] Documentation updated
