### PR TITLE
ci: add dependency-checker command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ go.work.sum
 
 # Local values files
 values.local.yaml
+
+# Website cache for the dependency checker
+cache

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,10 @@ markdown-links-lint:
 check-configuration-keys:
 	./ci/check_configuration_keys.py --values deploy/helm/sumologic/values.yaml --readme deploy/helm/sumologic/README.md
 
+.PHONY: check-dependencies
+check-dependencies:
+	@python ./ci/check_dependencies/main.py
+
 .PHONY: template-tests-lint
 template-tests-lint:
 	make -C ./tests/helm golint

--- a/ci/check_dependencies/.gitignore
+++ b/ci/check_dependencies/.gitignore
@@ -1,0 +1,129 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/ci/check_dependencies/README.md
+++ b/ci/check_dependencies/README.md
@@ -1,0 +1,35 @@
+# dependency-checker
+
+Dependency checker uses web scraping to get information about:
+
+- platforms suppported by [Sumologic Kubernetes Helm Chart][helm-chart]
+- subcharts which are use in [Sumologic Kubernetes Helm Chart][helm-chart]
+
+## Usage
+
+### Prepare a virtualenv and activate it
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+```
+
+### Install dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+### Run the script
+
+```bash
+python main.py
+```
+
+Web pages used to get information are saved in `cache` directory to clean it please run:
+
+```bash
+rm -r ./cache
+```
+
+[helm-chart]: https://github.com/SumoLogic/sumologic-kubernetes-collection

--- a/ci/check_dependencies/aks.py
+++ b/ci/check_dependencies/aks.py
@@ -1,0 +1,71 @@
+import requests
+import os
+import json
+import lxml.html as lh
+import traceback
+
+import requests
+from bs4 import BeautifulSoup
+import pandas as pd
+from datetime import datetime, timedelta
+
+import common
+
+
+def get_pd_dataframe_from_html(html):
+    soup = BeautifulSoup(html, "lxml")
+
+    # get information from second table on web page
+    calendar_table = soup.select_one("table:nth-of-type(1)")
+
+    # Obtain every title of columns with tag <th>
+    headers = []
+    for i in calendar_table.find_all("th"):
+        title = i.text
+        headers.append(title)
+
+    data = pd.DataFrame(columns=headers)
+
+    # Create a for loop to fill pandas dataframe
+    for j in calendar_table.find_all("tr")[1:]:
+        row_data = j.find_all("td")
+        row = [i.text for i in row_data]
+        length = len(data)
+        data.loc[length] = row
+
+    return data
+
+
+def get_supported_releases(html_calendar):
+    pd_data = get_pd_dataframe_from_html(html_calendar)
+
+    # AKS adds an asterisk to the LTS version, we remove it
+    pd_data["K8s version"] = pd_data["K8s version"].apply(lambda s: s.strip("*"))
+
+    pd_data = pd_data.set_index("K8s version")
+    pd_data["AKS GA date"] = pd.to_datetime(
+        pd_data["AKS GA"], format="%b %Y", errors="coerce"
+    ).fillna(datetime.now() + timedelta(days=50 * 365))
+
+    today = datetime.now()
+    supported_releases = []
+    for index, row in pd_data.iterrows():
+        if row["AKS GA date"] < today:
+            dependent_version = row["Platform support"].replace("GA", "").replace("Until", "").strip()
+            if dependent_version in pd_data.index:
+                dependent_version_GA_date = pd_data.loc[dependent_version][
+                    "AKS GA date"
+                ]
+                if dependent_version_GA_date > today:
+                    supported_releases.append(index)
+            else:
+                supported_releases.append(index)
+    return supported_releases
+
+
+def get_info():
+    cache_file = "cache/aks_calendar.html"
+    calendar_web_page = "https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar"
+    html_calendar = common.get_page(calendar_web_page, cache_file)
+    officially_supported = get_supported_releases(html_calendar)
+    common.get_info("AKS", officially_supported)

--- a/ci/check_dependencies/common.py
+++ b/ci/check_dependencies/common.py
@@ -1,0 +1,71 @@
+import kubernetes_collection
+
+import requests
+import os
+import json
+import lxml.html as lh
+import traceback
+
+import requests
+from bs4 import BeautifulSoup
+import pandas as pd
+from datetime import datetime, timedelta
+
+cache_path = "cache/"
+
+
+def prepare_cache_dir():
+    if not os.path.exists(cache_path):
+        os.makedirs(cache_path)
+
+
+def is_cache_updated(cache_file):
+    if os.path.isfile(cache_file):
+        return True
+    return False
+
+
+def get_page(web_page, cache_file):
+    prepare_cache_dir()
+    calendar = ""
+    if is_cache_updated(cache_file):
+        # print("{} available in cache, getting from file".format(web_page))
+        with open(cache_file, "r") as f:
+            calendar = f.read()
+    else:
+        # print("{} not available in cache".format(web_page))
+        result = requests.get(web_page)
+        if result.status_code == 200:
+            with open(cache_file, "w") as f:
+                f.write(result.text)
+                calendar = result.text
+    return calendar
+
+
+def get_info(platform, officially_supported):
+    if platform == "OpenShift":
+        line_pattern = platform
+    else:
+        line_pattern = "K8s with {}".format(platform)
+
+    print("{} officially supported versions".format(platform))
+    print(officially_supported)
+
+    print(
+        "Currently supported {} versions for Sumologic Kubernetes Collection Helm Chart".format(
+            platform
+        )
+    )
+    now_suppported = kubernetes_collection.get_supported_versions(line_pattern)
+    print(now_suppported)
+    print("\n")
+
+    versions_to_add = sorted(set(officially_supported) - set(now_suppported))
+    if len(versions_to_add) != 0:
+        print("Please add support to following {} versions:".format(platform))
+        print(versions_to_add)
+
+    versions_to_remove = sorted(set(now_suppported) - set(officially_supported))
+    if len(versions_to_remove) != 0:
+        print("Please remove support to following {} versions:".format(platform))
+        print(versions_to_remove)

--- a/ci/check_dependencies/eks.py
+++ b/ci/check_dependencies/eks.py
@@ -1,0 +1,69 @@
+import requests
+import traceback
+import os
+import json
+from datetime import datetime
+import kubernetes_collection
+import common
+
+
+def get_eks_doc_from_github():
+    result = requests.get(
+        "https://raw.githubusercontent.com/awsdocs/amazon-eks-user-guide/master/doc_source/kubernetes-versions.md"
+    )
+    if result.status_code == 200:
+        return result.text
+    return None
+
+
+def get_eks_calendar_table(doc):
+    lines = doc.split("\n")
+    eks_calendar_table = []
+
+    found_calendar = False
+    for line in lines:
+        if "Amazon EKS end of support" in line:
+            found_calendar = True
+        elif found_calendar:
+            if line != "":
+                eks_calendar_table.append(line)
+            else:
+                break
+    # remove first line related to table formatting in markdown
+    eks_calendar_table = eks_calendar_table[1:]
+    return eks_calendar_table
+
+
+def parse_eks_end_of_support_date(date):
+    try:
+        date_elements_len = len(date.split(" "))
+
+        if date_elements_len == 2:
+            end_of_support_date = datetime.strptime(date, "%B %Y")
+        else:
+            end_of_support_date = datetime.strptime(date, "%B %d, %Y")
+        return end_of_support_date
+    except:
+        print("Unexpected date format, date={}".format(date))
+        traceback.print_exc()
+
+
+def get_eks_officially_supported_releases():
+    doc = get_eks_doc_from_github()
+    eks_calendar_table = get_eks_calendar_table(doc)
+    today = datetime.now()
+
+    eks_supported_releases = []
+    for row in eks_calendar_table:
+        elements = [x for x in row.strip().split("|") if x]
+        release_version = elements[0].replace("\\", "").strip()
+        end_of_support = elements[-1].strip()
+        eof_of_support_date = parse_eks_end_of_support_date(end_of_support)
+        if today < eof_of_support_date:
+            eks_supported_releases.append(release_version)
+    return sorted(eks_supported_releases)
+
+
+def get_info():
+    officially_supported = get_eks_officially_supported_releases()
+    common.get_info("EKS", officially_supported)

--- a/ci/check_dependencies/gke.py
+++ b/ci/check_dependencies/gke.py
@@ -1,0 +1,97 @@
+import requests
+import os
+import json
+import lxml.html as lh
+import traceback
+
+import requests
+from bs4 import BeautifulSoup
+import pandas as pd
+from datetime import datetime, timedelta
+
+import common
+
+
+def get_pd_dataframe_from_html(html):
+    # parser-lxml = Change html to Python friendly format
+    soup = BeautifulSoup(html, "lxml")
+
+    # get information from first table on web page
+    calendar_table = soup.select_one("table:nth-of-type(1)")
+
+    # remove all <sup></sup> from table
+    for sup in calendar_table.find_all("sup"):
+        sup.decompose()
+
+    # # Obtain every title of columns with tag <th>
+    # headers = []
+    # for i in calendar_table.find_all('th'):
+    #   title = i.text
+    #   headers.append(title)
+
+    # # remove not needed header
+    # headers.remove('Control plane and node upgrades start on/after')
+    # headers = [x.strip() for x in headers]
+
+    headers = [
+        "Kubernetes version",
+        "Kubernetes release date",
+        "Rapid available",
+        "Rapid upgrade",
+        "Regular available",
+        "Regular upgrade",
+        "Stable available",
+        "Stable upgrade",
+        "End of life",
+    ]
+    data = pd.DataFrame(columns=headers)
+
+    # Create a for loop to fill pandas dataframe
+    for j in calendar_table.find_all("tr")[2:]:  # two first rows are empty
+        row_data = j.find_all("td")
+        row = [i.text for i in row_data]
+        length = len(data)
+        data.loc[length] = row
+
+    return data
+
+
+def parse_gke_dates(date):
+    try:
+        date_elements_len = len(date.split("-"))
+        date_converted = None
+        if date_elements_len == 3:
+            date_converted = datetime.strptime(date, "%Y-%m-%d")
+        else:
+            if "Q" in date or date == "TBD":
+                # TODO: add better parsing of dates with Q
+                # now sets date from the future, Q is used for not published releases
+                date_converted = datetime.now() + timedelta(days=50 * 365)
+            else:
+                date_converted = datetime.strptime(date, "%Y-%m")
+
+        return date_converted
+    except:
+        print("Unexpected date format, date={}".format(date))
+        traceback.print_exc()
+
+
+def get_supported_releases(html_calendar):
+    pd_data = get_pd_dataframe_from_html(html_calendar)
+    today = datetime.now()
+
+    supported_releases = []
+    for index, row in pd_data.iterrows():
+        end_of_life_date = parse_gke_dates(row["End of life"])
+        regular_release_date = parse_gke_dates(row["Regular available"])
+        if regular_release_date < today and today < end_of_life_date:
+            supported_releases.append(row["Kubernetes version"])
+    return supported_releases
+
+
+def get_info():
+    cache_file = "cache/gke_calendar.html"
+    calendar_web_page = "https://cloud.google.com/kubernetes-engine/docs/release-schedule#schedule_for_release_channels"
+    html_calendar = common.get_page(calendar_web_page, cache_file)
+    officially_supported = get_supported_releases(html_calendar)
+    common.get_info("GKE", officially_supported)

--- a/ci/check_dependencies/helm_charts.py
+++ b/ci/check_dependencies/helm_charts.py
@@ -1,0 +1,65 @@
+import common
+import yaml
+
+
+import pandas as pd
+from datetime import datetime
+
+
+time_format = "%Y-%m-%dT%H:%M:%S.%fZ"
+time_formate_with_zone = "%Y-%m-%dT%H:%M:%S.%f%z"
+VERSION_IDX = 0
+CREATED_IDX = 1
+
+
+def get_info():
+    cache_file = "cache/Chart.yaml"
+    chart_yaml_url = "https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/main/deploy/helm/sumologic/Chart.yaml"
+    collection_chart_yaml_str = common.get_page(chart_yaml_url, cache_file)
+    chart_yaml = yaml.safe_load(collection_chart_yaml_str)
+    deps = chart_yaml["dependencies"]
+
+    for dep in deps:
+        index_page = "{}/{}".format(dep["repository"], "index.yaml")
+        cache_file = "{}/{}.yaml".format("cache", dep["name"])
+        current_version = dep["version"]
+        dep_index_yaml_str = common.get_page(index_page, cache_file)
+        dep_yaml = yaml.safe_load(dep_index_yaml_str)
+
+        dep_entries = dep_yaml["entries"][dep["name"]]
+
+        pd_entries = pd.DataFrame(columns=["version", "created"])
+        for entry in dep_entries:
+            row = [entry["version"], entry["created"]]
+            length = len(pd_entries)
+            pd_entries.loc[length] = row
+
+        pd_entries["created"] = pd_entries["created"].str.replace("Z", "+00:00")
+        pd_entries["created date"] = pd.to_datetime(
+            pd_entries["created"], format=time_formate_with_zone
+        )
+
+        pd_sorted_entries = pd_entries.sort_values("created date", ascending=False)
+        latest_release = pd_sorted_entries.loc[0].values
+        current_release = (
+            pd_sorted_entries.loc[pd_sorted_entries["version"] == current_version]
+            .values.flatten()
+            .tolist()
+        )
+
+        if current_release[VERSION_IDX] != latest_release[VERSION_IDX]:
+            print(
+                "Please check newer version of {} subchart, version: {}, created: {}".format(
+                    dep["name"].upper(),
+                    latest_release[VERSION_IDX],
+                    latest_release[CREATED_IDX],
+                )
+            )
+            print(
+                "Currently used {} subchart, version: {}, created: {}".format(
+                    dep["name"].upper(),
+                    current_release[VERSION_IDX],
+                    current_release[CREATED_IDX],
+                )
+            )
+            print("")

--- a/ci/check_dependencies/kops.py
+++ b/ci/check_dependencies/kops.py
@@ -1,0 +1,75 @@
+import requests
+import traceback
+import os
+import json
+import kubernetes_collection
+
+kops_line_pattern = "K8s with Kops"
+
+
+# ref: https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#list-releases
+def get_releases(owner, repo):
+    result = requests.get(
+        "https://api.github.com/repos/{owner}/{repo}/releases".format(
+            owner=owner, repo=repo
+        )
+    )
+    if result.status_code == 200:
+        return result.json()
+    return None
+
+
+def get_minor_releases(owner, repo):
+    try:
+        releases = get_releases(owner, repo)
+
+        minor_releases = set()
+        for release in releases:
+            if "alpha" in release["name"] or "beta" in release["name"]:
+                continue
+            release_name_digits = release["name"].strip("v").split(".")
+            minor_releases.add(
+                "{major}.{minor}".format(
+                    major=release_name_digits[0], minor=release_name_digits[1]
+                )
+            )
+    except IndexError:
+        print("Wrong format of release name, name={}".format(release["name"]))
+        traceback.print_exc()
+    return sorted(minor_releases)
+
+
+def get_expected_supported_kops(kops_releases):
+    # we support kOps in the latest version and 4 versions backwards so e.g. when 1.25 is the latest version of kOps we support 1.21 - 1.25
+    # so we support 5 latest kops releases
+    return kops_releases[-5:]
+
+
+def get_info():
+    print("kOps latest versions from https://github.com/kubernetes/kops/releases")
+    kops_minor_releases = get_minor_releases("kubernetes", "kops")
+    print(kops_minor_releases)
+
+    print(
+        "Currently supported kOps versions for Sumologic Kubernetes Collection Helm Chart"
+    )
+    kops_now_suppported = kubernetes_collection.get_supported_versions(
+        kops_line_pattern
+    )
+    print(kops_now_suppported)
+
+    print(
+        "Expected supported kOps versions for Sumologic Kubernetes Collection Helm Chart"
+    )
+    kops_expected_supported = get_expected_supported_kops(kops_minor_releases)
+    print(kops_expected_supported)
+
+    versions_to_add = sorted(set(kops_expected_supported) - set(kops_now_suppported))
+    if len(versions_to_add) != 0:
+        print("\nPlease add support to following kOps versions:")
+        print(versions_to_add)
+
+    versions_to_remove = sorted(set(kops_now_suppported) - set(kops_expected_supported))
+    if len(versions_to_remove) != 0:
+        print("Please remove support to following kOps versions:")
+        print(versions_to_remove)

--- a/ci/check_dependencies/kubernetes_collection.py
+++ b/ci/check_dependencies/kubernetes_collection.py
@@ -1,0 +1,37 @@
+import requests
+import traceback
+import os
+import json
+import kubernetes_collection
+
+
+def get_kubernetes_collection_readme():
+    result = requests.get(
+        "https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/main/docs/README.md"
+    )
+    if result.status_code == 200:
+        return result.text
+    return None
+
+
+def get_platform_readme_line(readme, line_pattern):
+    lines = readme.split("\n")
+    platform_line = ""
+    for line in lines:
+        if line_pattern in line:
+            platform_line = line
+            break
+    return platform_line.strip()
+
+
+def get_platform_versions_from_readme(readme, line_pattern):
+    platform_line = get_platform_readme_line(readme, line_pattern)
+    platform_table = [x for x in platform_line.split("|") if x]
+    versions = platform_table[1].strip().split("<br/>")
+    return sorted(versions)
+
+
+def get_supported_versions(line_pattern):
+    readme = get_kubernetes_collection_readme()
+    versions = get_platform_versions_from_readme(readme, line_pattern)
+    return versions

--- a/ci/check_dependencies/main.py
+++ b/ci/check_dependencies/main.py
@@ -1,0 +1,30 @@
+import kops
+import eks
+import gke
+import aks
+import openshift
+
+import helm_charts
+
+if __name__ == "__main__":
+    print("Gardener helper")
+    print("#####################################################################\n")
+    print("#### kOps ####")
+    kops.get_info()
+    print("")
+    print("#### EKS ####")
+    eks.get_info()
+    print("")
+    print("#### GKE ####")
+    gke.get_info()
+    print("")
+    print("#### AKS ####")
+    aks.get_info()
+    print("")
+    print("#### OpenShift ####")
+    openshift.get_info()
+    print("")
+
+    print("#### Subcharts in Sumologic Kubernetes Collection Helm Chart ####")
+    print("")
+    helm_charts.get_info()

--- a/ci/check_dependencies/openshift.py
+++ b/ci/check_dependencies/openshift.py
@@ -1,0 +1,53 @@
+import os
+import json
+import lxml.html as lh
+import traceback
+
+import requests
+from bs4 import BeautifulSoup
+from datetime import datetime, timedelta
+
+import common
+
+# versions which are supported by Openshift but it is not desired to support them in sumologic kubernetes collection
+excluded_from_collection_support = {"3.11"}
+
+
+def get_options_in_versions_selector(html):
+    soup = BeautifulSoup(html, "lxml")
+    version_select = soup.find("select", id="version-selector")
+    options = version_select.find_all("option")
+    return [x.get_text() for x in options]
+
+
+def get_supported_releases(html_calendar):
+    lines = html_calendar.split("\n")
+    unsupported_versions_line = ""
+    for line in lines:
+        if "unsupported_versions =" in line:
+            unsupported_versions_line = line
+
+    unsupported_versions = (
+        unsupported_versions_line.replace("unsupported_versions =", "")
+        .replace("[", "")
+        .replace("]", "")
+        .replace('"', "")
+        .replace(";", "")
+        .replace(" ", "")
+        .split(",")
+    )
+    options = get_options_in_versions_selector(html_calendar)
+    supported_versions = (
+        set(options) - set(unsupported_versions) - excluded_from_collection_support
+    )
+
+    return sorted(supported_versions)
+
+
+def get_info():
+    cache_file = "cache/openshift_calendar.html"
+    # template for https://docs.openshift.com/container-platform/4.11/welcome/index.html
+    calendar_web_page = "https://raw.githubusercontent.com/openshift/openshift-docs/main/_templates/_page_openshift.html.erb"
+    html_calendar = common.get_page(calendar_web_page, cache_file)
+    officially_supported = get_supported_releases(html_calendar)
+    common.get_info("OpenShift", officially_supported)

--- a/ci/check_dependencies/requirements.txt
+++ b/ci/check_dependencies/requirements.txt
@@ -1,0 +1,5 @@
+requests~=2.31.0
+lxml~=4.9.3
+pandas~=2.1.2
+PyYaml~=6.0.1
+beautifulsoup4~=4.11.2

--- a/shell.nix
+++ b/shell.nix
@@ -21,6 +21,10 @@ pkgs.mkShell {
     pkgs.nodePackages.prettier
     pkgs.python311
     pkgs.python311Packages.pyyaml
+    pkgs.python311Packages.requests
+    pkgs.python311Packages.lxml
+    pkgs.python311Packages.pandas
+    pkgs.python311Packages.beautifulsoup4
     pkgs.python311Packages.towncrier
     pkgs.shellcheck
     pkgs.golangci-lint


### PR DESCRIPTION
Add a dependency checker tool that can provide a summary of dependencies which need to be updated. This includes platform support.

Right now this can just be run locally, but the intent is to have it run on a schedule in CI and create issues about dependencies needing updates.

Credit goes to @kkujawa-sumo and https://github.com/kkujawa-sumo/gardener-helper, of which this is a copy with some minor bug fixes.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [x] Documentation updated
