### PR TITLE
fix(logs)!: move JSON parsing after user-defined processors

### DIFF
--- a/.changelog/3281.fixed.txt
+++ b/.changelog/3281.fixed.txt
@@ -1,0 +1,5 @@
+fix(logs)!: move JSON parsing after user-defined processors
+
+The log body will now always be a string if accessed in extra processors.
+Users who want to access specific fields in their parsed JSON log
+should explicitly call ParseJSON in their processor definition.

--- a/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
@@ -445,12 +445,12 @@ service:
         - resource/containers_copy_node_to_host
         - sumologic_schema
         - source/containers
-        - transform/containers_parse_json
 {{- if .Values.sumologic.logs.container.otelcol.extraProcessors }}
 {{- range $processor := .Values.sumologic.logs.container.otelcol.extraProcessors }}
 {{ printf "- %s" ( $processor | keys | first ) | indent 8 }}
 {{- end }}
 {{- end }}
+        - transform/containers_parse_json
         - resource/remove_pod_name
         - resource/drop_annotations
         - transform/add_timestamp

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/templates.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/templates.output.yaml
@@ -329,9 +329,9 @@ data:
           - resource/containers_copy_node_to_host
           - sumologic_schema
           - source/containers
-          - transform/containers_parse_json
           - resource/add-resource-attribute-container
           - resource/remove-container
+          - transform/containers_parse_json
           - resource/remove_pod_name
           - resource/drop_annotations
           - transform/add_timestamp


### PR DESCRIPTION
It's easier for users to write processors if they can assume the log body is a string, as opposed to having to work with arbitrary structured data.

<!---
Describe your PR here
-->

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features
