### PR TITLE
docs: disable remote write proxy for otel metrics collector

### DIFF
--- a/docs/opentelemetry-collector/metrics.md
+++ b/docs/opentelemetry-collector/metrics.md
@@ -21,6 +21,8 @@ sumologic:
     collector:
       otelcol:
         enabled: true
+    remoteWriteProxy:
+      enabled: false
 
 kube-prometheus-stack:
   prometheus:

--- a/tests/integration/values/values_helm_ot_metrics.yaml
+++ b/tests/integration/values/values_helm_ot_metrics.yaml
@@ -7,6 +7,8 @@ sumologic:
     enabled: false
   metrics:
     enabled: true
+    remoteWriteProxy:
+      enabled: false
     collector:
       otelcol:
         enabled: true


### PR DESCRIPTION
After disabling keep-alives, remote write proxy isn't necessary anymore.

<!---
Describe your PR here
-->

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [x] Documentation updated
