### PR TITLE
fix(metrics/collector): drop scrape_* metrics

### DIFF
--- a/.changelog/3131.changed.txt
+++ b/.changelog/3131.changed.txt
@@ -1,0 +1,1 @@
+fix(metrics/collector): drop scrape_* metrics

--- a/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
@@ -31,6 +31,12 @@ processors:
           - delete_key(attributes, "id")
           - delete_key(attributes, "name")
 
+  filter/drop_unnecessary_metrics:
+    error_mode: ignore
+    metrics:
+      metric:
+        - IsMatch(name, "scrape_.*")
+
 receivers:
   prometheus:
     config:
@@ -161,6 +167,8 @@ service:
   pipelines:
     metrics:
       exporters: [otlphttp]
-      processors: [transform/drop_unnecessary_attributes]
+      processors:
+        - filter/drop_unnecessary_metrics
+        - transform/drop_unnecessary_attributes
       receivers: [prometheus]
 

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
@@ -86,6 +86,12 @@ spec:
               - delete_key(attributes, "id")
               - delete_key(attributes, "name")
 
+      filter/drop_unnecessary_metrics:
+        error_mode: ignore
+        metrics:
+          metric:
+            - IsMatch(name, "scrape_.*")
+
     receivers:
       prometheus:
         config:
@@ -212,5 +218,7 @@ spec:
       pipelines:
         metrics:
           exporters: [otlphttp]
-          processors: [transform/drop_unnecessary_attributes]
+          processors:
+            - filter/drop_unnecessary_metrics
+            - transform/drop_unnecessary_attributes
           receivers: [prometheus]

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
@@ -108,6 +108,12 @@ spec:
               - delete_key(attributes, "id")
               - delete_key(attributes, "name")
 
+      filter/drop_unnecessary_metrics:
+        error_mode: ignore
+        metrics:
+          metric:
+            - IsMatch(name, "scrape_.*")
+
     receivers:
       prometheus:
         config:
@@ -132,5 +138,7 @@ spec:
       pipelines:
         metrics:
           exporters: [otlphttp]
-          processors: [transform/drop_unnecessary_attributes]
+          processors:
+            - filter/drop_unnecessary_metrics
+            - transform/drop_unnecessary_attributes
           receivers: [prometheus]


### PR DESCRIPTION
By default, Prometheus receiver emits scrape metrics for each target, similar to Prometheus' `up`. We don't have these for Prometheus, so we should drop them by default for backwards compatibility.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [x] Template tests added for new features
- [ ] Integration tests added or modified for major features
