### PR TITLE
Revert "docs: add link to "Switching from Prometheus" to main README"

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,6 @@ Documentation links:
   - Metrics
     - [Collecting Kubernetes metrics](/docs/collecting-kubernetes-metrics.md)
     - [Collecting application metrics](/docs/collecting-application-metrics.md)
-    - [Switching from Prometheus to Otelcol](/docs/opentelemetry-collector/metrics.md#metrics-collector) :new:
   - [Advanced Configuration/Best Practices](/docs/best-practices.md)
   - [Advanced Configuration/Security best practices](/docs/security-best-practices.md)
   - [Authenticating with container registry](/docs/working-with-container-registries.md#authenticating-with-container-registry)


### PR DESCRIPTION
Reverts SumoLogic/sumologic-kubernetes-collection#3263

My bad, that PR was only meant for `release-v3` branch and not `main`. 