### PR TITLE
fix(metrics): don't forward duplicate metrics from annotated Pods

### DIFF
--- a/.changelog/3171.fixed.txt
+++ b/.changelog/3171.fixed.txt
@@ -1,0 +1,1 @@
+fix(metrics): don't forward duplicate metrics from annotated Pods

--- a/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
@@ -38,7 +38,7 @@ processors:
     metrics:
       metric:
         # we let the metrics from annotations ("kubernetes-pods") through as they are
-        - resource.attributes["service.name"] != "kubernetes-pods" and IsMatch(name, "scrape_.*")
+        - resource.attributes["service.name"] != "pod-annotations" and IsMatch(name, "scrape_.*")
 
 receivers:
   prometheus:
@@ -51,7 +51,7 @@ receivers:
         ##   - prometheus.io/path: /metrics - path which the metric should be scrape from
         ##   - prometheus.io/port: 9113 - port which the metric should be scrape from
         ## rel: https://github.com/prometheus-operator/kube-prometheus/pull/16#issuecomment-424318647
-        - job_name: "kubernetes-pods"
+        - job_name: "pod-annotations"
           kubernetes_sd_configs:
             - role: pod
           relabel_configs:

--- a/deploy/helm/sumologic/conf/metrics/otelcol/processors.yaml
+++ b/deploy/helm/sumologic/conf/metrics/otelcol/processors.yaml
@@ -156,6 +156,13 @@ routing:
     - exporters:
         - sumologic/state
       value: /prometheus.metrics.state
+    ## custom metrics
+    ## This entry is necessary due to a bug in routing processor that prevents the routing key from being deleted
+    ## if the default exporter is chosen
+    ## See: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/24644
+    - exporters:
+        - sumologic/default
+      value: /prometheus.metrics.applications.custom
 
 ## Configuration for Source Processor
 ## Source processor adds Sumo Logic related metadata

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -2119,7 +2119,7 @@ kube-prometheus-stack:
         ##   - prometheus.io/path: /metrics - path which the metric should be scrape from
         ##   - prometheus.io/port: 9113 - port which the metric should be scrape from
         ## rel: https://github.com/prometheus-operator/kube-prometheus/pull/16#issuecomment-424318647
-        - job_name: "kubernetes-pods"
+        - job_name: "pod-annotations"
           kubernetes_sd_configs:
             - role: pod
           relabel_configs:
@@ -2247,6 +2247,9 @@ kube-prometheus-stack:
         - url: http://$(METADATA_METRICS_SVC).$(NAMESPACE).svc.cluster.local.:9888/prometheus.metrics.operator.rule
           remoteTimeout: 5s
           writeRelabelConfigs:
+            - action: drop
+              regex: ^true$
+              sourceLabels: [_sumo_forward_]
             - action: keep
               regex: "cluster_quantile:apiserver_request_duration_seconds:histogram_quantile|instance:node_filesystem_usage:sum|instance:node_network_receive_bytes:rate:sum|cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile|cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile|cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile|cluster_quantile:scheduler_framework_extension_point_duration_seconds:histogram_quantile|node_namespace_pod:kube_pod_info:|:kube_pod_info_node_count:|node:node_num_cpu:sum|:node_cpu_utilisation:avg1m|node:node_cpu_utilisation:avg1m|node:cluster_cpu_utilisation:ratio|:node_cpu_saturation_load1:|node:node_cpu_saturation_load1:|:node_memory_utilisation:|node:node_memory_bytes_total:sum|node:node_memory_utilisation:ratio|node:cluster_memory_utilisation:ratio|:node_memory_swap_io_bytes:sum_rate|node:node_memory_utilisation:|node:node_memory_utilisation_2:|node:node_memory_swap_io_bytes:sum_rate|:node_disk_utilisation:avg_irate|node:node_disk_utilisation:avg_irate|:node_disk_saturation:avg_irate|node:node_disk_saturation:avg_irate|node:node_filesystem_usage:|node:node_filesystem_avail:|:node_net_utilisation:sum_irate|node:node_net_utilisation:sum_irate|:node_net_saturation:sum_irate|node:node_net_saturation:sum_irate|node:node_inodes_total:|node:node_inodes_free:"
               sourceLabels: [__name__]
@@ -2322,6 +2325,9 @@ kube-prometheus-stack:
         - url: http://$(METADATA_METRICS_SVC).$(NAMESPACE).svc.cluster.local.:9888/prometheus.metrics.applications.nginx-ingress
           remoteTimeout: 5s
           writeRelabelConfigs:
+            - action: drop
+              regex: ^true$
+              sourceLabels: [_sumo_forward_]
             - action: keep
               regex: (?:nginx_ingress_controller_ingress_resources_total|nginx_ingress_controller_nginx_(last_reload_(milliseconds|status)|reload(s|_errors)_total)|nginx_ingress_controller_virtualserver(|route)_resources_total|nginx_ingress_nginx_connections_(accepted|active|handled|reading|waiting|writing)|nginx_ingress_nginx_http_requests_total|nginx_ingress_nginxplus_(connections_(accepted|active|dropped|idle)|http_requests_(current|total)|resolver_(addr|formerr|name|noerror|notimp|nxdomain|refused|servfail|srv|timedout|unknown)|ssl_(handshakes_failed|session_reuses)|stream_server_zone_(connections|received|sent)|stream_upstream_server_(active|connect_time|fails|health_checks_fails|health_checks_unhealthy|received|response_time|sent|unavail|state)|(location|server)_zone_(discarded|received|requests|responses|sent|processing)|upstream_server_(fails|header_time|health_checks_fails|health_checks_unhealthy|received|sent|unavail|response_time|responses|requests)))
               sourceLabels: [__name__]
@@ -2415,6 +2421,9 @@ kube-prometheus-stack:
         - url: http://$(METADATA_METRICS_SVC).$(NAMESPACE).svc.cluster.local.:9888/prometheus.metrics.applications.nginx
           remoteTimeout: 5s
           writeRelabelConfigs:
+            - action: drop
+              regex: ^true$
+              sourceLabels: [_sumo_forward_]
             - action: keep
               regex: (?:nginx_(accepts|active|handled|reading|requests|waiting|writing)|nginx_plus_api_connections_(accepted|active|dropped|idle)|nginx_plus_api_http_caches_(cold|hit_bytes|max_size|miss_bytes|size|updating_bytes)|nginx_plus_api_http_location_zones_(discarded|received|requests|sent)|nginx_plus_api_http_location_zones_responses_(1xx|2xx|3xx|4xx|5xx|total)|nginx_plus_api_http_requests_(current|total)|nginx_plus_api_http_server_zones_(discarded|processing|received|requests|sent)|nginx_plus_api_http_server_zones_responses_(1xx|2xx|3xx|4xx|5xx|total)|nginx_plus_api_http_upstream_peers_(backup|downtime|fails|healthchecks_fails|healthchecks_unhealthy|received|requests|sent|unavail|response_time)|nginx_plus_api_http_upstream_peers_responses_(1xx|2xx|3xx|4xx|5xx|total)|nginx_plus_api_resolver_zones_(addr|formerr|name|noerror|notimp|nxdomain|refused|servfail|srv|timedout)|nginx_plus_api_ssl_(handshakes_failed|session_reuses)|nginx_plus_api_stream_server_zones_(connections|received|sent)|nginx_plus_api_stream_upstream_peers_(active|backup|connect_time|downtime|fails|healthchecks_fails|healthchecks_last_passed|healthchecks_unhealthy|received|response_time|sent|unavail))
               sourceLabels: [__name__]
@@ -2452,6 +2461,9 @@ kube-prometheus-stack:
         - url: http://$(METADATA_METRICS_SVC).$(NAMESPACE).svc.cluster.local.:9888/prometheus.metrics.applications.redis
           remoteTimeout: 5s
           writeRelabelConfigs:
+            - action: drop
+              regex: ^true$
+              sourceLabels: [_sumo_forward_]
             - action: keep
               regex: (?:redis_((blocked_|)clients|cluster_enabled|cmdstat_calls|connected_slaves|(evicted|expired|tracking_total)_keys|instantaneous_ops_per_sec|keyspace_(hitrate|hits|misses)|(master|slave)_repl_offset|maxmemory|mem_fragmentation_(bytes|ratio)|rdb_changes_since_last_save|rejected_connections|total_commands_processed|total_net_(input|output)_bytes|uptime|used_(cpu_(sys|user)|memory(_overhead|_rss|_startup|))))
               sourceLabels: [__name__]
@@ -2520,6 +2532,9 @@ kube-prometheus-stack:
         - url: http://$(METADATA_METRICS_SVC).$(NAMESPACE).svc.cluster.local.:9888/prometheus.metrics.applications.jmx
           remoteTimeout: 5s
           writeRelabelConfigs:
+            - action: drop
+              regex: ^true$
+              sourceLabels: [_sumo_forward_]
             - action: keep
               regex: (?:java_lang_(ClassLoading_(TotalL|Unl|L)oadedClassCount|Compilation_TotalCompilationTime|GarbageCollector_(Collection(Count|Time)|LastGcInfo_(GcThreadCount|duration|(memoryU|u)sage(After|Before)Gc_.*_used))|MemoryPool_(CollectionUsage(ThresholdSupported|_committed|_max|_used)|(Peak|)Usage_(committed|max|used)|UsageThresholdSupported)|Memory_((Non|)HeapMemoryUsage_(committed|max|used)|ObjectPendingFinalizationCount)|OperatingSystem_(AvailableProcessors|(CommittedVirtual|(Free|Total)(Physical|))MemorySize|(Free|Total)SwapSpaceSize|(Max|Open)FileDescriptorCount|ProcessCpu(Load|Time)|System(CpuLoad|LoadAverage))|Runtime_(BootClassPathSupported|Pid|Uptime|StartTime)|Threading_(CurrentThread(AllocatedBytes|(Cpu|User)Time)|(Daemon|Peak|TotalStarted|)ThreadCount|(ObjectMonitor|Synchronizer)UsageSupported|Thread(AllocatedMemory.*|ContentionMonitoring.*|CpuTime.*))))
               sourceLabels: [__name__]
@@ -2542,6 +2557,9 @@ kube-prometheus-stack:
         - url: http://$(METADATA_METRICS_SVC).$(NAMESPACE).svc.cluster.local.:9888/prometheus.metrics.applications.kafka
           remoteTimeout: 5s
           writeRelabelConfigs:
+            - action: drop
+              regex: ^true$
+              sourceLabels: [_sumo_forward_]
             - action: keep
               regex: (?:kafka_(broker_.*|controller_.*|java_lang_.*|partition_.*|purgatory_.*|network_.*|replica_.*|request_.*|topic_.*|topics_.*|zookeeper_.*))
               sourceLabels: [__name__]
@@ -2583,6 +2601,9 @@ kube-prometheus-stack:
         - url: http://$(METADATA_METRICS_SVC).$(NAMESPACE).svc.cluster.local.:9888/prometheus.metrics.applications.mysql
           remoteTimeout: 5s
           writeRelabelConfigs:
+            - action: drop
+              regex: ^true$
+              sourceLabels: [_sumo_forward_]
             - action: keep
               regex: (?:mysql_((uptime|connection_errors_.*|queries|slow_queries|questions|table_open_cache_.*|table_locks_.*|commands_.*|select_.*|sort_.*|mysqlx_connections_.*|mysqlx_worker_.*|connections|aborted_.*|locked_connects|bytes_.*|qcache_.*|threads_.*|opened_.*|created_tmp_.*)|innodb_(buffer_pool_.*|data_.*|rows_.*|row_lock_.*|log_waits)|perf_schema_(events_statements_.*|table_io_waits_.*|index_io_waits_.*|read.*|write.*)))
               sourceLabels: [__name__]
@@ -2639,6 +2660,9 @@ kube-prometheus-stack:
         - url: http://$(METADATA_METRICS_SVC).$(NAMESPACE).svc.cluster.local.:9888/prometheus.metrics.applications.postgresql
           remoteTimeout: 5s
           writeRelabelConfigs:
+            - action: drop
+              regex: ^true$
+              sourceLabels: [_sumo_forward_]
             - action: keep
               regex: (?:postgresql_(blks_(hit|read)|buffers_(backend|checkpoint|clean)|checkpoints_(req|timed)|db_size|deadlocks|flush_lag|heap_blks_(hit|read)|idx_blks_(hit|read)|idx_scan|idx_tup_(fetch|read)|index_size|n_dead_tup|n_live_tup|n_tup_(upd|ins|del|hot_upd)|num_locks|numbackends|replay_lag|replication_(delay|lag)|seq_scan|seq_tup_read|stat_ssl_compression_count|table_size|tidx_blks_(hit|read)|toast_blks_(hit|read)|tup_(deleted|fetched|inserted|returned|updated)|write_lag|xact_(commit|rollback)))
               sourceLabels: [__name__]
@@ -2682,6 +2706,9 @@ kube-prometheus-stack:
         - url: http://$(METADATA_METRICS_SVC).$(NAMESPACE).svc.cluster.local.:9888/prometheus.metrics.applications.apache
           remoteTimeout: 5s
           writeRelabelConfigs:
+            - action: drop
+              regex: ^true$
+              sourceLabels: [_sumo_forward_]
             - action: keep
               regex: (?:apache_((BusyWorkers|BytesPerReq|BytesPerSec|CPUChildrenSystem|CPUChildrenUser|CPULoad|CPUSystem|CPUUser|DurationPerReq|IdleWorkers|Load1|Load15|Load5|ParentServerConfigGeneration|ParentServerMPMGeneration|ReqPerSec|ServerUptimeSeconds|TotalAccesses|TotalDuration|TotalkBytes|Uptime)|(scboard_(closing|dnslookup|finishing|idle_cleanup|keepalive|logging|open|reading|sending|starting|waiting))))
               sourceLabels: [__name__]
@@ -2703,6 +2730,9 @@ kube-prometheus-stack:
         - url: http://$(METADATA_METRICS_SVC).$(NAMESPACE).svc.cluster.local.:9888/prometheus.metrics.applications.sqlserver
           remoteTimeout: 5s
           writeRelabelConfigs:
+            - action: drop
+              regex: ^true$
+              sourceLabels: [_sumo_forward_]
             - action: keep
               regex: (?:sqlserver_(cpu_sqlserver_process_cpu|database_io_(read_(bytes|latency_ms)|write_(bytes|latency_ms))|memory_clerks_size_kb|performance_value|server_properties_server_memory|volume_space_(total_space_bytes|used_space_bytes)))
               sourceLabels: [__name__]
@@ -2738,6 +2768,9 @@ kube-prometheus-stack:
         - url: http://$(METADATA_METRICS_SVC).$(NAMESPACE).svc.cluster.local.:9888/prometheus.metrics.applications.haproxy
           remoteTimeout: 5s
           writeRelabelConfigs:
+            - action: drop
+              regex: ^true$
+              sourceLabels: [_sumo_forward_]
             - action: keep
               regex: (?:haproxy_(active_servers|backup_servers|bin|bout|chkfail|ctime|dreq|dresp|econ|ereq|eresp|http_response_(1xx|2xx|3xx|4xx|5xx|other)|qcur|qmax|qtime|rate|rtime|scur|slim|smax|ttime|weight|wredis|wretr))
               sourceLabels: [__name__]
@@ -2807,6 +2840,9 @@ kube-prometheus-stack:
         - url: http://$(METADATA_METRICS_SVC).$(NAMESPACE).svc.cluster.local.:9888/prometheus.metrics.applications.cassandra
           remoteTimeout: 5s
           writeRelabelConfigs:
+            - action: drop
+              regex: ^true$
+              sourceLabels: [_sumo_forward_]
             - action: keep
               regex: (?:cassandra_(CacheMetrics_ChunkCache_OneMinuteRate|ClientMetrics_(connectedNativeClients_Value|RequestDiscarded_OneMinuteRate)|CommitLogMetrics_(CompletedTasks_Value|PendingTasks_Value)|DroppedMessageMetrics_Dropped_OneMinuteRate|java_(GarbageCollector_(ConcurrentMarkSweep|ParNew)_(CollectionCount|CollectionTime|LastGcInfo_duration|LastGcInfo_GcThreadCount|LastGcInfo_memoryUsageAfterGc_.*_used|LastGcInfo_memoryUsageBeforeGc_.*_used)|Memory_HeapMemoryUsage_used|OperatingSystem_(AvailableProcessors|FreePhysicalMemorySize|SystemCpuLoad|TotalPhysicalMemorySize|TotalSwapSpaceSize))|Net_FailureDetector_(DownEndpointCount|UpEndpointCount)|TableMetrics_(AllMemtablesHeapSize_Value|AllMemtablesLiveDataSize_Value|CompactionBytesWritten_Count|EstimatedPartitionCount_Value|KeyCacheHitRate_Value|LiveSSTableCount_Value|MemtableColumnsCount_Value|MemtableLiveDataSize_Value|MemtableOffHeapSize_Value|MemtableOnHeapSize_Value|MemtableSwitchCount_Count|PendingCompactions_Value|PendingFlushes_Count|PercentRepaired_Value|RangeLatency_Count|ReadLatency_50thPercentile|ReadLatency_Max|ReadLatency_OneMinuteRate|RowCacheHit_Count|RowCacheMiss_Count|SSTablesPerReadHistogram_50thPercentile|SSTablesPerReadHistogram_99thPercentile|SSTablesPerReadHistogram_Count|SSTablesPerReadHistogram_Max|TombstoneScannedHistogram_50thPercentile|TombstoneScannedHistogram_99thPercentile|TombstoneScannedHistogram_Max|TotalDiskSpaceUsed_Count|WaitingOnFreeMemtableSpace_Max|WriteLatency_50thPercentile|WriteLatency_99thPercentile|WriteLatency_Max|WriteLatency_OneMinuteRate)|ThreadPoolMetrics_(internal_(Count|Value)|request_(Count|Value)|transport_(Count|Value))))
               sourceLabels: [__name__]
@@ -2849,6 +2885,9 @@ kube-prometheus-stack:
         - url: http://$(METADATA_METRICS_SVC).$(NAMESPACE).svc.cluster.local.:9888/prometheus.metrics.applications.mongodb
           remoteTimeout: 5s
           writeRelabelConfigs:
+            - action: drop
+              regex: ^true$
+              sourceLabels: [_sumo_forward_]
             - action: keep
               regex: (?:mongodb_(active_(reads|writes)|commands_per_sec|connections_current|db_stats_storage_size|deletes_per_sec|document_.*|flushes_per_sec|getmores_per_sec|inserts_per_sec|net_.*_bytes_count|open_connections|page_faults|percent_cache_(dirty|used)|queries_per_sec|queued_(reads|writes)|repl_((commands|deletes|getmores|inserts|oplog|queries|updates)_per_sec|queries|oplog_window_sec)|resident_megabytes|updates_per_sec|uptime_ns|vsize_megabytes|wtcache_bytes_read_into))
               sourceLabels: [__name__]
@@ -2889,6 +2928,9 @@ kube-prometheus-stack:
         - url: http://$(METADATA_METRICS_SVC).$(NAMESPACE).svc.cluster.local.:9888/prometheus.metrics.applications.rabbitmq
           remoteTimeout: 5s
           writeRelabelConfigs:
+            - action: drop
+              regex: ^true$
+              sourceLabels: [_sumo_forward_]
             - action: keep
               regex: (?:rabbitmq_(exchange_messages_publish_(in_rate|in|out_rate|out)|node_(disk_free_limit|disk_free|mem_(limit|used)|uptime|fd_used|mnesia_(disk_tx_count|ram_tx_count)|gc_num_rate)|overview_(clustering_listerners|connections|exchanges|consumers|queues|messages_(delivered|published|unacked))|queue_(consumers|memory|slave_nodes|messages_(publish_rate|deliver_rate|memory|max_time|unack))))
               sourceLabels: [__name__]
@@ -2934,6 +2976,9 @@ kube-prometheus-stack:
         - url: http://$(METADATA_METRICS_SVC).$(NAMESPACE).svc.cluster.local.:9888/prometheus.metrics.applications.tomcat
           remoteTimeout: 5s
           writeRelabelConfigs:
+            - action: drop
+              regex: ^true$
+              sourceLabels: [_sumo_forward_]
             - action: keep
               regex: (?:tomcat_(connector_(bytes_(received|sent)|current_(thread_(busy|count)|threads_busy)|error_count|max_threads|max_time|processing_time|request_count)|jmx_(jvm_memory_(HeapMemoryUsage_(max|used)|NonHeapMemoryUsage_(max|used))|OperatingSystem_(FreePhysicalMemorySize|FreeSwapSpaceSize|SystemCpuLoad|TotalPhysicalMemorySize|TotalSwapSpaceSize)|Servlet_processingTime)|jvm_memory_(free|max|total)|jvm_memorypool_(bytes_(received|sent)|current_thread_count|current_threads_busy|error_count|max_threads|max_time|max|processing_time|request_count|used)))
               sourceLabels: [__name__]
@@ -3007,6 +3052,9 @@ kube-prometheus-stack:
         - url: http://$(METADATA_METRICS_SVC).$(NAMESPACE).svc.cluster.local.:9888/prometheus.metrics.applications.varnish
           remoteTimeout: 5s
           writeRelabelConfigs:
+            - action: drop
+              regex: ^true$
+              sourceLabels: [_sumo_forward_]
             - action: keep
               regex: (?:varnish_(backend_(busy|conn|fail|recycle|req|retry|reuse|unhealthy)|bans_(completed|deleted|dups|lurker_(contention|obj_killed|tests_tested|tested|)|obj_killed|obj|persisted_(bytes|fragmentation))|bans|boot_.*_.*_(bodybytes|hdrbytes)|cache_(hit_grace|hitpass|miss|hit)|client_(req_400|req_417|req|resp_500)|n_(backend|expired|lru_nuked|vcl_avail)|pools|s0_g_(bytes|space)|s_(fetch|pipe_(in|out)|req_(bodybytes|hdrbytes)|resp_(bodybytes|hdrbytes)|sess)|sess_(closed_err|closed|conn|drop|dropped|fail|queued)|thread_queue_len|threads_(created|destroyed|failed|limited)|threads|uptime|vmods))
               sourceLabels: [__name__]
@@ -3050,6 +3098,9 @@ kube-prometheus-stack:
         - url: http://$(METADATA_METRICS_SVC).$(NAMESPACE).svc.cluster.local.:9888/prometheus.metrics.applications.memcached
           remoteTimeout: 5s
           writeRelabelConfigs:
+            - action: drop
+              regex: ^true$
+              sourceLabels: [_sumo_forward_]
             - action: keep
               regex: (?:memcached_(accepting_conns|auth_(cmds|errors)|bytes_(read|written)|bytes|cas_*|cmd_.*|conn_yields|connection_structures|curr_(connections|items)|decr_.*|delete_.*|evictions|get_(hits|misses)|hash_(bytes|is_expanding)|incr_.*|limit_maxbytes|listen_disabled_num|reclaimed|threads|total_(connections|items)|uptime))
               sourceLabels: [__name__]
@@ -3137,6 +3188,9 @@ kube-prometheus-stack:
         - url: http://$(METADATA_METRICS_SVC).$(NAMESPACE).svc.cluster.local.:9888/prometheus.metrics.applications.elasticsearch
           remoteTimeout: 5s
           writeRelabelConfigs:
+            - action: drop
+              regex: ^true$
+              sourceLabels: [_sumo_forward_]
             - action: keep
               regex: (?:elasticsearch_(cluster_health_(active_(primary_shards|shards)|delayed_unassigned_shards|indices_status_code|initializing_shards|number_of_(data_nodes|nodes|pending_tasks)|relocating_shards|unassigned_shards)|clusterstats_(indices_fielddata_evictions|nodes_jvm_mem_heap_used_in_bytes)|fs_total_(free_in_bytes|total_in_bytes)|indices_(flush_(total|total_time_in_millis)|get_(exists_time_in_millis|exists_total|missing_time_in_millis|missing_total|time_in_millis|total)|indexing_delete_time_in_millis|indexing_delete_total|indexing_index_time_in_millis|indexing_index_total|merges_total_time_in_millis|search_query_time_in_millis|search_query_total|segments_fixed_bit_set_memory_in_bytes|segments_terms_memory_in_bytes|stats_primaries_(docs_count|indexing_index_time_in_millis|query_cache_cache_size|query_cache_evictions|segments_doc_values_memory_in_bytes|segments_index_writer_memory_in_bytes|segments_memory_in_bytes)|stats_total___(fielddata_memory_size_in_bytes|indexing_index_total|merges_total)|stats_total_(docs_count|fielddata_memory_size_in_bytes|flush_total_time_in_millis|indexing_delete_total|indexing_index_time_in_millis|indexing_index_total|merges_total_docs|merges_total_size_in_bytes|merges_total_time_in_millis|query_cache_evictions|refresh_total|refresh_total_time_in_millis|search_fetch_time_in_millis|search_fetch_total|search_query_time_in_millis|search_query_total|segments_fixed_bit_set_memory_in_bytes|segments_index_writer_memory_in_bytes|segments_memory_in_bytes|segments_terms_memory_in_bytes|store_size_in_bytes|translog_operations|translog_size_in_bytes))|jvm_(gc_collectors_.*_collection_time_in_millis|mem_heap_committed_in_bytes|mem_heap_used_in_bytes|mem_heap_used_percent)|os_cpu_(load_average_5m|percent)|process_open_file_descriptors|thread_pool_(analyze_completed|analyze_threads|get_rejected|search_queue)|transport_(rx_size_in_bytes|tx_size_in_bytes)))
               sourceLabels: [__name__]
@@ -3169,6 +3223,9 @@ kube-prometheus-stack:
         - url: http://$(METADATA_METRICS_SVC).$(NAMESPACE).svc.cluster.local.:9888/prometheus.metrics.applications.activemq
           remoteTimeout: 5s
           writeRelabelConfigs:
+            - action: drop
+              regex: ^true$
+              sourceLabels: [_sumo_forward_]
             - action: keep
               regex: (?:activemq_(topic_.*|queue_.*|.*_QueueSize|broker_(AverageMessageSize|CurrentConnectionsCount|MemoryLimit|StoreLimit|TempLimit|TotalConnectionsCount|TotalConsumerCount|TotalDequeueCount|TotalEnqueueCount|TotalMessageCount|TotalProducerCount|UptimeMillis)|jvm_memory_(HeapMemoryUsage_max|HeapMemoryUsage_used|NonHeapMemoryUsage_used)|jvm_runtime_Uptime|OperatingSystem_(FreePhysicalMemorySize|SystemCpuLoad|TotalPhysicalMemorySize)))
               sourceLabels: [__name__]
@@ -3236,6 +3293,9 @@ kube-prometheus-stack:
         - url: http://$(METADATA_METRICS_SVC).$(NAMESPACE).svc.cluster.local.:9888/prometheus.metrics.applications.couchbase
           remoteTimeout: 5s
           writeRelabelConfigs:
+            - action: drop
+              regex: ^true$
+              sourceLabels: [_sumo_forward_]
             - action: keep
               regex: (?:couchbase_(node_.*|bucket_(ep_.*|vb_.*|delete_.*|cmd.*|bytes_.*|item_count|curr_connections|ops_per_sec|disk_write_queue|mem_.*|cas_hits|ops|curr_items|cpu_utilization_rate|swap_used|disk_used|rest_requests|hibernated_waked|xdc_ops)))
               sourceLabels: [__name__]
@@ -3277,6 +3337,9 @@ kube-prometheus-stack:
         - url: http://$(METADATA_METRICS_SVC).$(NAMESPACE).svc.cluster.local.:9888/prometheus.metrics.applications.squidproxy
           remoteTimeout: 5s
           writeRelabelConfigs:
+            - action: drop
+              regex: ^true$
+              sourceLabels: [_sumo_forward_]
             - action: keep
               regex: (?:squid_(uptime|cache(Ip(Entries|Requests|Hits)|Fqdn(Entries|Requests|Misses|NegativeHits)|Dns(Requests|Replies|SvcTime5)|Sys(PageFaults|NumReads)|Current(FileDescrCnt|UnusedFDescrCnt|ResFileDescrCnt)|Server(Requests|InKb|OutKb)|Http(AllSvcTime5|Errors|InKb|OutKb|AllSvcTime1)|Mem(MaxSize|Usage)|NumObjCount|CpuTime|MaxResSize|ProtoClientHttpRequests|Clients)))
               sourceLabels: [__name__]

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/additional_endpoints.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/additional_endpoints.output.yaml
@@ -220,6 +220,9 @@ data:
         - exporters:
           - sumologic/state
           value: /prometheus.metrics.state
+        - exporters:
+          - sumologic/default
+          value: /prometheus.metrics.applications.custom
       source:
         collector: kubernetes
       sumologic_schema:

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/basic.output.yaml
@@ -220,6 +220,9 @@ data:
         - exporters:
           - sumologic/state
           value: /prometheus.metrics.state
+        - exporters:
+          - sumologic/default
+          value: /prometheus.metrics.applications.custom
       source:
         collector: kubernetes
       sumologic_schema:

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
@@ -93,7 +93,7 @@ spec:
         metrics:
           metric:
             # we let the metrics from annotations ("kubernetes-pods") through as they are
-            - resource.attributes["service.name"] != "kubernetes-pods" and IsMatch(name, "scrape_.*")
+            - resource.attributes["service.name"] != "pod-annotations" and IsMatch(name, "scrape_.*")
 
     receivers:
       prometheus:
@@ -106,7 +106,7 @@ spec:
             ##   - prometheus.io/path: /metrics - path which the metric should be scrape from
             ##   - prometheus.io/port: 9113 - port which the metric should be scrape from
             ## rel: https://github.com/prometheus-operator/kube-prometheus/pull/16#issuecomment-424318647
-            - job_name: "kubernetes-pods"
+            - job_name: "pod-annotations"
               kubernetes_sd_configs:
                 - role: pod
               relabel_configs:

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
@@ -115,7 +115,7 @@ spec:
         metrics:
           metric:
             # we let the metrics from annotations ("kubernetes-pods") through as they are
-            - resource.attributes["service.name"] != "kubernetes-pods" and IsMatch(name, "scrape_.*")
+            - resource.attributes["service.name"] != "pod-annotations" and IsMatch(name, "scrape_.*")
 
     receivers:
       prometheus:
@@ -128,7 +128,7 @@ spec:
             ##   - prometheus.io/path: /metrics - path which the metric should be scrape from
             ##   - prometheus.io/port: 9113 - port which the metric should be scrape from
             ## rel: https://github.com/prometheus-operator/kube-prometheus/pull/16#issuecomment-424318647
-            - job_name: "kubernetes-pods"
+            - job_name: "pod-annotations"
               kubernetes_sd_configs:
                 - role: pod
               relabel_configs:

--- a/tests/integration/helm_fluentbit_fluentd_test.go
+++ b/tests/integration/helm_fluentbit_fluentd_test.go
@@ -25,9 +25,11 @@ func Test_Helm_FluentBit_Fluentd(t *testing.T) {
 
 	featMetrics := GetMetricsFeature(expectedMetrics, Fluentd)
 
+	featTelegrafMetrics := GetTelegrafMetricsFeature(internal.NginxMetrics, Fluentd, false)
+
 	featLogs := GetLogsFeature()
 
 	featEvents := GetEventsFeature()
 
-	testenv.Test(t, featInstall, featMetrics, featLogs, featEvents)
+	testenv.Test(t, featInstall, featMetrics, featTelegrafMetrics, featLogs, featEvents)
 }

--- a/tests/integration/helm_ot_default_test.go
+++ b/tests/integration/helm_ot_default_test.go
@@ -29,6 +29,8 @@ func Test_Helm_Default_OT(t *testing.T) {
 
 	featMetrics := GetMetricsFeature(expectedMetrics, Prometheus)
 
+	featTelegrafMetrics := GetTelegrafMetricsFeature(internal.NginxMetrics, Prometheus, false)
+
 	featLogs := GetLogsFeature()
 
 	featMultilineLogs := GetMultilineLogsFeature()
@@ -37,5 +39,5 @@ func Test_Helm_Default_OT(t *testing.T) {
 
 	featTraces := GetTracesFeature()
 
-	testenv.Test(t, featInstall, featMetrics, featLogs, featMultilineLogs, featEvents, featTraces)
+	testenv.Test(t, featInstall, featMetrics, featTelegrafMetrics, featLogs, featMultilineLogs, featEvents, featTraces)
 }

--- a/tests/integration/helm_ot_metrics_test.go
+++ b/tests/integration/helm_ot_metrics_test.go
@@ -58,5 +58,7 @@ func Test_Helm_OT_Metrics(t *testing.T) {
 
 	featMetrics := GetMetricsFeature(expectedMetrics, Otelcol)
 
-	testenv.Test(t, featInstall, featMetrics)
+	featTelegrafMetrics := GetTelegrafMetricsFeature(internal.NginxMetrics, Otelcol, false)
+
+	testenv.Test(t, featInstall, featMetrics, featTelegrafMetrics)
 }

--- a/tests/integration/internal/constants.go
+++ b/tests/integration/internal/constants.go
@@ -41,6 +41,9 @@ const (
 	TailingSidecarTest               = "yamls/tailing-sidecar-test.yaml"
 	TailingSidecarTestDeploymentName = "test-tailing-sidecar-operator"
 
+	NginxTelegrafMetricsTest = "yamls/nginx.yaml"
+	NginxTelegrafNamespace   = "nginx"
+
 	// useful regular expressions for matching metadata
 	PodDeploymentSuffixRegex = "-[a-z0-9]{9,10}-[a-z0-9]{4,5}" // the Pod suffix for Deployments
 	PodDaemonSetSuffixRegex  = "-[a-z0-9]{4,5}"
@@ -386,6 +389,16 @@ var (
 		"receiver_mock_logs_bytes_count",
 		"receiver_mock_logs_bytes_ip_count",
 		"receiver_mock_metrics_ip_count",
+	}
+
+	NginxMetrics = []string{
+		"nginx_accepts",
+		"nginx_active",
+		"nginx_handled",
+		"nginx_reading",
+		"nginx_requests",
+		"nginx_waiting",
+		"nginx_writing",
 	}
 )
 

--- a/tests/integration/internal/k8s/pods.go
+++ b/tests/integration/internal/k8s/pods.go
@@ -1,10 +1,13 @@
 package k8s
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
 
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal"
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/ctxopts"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/stretchr/testify/require"
@@ -70,6 +73,17 @@ func WaitUntilPodsAvailableE(
 	}
 	t.Log(message)
 	return nil
+}
+
+func WaitUntilReceiverMockAvailable(
+	ctx context.Context,
+	t *testing.T,
+	waitDuration time.Duration,
+	tickDuration time.Duration,
+) {
+	kubectlOpts := *ctxopts.KubectlOptions(ctx)
+	kubectlOpts.Namespace = internal.ReceiverMockNamespace
+	k8s.WaitUntilServiceAvailable(t, &kubectlOpts, internal.ReceiverMockServiceName, int(waitDuration), tickDuration)
 }
 
 func formatSelectors(listOptions v1.ListOptions) string {

--- a/tests/integration/values/values_common.yaml
+++ b/tests/integration/values/values_common.yaml
@@ -248,3 +248,13 @@ otellogs:
           path: /run/log/journal
           type: DirectoryOrCreate
         name: run-log-journal
+
+telegraf-operator:
+  resources:
+    requests:
+      cpu: 5m
+      memory: 32Mi
+  sidecarResources:
+    requests:
+      cpu: 5m
+      memory: 10Mi

--- a/tests/integration/values/values_helm_default_ot.yaml
+++ b/tests/integration/values/values_helm_default_ot.yaml
@@ -1,0 +1,2 @@
+telegraf-operator:
+  enabled: true

--- a/tests/integration/values/values_helm_fluentbit_fluentd.yaml
+++ b/tests/integration/values/values_helm_fluentbit_fluentd.yaml
@@ -15,3 +15,6 @@ sumologic:
 
 fluent-bit:
   enabled: true
+
+telegraf-operator:
+  enabled: true

--- a/tests/integration/values/values_helm_ot_metrics.yaml
+++ b/tests/integration/values/values_helm_ot_metrics.yaml
@@ -25,3 +25,6 @@ kube-prometheus-stack:
 
 opentelemetry-operator:
   enabled: true
+
+telegraf-operator:
+  enabled: true

--- a/tests/integration/yamls/nginx.yaml
+++ b/tests/integration/yamls/nginx.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nginx
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  namespace: nginx
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+      annotations:
+        telegraf.influxdata.com/inputs: |+
+          [[inputs.nginx]]
+            urls = ["http://localhost/nginx_status"]
+        telegraf.influxdata.com/class: sumologic-prometheus
+        telegraf.influxdata.com/limits-cpu: "750m"
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9273"
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.25.1-alpine
+          resources:
+            requests:
+              cpu: 5m
+              memory: 16M
+            limits:
+              cpu: 100m
+              memory: 64M
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+      volumes:
+        - name: config-volume
+          configMap:
+            name: nginx-config
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config
+  namespace: nginx
+data:
+  default.conf: |-
+    server {
+      listen       80;
+      listen  [::]:80;
+      server_name  localhost;
+
+      location /nginx_status {
+          stub_status on;
+          access_log  on;           
+          allow all;  # REPLACE with your access policy
+      }
+
+      location / {
+          root   /usr/share/nginx/html;
+          index  index.html index.htm;
+      }
+      error_page   500 502 503 504  /50x.html;
+      location = /50x.html {
+          root   /usr/share/nginx/html;
+      }
+    }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  namespace: nginx
+  labels:
+    app: nginx
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+  selector:
+    app: nginx


### PR DESCRIPTION
Don't forward App metrics if they originate from a Pod scraped due to annotations. We tell customers to do this for these metrics (https://help.sumologic.com/docs/integrations/web-servers/nginx/#configure-metrics-collection), but we have separate remote writes for these cases, and so they are forwarded twice, and with different labels.

I ended up making a bunch of additional changes:
* I've added a integration test for nginx metrics using Telegraf operator
* Refactored some receiver-mock related code in integration tests
* Added a utility function to assert metrics are present for a given filter
* Fixed some minor issues

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [x] Integration tests added or modified for major features
