### PR TITLE
chore: use zstd compression for internal otlp data

### DIFF
--- a/.changelog/3156.changed.txt
+++ b/.changelog/3156.changed.txt
@@ -1,0 +1,1 @@
+chore: use zstd compression for internal otlp data

--- a/deploy/helm/sumologic/conf/logs/collector/otelcloudwatch/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/collector/otelcloudwatch/config.yaml
@@ -1,6 +1,7 @@
 exporters:
   otlphttp:
     endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local.:4318
+    compression: zstd
     sending_queue:
       queue_size: 10
 

--- a/deploy/helm/sumologic/conf/logs/collector/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/collector/otelcol/config.yaml
@@ -1,6 +1,7 @@
 exporters:
   otlphttp:
     endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local.:4318
+    compression: zstd
     sending_queue:
       queue_size: 10
 

--- a/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
@@ -1,6 +1,7 @@
 exporters:
   otlphttp:
     endpoint: http://${METADATA_METRICS_SVC}.${NAMESPACE}.svc.cluster.local.:4318
+    compression: zstd
     sending_queue:
       queue_size: 10000
       num_consumers: 10

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -3757,6 +3757,7 @@ otelcolInstrumentation:
           queue_size: 5000
       otlphttp/traces:
         endpoint: 'http://{{ include "otelcolinstrumentation.exporter.endpoint" . }}:4318'
+        compression: zstd
     service:
       extensions: [health_check, memory_ballast, pprof]
       pipelines:

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -310,6 +310,7 @@ otellogs:
       exporters:
         otlphttp/extrafiles:
           endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local.:4319
+          compression: zstd
       service:
         pipelines:
           logs/extrafiles:

--- a/tests/helm/testdata/goldenfile/logs_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc/basic.output.yaml
@@ -14,6 +14,7 @@ data:
   config.yaml: |
     exporters:
       otlphttp:
+        compression: zstd
         endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local.:4318
         sending_queue:
           queue_size: 10

--- a/tests/helm/testdata/goldenfile/logs_otc/options.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc/options.output.yaml
@@ -14,6 +14,7 @@ data:
   config.yaml: |
     exporters:
       otlphttp:
+        compression: zstd
         endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local.:4318
         sending_queue:
           queue_size: 10

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
@@ -56,6 +56,7 @@ spec:
     exporters:
       otlphttp:
         endpoint: http://${METADATA_METRICS_SVC}.${NAMESPACE}.svc.cluster.local.:4318
+        compression: zstd
         sending_queue:
           queue_size: 10000
           num_consumers: 10

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
@@ -78,6 +78,7 @@ spec:
     exporters:
       otlphttp:
         endpoint: http://${METADATA_METRICS_SVC}.${NAMESPACE}.svc.cluster.local.:4318
+        compression: zstd
         sending_queue:
           queue_size: 10000
           num_consumers: 10

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/traces-gateway-disabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/traces-gateway-disabled.output.yaml
@@ -14,6 +14,7 @@ data:
   otelcol.instrumentation.conf.yaml: |
     exporters:
       otlphttp/traces:
+        compression: zstd
         endpoint: http://RELEASE-NAME-sumologic-traces-sampler.sumologic:4318
       sumologic/metrics:
         compress_encoding: gzip

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/traces-gateway-enabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/traces-gateway-enabled.output.yaml
@@ -14,6 +14,7 @@ data:
   otelcol.instrumentation.conf.yaml: |
     exporters:
       otlphttp/traces:
+        compression: zstd
         endpoint: http://RELEASE-NAME-sumologic-traces-gateway.sumologic:4318
       sumologic/metrics:
         compress_encoding: gzip


### PR DESCRIPTION
We transfer a bunch of data between components via OTLP. The default compression is gzip for the exporter, but the receiver supports ztsd since 0.81.0, which is a lot more efficient.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
