### PR TITLE
ci: include preview releases in platform support checks

### DIFF
--- a/ci/check_dependencies/aks.py
+++ b/ci/check_dependencies/aks.py
@@ -46,11 +46,13 @@ def get_supported_releases(html_calendar):
     pd_data["AKS GA date"] = pd.to_datetime(
         pd_data["AKS GA"], format="%b %Y", errors="coerce"
     ).fillna(datetime.now() + timedelta(days=50 * 365))
-
+    pd_data["AKS Preview date"] = pd.to_datetime(
+        pd_data["AKS preview"], format="%b %Y", errors="coerce"
+    ).fillna(datetime.now() + timedelta(days=50 * 365))
     today = datetime.now()
     supported_releases = []
     for index, row in pd_data.iterrows():
-        if row["AKS GA date"] < today:
+        if row["AKS Preview date"] < today:
             dependent_version = row["Platform support"].replace("GA", "").replace("Until", "").strip()
             if dependent_version in pd_data.index:
                 dependent_version_GA_date = pd_data.loc[dependent_version][

--- a/ci/check_dependencies/eks.py
+++ b/ci/check_dependencies/eks.py
@@ -9,7 +9,7 @@ import common
 
 def get_eks_doc_from_github():
     result = requests.get(
-        "https://raw.githubusercontent.com/awsdocs/amazon-eks-user-guide/master/doc_source/kubernetes-versions.md"
+        "https://raw.githubusercontent.com/awsdocs/amazon-eks-user-guide/main/doc_source/kubernetes-versions.md"
     )
     if result.status_code == 200:
         return result.text
@@ -22,15 +22,13 @@ def get_eks_calendar_table(doc):
 
     found_calendar = False
     for line in lines:
-        if "Amazon EKS end of support" in line:
+        if "| --- |" in line:
             found_calendar = True
         elif found_calendar:
             if line != "":
                 eks_calendar_table.append(line)
             else:
                 break
-    # remove first line related to table formatting in markdown
-    eks_calendar_table = eks_calendar_table[1:]
     return eks_calendar_table
 
 
@@ -57,8 +55,8 @@ def get_eks_officially_supported_releases():
     for row in eks_calendar_table:
         elements = [x for x in row.strip().split("|") if x]
         release_version = elements[0].replace("\\", "").strip()
-        end_of_support = elements[-1].strip()
-        eof_of_support_date = parse_eks_end_of_support_date(end_of_support)
+        end_of_standard_support = elements[3].strip()
+        eof_of_support_date = parse_eks_end_of_support_date(end_of_standard_support)
         if today < eof_of_support_date:
             eks_supported_releases.append(release_version)
     return sorted(eks_supported_releases)

--- a/ci/check_dependencies/kops.py
+++ b/ci/check_dependencies/kops.py
@@ -26,8 +26,6 @@ def get_minor_releases(owner, repo):
 
         minor_releases = set()
         for release in releases:
-            if "alpha" in release["name"] or "beta" in release["name"]:
-                continue
             release_name_digits = release["name"].strip("v").split(".")
             minor_releases.add(
                 "{major}.{minor}".format(


### PR DESCRIPTION
Include preview releases in checks for platform support. We want this to be closely aligned with testability - if it's possible to provision a new cluster with a given version, and it's not explicitly out-of-support, then we want to keep supporting it.

It also turned out that our EKS checker used the wrong branch - the repo it was referencing made the switch from `master` to `main` recently.

With these changes, I get the following output:

```
Gardener helper
#####################################################################


#### Kops ####
Kops officially supported versions
['1.25', '1.26', '1.27', '1.28', '1.29']
Currently supported Kops versions for Sumologic Kubernetes Collection Helm Chart
['1.24', '1.25', '1.26', '1.27', '1.28', '1.29']


Please remove support to following Kops versions:
['1.24']

#### EKS ####
EKS officially supported versions
['1.25', '1.26', '1.27', '1.28', '1.29']
Currently supported EKS versions for Sumologic Kubernetes Collection Helm Chart
['1.24', '1.25', '1.26', '1.27', '1.28', '1.29']


Please remove support to following EKS versions:
['1.24']

#### OpenShift ####
OpenShift officially supported versions
['4.12', '4.13', '4.14']
Currently supported OpenShift versions for Sumologic Kubernetes Collection Helm Chart
['4.11', '4.12', '4.13', '4.14']


Please remove support to following OpenShift versions:
['4.11']

#### Subcharts in Sumologic Kubernetes Collection Helm Chart ####

Please check newer version of FALCO subchart, version: 4.2.2, created: 2024-02-16T14:39:55.476307574+00:00
Currently used FALCO subchart, version: 3.8.7, created: 2023-12-18T16:37:25.329322556+00:00
```