### PR TITLE
chore: remove clear_logs_timestamp from otelcol configuration

### DIFF
--- a/.changelog/3574.changed.txt
+++ b/.changelog/3574.changed.txt
@@ -1,0 +1,1 @@
+chore: remove clear_logs_timestamp from otelcol configuration

--- a/deploy/helm/sumologic/conf/events/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/events/otelcol/config.yaml
@@ -3,7 +3,6 @@ exporters:
     client: {{ include "sumologic.sumo_client" . }}
     endpoint: {{ include "sumologic.events.exporter.endpoint" . }}
     log_format: {{ include "sumologic.events.exporter.format" . }}
-    clear_logs_timestamp: false # this only affects the otlp format
     sending_queue:
       enabled: true
 {{- if .Values.sumologic.events.persistence.enabled }}
@@ -20,7 +19,6 @@ exporters:
     client: {{ include "sumologic.sumo_client" . }}
     endpoint: {{ include "sumologic-mock.receiver-endpoint" . }}
     log_format: {{ include "sumologic.events.exporter.format" . }}
-    clear_logs_timestamp: false # this only affects the otlp format
     sending_queue:
       enabled: true
 {{- end }}

--- a/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
@@ -72,7 +72,6 @@ exporters:
     client: {{ include "sumologic.sumo_client" . }}
     endpoint: ${SUMO_ENDPOINT_DEFAULT_OTLP_LOGS_SOURCE}
     log_format: otlp
-    clear_logs_timestamp: false
     sending_queue:
       enabled: true
       num_consumers: 10
@@ -86,7 +85,6 @@ exporters:
     client: {{ include "sumologic.sumo_client" . }}
     endpoint: {{ include "sumologic-mock.receiver-endpoint" . }}
     log_format: otlp
-    clear_logs_timestamp: false
     sending_queue:
       enabled: true
       num_consumers: 10

--- a/tests/helm/testdata/goldenfile/events_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc/basic.output.yaml
@@ -14,7 +14,6 @@ data:
   config.yaml: |
     exporters:
       sumologic:
-        clear_logs_timestamp: false
         client: k8s_%CURRENT_CHART_VERSION%
         endpoint: ${SUMO_ENDPOINT_DEFAULT_OTLP_EVENTS_SOURCE}
         log_format: otlp

--- a/tests/helm/testdata/goldenfile/events_otc/options.output.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc/options.output.yaml
@@ -14,7 +14,6 @@ data:
   config.yaml: |
     exporters:
       sumologic:
-        clear_logs_timestamp: false
         client: k8s_%CURRENT_CHART_VERSION%
         endpoint: ${SUMO_ENDPOINT_DEFAULT_OTLP_EVENTS_SOURCE}
         log_format: otlp

--- a/tests/helm/testdata/goldenfile/events_otc/sumologic-mock.output.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc/sumologic-mock.output.yaml
@@ -16,7 +16,6 @@ data:
       debug:
         verbosity: detailed
       sumologic:
-        clear_logs_timestamp: false
         client: k8s_%CURRENT_CHART_VERSION%
         endpoint: ${SUMO_ENDPOINT_DEFAULT_OTLP_EVENTS_SOURCE}
         log_format: otlp
@@ -24,7 +23,6 @@ data:
           enabled: true
           storage: file_storage
       sumologic/sumologic-mock:
-        clear_logs_timestamp: false
         client: k8s_%CURRENT_CHART_VERSION%
         endpoint: http://RELEASE-NAME-sumologic-mock.sumologic:3000/receiver
         log_format: otlp

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/debug.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/debug.output.yaml
@@ -16,7 +16,6 @@ data:
       debug:
         verbosity: detailed
       sumologic:
-        clear_logs_timestamp: false
         client: k8s_%CURRENT_CHART_VERSION%
         endpoint: ${SUMO_ENDPOINT_DEFAULT_OTLP_LOGS_SOURCE}
         log_format: otlp

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/debug_with_sumologic_mock.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/debug_with_sumologic_mock.output.yaml
@@ -16,7 +16,6 @@ data:
       debug:
         verbosity: detailed
       sumologic:
-        clear_logs_timestamp: false
         client: k8s_%CURRENT_CHART_VERSION%
         endpoint: ${SUMO_ENDPOINT_DEFAULT_OTLP_LOGS_SOURCE}
         log_format: otlp
@@ -26,7 +25,6 @@ data:
           queue_size: 10000
           storage: file_storage
       sumologic/sumologic-mock:
-        clear_logs_timestamp: false
         client: k8s_%CURRENT_CHART_VERSION%
         endpoint: http://RELEASE-NAME-sumologic-mock.sumologic:3000/receiver
         log_format: otlp

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/otel.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/otel.output.yaml
@@ -14,7 +14,6 @@ data:
   config.yaml: |
     exporters:
       sumologic:
-        clear_logs_timestamp: false
         client: k8s_%CURRENT_CHART_VERSION%
         endpoint: ${SUMO_ENDPOINT_DEFAULT_OTLP_LOGS_SOURCE}
         log_format: otlp

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/templates.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/templates.output.yaml
@@ -14,7 +14,6 @@ data:
   config.yaml: |
     exporters:
       sumologic:
-        clear_logs_timestamp: false
         client: k8s_%CURRENT_CHART_VERSION%
         endpoint: ${SUMO_ENDPOINT_DEFAULT_OTLP_LOGS_SOURCE}
         log_format: otlp


### PR DESCRIPTION
chore: remove clear_logs_timestamp from otelcol configuration
related pull request: https://github.com/SumoLogic/sumologic-otel-collector/pull/1455

I'll update otelcol in the next pull request.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [x] Template tests added for new features
- [ ] Integration tests added or modified for major features
