### PR TITLE
feat(metrics/collector): support remote write proxy

### DIFF
--- a/.changelog/3221.added.txt
+++ b/.changelog/3221.added.txt
@@ -1,0 +1,1 @@
+feat(metrics/collector): support remote write proxy

--- a/deploy/helm/sumologic/conf/metrics/remote-write-proxy/remote-write-proxy.conf
+++ b/deploy/helm/sumologic/conf/metrics/remote-write-proxy/remote-write-proxy.conf
@@ -1,5 +1,9 @@
-upstream remote {
+upstream remote_prometheus {
     server {{ template "sumologic.metadata.name.metrics.service" . }}:9888;
+}
+
+upstream remote_otel {
+    server {{ template "sumologic.metadata.name.metrics.service" . }}:4318;
 }
 
 server {
@@ -9,6 +13,17 @@ server {
 {{- end }}
     location / {
         client_body_buffer_size {{ .Values.sumologic.metrics.remoteWriteProxy.config.clientBodyBufferSize }};
-        proxy_pass http://remote;
+        proxy_pass http://remote_prometheus;
+    }
+}
+
+server {
+    listen 4318 default_server;
+{{- if not .Values.sumologic.metrics.remoteWriteProxy.config.enableAccessLogs }}
+    access_log off;
+{{- end }}
+    location / {
+        client_body_buffer_size {{ .Values.sumologic.metrics.remoteWriteProxy.config.clientBodyBufferSize }};
+        proxy_pass http://remote_otel;
     }
 }

--- a/deploy/helm/sumologic/templates/metrics/collector/otelcol/opentelemetrycollector.yaml
+++ b/deploy/helm/sumologic/templates/metrics/collector/otelcol/opentelemetrycollector.yaml
@@ -59,7 +59,10 @@ spec:
 {{- end }}
   env:
   - name: METADATA_METRICS_SVC
-    value: {{ template "sumologic.metadata.name.metrics.service" . }} # no need for remote write proxy here
+    valueFrom:
+      configMapKeyRef:
+        name: sumologic-configmap
+        key: metadataMetrics
   - name: NAMESPACE
     valueFrom:
       fieldRef:

--- a/deploy/helm/sumologic/templates/metrics/remote-write-proxy/deployment.yaml
+++ b/deploy/helm/sumologic/templates/metrics/remote-write-proxy/deployment.yaml
@@ -59,6 +59,7 @@ spec:
         imagePullPolicy: {{ .Values.sumologic.metrics.remoteWriteProxy.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.sumologic.metrics.remoteWriteProxy.config.port }}
+        - containerPort: 4318
         resources:
           {{- toYaml .Values.sumologic.metrics.remoteWriteProxy.resources | nindent 10 }}
         livenessProbe:

--- a/deploy/helm/sumologic/templates/metrics/remote-write-proxy/service.yaml
+++ b/deploy/helm/sumologic/templates/metrics/remote-write-proxy/service.yaml
@@ -9,9 +9,12 @@ metadata:
     {{- include "sumologic.labels.common" . | nindent 4 }}
 spec:
   ports:
-    - name: http
+    - name: prometheus
       port: 9888
       targetPort: {{ .Values.sumologic.metrics.remoteWriteProxy.config.port }}
+    - name: otel
+      port: 4318
+      targetPort: 4318
   selector:
     app: {{ template "sumologic.labels.app.remoteWriteProxy.pod" . }}
 {{- end }}

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
@@ -29,7 +29,10 @@ spec:
         release: RELEASE-NAME
   env:
     - name: METADATA_METRICS_SVC
-      value: RELEASE-NAME-sumologic-metadata-metrics # no need for remote write proxy here
+      valueFrom:
+        configMapKeyRef:
+          name: sumologic-configmap
+          key: metadataMetrics
     - name: NAMESPACE
       valueFrom:
         fieldRef:

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
@@ -45,7 +45,10 @@ spec:
     targetMemoryUtilization: 90
   env:
     - name: METADATA_METRICS_SVC
-      value: RELEASE-NAME-sumologic-metadata-metrics # no need for remote write proxy here
+      valueFrom:
+        configMapKeyRef:
+          name: sumologic-configmap
+          key: metadataMetrics
     - name: NAMESPACE
       valueFrom:
         fieldRef:

--- a/tests/helm/testdata/goldenfile/remote_write_proxy/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/remote_write_proxy/basic.output.yaml
@@ -32,6 +32,7 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
+            - containerPort: 4318
           resources:
             limits:
               cpu: 1000m

--- a/tests/helm/testdata/goldenfile/remote_write_proxy/full_config.output.yaml
+++ b/tests/helm/testdata/goldenfile/remote_write_proxy/full_config.output.yaml
@@ -65,6 +65,7 @@ spec:
           imagePullPolicy: Always
           ports:
             - containerPort: 80
+            - containerPort: 4318
           resources:
             limits:
               cpu: 400m

--- a/tests/helm/testdata/goldenfile/remote_write_proxy/full_configmap.output.yaml
+++ b/tests/helm/testdata/goldenfile/remote_write_proxy/full_configmap.output.yaml
@@ -12,14 +12,26 @@ metadata:
     heritage: "Helm"
 data:
   remote-write-proxy.conf: |
-    upstream remote {
+    upstream remote_prometheus {
         server RELEASE-NAME-sumologic-metadata-metrics:9888;
+    }
+
+    upstream remote_otel {
+        server RELEASE-NAME-sumologic-metadata-metrics:4318;
     }
 
     server {
         listen 80 default_server;
         location / {
             client_body_buffer_size 32k;
-            proxy_pass http://remote;
+            proxy_pass http://remote_prometheus;
+        }
+    }
+
+    server {
+        listen 4318 default_server;
+        location / {
+            client_body_buffer_size 32k;
+            proxy_pass http://remote_otel;
         }
     }

--- a/tests/integration/internal/constants.go
+++ b/tests/integration/internal/constants.go
@@ -364,6 +364,7 @@ var (
 		"otelcol_otelsvc_k8s_ip_lookup_miss",
 		"otelcol_otelsvc_k8s_other_deleted",
 		"kube_pod_container_status_waiting_reason",
+		"kube_pod_container_status_terminated_reason",
 		// TODO: check different metrics depending on K8s version
 		// scheduler_scheduling_duration_seconds is present for K8s <1.23
 		// scheduler_scheduling_attempt_duration_seconds is present for K8s >=1.23

--- a/tests/integration/values/values_helm_ot_metrics.yaml
+++ b/tests/integration/values/values_helm_ot_metrics.yaml
@@ -7,8 +7,6 @@ sumologic:
     enabled: false
   metrics:
     enabled: true
-    remoteWriteProxy:
-      enabled: false
     collector:
       otelcol:
         enabled: true


### PR DESCRIPTION
The remote write proxy was originally disabled for the otel metrics collector. Until we've added the ability to disable persistent connections in the upstream collector, it's still useful for load balancing.

<!---
Describe your PR here
-->

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features
