### PR TITLE
feat(metrics/collector): collect metrics from annotated Pods

### DIFF
--- a/.changelog/3162.added.txt
+++ b/.changelog/3162.added.txt
@@ -1,0 +1,1 @@
+feat(metrics/collector): collect metrics from annotated Pods

--- a/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
@@ -37,15 +37,71 @@ processors:
     error_mode: ignore
     metrics:
       metric:
-        - IsMatch(name, "scrape_.*")
+        # we let the metrics from annotations ("kubernetes-pods") through as they are
+        - resource.attributes["service.name"] != "kubernetes-pods" and IsMatch(name, "scrape_.*")
 
 receivers:
   prometheus:
     config:
       global:
         scrape_interval: 30s
-      ## As of right now, if scrape_configs is empty, it needs to be an empty list, otherwise otel-operator rejects it
-      scrape_configs: {{ not (or .Values.sumologic.metrics.collector.otelcol.kubelet.enabled .Values.sumologic.metrics.collector.otelcol.cAdvisor.enabled) | ternary "[]" "" }}
+      scrape_configs:
+        ## scraping metrics basing on annotations:
+        ##   - prometheus.io/scrape: true - to scrape metrics from the pod
+        ##   - prometheus.io/path: /metrics - path which the metric should be scrape from
+        ##   - prometheus.io/port: 9113 - port which the metric should be scrape from
+        ## rel: https://github.com/prometheus-operator/kube-prometheus/pull/16#issuecomment-424318647
+        - job_name: "kubernetes-pods"
+          kubernetes_sd_configs:
+            - role: pod
+          relabel_configs:
+            - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+              action: keep
+              regex: true
+            - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+              action: replace
+              target_label: __metrics_path__
+              regex: (.+)
+            - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+              action: replace
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: $1:$2
+              target_label: __address__
+            - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
+              separator: ;
+              regex: Node;(.*)
+              target_label: node
+              replacement: $1
+              action: replace
+            - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
+              separator: ;
+              regex: Pod;(.*)
+              target_label: pod
+              replacement: $1
+              action: replace
+            - source_labels: [__metrics_path__]
+              separator: ;
+              regex: (.*)
+              target_label: endpoint
+              replacement: $1
+              action: replace
+            - source_labels: [__meta_kubernetes_namespace]
+              action: replace
+              target_label: namespace
+            - action: labelmap
+              regex: __meta_kubernetes_pod_label_(.+)
+            - source_labels: [__meta_kubernetes_service_name]
+              separator: ;
+              regex: (.*)
+              target_label: service
+              replacement: $1
+              action: replace
+            - source_labels: [__meta_kubernetes_pod_name]
+              separator: ;
+              regex: (.*)
+              target_label: pod
+              replacement: $1
+              action: replace
 {{- if .Values.sumologic.metrics.collector.otelcol.kubelet.enabled }}
         ## These scrape configs are for kubelet metrics
         ## Prometheus operator does this by manually maintaining a Service with Endpoints for all Nodes

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
@@ -92,15 +92,71 @@ spec:
         error_mode: ignore
         metrics:
           metric:
-            - IsMatch(name, "scrape_.*")
+            # we let the metrics from annotations ("kubernetes-pods") through as they are
+            - resource.attributes["service.name"] != "kubernetes-pods" and IsMatch(name, "scrape_.*")
 
     receivers:
       prometheus:
         config:
           global:
             scrape_interval: 30s
-          ## As of right now, if scrape_configs is empty, it needs to be an empty list, otherwise otel-operator rejects it
-          scrape_configs: 
+          scrape_configs:
+            ## scraping metrics basing on annotations:
+            ##   - prometheus.io/scrape: true - to scrape metrics from the pod
+            ##   - prometheus.io/path: /metrics - path which the metric should be scrape from
+            ##   - prometheus.io/port: 9113 - port which the metric should be scrape from
+            ## rel: https://github.com/prometheus-operator/kube-prometheus/pull/16#issuecomment-424318647
+            - job_name: "kubernetes-pods"
+              kubernetes_sd_configs:
+                - role: pod
+              relabel_configs:
+                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+                  action: keep
+                  regex: true
+                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+                  action: replace
+                  target_label: __metrics_path__
+                  regex: (.+)
+                - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+                  action: replace
+                  regex: ([^:]+)(?::\d+)?;(\d+)
+                  replacement: $1:$2
+                  target_label: __address__
+                - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
+                  separator: ;
+                  regex: Node;(.*)
+                  target_label: node
+                  replacement: $1
+                  action: replace
+                - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
+                  separator: ;
+                  regex: Pod;(.*)
+                  target_label: pod
+                  replacement: $1
+                  action: replace
+                - source_labels: [__metrics_path__]
+                  separator: ;
+                  regex: (.*)
+                  target_label: endpoint
+                  replacement: $1
+                  action: replace
+                - source_labels: [__meta_kubernetes_namespace]
+                  action: replace
+                  target_label: namespace
+                - action: labelmap
+                  regex: __meta_kubernetes_pod_label_(.+)
+                - source_labels: [__meta_kubernetes_service_name]
+                  separator: ;
+                  regex: (.*)
+                  target_label: service
+                  replacement: $1
+                  action: replace
+                - source_labels: [__meta_kubernetes_pod_name]
+                  separator: ;
+                  regex: (.*)
+                  target_label: pod
+                  replacement: $1
+                  action: replace
             ## These scrape configs are for kubelet metrics
             ## Prometheus operator does this by manually maintaining a Service with Endpoints for all Nodes
             ## We don't have that capability, so we need to use a static configuration

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
@@ -114,15 +114,71 @@ spec:
         error_mode: ignore
         metrics:
           metric:
-            - IsMatch(name, "scrape_.*")
+            # we let the metrics from annotations ("kubernetes-pods") through as they are
+            - resource.attributes["service.name"] != "kubernetes-pods" and IsMatch(name, "scrape_.*")
 
     receivers:
       prometheus:
         config:
           global:
             scrape_interval: 30s
-          ## As of right now, if scrape_configs is empty, it needs to be an empty list, otherwise otel-operator rejects it
-          scrape_configs: []
+          scrape_configs:
+            ## scraping metrics basing on annotations:
+            ##   - prometheus.io/scrape: true - to scrape metrics from the pod
+            ##   - prometheus.io/path: /metrics - path which the metric should be scrape from
+            ##   - prometheus.io/port: 9113 - port which the metric should be scrape from
+            ## rel: https://github.com/prometheus-operator/kube-prometheus/pull/16#issuecomment-424318647
+            - job_name: "kubernetes-pods"
+              kubernetes_sd_configs:
+                - role: pod
+              relabel_configs:
+                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+                  action: keep
+                  regex: true
+                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+                  action: replace
+                  target_label: __metrics_path__
+                  regex: (.+)
+                - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+                  action: replace
+                  regex: ([^:]+)(?::\d+)?;(\d+)
+                  replacement: $1:$2
+                  target_label: __address__
+                - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
+                  separator: ;
+                  regex: Node;(.*)
+                  target_label: node
+                  replacement: $1
+                  action: replace
+                - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
+                  separator: ;
+                  regex: Pod;(.*)
+                  target_label: pod
+                  replacement: $1
+                  action: replace
+                - source_labels: [__metrics_path__]
+                  separator: ;
+                  regex: (.*)
+                  target_label: endpoint
+                  replacement: $1
+                  action: replace
+                - source_labels: [__meta_kubernetes_namespace]
+                  action: replace
+                  target_label: namespace
+                - action: labelmap
+                  regex: __meta_kubernetes_pod_label_(.+)
+                - source_labels: [__meta_kubernetes_service_name]
+                  separator: ;
+                  regex: (.*)
+                  target_label: service
+                  replacement: $1
+                  action: replace
+                - source_labels: [__meta_kubernetes_pod_name]
+                  separator: ;
+                  regex: (.*)
+                  target_label: pod
+                  replacement: $1
+                  action: replace
         target_allocator:
           endpoint: http://RELEASE-NAME-sumologic-metrics-targetallocator
           interval: 30s

--- a/tests/integration/helm_ot_metrics_test.go
+++ b/tests/integration/helm_ot_metrics_test.go
@@ -34,6 +34,7 @@ func Test_Helm_OT_Metrics(t *testing.T) {
 		internal.AdditionalNodeExporterMetrics,
 		internal.DefaultOtelcolMetrics,
 		internal.MetricsCollectorOtelcolMetrics,
+		internal.ReceiverMockMetrics,
 		internal.OtherMetrics,
 	}
 	for _, metrics := range expectedMetricsGroups {

--- a/tests/integration/internal/constants.go
+++ b/tests/integration/internal/constants.go
@@ -350,6 +350,16 @@ var (
 		// "node:node_inodes_free:",  // looks like we're not collecting node_filesystem_files_free which this requires
 		"instance:node_network_receive_bytes:rate:sum",
 	}
+	// The receiver-mock Pod used for tests has a "prometheus.io/scrape: true" annotation
+	// TODO: remove this once we have a better test for this behaviour
+	ReceiverMockMetrics = []string{
+		"receiver_mock_metrics_count",
+		"receiver_mock_logs_count",
+		"scrape_series_added",
+		"scrape_samples_scraped",
+		"scrape_samples_post_metric_relabeling",
+		"scrape_duration_seconds",
+	}
 	OtherMetrics = []string{
 		"up",
 	}
@@ -371,6 +381,11 @@ var (
 		"scheduler_scheduling_attempt_duration_seconds_sum",
 		"scheduler_scheduling_attempt_duration_seconds_bucket",
 		"cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile",
+		// TODO: Remove this once we have a better test for annotation metrics
+		"receiver_mock_logs_ip_count",
+		"receiver_mock_logs_bytes_count",
+		"receiver_mock_logs_bytes_ip_count",
+		"receiver_mock_metrics_ip_count",
 	}
 )
 
@@ -394,6 +409,7 @@ var (
 		NodeExporterMetrics,
 		PrometheusMetrics,
 		RecordingRuleMetrics,
+		ReceiverMockMetrics,
 		OtherMetrics,
 	}
 	DefaultExpectedMetrics                 []string

--- a/tests/integration/yamls/receiver-mock.yaml
+++ b/tests/integration/yamls/receiver-mock.yaml
@@ -21,6 +21,11 @@ spec:
       labels:
         service: receiver-mock
         app: receiver-mock
+      ## this is used for checking if we collect metrics from Pods with these annotations
+      ## TODO: remove this once we have a better test for this behaviour
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "3000"
     spec:
       containers:
         - ports:


### PR DESCRIPTION
We collect metrics from Pods with standard Prometheus annotations - `prometheus.io/scrape`, and so on - when using Prometheus. This PR implements this for otel. This is basically done by copying the additional scrape config we have for Prometheus into the prometheus receiver configuration.

The tests are very messy and I intend to add better ones in a separate PR when I implement metric filtering for Sumo Apps. This is just a quick and dirty way to show the functionality works, by using receiver-mock itself as the target.

Note that for this specific source of metrics, we actually forward Prometheus `scrape_*` metrics as well. I made the metrics collector behave the same way for the sake of consistency.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [x] Template tests added for new features
- [x] Integration tests added or modified for major features
