### PR TITLE
fix(metrics)!: drop k8s.node.name attribute

### DIFF
--- a/.changelog/3295.fixed.txt
+++ b/.changelog/3295.fixed.txt
@@ -1,0 +1,1 @@
+fix(metrics)!: drop k8s.node.name attribute

--- a/deploy/helm/sumologic/conf/metrics/otelcol/processors.yaml
+++ b/deploy/helm/sumologic/conf/metrics/otelcol/processors.yaml
@@ -94,6 +94,11 @@ resource:
     - action: delete
       key: container  # remove container to avoid duplication when attribute translation is enabled
     - action: upsert
+      from_attribute: node
+      key: k8s.node.name  # add container in OpenTelemetry convention to unify configuration for Source processor
+    - action: delete
+      key: node  # remove container to avoid duplication when attribute translation is enabled
+    - action: upsert
       from_attribute: service
       key: prometheus_service
     - action: delete

--- a/docs/v4-migration-doc.md
+++ b/docs/v4-migration-doc.md
@@ -195,6 +195,10 @@ require additional action.
   - node_filesystem_avail_bytes
   - node_filesystem_size_bytes
 
+- Drop `k8s.node.name` attribute from metrics
+
+  The `node` attribute exists and has the same value, so this is superfluous.
+
 - Truncating full name to 22 characters
 
   Some Kubernetes objects, for example statefulsets, have a tight (63 characters) limit for their names. Because of that, we truncate the

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/additional_endpoints.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/additional_endpoints.output.yaml
@@ -169,6 +169,11 @@ data:
         - action: delete
           key: container
         - action: upsert
+          from_attribute: node
+          key: k8s.node.name
+        - action: delete
+          key: node
+        - action: upsert
           from_attribute: service
           key: prometheus_service
         - action: delete

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/basic.output.yaml
@@ -169,6 +169,11 @@ data:
         - action: delete
           key: container
         - action: upsert
+          from_attribute: node
+          key: k8s.node.name
+        - action: delete
+          key: node
+        - action: upsert
           from_attribute: service
           key: prometheus_service
         - action: delete

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/custom.output.yaml
@@ -99,6 +99,11 @@ data:
         - action: delete
           key: container
         - action: upsert
+          from_attribute: node
+          key: k8s.node.name
+        - action: delete
+          key: node
+        - action: upsert
           from_attribute: service
           key: prometheus_service
         - action: delete

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/filtered_app_metrics.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/filtered_app_metrics.output.yaml
@@ -193,6 +193,11 @@ data:
         - action: delete
           key: container
         - action: upsert
+          from_attribute: node
+          key: k8s.node.name
+        - action: delete
+          key: node
+        - action: upsert
           from_attribute: service
           key: prometheus_service
         - action: delete

--- a/tests/integration/features.go
+++ b/tests/integration/features.go
@@ -122,7 +122,6 @@ func GetMetricsFeature(expectedMetrics []string, metricsCollector MetricsCollect
 				expectedLabels = addCollectorSpecificMetricLabels(expectedLabels, releaseName, namespace, metricsCollector)
 				// drop some unnecessary labels
 				delete(expectedLabels, "prometheus_service")
-				delete(expectedLabels, "k8s.node.name")
 
 				return stepfuncs.WaitUntilExpectedMetricLabelsPresent(metricFilters, expectedLabels, waitDuration, tickDuration)(ctx, t, envConf)
 			},
@@ -169,7 +168,6 @@ func GetTelegrafMetricsFeature(expectedMetrics []string, metricsCollector Metric
 				expectedLabels = addCollectorSpecificMetricLabels(expectedLabels, releaseName, namespace, metricsCollector)
 
 				// drop some unnecessary labels
-				delete(expectedLabels, "k8s.node.name")
 				delete(expectedLabels, "prometheus_service")
 
 				return stepfuncs.WaitUntilExpectedMetricLabelsPresent(metricFilters, expectedLabels, waitDuration, tickDuration)(ctx, t, envConf)
@@ -187,7 +185,6 @@ func addCollectorSpecificMetricLabels(labels receivermock.Labels, releaseName st
 	}
 	prometheusLabels := receivermock.Labels{
 		"_collector":         "kubernetes",
-		"k8s.node.name":      internal.NodeNameRegex, // TODO: Remove this during the migration to v4
 		"instance":           internal.IpWithPortRegex,
 		"prometheus_replica": fmt.Sprintf("prometheus-%s-.*-0", releaseName),
 		"prometheus":         fmt.Sprintf("%s/%s-.*-prometheus", serviceMonitorNamespace, releaseName),


### PR DESCRIPTION
Use the `node` attribute instead. This was only part of the metrics metadata by mistake.

<!---
Describe your PR here
-->

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [x] Documentation updated
- [x] Template tests added for new features
- [x] Integration tests added or modified for major features
