### PR TITLE
chore: drop support for AKS 1.24

### DIFF
--- a/.changelog/3209.changed.txt
+++ b/.changelog/3209.changed.txt
@@ -1,0 +1,1 @@
+chore: drop support for AKS 1.24

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,7 +94,7 @@ The following table displays the tested Kubernetes and Helm versions.
 | K8s with EKS (fargate) | 1.24<br/>1.25<br/>1.26<br/>1.27          |
 | K8s with Kops          | 1.23<br/>1.24<br/>1.25<br/>1.26          |
 | K8s with GKE           | 1.23<br/>1.24<br/>1.25<br/>1.26<br/>1.27 |
-| K8s with AKS           | 1.24<br/>1.25<br/>1.26<br/>1.27          |
+| K8s with AKS           | 1.25<br/>1.26<br/>1.27                   |
 | OpenShift              | 4.10<br/>4.11<br/>4.12</br>4.13          |
 | Helm                   | 3.8.2 (Linux)                            |
 | kubectl                | 1.23.6                                   |


### PR DESCRIPTION
AKS doesn't allow creation of new clusters with 1.24, making it impossible to test.

<!---
Describe your PR here
-->

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [x] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features
