### PR TITLE
chore(helm/tests): bump defaultK8sVersion to 1.26

### DIFF
--- a/tests/helm/const.go
+++ b/tests/helm/const.go
@@ -7,7 +7,7 @@ const (
 	chartName                = "sumologic"
 	releaseName              = "collection-test"
 	defaultNamespace         = "sumologic"
-	defaultK8sVersion        = "1.23.0"
+	defaultK8sVersion        = "1.26.0"
 	testDataDirectory        = "./testdata"
 	otelConfigFileName       = "config.yaml"
 	otelImageFIPSSuffix      = "-fips"

--- a/tests/helm/testdata/goldenfile/logs_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc/basic.output.yaml
@@ -54,7 +54,6 @@ data:
           type: remove
     receivers:
       filelog/containers:
-        fingerprint_size: 17408
         include:
         - /var/log/pods/*/*/*.log
         include_file_name: false

--- a/tests/helm/testdata/goldenfile/logs_otc_daemonset/multiple_multiline.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_daemonset/multiple_multiline.output.yaml
@@ -54,7 +54,6 @@ data:
           type: remove
     receivers:
       filelog/containers:
-        fingerprint_size: 17408
         include:
         - /var/log/pods/*/*/*.log
         include_file_name: false


### PR DESCRIPTION
Bumping to 1.26, because we don't support 1.27 on Kops yet.