### PR TITLE
feat: add description including helm version to collector

### DIFF
--- a/.changelog/3423.added.txt
+++ b/.changelog/3423.added.txt
@@ -1,0 +1,1 @@
+feat: add description including helm version to collector

--- a/deploy/helm/sumologic/conf/setup/resources.tf
+++ b/deploy/helm/sumologic/conf/setup/resources.tf
@@ -1,5 +1,6 @@
 resource "sumologic_collector" "collector" {
     name  = var.collector_name
+    description = {{ printf "Sumo Logic Kubernetes Collection\nversion: %s" .Chart.Version | quote }}
     fields  = {
       {{- $fields := .Values.sumologic.collector.fields }}
       {{- range $name, $value := $fields }}

--- a/tests/helm/testdata/goldenfile/terraform/all_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/all_fields.output.yaml
@@ -466,6 +466,7 @@ data:
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
+        description = "Sumo Logic Kubernetes Collection\nversion: %CURRENT_CHART_VERSION%"
         fields  = {
         }
     }

--- a/tests/helm/testdata/goldenfile/terraform/collector_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/collector_fields.output.yaml
@@ -465,6 +465,7 @@ data:
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
+        description = "Sumo Logic Kubernetes Collection\nversion: %CURRENT_CHART_VERSION%"
         fields  = {
           here_is_very_long_field_name = "another_value"
           test_fields                  = "test_value"

--- a/tests/helm/testdata/goldenfile/terraform/conditional_sources.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/conditional_sources.output.yaml
@@ -450,6 +450,7 @@ data:
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
+        description = "Sumo Logic Kubernetes Collection\nversion: %CURRENT_CHART_VERSION%"
         fields  = {
         }
     }

--- a/tests/helm/testdata/goldenfile/terraform/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/custom.output.yaml
@@ -450,6 +450,7 @@ data:
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
+        description = "Sumo Logic Kubernetes Collection\nversion: %CURRENT_CHART_VERSION%"
         fields  = {
         }
     }

--- a/tests/helm/testdata/goldenfile/terraform/default.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/default.output.yaml
@@ -465,6 +465,7 @@ data:
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
+        description = "Sumo Logic Kubernetes Collection\nversion: %CURRENT_CHART_VERSION%"
         fields  = {
         }
     }

--- a/tests/helm/testdata/goldenfile/terraform/disable_default_metrics.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disable_default_metrics.output.yaml
@@ -464,6 +464,7 @@ data:
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
+        description = "Sumo Logic Kubernetes Collection\nversion: %CURRENT_CHART_VERSION%"
         fields  = {
         }
     }

--- a/tests/helm/testdata/goldenfile/terraform/disabled_dashboards.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disabled_dashboards.output.yaml
@@ -465,6 +465,7 @@ data:
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
+        description = "Sumo Logic Kubernetes Collection\nversion: %CURRENT_CHART_VERSION%"
         fields  = {
         }
     }

--- a/tests/helm/testdata/goldenfile/terraform/disabled_monitors.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disabled_monitors.output.yaml
@@ -465,6 +465,7 @@ data:
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
+        description = "Sumo Logic Kubernetes Collection\nversion: %CURRENT_CHART_VERSION%"
         fields  = {
         }
     }

--- a/tests/helm/testdata/goldenfile/terraform/logs_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/logs_fields.output.yaml
@@ -491,6 +491,7 @@ data:
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
+        description = "Sumo Logic Kubernetes Collection\nversion: %CURRENT_CHART_VERSION%"
         fields  = {
         }
     }

--- a/tests/helm/testdata/goldenfile/terraform/monitors_with_email_notifications.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/monitors_with_email_notifications.output.yaml
@@ -471,6 +471,7 @@ data:
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
+        description = "Sumo Logic Kubernetes Collection\nversion: %CURRENT_CHART_VERSION%"
         fields  = {
         }
     }

--- a/tests/helm/testdata/goldenfile/terraform/monitors_with_single_email.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/monitors_with_single_email.output.yaml
@@ -471,6 +471,7 @@ data:
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
+        description = "Sumo Logic Kubernetes Collection\nversion: %CURRENT_CHART_VERSION%"
         fields  = {
         }
     }

--- a/tests/helm/testdata/goldenfile/terraform/strip_extrapolation.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/strip_extrapolation.output.yaml
@@ -466,6 +466,7 @@ data:
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
+        description = "Sumo Logic Kubernetes Collection\nversion: %CURRENT_CHART_VERSION%"
         fields  = {
         }
     }

--- a/tests/helm/testdata/goldenfile/terraform/traces.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/traces.output.yaml
@@ -453,6 +453,7 @@ data:
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
+        description = "Sumo Logic Kubernetes Collection\nversion: %CURRENT_CHART_VERSION%"
         fields  = {
         }
     }

--- a/tests/helm/testdata/goldenfile/terraform/tracing-metrics-disabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/tracing-metrics-disabled.output.yaml
@@ -465,6 +465,7 @@ data:
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
+        description = "Sumo Logic Kubernetes Collection\nversion: %CURRENT_CHART_VERSION%"
         fields  = {
         }
     }


### PR DESCRIPTION
Add description for collector. We are adding it to track coverage of helm chart versions. It won't work if setup job is disabled

![image](https://github.com/SumoLogic/sumologic-kubernetes-collection/assets/58699848/f785f363-9d8c-4c5c-8d78-70c745176d5f)


### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [ ] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features
