### PR TITLE
fix(metrics): don't collect internal Telegraf metrics

### DIFF
--- a/.changelog/3193.fixed.txt
+++ b/.changelog/3193.fixed.txt
@@ -1,0 +1,1 @@
+fix(metrics): don't collect internal Telegraf metrics

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -4408,6 +4408,11 @@ telegraf-operator:
           ## https://github.com/influxdata/telegraf/tree/master/plugins/outputs/prometheus_client#configuration
           listen = ":9273"
           metric_version = 2
+          ## Disable the default collectors
+          collectors_exclude = ["gocollector", "process"]
+          ## Telegraf operator adds the internal plugin by default, and the Helm Chart doesn't let us disable it
+          ## Instead, drop the metrics at the output
+          namedrop = ["internal*"]
   # imagePullSecrets: []
 
 ## Configure Falco

--- a/tests/integration/features.go
+++ b/tests/integration/features.go
@@ -140,7 +140,7 @@ func GetTelegrafMetricsFeature(expectedMetrics []string, metricsCollector Metric
 				expectedMetrics,
 				receivermock.MetadataFilters{"job": "pod-annotations"},
 				errOnExtra,
-				waitDuration,
+				waitDuration*2, // wait longer here, as it can take a bit of time for Nginx to start with the sidecar
 				tickDuration,
 			),
 		).

--- a/tests/integration/features.go
+++ b/tests/integration/features.go
@@ -138,7 +138,7 @@ func GetTelegrafMetricsFeature(expectedMetrics []string, metricsCollector Metric
 		Assess("expected metrics are present",
 			stepfuncs.WaitUntilExpectedMetricsPresentWithFilters(
 				expectedMetrics,
-				receivermock.MetadataFilters{"deployment": "nginx", "endpoint": "/metrics"},
+				receivermock.MetadataFilters{"job": "pod-annotations"},
 				errOnExtra,
 				waitDuration,
 				tickDuration,
@@ -146,7 +146,7 @@ func GetTelegrafMetricsFeature(expectedMetrics []string, metricsCollector Metric
 		).
 		Assess("expected labels are present for annotation metrics",
 			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
-				metricFilters := receivermock.MetadataFilters{"__name__": "nginx_accepts", "endpoint": "/metrics"}
+				metricFilters := receivermock.MetadataFilters{"__name__": "nginx_accepts", "job": "pod-annotations"}
 				releaseName := ctxopts.HelmRelease(ctx)
 				namespace := ctxopts.Namespace(ctx)
 				expectedLabels := receivermock.Labels{

--- a/tests/integration/helm_fluentbit_fluentd_test.go
+++ b/tests/integration/helm_fluentbit_fluentd_test.go
@@ -25,7 +25,7 @@ func Test_Helm_FluentBit_Fluentd(t *testing.T) {
 
 	featMetrics := GetMetricsFeature(expectedMetrics, Fluentd)
 
-	featTelegrafMetrics := GetTelegrafMetricsFeature(internal.NginxMetrics, Fluentd, false)
+	featTelegrafMetrics := GetTelegrafMetricsFeature(internal.DefaultExpectedNginxAnnotatedMetrics, Fluentd, true)
 
 	featLogs := GetLogsFeature()
 

--- a/tests/integration/helm_ot_default_test.go
+++ b/tests/integration/helm_ot_default_test.go
@@ -29,7 +29,7 @@ func Test_Helm_Default_OT(t *testing.T) {
 
 	featMetrics := GetMetricsFeature(expectedMetrics, Prometheus)
 
-	featTelegrafMetrics := GetTelegrafMetricsFeature(internal.NginxMetrics, Prometheus, false)
+	featTelegrafMetrics := GetTelegrafMetricsFeature(internal.DefaultExpectedNginxAnnotatedMetrics, Prometheus, true)
 
 	featLogs := GetLogsFeature()
 

--- a/tests/integration/helm_ot_metrics_test.go
+++ b/tests/integration/helm_ot_metrics_test.go
@@ -57,7 +57,7 @@ func Test_Helm_OT_Metrics(t *testing.T) {
 
 	featMetrics := GetMetricsFeature(expectedMetrics, Otelcol)
 
-	featTelegrafMetrics := GetTelegrafMetricsFeature(internal.NginxMetrics, Otelcol, false)
+	featTelegrafMetrics := GetTelegrafMetricsFeature(internal.DefaultExpectedNginxAnnotatedMetrics, Otelcol, true)
 
 	testenv.Test(t, featInstall, featMetrics, featTelegrafMetrics)
 }

--- a/tests/integration/internal/constants.go
+++ b/tests/integration/internal/constants.go
@@ -385,6 +385,14 @@ var (
 		"nginx_waiting",
 		"nginx_writing",
 	}
+
+	// By default we collect all metrics from annotated Pods, which include internal Prometheus metrics about scrapes
+	AdditionalAnnotatedPodMetrics = []string{
+		"scrape_series_added",
+		"scrape_samples_post_metric_relabeling",
+		"scrape_samples_scraped",
+		"scrape_duration_seconds",
+	}
 )
 
 var (
@@ -409,8 +417,14 @@ var (
 		RecordingRuleMetrics,
 		OtherMetrics,
 	}
+	DefaultExpectedNginxAnnotatedMetricsGroups = [][]string{
+		NginxMetrics,
+		AdditionalAnnotatedPodMetrics,
+		OtherMetrics,
+	}
 	DefaultExpectedMetrics                 []string
 	DefaultExpectedFluentdFluentbitMetrics []string
+	DefaultExpectedNginxAnnotatedMetrics   []string
 )
 
 type KindImagesSpec struct {
@@ -442,6 +456,11 @@ func InitializeConstants() error {
 	metricsGroupsWithOtelcol := append(DefaultExpectedMetricsGroups, DefaultOtelcolMetrics, LogsOtelcolMetrics)
 	for _, metrics := range metricsGroupsWithOtelcol {
 		DefaultExpectedMetrics = append(DefaultExpectedMetrics, metrics...)
+	}
+
+	DefaultExpectedNginxAnnotatedMetrics = []string{}
+	for _, metrics := range DefaultExpectedNginxAnnotatedMetricsGroups {
+		DefaultExpectedNginxAnnotatedMetrics = append(DefaultExpectedNginxAnnotatedMetrics, metrics...)
 	}
 
 	log.Printf("Successfully read kind images spec")


### PR DESCRIPTION
By default, Telegraf operator adds an `internal` input which collects Telegraf's own metrics. In addition, the Prometheus output exposes process and gocollector metrics. We don't want either of these enabled by default.

Unfortunately this behaviour of Telegraf operator can only be disabled via a flag passed on the command line, and the Helm Chart doesn't allow changing these. So instead we drop the metrics in the output.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [x] Integration tests added or modified for major features
