### PR TITLE
fix(metrics/collector): scrape configs disabled

### DIFF
--- a/.changelog/3195.fixed.txt
+++ b/.changelog/3195.fixed.txt
@@ -1,0 +1,1 @@
+fix(metrics/collector): scrape configs disabled

--- a/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
@@ -50,7 +50,7 @@ receivers:
       {{- /*
       As of right now, if scrape_configs is empty, it needs to be an empty list, otherwise otel-operator rejects it 
       */}}
-      scrape_configs: {{- not $scrapeConfigsPresent | ternary "[]" "" }}
+      scrape_configs: {{- not $scrapeConfigsPresent | ternary " []" "" }}
 {{- if $collectorConfig.annotatedPods.enabled }}
         ## scraping metrics basing on annotations:
         ##   - prometheus.io/scrape: true - to scrape metrics from the pod

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
@@ -123,7 +123,7 @@ spec:
         config:
           global:
             scrape_interval: 30s
-          scrape_configs:[]
+          scrape_configs: []
         target_allocator:
           endpoint: http://RELEASE-NAME-sumologic-metrics-targetallocator
           interval: 30s


### PR DESCRIPTION
When all the scrape configs were disabled, we'd generate invalid yaml for the Otel configuration.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [x] Template tests added for new features
- [ ] Integration tests added or modified for major features
