### PR TITLE
fix(metrics/collector): drop k8s labels

### DIFF
--- a/.changelog/3141.fixed.txt
+++ b/.changelog/3141.fixed.txt
@@ -1,0 +1,1 @@
+fix(metrics/collector): drop k8s labels

--- a/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
@@ -21,12 +21,16 @@ processors:
   transform/drop_unnecessary_attributes:
     error_mode: ignore
     metric_statements:
-      - context: datapoint
+      - context: resource
         statements:
-          - delete_key(resource.attributes, "http.scheme")
-          - delete_key(resource.attributes, "net.host.name")
-          - delete_key(resource.attributes, "net.host.port")
-          - delete_key(resource.attributes, "service.instance.id")
+          - delete_key(attributes, "http.scheme")
+          - delete_key(attributes, "net.host.name")
+          - delete_key(attributes, "net.host.port")
+          - delete_key(attributes, "service.instance.id")
+          # prometheus receiver adds these automatically
+          # we drop them to make the rest of our pipeline easier to reason about
+          # after the collector and metadata are merged, consider using them instead of k8sattributes processor
+          - delete_matching_keys(attributes, "k8s.*")
 
   filter/drop_unnecessary_metrics:
     error_mode: ignore

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
@@ -76,12 +76,16 @@ spec:
       transform/drop_unnecessary_attributes:
         error_mode: ignore
         metric_statements:
-          - context: datapoint
+          - context: resource
             statements:
-              - delete_key(resource.attributes, "http.scheme")
-              - delete_key(resource.attributes, "net.host.name")
-              - delete_key(resource.attributes, "net.host.port")
-              - delete_key(resource.attributes, "service.instance.id")
+              - delete_key(attributes, "http.scheme")
+              - delete_key(attributes, "net.host.name")
+              - delete_key(attributes, "net.host.port")
+              - delete_key(attributes, "service.instance.id")
+              # prometheus receiver adds these automatically
+              # we drop them to make the rest of our pipeline easier to reason about
+              # after the collector and metadata are merged, consider using them instead of k8sattributes processor
+              - delete_matching_keys(attributes, "k8s.*")
 
       filter/drop_unnecessary_metrics:
         error_mode: ignore

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
@@ -98,12 +98,16 @@ spec:
       transform/drop_unnecessary_attributes:
         error_mode: ignore
         metric_statements:
-          - context: datapoint
+          - context: resource
             statements:
-              - delete_key(resource.attributes, "http.scheme")
-              - delete_key(resource.attributes, "net.host.name")
-              - delete_key(resource.attributes, "net.host.port")
-              - delete_key(resource.attributes, "service.instance.id")
+              - delete_key(attributes, "http.scheme")
+              - delete_key(attributes, "net.host.name")
+              - delete_key(attributes, "net.host.port")
+              - delete_key(attributes, "service.instance.id")
+              # prometheus receiver adds these automatically
+              # we drop them to make the rest of our pipeline easier to reason about
+              # after the collector and metadata are merged, consider using them instead of k8sattributes processor
+              - delete_matching_keys(attributes, "k8s.*")
 
       filter/drop_unnecessary_metrics:
         error_mode: ignore


### PR DESCRIPTION
Prometheus receiver adds some attributes based on Prometheus' meta labels. This cannot be turned off explicitly or prevented by deleting the labels in relabel configs, because the labels are extracted from the context.

Drop these labels in a processor, as we don't need them, and their presence makes the pipeline more difficult to understand.

I've also added a test specifically for metadata of kube-state-metrics, which have specific requirements. For example, Prometheus incorrectly assigns Pod metadata to them, and the test checks whether we remove it.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [x] Integration tests added or modified for major features
