### PR TITLE
deps: update opentelemetry-operator to 0.42.0

### DIFF
--- a/.changelog/3394.changed.txt
+++ b/.changelog/3394.changed.txt
@@ -1,0 +1,1 @@
+deps: update opentelemetry-operator to 0.42.0

--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -33,6 +33,6 @@ dependencies:
     repository: https://sumologic.github.io/tailing-sidecar
     condition: tailing-sidecar-operator.enabled
   - name: opentelemetry-operator
-    version: 0.35.0
+    version: 0.42.0
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     condition: opentelemetry-operator.enabled,sumologic.metrics.collector.otelcol.enabled

--- a/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
@@ -189,10 +189,6 @@ receivers:
               target_label: instance
               action: replace
 {{- end }}
-    target_allocator:
-      endpoint: http://{{ template "sumologic.metadata.name.metrics.targetallocator.name" . }}
-      interval: 30s
-      collector_id: ${POD_NAME}
 
 service:
   telemetry:

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
@@ -236,10 +236,6 @@ spec:
             tls_config:
               ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
               insecure_skip_verify: true
-        target_allocator:
-          collector_id: ${POD_NAME}
-          endpoint: http://RELEASE-NAME-sumologic-metrics-targetallocator
-          interval: 30s
     service:
       extensions:
       - health_check

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
@@ -120,10 +120,6 @@ spec:
           global:
             scrape_interval: 60s
           scrape_configs: []
-        target_allocator:
-          collector_id: ${POD_NAME}
-          endpoint: http://RELEASE-NAME-sumologic-metrics-targetallocator
-          interval: 30s
     service:
       extensions:
       - health_check


### PR DESCRIPTION
I've also removed explicit configuration for prometheus receiver to use the target allocator, as the operator now injects this on its own.

<!---
Describe your PR here
-->

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added