### PR TITLE
fix(metrics/collector): explicitly set OT image

### DIFF
--- a/.changelog/3225.fixed.txt
+++ b/.changelog/3225.fixed.txt
@@ -1,0 +1,1 @@
+fix(metrics/collector): explicitly set OT image

--- a/deploy/helm/sumologic/templates/metrics/collector/otelcol/opentelemetrycollector.yaml
+++ b/deploy/helm/sumologic/templates/metrics/collector/otelcol/opentelemetrycollector.yaml
@@ -15,6 +15,7 @@ metadata:
     {{ toYaml .Values.sumologic.metrics.collector.otelcol.podLabels | nindent 4 }}
     {{- end }}
 spec:
+  image: {{ template "sumologic.metadata.image" . }}
   mode: statefulset
   replicas: {{ .Values.sumologic.metrics.collector.otelcol.replicaCount }}
   serviceAccount: {{ template "sumologic.metadata.name.metrics.collector.serviceaccount" . }}

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
@@ -13,6 +13,7 @@ metadata:
     heritage: "Helm"
     sumologic.com/scrape: "true"
 spec:
+  image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.83.0-sumo-0"
   mode: statefulset
   replicas: 1
   serviceAccount: RELEASE-NAME-sumologic-metrics

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
@@ -17,6 +17,7 @@ metadata:
 
     podKey: podValue
 spec:
+  image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.83.0-sumo-0"
   mode: statefulset
   replicas: 1
   serviceAccount: RELEASE-NAME-sumologic-metrics


### PR DESCRIPTION
If we only set the image as the operator's default, it doesn't upgrade existing OTC resources automatically.

<!---
Describe your PR here
-->

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
