### PR TITLE
fix(metrics): image pull secrets for metrics collector

### DIFF
--- a/.changelog/3539.fixed.txt
+++ b/.changelog/3539.fixed.txt
@@ -1,0 +1,1 @@
+fix(metrics): image pull secrets for metrics collector

--- a/deploy/helm/sumologic/templates/metrics/collector/otelcol/opentelemetrycollector.yaml
+++ b/deploy/helm/sumologic/templates/metrics/collector/otelcol/opentelemetrycollector.yaml
@@ -36,6 +36,7 @@ spec:
     filterStrategy: relabel-config
     prometheusCR:
       enabled: true
+      serviceAccount: {{ template "sumologic.metadata.name.metrics.targetallocator.serviceaccount" . }}
       scrapeInterval: {{ .Values.sumologic.metrics.collector.otelcol.scrapeInterval }}
       serviceMonitorSelector:
 {{- if .Values.sumologic.metrics.collector.otelcol.serviceMonitorSelector }}

--- a/deploy/helm/sumologic/templates/metrics/collector/otelcol/serviceaccount-targetallocator.yaml
+++ b/deploy/helm/sumologic/templates/metrics/collector/otelcol/serviceaccount-targetallocator.yaml
@@ -1,0 +1,14 @@
+{{ if and (eq (include "metrics.otelcol.enabled" .) "true") .Values.sumologic.metrics.collector.otelcol.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "sumologic.metadata.name.metrics.targetallocator.serviceaccount" . }}
+  namespace: {{ template "sumologic.namespace"  . }}
+  labels:
+    {{- include "sumologic.labels.metrics.serviceaccount" . | nindent 4 }}
+    {{- include "sumologic.labels.common" . | nindent 4 }}
+{{- if .Values.sumologic.pullSecrets }}
+imagePullSecrets:
+{{ toYaml .Values.sumologic.pullSecrets | indent 2 }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/sumologic/templates/metrics/collector/otelcol/serviceaccount.yaml
+++ b/deploy/helm/sumologic/templates/metrics/collector/otelcol/serviceaccount.yaml
@@ -7,4 +7,8 @@ metadata:
   labels:
     {{- include "sumologic.labels.metrics.serviceaccount" . | nindent 4 }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
+{{- if .Values.sumologic.pullSecrets }}
+imagePullSecrets:
+{{ toYaml .Values.sumologic.pullSecrets | indent 2 }}
+{{- end }}
 {{- end }}

--- a/tests/helm/testdata/everything-enabled.yaml
+++ b/tests/helm/testdata/everything-enabled.yaml
@@ -1,4 +1,10 @@
 sumologic:
+  pullSecrets:
+    - name: pullSecret
+  setup:
+    job:
+      pullSecrets:
+        - name: pullSecret
   logs:
     collector:
       allowSideBySide: true

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
@@ -22,6 +22,7 @@ spec:
     filterStrategy: relabel-config
     prometheusCR:
       enabled: true
+      serviceAccount: RELEASE-NAME-sumologic-metrics-targetallocator
       scrapeInterval: 30s
       serviceMonitorSelector:
         release: RELEASE-NAME

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
@@ -27,6 +27,7 @@ spec:
     filterStrategy: relabel-config
     prometheusCR:
       enabled: true
+      serviceAccount: RELEASE-NAME-sumologic-metrics-targetallocator
       scrapeInterval: 60s
       serviceMonitorSelector:
         smkey: smvalue

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/debug.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/debug.output.yaml
@@ -22,6 +22,7 @@ spec:
     filterStrategy: relabel-config
     prometheusCR:
       enabled: true
+      serviceAccount: RELEASE-NAME-sumologic-metrics-targetallocator
       scrapeInterval: 30s
       serviceMonitorSelector:
         release: RELEASE-NAME

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/kubelet.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/kubelet.output.yaml
@@ -22,6 +22,7 @@ spec:
     filterStrategy: relabel-config
     prometheusCR:
       enabled: true
+      serviceAccount: RELEASE-NAME-sumologic-metrics-targetallocator
       scrapeInterval: 30s
       serviceMonitorSelector:
         release: RELEASE-NAME


### PR DESCRIPTION
Ensure globally defined pull secrets are added to metrics collector ServiceAccounts. I've also added a test that checks all ServiceAccounts to ensure we catch this problem more easily in the future.

Fixes #3530 

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [x] Template tests added for new features
- [ ] Integration tests added or modified for major features
