### PR TITLE
fix(metrics): set nodeSelector and tolerations for target allocator

### DIFF
--- a/.changelog/3411.fixed.txt
+++ b/.changelog/3411.fixed.txt
@@ -1,0 +1,1 @@
+fix(metrics): set nodeSelector and tolerations for target allocator

--- a/deploy/helm/sumologic/templates/metrics/collector/otelcol/opentelemetrycollector.yaml
+++ b/deploy/helm/sumologic/templates/metrics/collector/otelcol/opentelemetrycollector.yaml
@@ -51,6 +51,14 @@ spec:
         release: {{ .Release.Name }}
 {{- end }}
 {{- if .Values.sumologic.metrics.collector.otelcol.nodeSelector }}
+    nodeSelector:
+{{ toYaml .Values.sumologic.metrics.collector.otelcol.nodeSelector | indent 6 }}
+{{- end }}
+{{- if .Values.sumologic.metrics.collector.otelcol.tolerations }}
+    tolerations:
+{{ toYaml .Values.sumologic.metrics.collector.otelcol.tolerations | indent 6 }}
+{{- end }}
+{{- if .Values.sumologic.metrics.collector.otelcol.nodeSelector }}
   nodeSelector:
 {{ toYaml .Values.sumologic.metrics.collector.otelcol.nodeSelector | indent 4 }}
 {{- end }}

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
@@ -33,6 +33,12 @@ spec:
         smkey: smvalue
       podMonitorSelector:
         pmkey: pmvalue
+    nodeSelector:
+      workingGroup: production
+    tolerations:
+      - effect: NoSchedule
+        key: null
+        operator: Exists
   nodeSelector:
     workingGroup: production
   tolerations:


### PR DESCRIPTION
It was an oversight that these weren't configurable. I've set them to be identical to the collector for now, we'll see if more fine grained control over them is necessary.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [x] Template tests added for new features
