### PR TITLE
fix(metrics/collector): disabling kubelet and cAdvisor metrics

### DIFF
--- a/.changelog/3133.added.txt
+++ b/.changelog/3133.added.txt
@@ -1,0 +1,1 @@
+feat(metrics/collector): allow disabling cadvisor and kubelet metrics

--- a/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
@@ -39,7 +39,8 @@ receivers:
     config:
       global:
         scrape_interval: 30s
-      scrape_configs:
+      ## As of right now, if scrape_configs is empty, it needs to be an empty list, otherwise otel-operator rejects it
+      scrape_configs: {{ not (or .Values.sumologic.metrics.collector.otelcol.kubelet.enabled .Values.sumologic.metrics.collector.otelcol.cAdvisor.enabled) | ternary "[]" "" }}
 {{- if .Values.sumologic.metrics.collector.otelcol.kubelet.enabled }}
         ## These scrape configs are for kubelet metrics
         ## Prometheus operator does this by manually maintaining a Service with Endpoints for all Nodes

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
@@ -94,7 +94,8 @@ spec:
         config:
           global:
             scrape_interval: 30s
-          scrape_configs:
+          ## As of right now, if scrape_configs is empty, it needs to be an empty list, otherwise otel-operator rejects it
+          scrape_configs: 
             ## These scrape configs are for kubelet metrics
             ## Prometheus operator does this by manually maintaining a Service with Endpoints for all Nodes
             ## We don't have that capability, so we need to use a static configuration

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
@@ -116,7 +116,8 @@ spec:
         config:
           global:
             scrape_interval: 30s
-          scrape_configs:
+          ## As of right now, if scrape_configs is empty, it needs to be an empty list, otherwise otel-operator rejects it
+          scrape_configs: []
         target_allocator:
           endpoint: http://RELEASE-NAME-sumologic-metrics-targetallocator
           interval: 30s


### PR DESCRIPTION
Make sure we explicitly have an empty scrape configs array if both kubelet and cAdvisor metrics are disabled for the Otel collector. Opentelemetry-operator errors if this isn't the case.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
