### PR TITLE
fix(metrics): use targetallocator serviceaccount created by the operator

### DIFF
--- a/.changelog/3447.fixed.txt
+++ b/.changelog/3447.fixed.txt
@@ -1,0 +1,1 @@
+fix(metrics): use targetallocator serviceaccount created by the operator

--- a/deploy/helm/sumologic/templates/metrics/collector/otelcol/opentelemetrycollector.yaml
+++ b/deploy/helm/sumologic/templates/metrics/collector/otelcol/opentelemetrycollector.yaml
@@ -32,6 +32,8 @@ spec:
 {{- if .Values.sumologic.metrics.collector.otelcol.allocationStrategy }}
     allocationStrategy: {{ .Values.sumologic.metrics.collector.otelcol.allocationStrategy }}
 {{- end }}
+    # we set serviceAccount to work around https://github.com/open-telemetry/opentelemetry-operator/issues/2443
+    # TODO: drop this after the above is fixed
     serviceAccount: {{ template "sumologic.metadata.name.metrics.targetallocator.serviceaccount" . }}
     enabled: true
     filterStrategy: relabel-config

--- a/deploy/helm/sumologic/templates/metrics/collector/otelcol/targetallocator-serviceaccount.yaml
+++ b/deploy/helm/sumologic/templates/metrics/collector/otelcol/targetallocator-serviceaccount.yaml
@@ -1,9 +1,0 @@
-{{ if and (eq (include "metrics.otelcol.enabled" .) "true") .Values.sumologic.metrics.collector.otelcol.enabled }}
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ template "sumologic.metadata.name.metrics.targetallocator.serviceaccount" . }}
-  labels:
-    {{- include "sumologic.labels.metrics.serviceaccount" . | nindent 4 }}
-    {{- include "sumologic.labels.common" . | nindent 4 }}
-{{- end }}

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
@@ -18,6 +18,8 @@ spec:
   replicas: 1
   serviceAccount: RELEASE-NAME-sumologic-metrics
   targetAllocator:
+    # we set serviceAccount to work around https://github.com/open-telemetry/opentelemetry-operator/issues/2443
+    # TODO: drop this after the above is fixed
     serviceAccount: RELEASE-NAME-sumologic-metrics-targetallocator
     enabled: true
     filterStrategy: relabel-config

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
@@ -23,6 +23,8 @@ spec:
   serviceAccount: RELEASE-NAME-sumologic-metrics
   targetAllocator:
     allocationStrategy: consistent-hashing
+    # we set serviceAccount to work around https://github.com/open-telemetry/opentelemetry-operator/issues/2443
+    # TODO: drop this after the above is fixed
     serviceAccount: RELEASE-NAME-sumologic-metrics-targetallocator
     enabled: true
     filterStrategy: relabel-config


### PR DESCRIPTION
There's currently a bug in otel operator (https://github.com/open-telemetry/opentelemetry-operator/issues/2443) which causes it to create a ServiceAccount for the Target Allocator even if we provide our own. In practice, we used the same name as the operator, so it only changed some labels. As a work around for this bug, we just let the operator handle this.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
