### PR TITLE
feat(metrics/collector): filter scrape configs in target allocator

### DIFF
--- a/.changelog/3208.changed.txt
+++ b/.changelog/3208.changed.txt
@@ -1,0 +1,1 @@
+feat(metrics/collector): filter scrape configs in target allocator

--- a/deploy/helm/sumologic/templates/metrics/collector/otelcol/opentelemetrycollector.yaml
+++ b/deploy/helm/sumologic/templates/metrics/collector/otelcol/opentelemetrycollector.yaml
@@ -21,6 +21,7 @@ spec:
   targetAllocator:
     serviceAccount: {{ template "sumologic.metadata.name.metrics.targetallocator.serviceaccount" . }}
     enabled: true
+    filterStrategy: relabel-config
     prometheusCR:
       enabled: true
       scrapeInterval: {{ .Values.sumologic.metrics.collector.otelcol.scrapeInterval }}

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
@@ -19,6 +19,7 @@ spec:
   targetAllocator:
     serviceAccount: RELEASE-NAME-sumologic-metrics-targetallocator
     enabled: true
+    filterStrategy: relabel-config
     prometheusCR:
       enabled: true
       scrapeInterval: 30s

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
@@ -23,6 +23,7 @@ spec:
   targetAllocator:
     serviceAccount: RELEASE-NAME-sumologic-metrics-targetallocator
     enabled: true
+    filterStrategy: relabel-config
     prometheusCR:
       enabled: true
       scrapeInterval: 60s


### PR DESCRIPTION
This change makes us drop scrape configs which are filtered out by relabelling rules in the target allocator, so they're not given to collectors at all. By default, each collector does this on its own.

<!---
Describe your PR here
-->

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [x] Template tests added for new features
- [ ] Integration tests added or modified for major features
