### PR TITLE
deps: update Falco and Metrics Server

### DIFF
--- a/.changelog/3507.changed.0.txt
+++ b/.changelog/3507.changed.0.txt
@@ -1,0 +1,1 @@
+deps: update Falco to 3.8.7

--- a/.changelog/3507.changed.1.txt
+++ b/.changelog/3507.changed.1.txt
@@ -1,0 +1,1 @@
+deps: update Metrics Server to 6.8.0

--- a/.changelog/3507.changed.2.txt
+++ b/.changelog/3507.changed.2.txt
@@ -1,0 +1,1 @@
+deps: update OpenTelemetry Operator to 0.46.0

--- a/.changelog/3507.changed.2.txt
+++ b/.changelog/3507.changed.2.txt
@@ -1,1 +1,0 @@
-deps: update OpenTelemetry Operator to 0.46.0

--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
     repository: https://falcosecurity.github.io/charts
     condition: falco.enabled
   - name: metrics-server
-    version: 6.6.5
+    version: 6.8.0
     repository: https://charts.bitnami.com/bitnami
     condition: metrics-server.enabled
   - name: telegraf-operator

--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -33,6 +33,6 @@ dependencies:
     repository: https://sumologic.github.io/tailing-sidecar
     condition: tailing-sidecar-operator.enabled
   - name: opentelemetry-operator
-    version: 0.44.2
+    version: 0.46.0
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     condition: opentelemetry-operator.enabled,sumologic.metrics.collector.otelcol.enabled

--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
     repository: https://prometheus-community.github.io/helm-charts
     condition: kube-prometheus-stack.enabled,sumologic.metrics.enabled
   - name: falco
-    version: 3.8.6
+    version: 3.8.7
     repository: https://falcosecurity.github.io/charts
     condition: falco.enabled
   - name: metrics-server

--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -33,6 +33,6 @@ dependencies:
     repository: https://sumologic.github.io/tailing-sidecar
     condition: tailing-sidecar-operator.enabled
   - name: opentelemetry-operator
-    version: 0.46.0
+    version: 0.44.2
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     condition: opentelemetry-operator.enabled,sumologic.metrics.collector.otelcol.enabled

--- a/docs/README.md
+++ b/docs/README.md
@@ -105,7 +105,7 @@ The following table displays the currently used software versions for our Helm c
 | Name                                      | Version |
 | ----------------------------------------- | ------- |
 | OpenTelemetry Collector                   | 0.90.1  |
-| OpenTelemetry Operator                    | 0.46.0  |
+| OpenTelemetry Operator                    | 0.44.2  |
 | kube-prometheus-stack/Prometheus Operator | 40.5.0  |
 | Falco                                     | 3.8.7   |
 | Telegraf Operator                         | 1.3.12  |

--- a/docs/README.md
+++ b/docs/README.md
@@ -107,7 +107,7 @@ The following table displays the currently used software versions for our Helm c
 | OpenTelemetry Collector                   | 0.90.1  |
 | OpenTelemetry Operator                    | 0.44.2  |
 | kube-prometheus-stack/Prometheus Operator | 40.5.0  |
-| Falco                                     | 3.8.6   |
+| Falco                                     | 3.8.7   |
 | Telegraf Operator                         | 1.3.12  |
 | Tailing Sidecar Operator                  | 0.9.0   |
 | Metrics Server                            | 6.6.5   |

--- a/docs/README.md
+++ b/docs/README.md
@@ -110,7 +110,7 @@ The following table displays the currently used software versions for our Helm c
 | Falco                                     | 3.8.7   |
 | Telegraf Operator                         | 1.3.12  |
 | Tailing Sidecar Operator                  | 0.9.0   |
-| Metrics Server                            | 6.6.5   |
+| Metrics Server                            | 6.8.0   |
 
 ### ARM support
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -105,7 +105,7 @@ The following table displays the currently used software versions for our Helm c
 | Name                                      | Version |
 | ----------------------------------------- | ------- |
 | OpenTelemetry Collector                   | 0.90.1  |
-| OpenTelemetry Operator                    | 0.44.2  |
+| OpenTelemetry Operator                    | 0.46.0  |
 | kube-prometheus-stack/Prometheus Operator | 40.5.0  |
 | Falco                                     | 3.8.7   |
 | Telegraf Operator                         | 1.3.12  |

--- a/tests/helm/testdata/goldenfile/metrics-server/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics-server/basic.output.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-server
     app.kubernetes.io/version: 0.6.4
-    helm.sh/chart: metrics-server-6.6.5
+    helm.sh/chart: metrics-server-6.8.0
 spec:
   replicas: 1
   selector:
@@ -26,8 +26,9 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: metrics-server
         app.kubernetes.io/version: 0.6.4
-        helm.sh/chart: metrics-server-6.6.5
+        helm.sh/chart: metrics-server-6.8.0
     spec:
+      automountServiceAccountToken: true
       serviceAccountName: RELEASE-NAME-metrics-server
       affinity:
         podAffinity:
@@ -46,7 +47,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
         - name: metrics-server
-          image: docker.io/bitnami/metrics-server:0.6.4-debian-11-r73
+          image: docker.io/bitnami/metrics-server:0.6.4-debian-11-r75
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false
@@ -59,6 +60,7 @@ spec:
             runAsUser: 1001
             seccompProfile:
               type: RuntimeDefault
+            seLinuxOptions: {}
           command:
             - metrics-server
           args:


### PR DESCRIPTION
Falco: 3.8.6 -> 3.8.7
Metrics Server: 6.6.5 -> 6.8.0 (still warm!)
OpenTelemetry Operator: 0.44.2 -> 0.46.0



- [X] Changelog updated or skip changelog label added
- [X] Documentation updated
- [X] Template tests added for new features
- [ ] Integration tests added or modified for major features
