### PR TITLE
fix(fluent-bit): set Time_Keep to On in containerd parser

### DIFF
--- a/.changelog/3227.fixed.txt
+++ b/.changelog/3227.fixed.txt
@@ -1,0 +1,1 @@
+fix(fluent-bit): set Time_Keep to On in containerd parser"

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1496,6 +1496,7 @@ fluent-bit:
           Format       regex
           Regex        ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<log>.*)$
           Time_Key     time
+          Time_Keep    On
           Time_Format  %Y-%m-%dT%H:%M:%S.%LZ
 
 ## Configure kube-prometheus-stack


### PR DESCRIPTION
Ref: https://github.com/fluent/fluent-bit/pull/3087

A customer reported this. Without setting this, the time attribute is empty.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [X] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features
