### PR TITLE
fix(otellogs): set fingerprint_size to 16kb to avoid of log duplication

### DIFF
--- a/.changelog/3158.fixed.txt
+++ b/.changelog/3158.fixed.txt
@@ -1,0 +1,1 @@
+fix(otellogs): set fingerprint_size to 16kb to avoid of log duplication

--- a/deploy/helm/sumologic/conf/logs/collector/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/collector/otelcol/config.yaml
@@ -51,10 +51,11 @@ receivers:
 {{- if .Values.sumologic.logs.container.enabled }}
   filelog/containers:
 {{ if lt (int .Capabilities.KubeVersion.Minor) 24 }}
-    ## sets fingerprint_size to 17kb in order to match the longest possible docker line (which by default is 16kb)
+    ## sets fingerprint_size to 16kb in order to match the longest possible docker line (which by default is 16kb)
     ## we want to include timestamp, which is at the end of the line
+    ## setting higher fingerprint_size is not recommended when https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22936 is not fixed
     ## Not necessary in 1.24 and later, as docker-shim is not present anymore
-    fingerprint_size: 17408
+    fingerprint_size: 16384
 {{ end }}
     include:
       - /var/log/pods/*/*/*.log

--- a/tests/helm/testdata/goldenfile/logs_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc/basic.output.yaml
@@ -54,7 +54,7 @@ data:
           type: remove
     receivers:
       filelog/containers:
-        fingerprint_size: 17408
+        fingerprint_size: 16384
         include:
         - /var/log/pods/*/*/*.log
         include_file_name: false


### PR DESCRIPTION
This prevents of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22936 which is caused by incorrect update of fingerprint when it is read in multiple iterations. The issue is not observed when `fingerprint_size` is not higher than default buffer size (16kb).

Two pull requests with approaches to fix https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22936 based on increasing buffer size for reader to fingerprint size (https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/22937 - not merged, https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/23183 - reverted). 

If `fingerprint_size` was set to 17kb only to match the longest possible docker line (which by default is 16kb) then it is reasonable to decrease `fingerprint_size` to 16kb which prevent of duplicated logs.

### Checklist

- [x] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features
