### PR TITLE
feat(metrics/collector): add batching

### DIFF
--- a/.changelog/3229.added.txt
+++ b/.changelog/3229.added.txt
@@ -1,0 +1,1 @@
+feat(metrics/collector): add batching

--- a/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
@@ -20,6 +20,11 @@ extensions:
 
 
 processors:
+  batch:
+    send_batch_max_size: 2000
+    send_batch_size: 1000
+    timeout: 1s
+
   transform/drop_unnecessary_attributes:
     error_mode: ignore
     metric_statements:
@@ -64,7 +69,7 @@ receivers:
       global:
         scrape_interval: {{ .Values.sumologic.metrics.collector.otelcol.scrapeInterval }}
       {{- /*
-      As of right now, if scrape_configs is empty, it needs to be an empty list, otherwise otel-operator rejects it 
+      As of right now, if scrape_configs is empty, it needs to be an empty list, otherwise otel-operator rejects it
       */}}
       scrape_configs: {{- not $scrapeConfigsPresent | ternary " []" "" }}
 {{- if $collectorConfig.annotatedPods.enabled }}
@@ -209,6 +214,7 @@ service:
     metrics:
       exporters: [otlphttp]
       processors:
+        - batch
 {{- if .Values.sumologic.metrics.dropHistogramBuckets }}
         - transform/extract_sum_count_from_histograms
 {{- end }}

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
@@ -84,6 +84,11 @@ spec:
 
 
     processors:
+      batch:
+        send_batch_max_size: 2000
+        send_batch_size: 1000
+        timeout: 1s
+
       transform/drop_unnecessary_attributes:
         error_mode: ignore
         metric_statements:
@@ -255,6 +260,7 @@ spec:
         metrics:
           exporters: [otlphttp]
           processors:
+            - batch
             - transform/extract_sum_count_from_histograms
             - filter/drop_unnecessary_metrics
             - transform/drop_unnecessary_attributes

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
@@ -103,6 +103,11 @@ spec:
 
 
     processors:
+      batch:
+        send_batch_max_size: 2000
+        send_batch_size: 1000
+        timeout: 1s
+
       transform/drop_unnecessary_attributes:
         error_mode: ignore
         metric_statements:
@@ -1063,6 +1068,7 @@ spec:
         metrics:
           exporters: [otlphttp]
           processors:
+            - batch
             - filter/drop_unnecessary_metrics
             - transform/drop_unnecessary_attributes
             - filter/app_metrics


### PR DESCRIPTION
Batching is more useful for splitting batches than aggregating them. In particular, kube-state-metrics in large clusters can produce very large batches that we want to split.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [x] Template tests added for new features
