### PR TITLE
[Backport release-v3] fix: disable keep-alives for internal traffic

### DIFF
--- a/.changelog/3267.fixed.txt
+++ b/.changelog/3267.fixed.txt
@@ -1,0 +1,1 @@
+fix: disable keep-alives for internal traffic

--- a/deploy/helm/sumologic/conf/logs/collector/otelcloudwatch/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/collector/otelcloudwatch/config.yaml
@@ -3,6 +3,8 @@ exporters:
     endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local.:4318
     sending_queue:
       queue_size: 10
+    # this improves load balancing at the cost of more network traffic
+    disable_keep_alives: true
 
 extensions:
 {{ if .Values.sumologic.logs.collector.otelcloudwatch.persistence.enabled }}

--- a/deploy/helm/sumologic/conf/logs/collector/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/collector/otelcol/config.yaml
@@ -3,6 +3,8 @@ exporters:
     endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local.:4318
     sending_queue:
       queue_size: 10
+    # this improves load balancing at the cost of more network traffic
+    disable_keep_alives: true
 
 extensions:
   file_storage:

--- a/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
@@ -7,6 +7,8 @@ exporters:
       queue_size: 10000
       num_consumers: 10
       storage: file_storage
+    # this improves load balancing at the cost of more network traffic
+    disable_keep_alives: true
 
 extensions:
   health_check: {}

--- a/tests/helm/testdata/goldenfile/logs_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc/basic.output.yaml
@@ -14,6 +14,7 @@ data:
   config.yaml: |
     exporters:
       otlphttp:
+        disable_keep_alives: true
         endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local.:4318
         sending_queue:
           queue_size: 10

--- a/tests/helm/testdata/goldenfile/logs_otc/options.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc/options.output.yaml
@@ -14,6 +14,7 @@ data:
   config.yaml: |
     exporters:
       otlphttp:
+        disable_keep_alives: true
         endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local.:4318
         sending_queue:
           queue_size: 10

--- a/tests/helm/testdata/goldenfile/logs_otc_daemonset/multiple_multiline.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_daemonset/multiple_multiline.output.yaml
@@ -14,6 +14,7 @@ data:
   config.yaml: |
     exporters:
       otlphttp:
+        disable_keep_alives: true
         endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local.:4318
         sending_queue:
           queue_size: 10

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
@@ -71,6 +71,8 @@ spec:
           queue_size: 10000
           num_consumers: 10
           storage: file_storage
+        # this improves load balancing at the cost of more network traffic
+        disable_keep_alives: true
 
     extensions:
       health_check: {}

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
@@ -90,6 +90,8 @@ spec:
           queue_size: 10000
           num_consumers: 10
           storage: file_storage
+        # this improves load balancing at the cost of more network traffic
+        disable_keep_alives: true
 
     extensions:
       health_check: {}


### PR DESCRIPTION
Replaces #3268, backporter bot can't handle multiple commits.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [ ] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features
