### PR TITLE
test(integration): don't check receiver-mock metrics

### DIFF
--- a/deploy/helm/sumologic/templates/metrics/collector/otelcol/opentelemetrycollector.yaml
+++ b/deploy/helm/sumologic/templates/metrics/collector/otelcol/opentelemetrycollector.yaml
@@ -14,15 +14,6 @@ metadata:
     {{- if .Values.sumologic.metrics.collector.otelcol.podLabels }}
     {{ toYaml .Values.sumologic.metrics.collector.otelcol.podLabels | nindent 4 }}
     {{- end }}
-{{- if or .Values.sumologic.podAnnotations .Values.sumologic.metrics.collector.otelcol.podAnnotations }}
-  annotations:
-    {{- if .Values.sumologic.podAnnotations }}
-    {{ toYaml .Values.sumologic.podAnnotations | nindent 4 }}
-    {{- end }}
-    {{- if .Values.sumologic.metrics.collector.otelcol.podAnnotations }}
-    {{ toYaml .Values.sumologic.metrics.collector.otelcol.podAnnotations | nindent 4 }}
-    {{- end }}
-{{- end }}
 spec:
   mode: statefulset
   replicas: {{ .Values.sumologic.metrics.collector.otelcol.replicaCount }}
@@ -63,6 +54,15 @@ spec:
     valueFrom:
       fieldRef:
         fieldPath: metadata.namespace
+  podAnnotations:
+    ## The operator adds this annotation by default, but we use our own ServiceMonitor
+    prometheus.io/scrape: "false"
+{{- if .Values.sumologic.podAnnotations -}}
+    {{ toYaml .Values.sumologic.podAnnotations | nindent 4 }}
+{{- end }}
+{{- if .Values.sumologic.metrics.collector.otelcol.podAnnotations -}}
+    {{ toYaml .Values.sumologic.metrics.collector.otelcol.podAnnotations | nindent 4 }}
+{{- end }}
   podSecurityContext:
     {{ .Values.sumologic.metrics.collector.otelcol.securityContext | toYaml | nindent 4 }}
   ports:

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
@@ -30,6 +30,9 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
+  podAnnotations:
+    ## The operator adds this annotation by default, but we use our own ServiceMonitor
+    prometheus.io/scrape: "false"
   podSecurityContext:
     fsGroup: 999
   ports:

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
@@ -16,10 +16,6 @@ metadata:
     podLabelKey: podLabelValue
 
     podKey: podValue
-  annotations:
-    podAnnotationKey: podAnnotationValue
-
-    annotationKey: annotationValue
 spec:
   mode: statefulset
   replicas: 3
@@ -52,6 +48,11 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
+  podAnnotations:
+    ## The operator adds this annotation by default, but we use our own ServiceMonitor
+    prometheus.io/scrape: "false"
+    podAnnotationKey: podAnnotationValue
+    annotationKey: annotationValue
   podSecurityContext:
     fsGroup: 999
   ports:

--- a/tests/integration/helm_ot_metrics_test.go
+++ b/tests/integration/helm_ot_metrics_test.go
@@ -34,7 +34,6 @@ func Test_Helm_OT_Metrics(t *testing.T) {
 		internal.AdditionalNodeExporterMetrics,
 		internal.DefaultOtelcolMetrics,
 		internal.MetricsCollectorOtelcolMetrics,
-		internal.ReceiverMockMetrics,
 		internal.OtherMetrics,
 	}
 	for _, metrics := range expectedMetricsGroups {

--- a/tests/integration/internal/constants.go
+++ b/tests/integration/internal/constants.go
@@ -353,16 +353,6 @@ var (
 		// "node:node_inodes_free:",  // looks like we're not collecting node_filesystem_files_free which this requires
 		"instance:node_network_receive_bytes:rate:sum",
 	}
-	// The receiver-mock Pod used for tests has a "prometheus.io/scrape: true" annotation
-	// TODO: remove this once we have a better test for this behaviour
-	ReceiverMockMetrics = []string{
-		"receiver_mock_metrics_count",
-		"receiver_mock_logs_count",
-		"scrape_series_added",
-		"scrape_samples_scraped",
-		"scrape_samples_post_metric_relabeling",
-		"scrape_duration_seconds",
-	}
 	OtherMetrics = []string{
 		"up",
 	}
@@ -384,11 +374,6 @@ var (
 		"scheduler_scheduling_attempt_duration_seconds_sum",
 		"scheduler_scheduling_attempt_duration_seconds_bucket",
 		"cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile",
-		// TODO: Remove this once we have a better test for annotation metrics
-		"receiver_mock_logs_ip_count",
-		"receiver_mock_logs_bytes_count",
-		"receiver_mock_logs_bytes_ip_count",
-		"receiver_mock_metrics_ip_count",
 	}
 
 	NginxMetrics = []string{
@@ -422,7 +407,6 @@ var (
 		NodeExporterMetrics,
 		PrometheusMetrics,
 		RecordingRuleMetrics,
-		ReceiverMockMetrics,
 		OtherMetrics,
 	}
 	DefaultExpectedMetrics                 []string

--- a/tests/integration/yamls/receiver-mock.yaml
+++ b/tests/integration/yamls/receiver-mock.yaml
@@ -21,11 +21,6 @@ spec:
       labels:
         service: receiver-mock
         app: receiver-mock
-      ## this is used for checking if we collect metrics from Pods with these annotations
-      ## TODO: remove this once we have a better test for this behaviour
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "3000"
     spec:
       containers:
         - ports:


### PR DESCRIPTION
Receiver-mock metrics were originally used for testing scraping from annotated Pods. This is now better accomplished with a dedicated test added in #3171. Therefore, I'm removing it.

I've also explicitly disabled the `prometheus.io/scrape` annotation, as the operator adds it by default.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
