### PR TITLE
chore: update tools

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [docs-changed]
     env:
-      PRETTIER_VERSION: 2.8.4
+      PRETTIER_VERSION: 2.8.8
     steps:
       - uses: actions/checkout@v4
       - name: install markdownlint and prettier
@@ -70,7 +70,7 @@ jobs:
   shellcheck:
     runs-on: ubuntu-22.04
     env:
-      YQ_VERSION: 4.33.2
+      YQ_VERSION: 4.34.1
       SHELLCHECK_VERSION: 0.9.0
     steps:
       - uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [chart-changed]
     env:
-      PRETTIER_VERSION: 2.8.4
+      PRETTIER_VERSION: 2.8.8
     steps:
       - uses: actions/checkout@v4
       - name: install yamllint
@@ -161,7 +161,7 @@ jobs:
         if: needs.chart-changed.outputs.any_changed == 'true'
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.52.2
+          version: v1.53.3
           working-directory: ./tests/helm/
           # Optional: golangci-lint command line arguments.
           args: --timeout=10m --verbose

--- a/shell.nix
+++ b/shell.nix
@@ -1,11 +1,11 @@
 { pkgs ? import (
     builtins.fetchGit {
-      name = "nixos-unstable-2023-04-13";
+      name = "nixos-unstable-2023-06-18";
       url = "https://github.com/nixos/nixpkgs/";
-      # Commit hash for nixos-unstable as of 2023-04-13
+      # Commit hash for nixos-unstable as of 2023-06-18
       # `git ls-remote https://github.com/nixos/nixpkgs nixos-unstable`
       ref = "refs/heads/nixos-unstable";
-      rev = "fe2ecaf706a5907b5e54d979fbde4924d84b65fc";
+      rev = "d1250206995000485096be3bedc5660ec956c46b";
     }
   ) {}
 }:
@@ -35,22 +35,22 @@ pkgs.mkShell {
 ## Output of `make tool-versions`:
 #
 # kubectl version --client=true --short 2>/dev/null
-# Client Version: v1.26.3
-# Kustomize Version: v4.5.7
+# Client Version: v1.27.2
+# Kustomize Version: v5.0.1
 # helm version
-# version.BuildInfo{Version:"v3.11.2", GitCommit:"v3.11.2", GitTreeState:"", GoVersion:"go1.20.3"}
+# version.BuildInfo{Version:"v3.12.1", GitCommit:"v3.12.1", GitTreeState:"", GoVersion:"go1.20.5"}
 # jq --version
 # jq-1.6
 # yq --version
-# yq (https://github.com/mikefarah/yq/) version v4.33.2
+# yq (https://github.com/mikefarah/yq/) version v4.34.1
 # markdown-link-check --version
-# 3.10.3
+# 3.11.2
 # markdownlint --version
-# 0.33.0
+# 0.34.0
 # prettier --version
-# 2.8.4
+# 2.8.8
 # python -V
-# Python 3.11.2
+# Python 3.11.4
 # towncrier --version
 # towncrier, version 22.12.0
 # shellcheck --version
@@ -59,8 +59,8 @@ pkgs.mkShell {
 # license: GNU General Public License, version 3
 # website: https://www.shellcheck.net
 # golangci-lint version
-# golangci-lint has version 1.52.2 built with go1.20.3 from v1.52.2 on 19700101-00:00:00
+# golangci-lint has version 1.53.3 built with go1.20.5 from v1.53.3 on 19700101-00:00:00
 # go version
-# go version go1.20.3 linux/amd64
+# go version go1.20.5 linux/amd64
 # kind version
-# kind v0.17.0 go1.20.3 linux/amd64
+# kind v0.20.0 go1.20.5 linux/amd64


### PR DESCRIPTION
Update local tools. I wanted to use a more recent revision, but ran into some issues with towncrier, so I used the earliest one that has kind 0.20.0.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
