### PR TITLE
chore(metrics): route based on job attributes

### DIFF
--- a/deploy/helm/sumologic/conf/metrics/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/metrics/otelcol/config.yaml
@@ -34,7 +34,6 @@ receivers:
         write_timeout = "30s"
         service_address = ":9888"
         data_format = "prometheusremotewrite"
-        path_tag = true
         paths = [
 {{ include "metric.endpoints" . | indent 10 }}
         ]

--- a/deploy/helm/sumologic/conf/metrics/otelcol/pipeline.yaml
+++ b/deploy/helm/sumologic/conf/metrics/otelcol/pipeline.yaml
@@ -33,10 +33,7 @@ processors:
 {{- end }}
   - batch
 {{- if eq .Values.sumologic.metrics.sourceType "http" }}
-  - transform/prepare_routing
   - routing
-{{- else }}
-  - transform/drop_routing_attribute
 {{- end }}
 receivers:
   - telegraf

--- a/deploy/helm/sumologic/conf/metrics/otelcol/processors.yaml
+++ b/deploy/helm/sumologic/conf/metrics/otelcol/processors.yaml
@@ -127,57 +127,42 @@ resource/remove_k8s_pod_pod_name:
       key: k8s.pod.pod_name
 
 {{- if eq .Values.sumologic.metrics.sourceType "http" }}
-## NOTE: below listed rules could be simplified if routingprocessor
-## supports regex matching. At this point we could group route entries
-## going to the same set of exporters.
 routing:
-  attribute_source: resource
   default_exporters:
     - sumologic/default
-  drop_resource_routing_attribute: true
-  from_attribute: http_listener_v2_path
+  error_mode: ignore
   table:
     ## apiserver metrics
     - exporters:
         - sumologic/apiserver
-      value: /prometheus.metrics.apiserver
+      statement: route() where resource.attributes["job"] == "apiserver"
     ## control-plane metrics
     - exporters:
         - sumologic/control_plane
-      value: /prometheus.metrics.control-plane.coredns
+      statement: route() where resource.attributes["job"] == "coredns"
     - exporters:
         - sumologic/control_plane
-      value: /prometheus.metrics.control-plane.kube-etcd
+      statement: route() where resource.attributes["job"] == "kube-etcd"
     ## controller metrics
     - exporters:
         - sumologic/controller
-      value: /prometheus.metrics.controller-manager
+      statement: route() where resource.attributes["job"] == "kube-controller-manager"
     ## kubelet metrics
     - exporters:
         - sumologic/kubelet
-      value: /prometheus.metrics.kubelet
+      statement: route() where resource.attributes["job"] == "kubelet"
     ## node metrics
     - exporters:
         - sumologic/node
-      value: /prometheus.metrics.node
+      statement: route() where resource.attributes["job"] == "node-exporter"
     ## scheduler metrics
     - exporters:
         - sumologic/scheduler
-      value: /prometheus.metrics.scheduler
+      statement: route() where resource.attributes["job"] == "kube-scheduler"
     ## state metrics
     - exporters:
         - sumologic/state
-      value: /prometheus.metrics.state
-    ## custom metrics
-    ## These entries are necessary due to a bug in routing processor that prevents the routing key from being deleted
-    ## if the default exporter is chosen
-    ## See: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/24644
-    - exporters:
-        - sumologic/default
-      value: /prometheus.metrics.applications.custom
-    - exporters:
-        - sumologic/default
-      value: /prometheus.metrics
+      statement: route() where resource.attributes["job"] == "kube-state-metrics"
 {{- end }}
 
 ## Configuration for Source Processor
@@ -191,29 +176,6 @@ source:
 ## so that the Sumo Logic apps can make full use of the ingested data.
 sumologic_schema:
   add_cloud_namespace: false
-
-{{- if eq .Values.sumologic.metrics.sourceType "http" }}
-transform/prepare_routing:
-  error_mode: ignore
-  metric_statements:
-    - context: metric
-      statements:
-        - set(resource.attributes["http_listener_v2_path"], "/prometheus.metrics.apiserver") where resource.attributes["job"] == "apiserver"
-        - set(resource.attributes["http_listener_v2_path"], "/prometheus.metrics.control-plane.coredns") where resource.attributes["job"] == "coredns"
-        - set(resource.attributes["http_listener_v2_path"], "/prometheus.metrics.control-plane.kube-etcd") where resource.attributes["job"] == "kube-etcd"
-        - set(resource.attributes["http_listener_v2_path"], "/prometheus.metrics.controller-manager") where resource.attributes["job"] == "kubelet" and IsMatch(name, "^cloudprovider_.*")
-        - set(resource.attributes["http_listener_v2_path"], "/prometheus.metrics.kubelet") where resource.attributes["job"] == "kubelet" and not IsMatch(name, "^cloudprovider_.*")
-        - set(resource.attributes["http_listener_v2_path"], "/prometheus.metrics.node") where resource.attributes["job"] == "node-exporter"
-        - set(resource.attributes["http_listener_v2_path"], "/prometheus.metrics.scheduler") where resource.attributes["job"] == "kube-scheduler"
-        - set(resource.attributes["http_listener_v2_path"], "/prometheus.metrics.state") where resource.attributes["job"] == "kube-state-metrics"
-{{ else }}
-transform/drop_routing_attribute:
-  error_mode: ignore
-  metric_statements:
-    - context: resource
-      statements:
-        - delete_key(attributes, "http_listener_v2_path")
-{{- end }}
 
 transform/remove_name:
   error_mode: ignore

--- a/tests/helm/metrics_test.go
+++ b/tests/helm/metrics_test.go
@@ -137,7 +137,6 @@ func TestMetadataMetricsOtelConfigExtraProcessors(t *testing.T) {
 		"transform/remove_name",
 		"filter/drop_unnecessary_metrics",
 		"batch",
-		"transform/prepare_routing",
 		"routing",
 	}
 
@@ -182,10 +181,8 @@ sumologic:
 	assert.Len(t, otelConfig.Exporters.Rest, 0)
 	assert.NotContains(t, otelConfig.Processors, "routing")
 	assert.NotContains(t, otelConfig.Processors, "transform/prepare_routing")
-	assert.Contains(t, otelConfig.Processors, "transform/drop_routing_attribute")
 	assert.NotContains(t, otelConfig.Service.Pipelines.Metrics.Processors, "routing")
 	assert.NotContains(t, otelConfig.Service.Pipelines.Metrics.Processors, "transform/prepare_routing")
-	assert.Contains(t, otelConfig.Service.Pipelines.Metrics.Processors, "transform/drop_routing_attribute")
 	assert.Equal(t, otelConfig.Service.Pipelines.Metrics.Exporters, []string{"sumologic/default"})
 }
 

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/additional_endpoints.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/additional_endpoints.output.yaml
@@ -197,69 +197,40 @@ data:
         - action: delete
           key: k8s.pod.pod_name
       routing:
-        attribute_source: resource
         default_exporters:
         - sumologic/default
-        drop_resource_routing_attribute: true
-        from_attribute: http_listener_v2_path
+        error_mode: ignore
         table:
         - exporters:
           - sumologic/apiserver
-          value: /prometheus.metrics.apiserver
+          statement: route() where resource.attributes["job"] == "apiserver"
         - exporters:
           - sumologic/control_plane
-          value: /prometheus.metrics.control-plane.coredns
+          statement: route() where resource.attributes["job"] == "coredns"
         - exporters:
           - sumologic/control_plane
-          value: /prometheus.metrics.control-plane.kube-etcd
+          statement: route() where resource.attributes["job"] == "kube-etcd"
         - exporters:
           - sumologic/controller
-          value: /prometheus.metrics.controller-manager
+          statement: route() where resource.attributes["job"] == "kube-controller-manager"
         - exporters:
           - sumologic/kubelet
-          value: /prometheus.metrics.kubelet
+          statement: route() where resource.attributes["job"] == "kubelet"
         - exporters:
           - sumologic/node
-          value: /prometheus.metrics.node
+          statement: route() where resource.attributes["job"] == "node-exporter"
         - exporters:
           - sumologic/scheduler
-          value: /prometheus.metrics.scheduler
+          statement: route() where resource.attributes["job"] == "kube-scheduler"
         - exporters:
           - sumologic/state
-          value: /prometheus.metrics.state
-        - exporters:
-          - sumologic/default
-          value: /prometheus.metrics.applications.custom
-        - exporters:
-          - sumologic/default
-          value: /prometheus.metrics
+          statement: route() where resource.attributes["job"] == "kube-state-metrics"
       source:
         collector: kubernetes
         exclude:
           k8s.namespace.name: ""
       sumologic_schema:
         add_cloud_namespace: false
-      transform/prepare_routing:
-        error_mode: ignore
-        metric_statements:
-        - context: metric
-          statements:
-          - set(resource.attributes["http_listener_v2_path"], "/prometheus.metrics.apiserver")
-            where resource.attributes["job"] == "apiserver"
-          - set(resource.attributes["http_listener_v2_path"], "/prometheus.metrics.control-plane.coredns")
-            where resource.attributes["job"] == "coredns"
-          - set(resource.attributes["http_listener_v2_path"], "/prometheus.metrics.control-plane.kube-etcd")
-            where resource.attributes["job"] == "kube-etcd"
-          - set(resource.attributes["http_listener_v2_path"], "/prometheus.metrics.controller-manager")
-            where resource.attributes["job"] == "kubelet" and IsMatch(name, "^cloudprovider_.*")
-          - set(resource.attributes["http_listener_v2_path"], "/prometheus.metrics.kubelet")
-            where resource.attributes["job"] == "kubelet" and not IsMatch(name, "^cloudprovider_.*")
-          - set(resource.attributes["http_listener_v2_path"], "/prometheus.metrics.node")
-            where resource.attributes["job"] == "node-exporter"
-          - set(resource.attributes["http_listener_v2_path"], "/prometheus.metrics.scheduler")
-            where resource.attributes["job"] == "kube-scheduler"
-          - set(resource.attributes["http_listener_v2_path"], "/prometheus.metrics.state")
-            where resource.attributes["job"] == "kube-state-metrics"
       transform/remove_name:
         error_mode: ignore
         metric_statements:
@@ -289,7 +260,6 @@ data:
             write_timeout = "30s"
             service_address = ":9888"
             data_format = "prometheusremotewrite"
-            path_tag = true
             paths = [
               "/prometheus.metrics",
               "/prometheus.metrics.custom",
@@ -326,7 +296,6 @@ data:
           - transform/remove_name
           - filter/drop_unnecessary_metrics
           - batch
-          - transform/prepare_routing
           - routing
           receivers:
           - telegraf

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/basic.output.yaml
@@ -197,69 +197,40 @@ data:
         - action: delete
           key: k8s.pod.pod_name
       routing:
-        attribute_source: resource
         default_exporters:
         - sumologic/default
-        drop_resource_routing_attribute: true
-        from_attribute: http_listener_v2_path
+        error_mode: ignore
         table:
         - exporters:
           - sumologic/apiserver
-          value: /prometheus.metrics.apiserver
+          statement: route() where resource.attributes["job"] == "apiserver"
         - exporters:
           - sumologic/control_plane
-          value: /prometheus.metrics.control-plane.coredns
+          statement: route() where resource.attributes["job"] == "coredns"
         - exporters:
           - sumologic/control_plane
-          value: /prometheus.metrics.control-plane.kube-etcd
+          statement: route() where resource.attributes["job"] == "kube-etcd"
         - exporters:
           - sumologic/controller
-          value: /prometheus.metrics.controller-manager
+          statement: route() where resource.attributes["job"] == "kube-controller-manager"
         - exporters:
           - sumologic/kubelet
-          value: /prometheus.metrics.kubelet
+          statement: route() where resource.attributes["job"] == "kubelet"
         - exporters:
           - sumologic/node
-          value: /prometheus.metrics.node
+          statement: route() where resource.attributes["job"] == "node-exporter"
         - exporters:
           - sumologic/scheduler
-          value: /prometheus.metrics.scheduler
+          statement: route() where resource.attributes["job"] == "kube-scheduler"
         - exporters:
           - sumologic/state
-          value: /prometheus.metrics.state
-        - exporters:
-          - sumologic/default
-          value: /prometheus.metrics.applications.custom
-        - exporters:
-          - sumologic/default
-          value: /prometheus.metrics
+          statement: route() where resource.attributes["job"] == "kube-state-metrics"
       source:
         collector: kubernetes
         exclude:
           k8s.namespace.name: ""
       sumologic_schema:
         add_cloud_namespace: false
-      transform/prepare_routing:
-        error_mode: ignore
-        metric_statements:
-        - context: metric
-          statements:
-          - set(resource.attributes["http_listener_v2_path"], "/prometheus.metrics.apiserver")
-            where resource.attributes["job"] == "apiserver"
-          - set(resource.attributes["http_listener_v2_path"], "/prometheus.metrics.control-plane.coredns")
-            where resource.attributes["job"] == "coredns"
-          - set(resource.attributes["http_listener_v2_path"], "/prometheus.metrics.control-plane.kube-etcd")
-            where resource.attributes["job"] == "kube-etcd"
-          - set(resource.attributes["http_listener_v2_path"], "/prometheus.metrics.controller-manager")
-            where resource.attributes["job"] == "kubelet" and IsMatch(name, "^cloudprovider_.*")
-          - set(resource.attributes["http_listener_v2_path"], "/prometheus.metrics.kubelet")
-            where resource.attributes["job"] == "kubelet" and not IsMatch(name, "^cloudprovider_.*")
-          - set(resource.attributes["http_listener_v2_path"], "/prometheus.metrics.node")
-            where resource.attributes["job"] == "node-exporter"
-          - set(resource.attributes["http_listener_v2_path"], "/prometheus.metrics.scheduler")
-            where resource.attributes["job"] == "kube-scheduler"
-          - set(resource.attributes["http_listener_v2_path"], "/prometheus.metrics.state")
-            where resource.attributes["job"] == "kube-state-metrics"
       transform/remove_name:
         error_mode: ignore
         metric_statements:
@@ -289,7 +260,6 @@ data:
             write_timeout = "30s"
             service_address = ":9888"
             data_format = "prometheusremotewrite"
-            path_tag = true
             paths = [
               "/prometheus.metrics"
             ]
@@ -324,7 +294,6 @@ data:
           - transform/remove_name
           - filter/drop_unnecessary_metrics
           - batch
-          - transform/prepare_routing
           - routing
           receivers:
           - telegraf

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/custom.output.yaml
@@ -132,12 +132,6 @@ data:
           k8s.namespace.name: ""
       sumologic_schema:
         add_cloud_namespace: false
-      transform/drop_routing_attribute:
-        error_mode: ignore
-        metric_statements:
-        - context: resource
-          statements:
-          - delete_key(attributes, "http_listener_v2_path")
       transform/remove_name:
         error_mode: ignore
         metric_statements:
@@ -167,7 +161,6 @@ data:
             write_timeout = "30s"
             service_address = ":9888"
             data_format = "prometheusremotewrite"
-            path_tag = true
             paths = [
               "/prometheus.metrics"
             ]
@@ -195,7 +188,6 @@ data:
           - transform/remove_name
           - filter/drop_unnecessary_metrics
           - batch
-          - transform/drop_routing_attribute
           receivers:
           - telegraf
           - otlp

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/filtered_app_metrics.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/filtered_app_metrics.output.yaml
@@ -221,69 +221,40 @@ data:
         - action: delete
           key: k8s.pod.pod_name
       routing:
-        attribute_source: resource
         default_exporters:
         - sumologic/default
-        drop_resource_routing_attribute: true
-        from_attribute: http_listener_v2_path
+        error_mode: ignore
         table:
         - exporters:
           - sumologic/apiserver
-          value: /prometheus.metrics.apiserver
+          statement: route() where resource.attributes["job"] == "apiserver"
         - exporters:
           - sumologic/control_plane
-          value: /prometheus.metrics.control-plane.coredns
+          statement: route() where resource.attributes["job"] == "coredns"
         - exporters:
           - sumologic/control_plane
-          value: /prometheus.metrics.control-plane.kube-etcd
+          statement: route() where resource.attributes["job"] == "kube-etcd"
         - exporters:
           - sumologic/controller
-          value: /prometheus.metrics.controller-manager
+          statement: route() where resource.attributes["job"] == "kube-controller-manager"
         - exporters:
           - sumologic/kubelet
-          value: /prometheus.metrics.kubelet
+          statement: route() where resource.attributes["job"] == "kubelet"
         - exporters:
           - sumologic/node
-          value: /prometheus.metrics.node
+          statement: route() where resource.attributes["job"] == "node-exporter"
         - exporters:
           - sumologic/scheduler
-          value: /prometheus.metrics.scheduler
+          statement: route() where resource.attributes["job"] == "kube-scheduler"
         - exporters:
           - sumologic/state
-          value: /prometheus.metrics.state
-        - exporters:
-          - sumologic/default
-          value: /prometheus.metrics.applications.custom
-        - exporters:
-          - sumologic/default
-          value: /prometheus.metrics
+          statement: route() where resource.attributes["job"] == "kube-state-metrics"
       source:
         collector: kubernetes
         exclude:
           k8s.namespace.name: ""
       sumologic_schema:
         add_cloud_namespace: false
-      transform/prepare_routing:
-        error_mode: ignore
-        metric_statements:
-        - context: metric
-          statements:
-          - set(resource.attributes["http_listener_v2_path"], "/prometheus.metrics.apiserver")
-            where resource.attributes["job"] == "apiserver"
-          - set(resource.attributes["http_listener_v2_path"], "/prometheus.metrics.control-plane.coredns")
-            where resource.attributes["job"] == "coredns"
-          - set(resource.attributes["http_listener_v2_path"], "/prometheus.metrics.control-plane.kube-etcd")
-            where resource.attributes["job"] == "kube-etcd"
-          - set(resource.attributes["http_listener_v2_path"], "/prometheus.metrics.controller-manager")
-            where resource.attributes["job"] == "kubelet" and IsMatch(name, "^cloudprovider_.*")
-          - set(resource.attributes["http_listener_v2_path"], "/prometheus.metrics.kubelet")
-            where resource.attributes["job"] == "kubelet" and not IsMatch(name, "^cloudprovider_.*")
-          - set(resource.attributes["http_listener_v2_path"], "/prometheus.metrics.node")
-            where resource.attributes["job"] == "node-exporter"
-          - set(resource.attributes["http_listener_v2_path"], "/prometheus.metrics.scheduler")
-            where resource.attributes["job"] == "kube-scheduler"
-          - set(resource.attributes["http_listener_v2_path"], "/prometheus.metrics.state")
-            where resource.attributes["job"] == "kube-state-metrics"
       transform/remove_name:
         error_mode: ignore
         metric_statements:
@@ -313,7 +284,6 @@ data:
             write_timeout = "30s"
             service_address = ":9888"
             data_format = "prometheusremotewrite"
-            path_tag = true
             paths = [
               "/prometheus.metrics"
             ]
@@ -349,7 +319,6 @@ data:
           - filter/drop_unnecessary_metrics
           - filter/app_metrics
           - batch
-          - transform/prepare_routing
           - routing
           receivers:
           - telegraf


### PR DESCRIPTION
We can do this after having consolidated our remote writes.

I've decided to just send the `cloudprovider_*` metrics to the kubelet source if it's reported by the kubelet. Never really made sense that we sent it to the controller-manager source. In any case, OTLP source is going to be the default in v4, so this routing setup will only matter for users who manually switch back to the HTTP source.

<!---
Describe your PR here
-->

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [x] Template tests added for new features
