### PR TITLE
fix(otellogs): fix configuration for filelog/container to use default settings for fingerprint_size on k8s >=1.24

### DIFF
--- a/.changelog/3185.fixed.txt
+++ b/.changelog/3185.fixed.txt
@@ -1,0 +1,1 @@
+fix(otellogs): fix configuration for filelog/container to use default settings for fingerprint_size on k8s >=1.24

--- a/deploy/helm/sumologic/conf/logs/collector/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/collector/otelcol/config.yaml
@@ -51,7 +51,7 @@ processors:
 receivers:
 {{- if .Values.sumologic.logs.container.enabled }}
   filelog/containers:
-{{ if lt (int .Capabilities.KubeVersion.Minor) 24 }}
+{{ if lt (int (include "kubernetes.minor" .)) 24 }}
     ## sets fingerprint_size to 17kb in order to match the longest possible docker line (which by default is 16kb)
     ## we want to include timestamp, which is at the end of the line
     ## Not necessary in 1.24 and later, as docker-shim is not present anymore


### PR DESCRIPTION
fix configuration for filelog/container to use default settings for `fingerprint_size` on k8s >=1.24

Problem with previous form of condition was observed on EKS 1.24 (I see [tests](https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/fcac957b08d96c6cc867dd4ae482e378374f4f1f/tests/helm/logs_test.go#L399-L433) for this condition so it looks like there is different form of `.Capabilities.KubeVersion.Minor` on EKS) - this pull request uses `kubernetes.minor` function which is used in other places in our Helm Chart
 
When fingerprint_size is set to 1kb (default value) the issue with duplicated logs is not observed, https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22936

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features
