### PR TITLE
test(integration): support k8s 1.28

### DIFF
--- a/.github/workflows/workflow-integration-tests.yaml
+++ b/.github/workflows/workflow-integration-tests.yaml
@@ -2,7 +2,7 @@ on:
   workflow_call:
 
 env:
-  KIND_VERSION: 0.17.0
+  KIND_VERSION: 0.20.0
 
 jobs:
   setup-integration-tests:

--- a/tests/integration/kind_images.json
+++ b/tests/integration/kind_images.json
@@ -1,10 +1,10 @@
 {
   "supported": [
-    "kindest/node:v1.27.3",
-    "kindest/node:v1.26.3",
-    "kindest/node:v1.25.8",
-    "kindest/node:v1.24.12",
-    "kindest/node:v1.23.17"
+    "kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72",
+    "kindest/node:v1.26.6@sha256:6e2d8b28a5b601defe327b98bd1c2d1930b49e5d8c512e1895099e4504007adb",
+    "kindest/node:v1.25.11@sha256:227fa11ce74ea76a0474eeefb84cb75d8dad1b08638371ecf0e86259b35be0c8",
+    "kindest/node:v1.24.15@sha256:7db4f8bea3e14b82d12e044e25e34bd53754b7f2b0e9d56df21774e6f66a70ab",
+    "kindest/node:v1.23.17@sha256:59c989ff8a517a93127d4a536e7014d28e235fb3529d9fba91b3951d461edfdb"
   ],
   "default": "kindest/node:v1.27.3"
 }

--- a/tests/integration/kind_images.json
+++ b/tests/integration/kind_images.json
@@ -1,10 +1,11 @@
 {
   "supported": [
+    "kindest/node:v1.28.0@sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31",
     "kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72",
     "kindest/node:v1.26.6@sha256:6e2d8b28a5b601defe327b98bd1c2d1930b49e5d8c512e1895099e4504007adb",
     "kindest/node:v1.25.11@sha256:227fa11ce74ea76a0474eeefb84cb75d8dad1b08638371ecf0e86259b35be0c8",
     "kindest/node:v1.24.15@sha256:7db4f8bea3e14b82d12e044e25e34bd53754b7f2b0e9d56df21774e6f66a70ab",
     "kindest/node:v1.23.17@sha256:59c989ff8a517a93127d4a536e7014d28e235fb3529d9fba91b3951d461edfdb"
   ],
-  "default": "kindest/node:v1.27.3"
+  "default": "kindest/node:v1.28.0@sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31"
 }


### PR DESCRIPTION
Run integration tests on k8s 1.28. It was necessary to upgrade kind to do this, and I've also bumped all the images as per https://github.com/kubernetes-sigs/kind/releases/tag/v0.20.0.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
