### PR TITLE
chore: prepare release v3.9.1

### DIFF
--- a/.changelog/3098.changed.txt
+++ b/.changelog/3098.changed.txt
@@ -1,1 +1,0 @@
-chore: Upgrade kubernetes setup to v3.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 <!-- towncrier release notes start -->
 
+## [v3.9.1]
+
+### Released 2023-06-30
+
+### Changed
+
+- chore: Upgrade kubernetes setup to v3.9.0 [#3098]
+
+[#3098]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/3098
+[v3.9.1]: https://github.com/SumoLogic/sumologic-kubernetes-collection/releases/v3.9.1
+
 ## [v3.9.0]
 
 ### Released 2023-06-14

--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sumologic
-version: 3.9.0
-appVersion: 3.9.0
+version: 3.9.1
+appVersion: 3.9.1
 description: A Helm chart for collecting Kubernetes logs, metrics, traces and events into Sumo Logic.
 type: application
 keywords:


### PR DESCRIPTION

This pull request fixes  v3.9.1 release which was create from main branch https://github.com/SumoLogic/sumologic-kubernetes-collection/commit/f6e9329b54adc0865b51bd9bfe7bae1cfe75c75f

Necessary changes are already on branch: https://github.com/SumoLogic/sumologic-kubernetes-collection/commit/63061a1bd6abff815079eb3dd9200c4fb313b7cb

- [x] Changelog updated or skip changelog label added
