### PR TITLE
feat: add endpointslices RBAC permission

### DIFF
--- a/.changelog/3491.added.txt
+++ b/.changelog/3491.added.txt
@@ -1,0 +1,1 @@
+feat: add endpointslices RBAC permission

--- a/deploy/helm/sumologic/templates/clusterrole.yaml
+++ b/deploy/helm/sumologic/templates/clusterrole.yaml
@@ -6,12 +6,13 @@ metadata:
     app: {{ template "sumologic.labels.app.roles.clusterrole" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 rules:
-- apiGroups: ["", "apps", "extensions", "events.k8s.io"]
+- apiGroups: ["", "apps", "extensions", "batch", "events.k8s.io", "discovery.k8s.io"]
   resources:
   - configmaps
   - daemonsets
   - deployments
   - endpoints
+  - endpointslices
   - events
   - namespaces
   - nodes
@@ -19,9 +20,6 @@ rules:
   - replicasets
   - services
   - statefulsets
-  verbs: ["get", "list", "watch"]
-- apiGroups: ["batch"]
-  resources:
   - cronjobs
   - jobs
   verbs: ["get", "list", "watch"]

--- a/tests/helm/testdata/goldenfile/common/clusterrole.output.yaml
+++ b/tests/helm/testdata/goldenfile/common/clusterrole.output.yaml
@@ -1,0 +1,37 @@
+---
+# Source: sumologic/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: RELEASE-NAME-sumologic
+  labels:
+    app: RELEASE-NAME-sumologic
+    chart: "sumologic-%CURRENT_CHART_VERSION%"
+    release: "RELEASE-NAME"
+    heritage: "Helm"
+rules:
+  - apiGroups: ["", "apps", "extensions", "batch", "events.k8s.io", "discovery.k8s.io"]
+    resources:
+      - configmaps
+      - daemonsets
+      - deployments
+      - endpoints
+      - endpointslices
+      - events
+      - namespaces
+      - nodes
+      - pods
+      - replicasets
+      - services
+      - statefulsets
+      - cronjobs
+      - jobs
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    verbs: ["create", "patch"]
+  - apiGroups: ["opentelemetry.io"]
+    resources:
+      - instrumentations
+    verbs: ["patch", "get", "create"]


### PR DESCRIPTION
Add permission to get/list/watch EndpointSlice resources. We're planning to use these instead of Endpoints to track Pod to Service relationships in our Kubernetes metadata Otel processor.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [x] Template tests added for new features
