### PR TITLE
fix: fix add_timestamp behavior

### DIFF
--- a/.changelog/3434.fixed.txt
+++ b/.changelog/3434.fixed.txt
@@ -1,0 +1,1 @@
+fix: fix add_timestamp behavior

--- a/deploy/helm/sumologic/conf/events/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/events/otelcol/config.yaml
@@ -47,6 +47,7 @@ processors:
       - context: log
         statements:
           - set(attributes["timestamp"], Int(time_unix_nano / 1000000))
+          - set(attributes["timestamp"], UnixMilli(Now())) where attributes["timestamp"] == 0
 
 receivers:
   raw_k8s_events: {}

--- a/deploy/helm/sumologic/conf/events/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/events/otelcol/config.yaml
@@ -46,8 +46,8 @@ processors:
     log_statements:
       - context: log
         statements:
+          - set(time, Now()) where time_unix_nano == 0
           - set(attributes["timestamp"], Int(time_unix_nano / 1000000))
-          - set(attributes["timestamp"], UnixMilli(Now())) where attributes["timestamp"] == 0
 
 receivers:
   raw_k8s_events: {}

--- a/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
@@ -376,8 +376,8 @@ processors:
     log_statements:
       - context: log
         statements:
+          - set(time, Now()) where time_unix_nano == 0
           - set(attributes["timestamp"], Int(time_unix_nano / 1000000))
-          - set(attributes["timestamp"], UnixMilli(Now())) where attributes["timestamp"] == 0
 
   ## Move attributes from the body to the record and drop the body if it's a map
   ## The map check isn't perfect, as there's no way to check for this explicitly in OTTL

--- a/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
@@ -377,6 +377,7 @@ processors:
       - context: log
         statements:
           - set(attributes["timestamp"], Int(time_unix_nano / 1000000))
+          - set(attributes["timestamp"], UnixMilli(Now())) where attributes["timestamp"] == 0
 
   ## Move attributes from the body to the record and drop the body if it's a map
   ## The map check isn't perfect, as there's no way to check for this explicitly in OTTL

--- a/tests/helm/testdata/goldenfile/events_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc/basic.output.yaml
@@ -52,9 +52,8 @@ data:
         log_statements:
         - context: log
           statements:
+          - set(time, Now()) where time_unix_nano == 0
           - set(attributes["timestamp"], Int(time_unix_nano / 1000000))
-          - set(attributes["timestamp"], UnixMilli(Now())) where attributes["timestamp"]
-            == 0
     receivers:
       raw_k8s_events: {}
     service:

--- a/tests/helm/testdata/goldenfile/events_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc/basic.output.yaml
@@ -53,6 +53,7 @@ data:
         - context: log
           statements:
           - set(attributes["timestamp"], Int(time_unix_nano / 1000000))
+          - set(attributes["timestamp"], UnixMilli(Now())) where attributes["timestamp"] == 0
     receivers:
       raw_k8s_events: {}
     service:

--- a/tests/helm/testdata/goldenfile/events_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc/basic.output.yaml
@@ -53,7 +53,8 @@ data:
         - context: log
           statements:
           - set(attributes["timestamp"], Int(time_unix_nano / 1000000))
-          - set(attributes["timestamp"], UnixMilli(Now())) where attributes["timestamp"] == 0
+          - set(attributes["timestamp"], UnixMilli(Now())) where attributes["timestamp"]
+            == 0
     receivers:
       raw_k8s_events: {}
     service:

--- a/tests/helm/testdata/goldenfile/events_otc/options.output.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc/options.output.yaml
@@ -48,9 +48,8 @@ data:
         log_statements:
         - context: log
           statements:
+          - set(time, Now()) where time_unix_nano == 0
           - set(attributes["timestamp"], Int(time_unix_nano / 1000000))
-          - set(attributes["timestamp"], UnixMilli(Now())) where attributes["timestamp"]
-            == 0
     receivers:
       raw_k8s_events: {}
     service:

--- a/tests/helm/testdata/goldenfile/events_otc/options.output.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc/options.output.yaml
@@ -49,6 +49,7 @@ data:
         - context: log
           statements:
           - set(attributes["timestamp"], Int(time_unix_nano / 1000000))
+          - set(attributes["timestamp"], UnixMilli(Now())) where attributes["timestamp"] == 0
     receivers:
       raw_k8s_events: {}
     service:

--- a/tests/helm/testdata/goldenfile/events_otc/options.output.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc/options.output.yaml
@@ -49,7 +49,8 @@ data:
         - context: log
           statements:
           - set(attributes["timestamp"], Int(time_unix_nano / 1000000))
-          - set(attributes["timestamp"], UnixMilli(Now())) where attributes["timestamp"] == 0
+          - set(attributes["timestamp"], UnixMilli(Now())) where attributes["timestamp"]
+            == 0
     receivers:
       raw_k8s_events: {}
     service:

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/otel.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/otel.output.yaml
@@ -248,9 +248,8 @@ data:
         log_statements:
         - context: log
           statements:
+          - set(time, Now()) where time_unix_nano == 0
           - set(attributes["timestamp"], Int(time_unix_nano / 1000000))
-          - set(attributes["timestamp"], UnixMilli(Now())) where attributes["timestamp"]
-            == 0
       transform/containers_parse_json:
         error_mode: ignore
         log_statements:

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/otel.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/otel.output.yaml
@@ -249,6 +249,7 @@ data:
         - context: log
           statements:
           - set(attributes["timestamp"], Int(time_unix_nano / 1000000))
+          - set(attributes["timestamp"], UnixMilli(Now())) where attributes["timestamp"] == 0
       transform/containers_parse_json:
         error_mode: ignore
         log_statements:

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/otel.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/otel.output.yaml
@@ -249,7 +249,8 @@ data:
         - context: log
           statements:
           - set(attributes["timestamp"], Int(time_unix_nano / 1000000))
-          - set(attributes["timestamp"], UnixMilli(Now())) where attributes["timestamp"] == 0
+          - set(attributes["timestamp"], UnixMilli(Now())) where attributes["timestamp"]
+            == 0
       transform/containers_parse_json:
         error_mode: ignore
         log_statements:

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/templates.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/templates.output.yaml
@@ -276,6 +276,7 @@ data:
         - context: log
           statements:
           - set(attributes["timestamp"], Int(time_unix_nano / 1000000))
+          - set(attributes["timestamp"], UnixMilli(Now())) where attributes["timestamp"] == 0
       transform/containers_parse_json:
         error_mode: ignore
         log_statements:

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/templates.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/templates.output.yaml
@@ -276,7 +276,8 @@ data:
         - context: log
           statements:
           - set(attributes["timestamp"], Int(time_unix_nano / 1000000))
-          - set(attributes["timestamp"], UnixMilli(Now())) where attributes["timestamp"] == 0
+          - set(attributes["timestamp"], UnixMilli(Now())) where attributes["timestamp"]
+            == 0
       transform/containers_parse_json:
         error_mode: ignore
         log_statements:

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/templates.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/templates.output.yaml
@@ -275,9 +275,8 @@ data:
         log_statements:
         - context: log
           statements:
+          - set(time, Now()) where time_unix_nano == 0
           - set(attributes["timestamp"], Int(time_unix_nano / 1000000))
-          - set(attributes["timestamp"], UnixMilli(Now())) where attributes["timestamp"]
-            == 0
       transform/containers_parse_json:
         error_mode: ignore
         log_statements:


### PR DESCRIPTION
get current timestamp in case log timestamp is empty

Covers this piece of code: https://github.com/SumoLogic/sumologic-otel-collector/blob/a42dba41373bd03f81cc0204fb915c1997dc20dd/pkg/exporter/sumologicexporter/sender.go#L396-L398

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [ ] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features
