### PR TITLE
Revert "chore: use zstd compression for internal otlp data"

### DIFF
--- a/.changelog/3197.fixed.txt
+++ b/.changelog/3197.fixed.txt
@@ -1,0 +1,1 @@
+fix: disable zstd compression internally

--- a/deploy/helm/sumologic/conf/logs/collector/otelcloudwatch/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/collector/otelcloudwatch/config.yaml
@@ -1,7 +1,6 @@
 exporters:
   otlphttp:
     endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local.:4318
-    compression: zstd
     sending_queue:
       queue_size: 10
 

--- a/deploy/helm/sumologic/conf/logs/collector/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/collector/otelcol/config.yaml
@@ -1,7 +1,6 @@
 exporters:
   otlphttp:
     endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local.:4318
-    compression: zstd
     sending_queue:
       queue_size: 10
 

--- a/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
@@ -3,7 +3,6 @@
 exporters:
   otlphttp:
     endpoint: http://${METADATA_METRICS_SVC}.${NAMESPACE}.svc.cluster.local.:4318
-    compression: zstd
     sending_queue:
       queue_size: 10000
       num_consumers: 10

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -3610,7 +3610,6 @@ otelcolInstrumentation:
           queue_size: 5000
       otlphttp/traces:
         endpoint: 'http://{{ include "otelcolinstrumentation.exporter.endpoint" . }}:4318'
-        compression: zstd
     service:
       extensions: [health_check, memory_ballast, pprof]
       pipelines:

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -311,7 +311,6 @@ otellogs:
       exporters:
         otlphttp/extrafiles:
           endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local.:4319
-          compression: zstd
       service:
         pipelines:
           logs/extrafiles:

--- a/tests/helm/testdata/goldenfile/logs_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc/basic.output.yaml
@@ -14,7 +14,6 @@ data:
   config.yaml: |
     exporters:
       otlphttp:
-        compression: zstd
         endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local.:4318
         sending_queue:
           queue_size: 10

--- a/tests/helm/testdata/goldenfile/logs_otc/options.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc/options.output.yaml
@@ -14,7 +14,6 @@ data:
   config.yaml: |
     exporters:
       otlphttp:
-        compression: zstd
         endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local.:4318
         sending_queue:
           queue_size: 10

--- a/tests/helm/testdata/goldenfile/logs_otc_daemonset/multiple_multiline.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_daemonset/multiple_multiline.output.yaml
@@ -14,7 +14,6 @@ data:
   config.yaml: |
     exporters:
       otlphttp:
-        compression: zstd
         endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local.:4318
         sending_queue:
           queue_size: 10

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
@@ -59,7 +59,6 @@ spec:
     exporters:
       otlphttp:
         endpoint: http://${METADATA_METRICS_SVC}.${NAMESPACE}.svc.cluster.local.:4318
-        compression: zstd
         sending_queue:
           queue_size: 10000
           num_consumers: 10

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
@@ -79,7 +79,6 @@ spec:
     exporters:
       otlphttp:
         endpoint: http://${METADATA_METRICS_SVC}.${NAMESPACE}.svc.cluster.local.:4318
-        compression: zstd
         sending_queue:
           queue_size: 10000
           num_consumers: 10

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/traces-gateway-disabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/traces-gateway-disabled.output.yaml
@@ -14,7 +14,6 @@ data:
   otelcol.instrumentation.conf.yaml: |
     exporters:
       otlphttp/traces:
-        compression: zstd
         endpoint: http://RELEASE-NAME-sumologic-traces-sampler.sumologic:4318
       sumologic/metrics:
         compress_encoding: gzip

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/traces-gateway-enabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/traces-gateway-enabled.output.yaml
@@ -14,7 +14,6 @@ data:
   otelcol.instrumentation.conf.yaml: |
     exporters:
       otlphttp/traces:
-        compression: zstd
         endpoint: http://RELEASE-NAME-sumologic-traces-gateway.sumologic:4318
       sumologic/metrics:
         compress_encoding: gzip


### PR DESCRIPTION
This reverts commit c18580380e4c680b1351fca46c113f847cf8c4c5. See: https://github.com/open-telemetry/opentelemetry-collector/issues/8216.

I'm going to backport this fix to 3.12 and 3.11, as it's quite disruptive.

<!---
Describe your PR here
-->

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features
