### PR TITLE
test(integration): check metric labels strictly

### DIFF
--- a/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
@@ -16,7 +16,15 @@ extensions:
       on_rebound: true
       directory: /tmp
 
-processors: {}
+# TODO: Delete this once we upgrade operator past https://github.com/open-telemetry/opentelemetry-operator/issues/958
+processors:
+  transform/drop_id_name:
+    error_mode: ignore
+    metric_statements:
+      - context: datapoint
+        statements:
+          - delete_key(attributes, "id")
+          - delete_key(attributes, "name")
 
 receivers:
   prometheus:
@@ -122,5 +130,6 @@ service:
   pipelines:
     metrics:
       exporters: [otlphttp]
+      processors: [transform/drop_id_name]
       receivers: [prometheus]
 

--- a/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
@@ -16,13 +16,18 @@ extensions:
       on_rebound: true
       directory: /tmp
 
-# TODO: Delete this once we upgrade operator past https://github.com/open-telemetry/opentelemetry-operator/issues/958
+
 processors:
-  transform/drop_id_name:
+  transform/drop_unnecessary_attributes:
     error_mode: ignore
     metric_statements:
       - context: datapoint
         statements:
+          - delete_key(resource.attributes, "http.scheme")
+          - delete_key(resource.attributes, "net.host.name")
+          - delete_key(resource.attributes, "net.host.port")
+          - delete_key(resource.attributes, "service.instance.id")
+          # TODO: Delete these two once we upgrade operator past https://github.com/open-telemetry/opentelemetry-operator/issues/958
           - delete_key(attributes, "id")
           - delete_key(attributes, "name")
 
@@ -130,6 +135,6 @@ service:
   pipelines:
     metrics:
       exporters: [otlphttp]
-      processors: [transform/drop_id_name]
+      processors: [transform/drop_unnecessary_attributes]
       receivers: [prometheus]
 

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
@@ -71,7 +71,15 @@ spec:
           on_rebound: true
           directory: /tmp
 
-    processors: {}
+    # TODO: Delete this once we upgrade operator past https://github.com/open-telemetry/opentelemetry-operator/issues/958
+    processors:
+      transform/drop_id_name:
+        error_mode: ignore
+        metric_statements:
+          - context: datapoint
+            statements:
+              - delete_key(attributes, "id")
+              - delete_key(attributes, "name")
 
     receivers:
       prometheus:
@@ -177,4 +185,5 @@ spec:
       pipelines:
         metrics:
           exporters: [otlphttp]
+          processors: [transform/drop_id_name]
           receivers: [prometheus]

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
@@ -71,13 +71,18 @@ spec:
           on_rebound: true
           directory: /tmp
 
-    # TODO: Delete this once we upgrade operator past https://github.com/open-telemetry/opentelemetry-operator/issues/958
+
     processors:
-      transform/drop_id_name:
+      transform/drop_unnecessary_attributes:
         error_mode: ignore
         metric_statements:
           - context: datapoint
             statements:
+              - delete_key(resource.attributes, "http.scheme")
+              - delete_key(resource.attributes, "net.host.name")
+              - delete_key(resource.attributes, "net.host.port")
+              - delete_key(resource.attributes, "service.instance.id")
+              # TODO: Delete these two once we upgrade operator past https://github.com/open-telemetry/opentelemetry-operator/issues/958
               - delete_key(attributes, "id")
               - delete_key(attributes, "name")
 
@@ -185,5 +190,5 @@ spec:
       pipelines:
         metrics:
           exporters: [otlphttp]
-          processors: [transform/drop_id_name]
+          processors: [transform/drop_unnecessary_attributes]
           receivers: [prometheus]

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
@@ -93,7 +93,15 @@ spec:
           on_rebound: true
           directory: /tmp
 
-    processors: {}
+    # TODO: Delete this once we upgrade operator past https://github.com/open-telemetry/opentelemetry-operator/issues/958
+    processors:
+      transform/drop_id_name:
+        error_mode: ignore
+        metric_statements:
+          - context: datapoint
+            statements:
+              - delete_key(attributes, "id")
+              - delete_key(attributes, "name")
 
     receivers:
       prometheus:
@@ -199,4 +207,5 @@ spec:
       pipelines:
         metrics:
           exporters: [otlphttp]
+          processors: [transform/drop_id_name]
           receivers: [prometheus]

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
@@ -93,13 +93,18 @@ spec:
           on_rebound: true
           directory: /tmp
 
-    # TODO: Delete this once we upgrade operator past https://github.com/open-telemetry/opentelemetry-operator/issues/958
+
     processors:
-      transform/drop_id_name:
+      transform/drop_unnecessary_attributes:
         error_mode: ignore
         metric_statements:
           - context: datapoint
             statements:
+              - delete_key(resource.attributes, "http.scheme")
+              - delete_key(resource.attributes, "net.host.name")
+              - delete_key(resource.attributes, "net.host.port")
+              - delete_key(resource.attributes, "service.instance.id")
+              # TODO: Delete these two once we upgrade operator past https://github.com/open-telemetry/opentelemetry-operator/issues/958
               - delete_key(attributes, "id")
               - delete_key(attributes, "name")
 
@@ -207,5 +212,5 @@ spec:
       pipelines:
         metrics:
           exporters: [otlphttp]
-          processors: [transform/drop_id_name]
+          processors: [transform/drop_unnecessary_attributes]
           receivers: [prometheus]

--- a/tests/integration/helm_fluentbit_fluentd_test.go
+++ b/tests/integration/helm_fluentbit_fluentd_test.go
@@ -23,7 +23,7 @@ func Test_Helm_FluentBit_Fluentd(t *testing.T) {
 
 	featInstall := GetInstallFeature(installChecks)
 
-	featMetrics := GetMetricsFeature(expectedMetrics, Prometheus)
+	featMetrics := GetMetricsFeature(expectedMetrics, Fluentd)
 
 	featLogs := GetLogsFeature()
 

--- a/tests/integration/internal/receivermock/labels.go
+++ b/tests/integration/internal/receivermock/labels.go
@@ -60,3 +60,29 @@ func (labels Labels) MatchAll(requested Labels) bool {
 	}
 	return ret
 }
+
+// DiffLabelNames calculates the difference in label names between the two label sets. It returns two slices of strings:
+// the names of labels from origin not in `requested`, and the names of labels from requested not in origin
+func (labels Labels) DiffLabelNames(requested Labels, skipRegex *regexp.Regexp) (extra []string, missing []string) {
+	extra, missing = []string{}, []string{}
+	for label := range requested {
+		if skipRegex != nil && skipRegex.MatchString(label) {
+			continue
+		}
+		if _, ok := labels[label]; !ok {
+			missing = append(missing, label)
+		}
+	}
+
+	for label := range labels {
+		if skipRegex != nil && skipRegex.MatchString(label) {
+			continue
+		}
+
+		if _, ok := requested[label]; !ok && !skipRegex.MatchString(label) {
+			extra = append(extra, label)
+		}
+	}
+
+	return
+}


### PR DESCRIPTION
In metrics integration tests, check the expected labels strictly. Until now, we've only been checking if the expected attributes exist - now we also check if there are any extras, and fail the test in that case.

I've also dropped some attributes for metrics collected by the metrics collector.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
