### PR TITLE
fix(helm/metrics): exclude namespace if collectionMonitoring is disabled

### DIFF
--- a/.changelog/3170.fixed.txt
+++ b/.changelog/3170.fixed.txt
@@ -1,0 +1,1 @@
+fix(helm/metrics): exclude namespace if collectionMonitoring is disabled

--- a/deploy/helm/sumologic/conf/metrics/otelcol/processors.yaml
+++ b/deploy/helm/sumologic/conf/metrics/otelcol/processors.yaml
@@ -161,6 +161,8 @@ routing:
 ## Source processor adds Sumo Logic related metadata
 source:
   collector: {{ .Values.sumologic.collectorName | default .Values.sumologic.clusterName | quote }}
+  exclude:
+    k8s.namespace.name: {{ include "logs.excludeNamespaces" . }}
 
 ## The Sumo Logic Schema processor modifies the metadata on logs, metrics and traces sent to Sumo Logic
 ## so that the Sumo Logic apps can make full use of the ingested data.

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/additional_endpoints.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/additional_endpoints.output.yaml
@@ -222,6 +222,8 @@ data:
           value: /prometheus.metrics.state
       source:
         collector: kubernetes
+        exclude:
+          k8s.namespace.name: ""
       sumologic_schema:
         add_cloud_namespace: false
       transform/prepare_routing:

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/basic.output.yaml
@@ -222,6 +222,8 @@ data:
           value: /prometheus.metrics.state
       source:
         collector: kubernetes
+        exclude:
+          k8s.namespace.name: ""
       sumologic_schema:
         add_cloud_namespace: false
       transform/prepare_routing:


### PR DESCRIPTION
### Checklist

Until the change is released, the following configuration may be use:

```
metadata:
  metrics:
    config:
      merge:
        processors:
          source:
            exclude:
              k8s.namespace.name: sumologic
``` 

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [ ] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features
