### PR TITLE
use autoscaling/v2 if available on the cluster

### DIFF
--- a/.changelog/3315.fixed.txt
+++ b/.changelog/3315.fixed.txt
@@ -1,0 +1,1 @@
+use autoscaling/v2 if available on the cluster

--- a/deploy/helm/sumologic/templates/_helpers/_api_versions.tpl
+++ b/deploy/helm/sumologic/templates/_helpers/_api_versions.tpl
@@ -12,3 +12,18 @@ policy/v1
 policy/v1beta1
 {{- end -}}
 {{- end -}}
+
+{{/*
+Use HorizontalPodAutoscaler apiVersion that is available on the cluster
+
+Example Usage:
+apiVersion: {{ include "apiVersion.horizontalPodAutoscaler" . }}
+
+*/}}
+{{- define "apiVersion.horizontalPodAutoscaler" -}}
+{{- if .Capabilities.APIVersions.Has "autoscaling/v2" -}}
+autoscaling/v2
+{{- else -}}
+autoscaling/v2beta2
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/sumologic/templates/instrumentation/otelcol-instrumentation/hpa.yaml
+++ b/deploy/helm/sumologic/templates/instrumentation/otelcol-instrumentation/hpa.yaml
@@ -1,11 +1,7 @@
 {{ $otelcolInstrumentation := .Values.otelcolInstrumentation }}
 {{ $tracesEnabled := .Values.sumologic.traces.enabled }}
 {{- if and $tracesEnabled $otelcolInstrumentation.enabled $otelcolInstrumentation.autoscaling.enabled }}
-{{- if and (eq .Capabilities.KubeVersion.Major "1") (lt (int (include "kubernetes.minor" .)) 23) }}
-apiVersion: autoscaling/v2beta2
-{{- else }}
-apiVersion: autoscaling/v2
-{{- end }}
+apiVersion: {{ include "apiVersion.horizontalPodAutoscaler" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "sumologic.metadata.name.otelcolinstrumentation.hpa" . }}

--- a/deploy/helm/sumologic/templates/instrumentation/traces-gateway/hpa.yaml
+++ b/deploy/helm/sumologic/templates/instrumentation/traces-gateway/hpa.yaml
@@ -1,11 +1,7 @@
 {{ $tracesGateway := .Values.tracesGateway }}
 {{ $tracesEnabled := .Values.sumologic.traces.enabled }}
 {{- if and $tracesEnabled $tracesGateway.enabled $tracesGateway.autoscaling.enabled }}
-{{- if and (eq .Capabilities.KubeVersion.Major "1") (lt (int (include "kubernetes.minor" .)) 23) }}
-apiVersion: autoscaling/v2beta2
-{{- else }}
-apiVersion: autoscaling/v2
-{{- end }}
+apiVersion: {{ include "apiVersion.horizontalPodAutoscaler" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "sumologic.metadata.name.tracesgateway.hpa" . }}

--- a/deploy/helm/sumologic/templates/logs/common/hpa.yaml
+++ b/deploy/helm/sumologic/templates/logs/common/hpa.yaml
@@ -1,9 +1,5 @@
 {{- if and (eq (include "logs.otelcol.enabled" .) "true") (.Values.metadata.logs.autoscaling.enabled) }}
-{{- if and (eq .Capabilities.KubeVersion.Major "1") (lt (int (include "kubernetes.minor" .)) 23) }}
-apiVersion: autoscaling/v2beta2
-{{- else }}
-apiVersion: autoscaling/v2
-{{- end }}
+apiVersion: {{ include "apiVersion.horizontalPodAutoscaler" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "sumologic.metadata.name.logs.hpa" . }}

--- a/deploy/helm/sumologic/templates/metrics/common/hpa.yaml
+++ b/deploy/helm/sumologic/templates/metrics/common/hpa.yaml
@@ -1,9 +1,5 @@
 {{- if and (eq (include "metrics.otelcol.enabled" .) "true") ( .Values.metadata.metrics.autoscaling.enabled) }}
-{{- if and (eq .Capabilities.KubeVersion.Major "1") (lt (int (include "kubernetes.minor" .)) 23) }}
-apiVersion: autoscaling/v2beta2
-{{- else }}
-apiVersion: autoscaling/v2
-{{- end }}
+apiVersion: {{ include "apiVersion.horizontalPodAutoscaler" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "sumologic.metadata.name.metrics.hpa" . }}


### PR DESCRIPTION
Similar to https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/3155, this change attempts to address https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/3154 which still appears to be an issue as of chart v3.15.0 when targeting a 1.26 cluster (i.e., the chart still renders `autoscaling/v2beta2` which was removed in 1.26).

This implementation uses `Capabilities.APIVersions.Has $version` instead of attempting to compare against `Capabilities.KubeVersion.{Major,Minor}` values. This implementation was based on the approach used for `PodDisruptionBudget`: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/a7e8fe99b614f869f22682907d8d856fa6101ffb/deploy/helm/sumologic/templates/logs/common/pdb.yaml#L3

### Checklist

- [x] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features
