### PR TITLE
Use either minAvailable or maxUnavailable for logs pdb

### DIFF
--- a/.changelog/3231.fixed.txt
+++ b/.changelog/3231.fixed.txt
@@ -1,1 +1,1 @@
-Use either minAvailable or maxUnavailable for logs pdb
+feat: use either minAvailable or maxUnavailable for logs pdb

--- a/.changelog/3231.fixed.txt
+++ b/.changelog/3231.fixed.txt
@@ -1,0 +1,1 @@
+Use either minAvailable or maxUnavailable for logs pdb

--- a/deploy/helm/sumologic/templates/logs/common/pdb.yaml
+++ b/deploy/helm/sumologic/templates/logs/common/pdb.yaml
@@ -11,6 +11,10 @@ spec:
   selector:
     matchLabels:
       app: {{ template "sumologic.labels.app.logs.statefulset" . }}
-{{ toYaml .Values.metadata.logs.podDisruptionBudget | indent 2 }}
+{{- if hasKey .Values.metadata.logs.podDisruptionBudget "maxUnavailable" }}
+  maxUnavailable: {{ .Values.metadata.logs.podDisruptionBudget.maxUnavailable }}
+{{- else }}
+  minAvailable: {{ .Values.metadata.logs.podDisruptionBudget.minAvailable }}
+{{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
This change updates the logs pdb.yaml to either use maxUnavailable, if defined, or minAvailable as a default.

The current behavior is to always include minAvailable since it's specified as a default in values.yaml file. There's no way in helm to unset this. With this change it will use maxUnavailable if defined and if not it will fall back to minAvailable.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features
