### PR TITLE
chore(otelcolInstrumentation):  use loadbalancing exporter when traces-gateway is disabled

### DIFF
--- a/.changelog/3538.changed.txt
+++ b/.changelog/3538.changed.txt
@@ -1,0 +1,1 @@
+chore(otelcolInstrumentation): use loadbalancing exporter when traces-gateway is disabled

--- a/deploy/helm/sumologic/conf/instrumentation/otelcol.instrumentation.conf.yaml
+++ b/deploy/helm/sumologic/conf/instrumentation/otelcol.instrumentation.conf.yaml
@@ -39,8 +39,25 @@ exporters:
       ## num_seconds is the number of seconds to buffer in case of a backend outage
       ## requests_per_second is the average number of requests per seconds.
       queue_size: 5000
+{{- if eq .Values.tracesGateway.enabled true }}
   otlphttp/traces:
     endpoint: 'http://{{ include "otelcolinstrumentation.exporter.endpoint" . }}:4318'
+{{- else }}
+  loadbalancing:
+    protocol:
+      otlp:
+        timeout: 10s
+        tls:
+          insecure: true
+        sending_queue:
+          enabled: true
+          num_consumers: 10
+          queue_size: 10_000
+    resolver:
+      dns:
+        hostname: '{{ include "tracesgateway.exporter.loadbalancing.endpoint" . }}'
+        port: 4317
+{{- end }}
 receivers:
   jaeger:
     protocols:
@@ -167,7 +184,11 @@ service:
     traces:
       receivers: [jaeger, opencensus, otlp, otlp/deprecated, zipkin]
       processors: [memory_limiter, k8s_tagger, source, resource, batch]
+{{- if eq .Values.tracesGateway.enabled true }}
       exporters: [otlphttp/traces]
+{{- else }}
+      exporters: [loadbalancing]
+{{- end}}
     metrics:
       receivers: [otlp, otlp/deprecated]
       processors: [memory_limiter, k8s_tagger, source, resource, batch]

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/traces-gateway-disabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/traces-gateway-disabled.output.yaml
@@ -13,8 +13,20 @@ metadata:
 data:
   otelcol.instrumentation.conf.yaml: |
     exporters:
-      otlphttp/traces:
-        endpoint: http://RELEASE-NAME-sumologic-traces-sampler.sumologic:4318
+      loadbalancing:
+        protocol:
+          otlp:
+            sending_queue:
+              enabled: true
+              num_consumers: 10
+              queue_size: 10000
+            timeout: 10s
+            tls:
+              insecure: true
+        resolver:
+          dns:
+            hostname: RELEASE-NAME-sumologic-traces-sampler-headless.sumologic
+            port: 4317
       sumologic/metrics:
         client: k8s_%CURRENT_CHART_VERSION%
         compress_encoding: gzip
@@ -143,7 +155,7 @@ data:
           - otlp/deprecated
         traces:
           exporters:
-          - otlphttp/traces
+          - loadbalancing
           processors:
           - memory_limiter
           - k8s_tagger

--- a/tests/integration/features.go
+++ b/tests/integration/features.go
@@ -805,6 +805,38 @@ func CheckTracesInstall(builder *features.FeatureBuilder) *features.FeatureBuild
 
 }
 
+func CheckTracesWithoutGatewayInstall(builder *features.FeatureBuilder) *features.FeatureBuilder {
+	return builder.
+		Assess("traces-sampler deployment is ready",
+			stepfuncs.WaitUntilDeploymentIsReady(
+				waitDuration,
+				tickDuration,
+				stepfuncs.WithNameF(
+					stepfuncs.ReleaseFormatter("%s-sumologic-traces-gateway"),
+				),
+				stepfuncs.WithLabelsF(stepfuncs.LabelFormatterKV{
+					K: "app",
+					V: stepfuncs.ReleaseFormatter("%s-sumologic-traces-gateway"),
+				},
+				),
+			)).
+		Assess("otelcol-instrumentation statefulset is ready",
+			stepfuncs.WaitUntilStatefulSetIsReady(
+				waitDuration,
+				tickDuration,
+				stepfuncs.WithNameF(
+					stepfuncs.ReleaseFormatter("%s-sumologic-otelcol-instrumentation"),
+				),
+				stepfuncs.WithLabelsF(
+					stepfuncs.LabelFormatterKV{
+						K: "app",
+						V: stepfuncs.ReleaseFormatter("%s-sumologic-otelcol-instrumentation"),
+					},
+				),
+			),
+		)
+}
+
 func CheckTailingSidecarOperatorInstall(builder *features.FeatureBuilder) *features.FeatureBuilder {
 	return builder.
 		Assess("tailing sidecar deployment is ready",

--- a/tests/integration/features.go
+++ b/tests/integration/features.go
@@ -766,11 +766,11 @@ func CheckTracesInstall(builder *features.FeatureBuilder) *features.FeatureBuild
 				waitDuration,
 				tickDuration,
 				stepfuncs.WithNameF(
-					stepfuncs.ReleaseFormatter("%s-sumologic-traces-gateway"),
+					stepfuncs.ReleaseFormatter("%s-sumologic-traces-sampler"),
 				),
 				stepfuncs.WithLabelsF(stepfuncs.LabelFormatterKV{
 					K: "app",
-					V: stepfuncs.ReleaseFormatter("%s-sumologic-traces-gateway"),
+					V: stepfuncs.ReleaseFormatter("%s-sumologic-traces-sampler"),
 				},
 				),
 			)).
@@ -812,11 +812,11 @@ func CheckTracesWithoutGatewayInstall(builder *features.FeatureBuilder) *feature
 				waitDuration,
 				tickDuration,
 				stepfuncs.WithNameF(
-					stepfuncs.ReleaseFormatter("%s-sumologic-traces-gateway"),
+					stepfuncs.ReleaseFormatter("%s-sumologic-traces-sampler"),
 				),
 				stepfuncs.WithLabelsF(stepfuncs.LabelFormatterKV{
 					K: "app",
-					V: stepfuncs.ReleaseFormatter("%s-sumologic-traces-gateway"),
+					V: stepfuncs.ReleaseFormatter("%s-sumologic-traces-sampler"),
 				},
 				),
 			)).

--- a/tests/integration/helm_traces_gateway_disabled_test.go
+++ b/tests/integration/helm_traces_gateway_disabled_test.go
@@ -1,0 +1,22 @@
+//go:build allversions
+// +build allversions
+
+package integration
+
+import (
+	"testing"
+)
+
+func Test_Helm_Traces_Gateway_Disabled(t *testing.T) {
+
+	installChecks := []featureCheck{
+		CheckSumologicSecret(15),
+		CheckTracesWithoutGatewayInstall,
+	}
+
+	featInstall := GetInstallFeature(installChecks)
+
+	featTraces := GetTracesFeature()
+
+	testenv.Test(t, featInstall, featTraces)
+}

--- a/tests/integration/helm_traces_gateway_disabled_test.go
+++ b/tests/integration/helm_traces_gateway_disabled_test.go
@@ -10,7 +10,7 @@ import (
 func Test_Helm_Traces_Gateway_Disabled(t *testing.T) {
 
 	installChecks := []featureCheck{
-		CheckSumologicSecret(15),
+		CheckSumologicSecret(3),
 		CheckTracesWithoutGatewayInstall,
 	}
 

--- a/tests/integration/values/values_helm_traces_gateway_disabled.yaml
+++ b/tests/integration/values/values_helm_traces_gateway_disabled.yaml
@@ -1,0 +1,14 @@
+# Request less resources so that this fits on Github actions runners environment
+sumologic:
+  events:
+    enabled: false
+  logs:
+    enabled: false
+  metrics:
+    enabled: false
+
+tracesGateway:
+  enabled: false
+
+opentelemetry-operator:
+  enabled: false


### PR DESCRIPTION
Use `loadbalancingexporter` when `traces-gateway` is disabled to ensure that traces are sent to proper `traces-sampler` instance.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [x] Integration tests added or modified for major features
