### PR TITLE
ci: add integration test success job

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -183,8 +183,21 @@ jobs:
         if: needs.chart-changed.outputs.any_changed == 'true'
         run: make test-templates
 
-  integration-tests:
-    name: Integration Tests
+  run-integration-tests:
+    name: Run Integration Tests
     needs: [chart-changed]
     if: needs.chart-changed.outputs.any_changed == 'true'
     uses: ./.github/workflows/workflow-integration-tests.yaml
+
+  integration-tests-success:
+    name: Integration tests succeded
+    runs-on: ubuntu-22.04
+    needs: [run-integration-tests]
+    if: ${{ always() }}
+    steps:
+      - name: Success
+        if: ${{ always() && (needs.run-integration-tests.result == 'success' || needs.run-integration-tests.result == 'skipped') }}
+        run: exit 0
+      - name: Failure
+        if: ${{ always() && !(needs.run-integration-tests.result == 'success' || needs.run-integration-tests.result == 'skipped') }}
+        run: exit 1


### PR DESCRIPTION
Integration tests run as an optional reusable workflow. We want to require that they pass for each PR, but only if they weren't skipped. This PR achieves this by adding a job that deals with the possible results correctly.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
