### PR TITLE
fix(metrics): decompose OTLP histograms

### DIFF
--- a/.changelog/3289.fixed.txt
+++ b/.changelog/3289.fixed.txt
@@ -1,0 +1,1 @@
+fix(metrics): decompose OTLP histograms

--- a/deploy/helm/sumologic/conf/metrics/otelcol/exporters.yaml
+++ b/deploy/helm/sumologic/conf/metrics/otelcol/exporters.yaml
@@ -3,6 +3,8 @@
 sumologic/default:
   metric_format: {{ include "metrics.otelcol.exporter.format" . }}
   endpoint: {{ include "metrics.otelcol.exporter.endpoint" . }}
+  ## Sumo doesn't yet natively support OTLP Histograms
+  decompose_otlp_histograms: true
   ## Configuration for sending queue
   ## ref: https://github.com/open-telemetry/opentelemetry-collector/tree/release/v0.37.x/exporter/exporterhelper#configuration
   sending_queue:

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/additional_endpoints.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/additional_endpoints.output.yaml
@@ -44,6 +44,7 @@ data:
           storage: file_storage
         timeout: 30s
       sumologic/default:
+        decompose_otlp_histograms: true
         endpoint: ${SUMO_ENDPOINT_DEFAULT_METRICS_SOURCE}
         max_request_body_size: 16777216
         metric_format: prometheus

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/basic.output.yaml
@@ -44,6 +44,7 @@ data:
           storage: file_storage
         timeout: 30s
       sumologic/default:
+        decompose_otlp_histograms: true
         endpoint: ${SUMO_ENDPOINT_DEFAULT_METRICS_SOURCE}
         max_request_body_size: 16777216
         metric_format: prometheus

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/custom.output.yaml
@@ -14,6 +14,7 @@ data:
   config.yaml: |
     exporters:
       sumologic/default:
+        decompose_otlp_histograms: true
         endpoint: ${SUMO_ENDPOINT_DEFAULT_OTLP_METRICS_SOURCE}
         max_request_body_size: 16777216
         metric_format: otlp

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/filtered_app_metrics.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/filtered_app_metrics.output.yaml
@@ -44,6 +44,7 @@ data:
           storage: file_storage
         timeout: 30s
       sumologic/default:
+        decompose_otlp_histograms: true
         endpoint: ${SUMO_ENDPOINT_DEFAULT_METRICS_SOURCE}
         max_request_body_size: 16777216
         metric_format: prometheus


### PR DESCRIPTION
Sumo doesn't support OTLP Histograms natively yet. Enable decomposing these histograms into Gauge metrics in the exporter.

<!---
Describe your PR here
-->

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
