### PR TITLE
Change the minimum version for using autoscaling/v2 api to 1.23

### DIFF
--- a/.changelog/3155.fixed.txt
+++ b/.changelog/3155.fixed.txt
@@ -1,1 +1,1 @@
-Change the minimum version for using autoscaling/v2 api to 1.23
+feat(helm): change the minimum version for using autoscaling/v2 api to 1.23

--- a/.changelog/3155.fixed.txt
+++ b/.changelog/3155.fixed.txt
@@ -1,0 +1,1 @@
+Change the minimum version for using autoscaling/v2 api to 1.23

--- a/deploy/helm/sumologic/templates/logs/common/hpa.yaml
+++ b/deploy/helm/sumologic/templates/logs/common/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and (eq (include "logs.otelcol.enabled" .) "true") (.Values.metadata.logs.autoscaling.enabled) }}
-{{- if and (eq .Capabilities.KubeVersion.Major "1") (lt (int (include "kubernetes.minor" .)) 26) }}
+{{- if and (eq .Capabilities.KubeVersion.Major "1") (lt (int (include "kubernetes.minor" .)) 23) }}
 apiVersion: autoscaling/v2beta2
 {{- else }}
 apiVersion: autoscaling/v2

--- a/deploy/helm/sumologic/templates/logs/fluentd/hpa.yaml
+++ b/deploy/helm/sumologic/templates/logs/fluentd/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and (eq (include "logs.fluentd.enabled" .) "true") (.Values.fluentd.logs.autoscaling.enabled) }}
-{{- if and (eq .Capabilities.KubeVersion.Major "1") (lt (int (include "kubernetes.minor" .)) 26) }}
+{{- if and (eq .Capabilities.KubeVersion.Major "1") (lt (int (include "kubernetes.minor" .)) 23) }}
 apiVersion: autoscaling/v2beta2
 {{- else }}
 apiVersion: autoscaling/v2

--- a/deploy/helm/sumologic/templates/metrics/common/hpa.yaml
+++ b/deploy/helm/sumologic/templates/metrics/common/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and (eq (include "metrics.otelcol.enabled" .) "true") ( .Values.metadata.metrics.autoscaling.enabled) }}
-{{- if and (eq .Capabilities.KubeVersion.Major "1") (lt (int (include "kubernetes.minor" .)) 26) }}
+{{- if and (eq .Capabilities.KubeVersion.Major "1") (lt (int (include "kubernetes.minor" .)) 23) }}
 apiVersion: autoscaling/v2beta2
 {{- else }}
 apiVersion: autoscaling/v2

--- a/deploy/helm/sumologic/templates/metrics/fluentd/hpa.yaml
+++ b/deploy/helm/sumologic/templates/metrics/fluentd/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and (eq (include "metrics.fluentd.enabled" .) "true") ( .Values.fluentd.metrics.autoscaling.enabled) }}
-{{- if and (eq .Capabilities.KubeVersion.Major "1") (lt (int (include "kubernetes.minor" .)) 26) }}
+{{- if and (eq .Capabilities.KubeVersion.Major "1") (lt (int (include "kubernetes.minor" .)) 23) }}
 apiVersion: autoscaling/v2beta2
 {{- else }}
 apiVersion: autoscaling/v2


### PR DESCRIPTION
This addresses issue #3154

### Checklist

- [x] Changelog updated or skip changelog label added
