### PR TITLE
Revert "chore: drop support for GKE 1.24"

### DIFF
--- a/.changelog/3387.changed.2.txt
+++ b/.changelog/3387.changed.2.txt
@@ -1,1 +1,0 @@
-chore: drop support for GKE 1.24

--- a/docs/README.md
+++ b/docs/README.md
@@ -93,7 +93,7 @@ The following table displays the tested Kubernetes and Helm versions.
 | K8s with EKS           | 1.24<br/>1.25<br/>1.26<br/>1.27<br/>1.28 |
 | K8s with EKS (fargate) | 1.24<br/>1.25<br/>1.26<br/>1.27<br/>1.28 |
 | K8s with Kops          | 1.24<br/>1.25<br/>1.26<br/>1.27<br/>1.28 |
-| K8s with GKE           | 1.25<br/>1.26<br/>1.27                   |
+| K8s with GKE           | 1.24<br/>1.25<br/>1.26<br/>1.27          |
 | K8s with AKS           | 1.25<br/>1.26<br/>1.27<br/>1.28          |
 | OpenShift              | 4.11<br/>4.12<br/>4.13<br/>4.14          |
 | Helm                   | 3.8.2 (Linux)                            |


### PR DESCRIPTION
This was removed by mistake.

This reverts commit 23f7b3425f54f226a0023cbbb6c6e18c03f5b5d6.

<!---
Describe your PR here
-->

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [x] Documentation updated
