### PR TITLE
fix(metrics): kube-state-metrics pod metadata

### DIFF
--- a/.changelog/3323.fixed.txt
+++ b/.changelog/3323.fixed.txt
@@ -1,0 +1,1 @@
+fix(metrics): kube-state-metrics pod metadata

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1062,16 +1062,17 @@ kube-prometheus-stack:
             sourceLabels: [__name__]
           ## Drop unnecessary labels Prometheus adds to these metrics
           ## We don't want container=kube-state-metrics on everything
+          ## But we do want to keep these on pod metrics, which we check for via the `uid` attribute
           - action: labeldrop
             regex: service
           - action: replace
-            sourceLabels: [container]
-            regex: kube-state-metrics
+            sourceLabels: [container, uid]
+            regex: kube-state-metrics;
             targetLabel: container
             replacement: ""
           - action: replace
-            sourceLabels: [pod]
-            regex: ".*kube-state-metrics.*"
+            sourceLabels: [pod, uid]
+            regex: ".*kube-state-metrics.*;"
             targetLabel: pod
             replacement: ""
           - action: labelmap


### PR DESCRIPTION
We always drop `container` and `pod` attributes from kube state metrics if their value is the kube-state-metrics pod/container itself. This is usually wrong, as the attributes are added by the ServiceMonitor configuration to metrics which aren't about pods to begin with, like `kube_deployment_status_replicas`, for example.

However, this means we incorrectly drop these attributes from pod metrics about the `kube-state-metrics` pod itself, like `kube_pod_status_phase`.

This PR fixes this bug by checking for the `uid` attribute, which kube-state-metrics adds to all metrics about pods.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [x] Integration tests added or modified for major features
