### PR TITLE
fix(logs): fix text format for otlp source

### DIFF
--- a/.changelog/3212.fixed.txt
+++ b/.changelog/3212.fixed.txt
@@ -1,0 +1,1 @@
+fix(logs): fix text format for otlp source

--- a/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
@@ -569,12 +569,12 @@ service:
 {{- end }}
         - resource/remove_pod_name
         - resource/drop_annotations
+        - transform/add_timestamp
 {{- if eq .Values.sumologic.logs.container.format "text" }} 
         - transform/remove_attributes
 {{- else if eq .Values.sumologic.logs.container.format "json_merge" }} 
         - transform/flatten
 {{- end }}
-        - transform/add_timestamp
         - batch
       receivers:
         - otlp


### PR DESCRIPTION
For OTLP sources, the text format is implemented by removing all record attributes. However, we were adding the timestamp attribute afterwards, causing the logs to be rendered as json. Fix this by moving the timestamp processor before the attribute removal.

<!---
Describe your PR here
-->

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [X] Template tests added for new features
