### PR TITLE
chore: add support for k8s 1.27 with KOPS

### DIFF
--- a/.changelog/3332.added.txt
+++ b/.changelog/3332.added.txt
@@ -1,0 +1,1 @@
+chore: add support for k8s 1.27 with KOPS

--- a/docs/README.md
+++ b/docs/README.md
@@ -91,7 +91,7 @@ The following table displays the tested Kubernetes and Helm versions.
 | ---------------------- | ---------------------------------------- |
 | K8s with EKS           | 1.23<br/>1.24<br/>1.25<br/>1.26<br/>1.27 |
 | K8s with EKS (fargate) | 1.24<br/>1.25<br/>1.26<br/>1.27          |
-| K8s with Kops          | 1.23<br/>1.24<br/>1.25<br/>1.26          |
+| K8s with Kops          | 1.23<br/>1.24<br/>1.25<br/>1.26<br/>1.27 |
 | K8s with GKE           | 1.23<br/>1.24<br/>1.25<br/>1.26<br/>1.27 |
 | K8s with AKS           | 1.25<br/>1.26<br/>1.27                   |
 | OpenShift              | 4.10<br/>4.11<br/>4.12</br>4.13          |


### PR DESCRIPTION
Wait with merging: PR that adds automatic test runs on this version has not been merged yet.