### PR TITLE
fix(metrics): drop stale datapoints

### DIFF
--- a/.changelog/3318.fixed.txt
+++ b/.changelog/3318.fixed.txt
@@ -1,0 +1,1 @@
+fix(metrics): drop stale datapoints

--- a/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
@@ -27,6 +27,12 @@ processors:
     send_batch_size: 1000
     timeout: 1s
 
+  # staleness markers may simply indicate targets being moved between collector Pods, so they do more harm than good
+  filter/drop_stale_datapoints:
+    metrics:
+      datapoint:
+      - 'flags == FLAG_NO_RECORDED_VALUE'
+
   transform/drop_unnecessary_attributes:
     error_mode: ignore
     metric_statements:
@@ -203,6 +209,7 @@ service:
       exporters: [otlphttp]
       processors:
         - batch
+        - filter/drop_stale_datapoints
 {{- if .Values.sumologic.metrics.dropHistogramBuckets }}
         - transform/extract_sum_count_from_histograms
 {{- end }}

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
@@ -86,6 +86,10 @@ spec:
         send_batch_max_size: 2000
         send_batch_size: 1000
         timeout: 1s
+      filter/drop_stale_datapoints:
+        metrics:
+          datapoint:
+          - flags == FLAG_NO_RECORDED_VALUE
       transform/drop_unnecessary_attributes:
         error_mode: ignore
         metric_statements:
@@ -242,6 +246,7 @@ spec:
           - otlphttp
           processors:
           - batch
+          - filter/drop_stale_datapoints
           - transform/extract_sum_count_from_histograms
           - transform/drop_unnecessary_attributes
           receivers:

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
@@ -105,6 +105,10 @@ spec:
         send_batch_max_size: 2000
         send_batch_size: 5000
         timeout: 1s
+      filter/drop_stale_datapoints:
+        metrics:
+          datapoint:
+          - flags == FLAG_NO_RECORDED_VALUE
       transform/drop_unnecessary_attributes:
         error_mode: ignore
         metric_statements:
@@ -136,6 +140,7 @@ spec:
           - otlphttp
           processors:
           - batch
+          - filter/drop_stale_datapoints
           - transform/drop_unnecessary_attributes
           receivers:
           - prometheus


### PR DESCRIPTION
Prometheus and prometheus receiver emit staleness markers in the form of samples with a `NaN` value whenever a target disappears. These markers aren't that useful when a target is moved between collector Pods, and Sumo currently doesn't handle them correctly.

Drop them in the collector instead.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [x] Template tests added for new features
