### PR TITLE
feat(setup): check if pvcs can be created automatically

### DIFF
--- a/.changelog/3316.added.txt
+++ b/.changelog/3316.added.txt
@@ -1,0 +1,1 @@
+feat(setup): check if pvcs are going to be created correctly

--- a/deploy/helm/sumologic/templates/setup/job.yaml
+++ b/deploy/helm/sumologic/templates/setup/job.yaml
@@ -66,6 +66,8 @@ spec:
         - secretRef:
             name: {{ .Values.sumologic.envFromSecret | default (include "sumologic.metadata.name.setup.secret" .)}}
         env:
+        - name: TEST_PVC_NAMESPACE
+          value: {{ template "sumologic.namespace"  . }}
         - name: SUMOLOGIC_BASE_URL
           value: {{ .Values.sumologic.endpoint }}
         {{- include "proxy-env-variables" . | nindent 8 -}}

--- a/deploy/helm/sumologic/templates/setup/role.yaml
+++ b/deploy/helm/sumologic/templates/setup/role.yaml
@@ -15,4 +15,15 @@ rules:
     resources:
       - secrets
     verbs: ["get", "list", "describe", "create", "patch"]
+  - apiGroups:
+      - ""
+      - "apps"
+      - "autoscaling"
+      - "batch"
+    resources:
+      - "pods"
+      - "persistentvolumeclaims"
+      - "statefulsets"
+      - "services"
+    verbs: ["get", "list", "describe", "create", "delete", "watch"]
 {{- end }}


### PR DESCRIPTION
This PR adds to setup script a functionality to check if pvcs can be created automatically.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features
