### PR TITLE
chore(metrics): remove unnecessary relabellings

### DIFF
--- a/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
@@ -67,18 +67,6 @@ receivers:
               regex: ([^:]+)(?::\d+)?;(\d+)
               replacement: $1:$2
               target_label: __address__
-            - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
-              separator: ;
-              regex: Node;(.*)
-              target_label: node
-              replacement: $1
-              action: replace
-            - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
-              separator: ;
-              regex: Pod;(.*)
-              target_label: pod
-              replacement: $1
-              action: replace
             - source_labels: [__metrics_path__]
               separator: ;
               regex: (.*)
@@ -90,12 +78,6 @@ receivers:
               target_label: namespace
             - action: labelmap
               regex: __meta_kubernetes_pod_label_(.+)
-            - source_labels: [__meta_kubernetes_service_name]
-              separator: ;
-              regex: (.*)
-              target_label: service
-              replacement: $1
-              action: replace
             - source_labels: [__meta_kubernetes_pod_name]
               separator: ;
               regex: (.*)
@@ -122,19 +104,10 @@ receivers:
               source_labels: [__name__]
             - action: labeldrop
               regex: id
-          relabel_configs: # partially copied from what operator generates
+          relabel_configs:
             - source_labels:
               - __meta_kubernetes_node_name
               target_label: node
-            - source_labels:
-              - __meta_kubernetes_namespace
-              target_label: namespace
-            - source_labels:
-              - __meta_kubernetes_pod_name
-              target_label: pod
-            - source_labels:
-              - __meta_kubernetes_pod_container_name
-              target_label: container
             - target_label: endpoint
               replacement: https-metrics
             - source_labels:
@@ -178,23 +151,11 @@ receivers:
               regex: container_name
               replacement: container
             - action: drop
-              source_labels: [container]
+              source_labels: [container] # partially copied from what operator generates
               regex: POD
             - action: labeldrop
               regex: (id|name)
-          relabel_configs: # partially copied from what operator generates
-            - source_labels:
-              - __meta_kubernetes_node_name
-              target_label: node
-            - source_labels:
-              - __meta_kubernetes_namespace
-              target_label: namespace
-            - source_labels:
-              - __meta_kubernetes_pod_name
-              target_label: pod
-            - source_labels:
-              - __meta_kubernetes_pod_container_name
-              target_label: container
+          relabel_configs:
             - target_label: endpoint
               replacement: https-metrics
             - source_labels:

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -2135,18 +2135,6 @@ kube-prometheus-stack:
               regex: ([^:]+)(?::\d+)?;(\d+)
               replacement: $1:$2
               target_label: __address__
-            - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
-              separator: ;
-              regex: Node;(.*)
-              target_label: node
-              replacement: ${1}
-              action: replace
-            - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
-              separator: ;
-              regex: Pod;(.*)
-              target_label: pod
-              replacement: ${1}
-              action: replace
             - source_labels: [__metrics_path__]
               separator: ;
               regex: (.*)
@@ -2158,12 +2146,6 @@ kube-prometheus-stack:
               target_label: namespace
             - action: labelmap
               regex: __meta_kubernetes_pod_label_(.+)
-            - source_labels: [__meta_kubernetes_service_name]
-              separator: ;
-              regex: (.*)
-              target_label: service
-              replacement: $1
-              action: replace
             - source_labels: [__meta_kubernetes_pod_name]
               separator: ;
               regex: (.*)

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
@@ -122,18 +122,6 @@ spec:
                   regex: ([^:]+)(?::\d+)?;(\d+)
                   replacement: $1:$2
                   target_label: __address__
-                - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
-                  separator: ;
-                  regex: Node;(.*)
-                  target_label: node
-                  replacement: $1
-                  action: replace
-                - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
-                  separator: ;
-                  regex: Pod;(.*)
-                  target_label: pod
-                  replacement: $1
-                  action: replace
                 - source_labels: [__metrics_path__]
                   separator: ;
                   regex: (.*)
@@ -145,12 +133,6 @@ spec:
                   target_label: namespace
                 - action: labelmap
                   regex: __meta_kubernetes_pod_label_(.+)
-                - source_labels: [__meta_kubernetes_service_name]
-                  separator: ;
-                  regex: (.*)
-                  target_label: service
-                  replacement: $1
-                  action: replace
                 - source_labels: [__meta_kubernetes_pod_name]
                   separator: ;
                   regex: (.*)
@@ -176,19 +158,10 @@ spec:
                   source_labels: [__name__]
                 - action: labeldrop
                   regex: id
-              relabel_configs: # partially copied from what operator generates
+              relabel_configs:
                 - source_labels:
                   - __meta_kubernetes_node_name
                   target_label: node
-                - source_labels:
-                  - __meta_kubernetes_namespace
-                  target_label: namespace
-                - source_labels:
-                  - __meta_kubernetes_pod_name
-                  target_label: pod
-                - source_labels:
-                  - __meta_kubernetes_pod_container_name
-                  target_label: container
                 - target_label: endpoint
                   replacement: https-metrics
                 - source_labels:
@@ -230,23 +203,11 @@ spec:
                   regex: container_name
                   replacement: container
                 - action: drop
-                  source_labels: [container]
+                  source_labels: [container] # partially copied from what operator generates
                   regex: POD
                 - action: labeldrop
                   regex: (id|name)
-              relabel_configs: # partially copied from what operator generates
-                - source_labels:
-                  - __meta_kubernetes_node_name
-                  target_label: node
-                - source_labels:
-                  - __meta_kubernetes_namespace
-                  target_label: namespace
-                - source_labels:
-                  - __meta_kubernetes_pod_name
-                  target_label: pod
-                - source_labels:
-                  - __meta_kubernetes_pod_container_name
-                  target_label: container
+              relabel_configs:
                 - target_label: endpoint
                   replacement: https-metrics
                 - source_labels:

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
@@ -144,18 +144,6 @@ spec:
                   regex: ([^:]+)(?::\d+)?;(\d+)
                   replacement: $1:$2
                   target_label: __address__
-                - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
-                  separator: ;
-                  regex: Node;(.*)
-                  target_label: node
-                  replacement: $1
-                  action: replace
-                - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
-                  separator: ;
-                  regex: Pod;(.*)
-                  target_label: pod
-                  replacement: $1
-                  action: replace
                 - source_labels: [__metrics_path__]
                   separator: ;
                   regex: (.*)
@@ -167,12 +155,6 @@ spec:
                   target_label: namespace
                 - action: labelmap
                   regex: __meta_kubernetes_pod_label_(.+)
-                - source_labels: [__meta_kubernetes_service_name]
-                  separator: ;
-                  regex: (.*)
-                  target_label: service
-                  replacement: $1
-                  action: replace
                 - source_labels: [__meta_kubernetes_pod_name]
                   separator: ;
                   regex: (.*)


### PR DESCRIPTION
Remove some unnecessary relabel actions from both the otel metrics collector and our Pod annotation scrape config for Prometheus. These simply never exist for the kubernetes service discovery role they use, and are therefore noops. They mostly exist because we uncritically copied them from configurations emitted by prometheus-operator for ServiceMonitors.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
