### PR TITLE
docs: add 3.11.1 and 3.12.1 to changelog

### DIFF
--- a/.changelog/3197.fixed.txt
+++ b/.changelog/3197.fixed.txt
@@ -1,1 +1,0 @@
-fix: disable zstd compression internally

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 <!-- towncrier release notes start -->
 
+## [v3.12.1]
+
+### Released 2023-08-10
+
+### Fixed
+
+- fix: disable zstd compression internally [#3197]
+
+[v3.12.1]: https://github.com/SumoLogic/sumologic-kubernetes-collection/releases/v3.12.1
+
 ## [v3.12.0]
 
 ### Released 2023-08-07
@@ -31,6 +41,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [#3178]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/3178
 [#3185]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/3185
 [v3.12.0]: https://github.com/SumoLogic/sumologic-kubernetes-collection/releases/v3.12.0
+
+## [v3.11.1]
+
+### Released 2023-08-10
+
+### Fixed
+
+- fix: disable zstd compression internally [#3197]
+
+[#3197]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/3197
+[v3.11.1]: https://github.com/SumoLogic/sumologic-kubernetes-collection/releases/v3.11.1
 
 ## [v3.11.0]
 


### PR DESCRIPTION
We also drop the changelog entry for #3197, as it's already in 3.12.1.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
