### PR TITLE
feat(otellogs): allow to override all properties within additionalDaemonsets

### DIFF
--- a/.changelog/3586.changed.txt
+++ b/.changelog/3586.changed.txt
@@ -1,0 +1,1 @@
+feat(otellogs): allow to override all properties within additionalDaemonsets

--- a/deploy/helm/sumologic/templates/logs/collector/otelcol/daemonset.yaml
+++ b/deploy/helm/sumologic/templates/logs/collector/otelcol/daemonset.yaml
@@ -7,14 +7,11 @@
 {{- $daemonsets := dict "" $.Values.otellogs.daemonset  -}}
 {{- $daemonsets = deepCopy $daemonsets | merge $.Values.otellogs.additionalDaemonSets -}}
 {{- range $name, $daemonset := $daemonsets }}
+{{- $defaultDaemonset := deepCopy $.Values.otellogs.daemonset }}
+{{- $daemonset := mergeOverwrite $defaultDaemonset $daemonset -}}
 {{- if not (eq $name "") }}
 {{- $instance = (printf "-%s" $name ) }}
 {{- end }}
-{{- $res := .resources }}
-{{- if not $res }}
-{{- $res = dict }}
-{{- end }}
-{{- $resources := deepCopy $daemonset.resources | merge $res }}
 {{- $nodeSelector := "" }}
 {{- if .nodeSelector }}
 {{- $nodeSelector = (toYaml .nodeSelector) }}
@@ -108,7 +105,7 @@ spec:
             path: /
             port: 13133 # Health Check extension default port.
         resources:
-          {{- toYaml $resources | nindent 10 }}
+          {{- toYaml $daemonset.resources | nindent 10 }}
         volumeMounts:
         - mountPath: /etc/otelcol
           name: otelcol-config

--- a/deploy/helm/sumologic/templates/logs/collector/otelcol/daemonset.yaml
+++ b/deploy/helm/sumologic/templates/logs/collector/otelcol/daemonset.yaml
@@ -6,7 +6,7 @@
 {{- $defaultAffinity := (include "kubernetes.defaultAffinity" .) }}
 {{- $daemonsets := dict "" $.Values.otellogs.daemonset  -}}
 {{- $daemonsets = deepCopy $daemonsets | merge $.Values.otellogs.additionalDaemonSets -}}
-{{- range $name, $value := $daemonsets }}
+{{- range $name, $daemonset := $daemonsets }}
 {{- if not (eq $name "") }}
 {{- $instance = (printf "-%s" $name ) }}
 {{- end }}
@@ -14,7 +14,7 @@
 {{- if not $res }}
 {{- $res = dict }}
 {{- end }}
-{{- $resources := deepCopy $.Values.otellogs.daemonset.resources | merge $res }}
+{{- $resources := deepCopy $daemonset.resources | merge $res }}
 {{- $nodeSelector := "" }}
 {{- if .nodeSelector }}
 {{- $nodeSelector = (toYaml .nodeSelector) }}
@@ -39,15 +39,15 @@ kind: DaemonSet
 metadata:
   name: {{ printf "%s%s" (include "sumologic.metadata.name.logs.collector.daemonset" $ctx) $instance | trunc 63 | trimSuffix "-" }}
   namespace: {{ template "sumologic.namespace"  $ctx }}
-  {{- if $.Values.otellogs.daemonset.annotations }}
+  {{- if $daemonset.annotations }}
   annotations:
-{{ toYaml $.Values.otellogs.daemonset.annotations| indent 4 }}
+{{ toYaml $daemonset.annotations| indent 4 }}
 {{- end }}
   labels:
     app: {{ template "sumologic.labels.app.logs.collector.daemonset" $ctx }}
     {{- include "sumologic.labels.common" $ctx | nindent 4 }}
-{{- if $.Values.otellogs.daemonset.labels }}
-{{ toYaml $.Values.otellogs.daemonset.labels | indent 4 }}
+{{- if $daemonset.labels }}
+{{ toYaml $daemonset.labels | indent 4 }}
 {{- end }}
 spec:
   selector:
@@ -60,8 +60,8 @@ spec:
 {{- if $.Values.sumologic.podAnnotations }}
 {{ toYaml $.Values.sumologic.podAnnotations | indent 8 }}
 {{- end }}
-{{- if $.Values.otellogs.daemonset.podAnnotations }}
-{{ toYaml $.Values.otellogs.daemonset.podAnnotations | indent 8 }}
+{{- if $daemonset.podAnnotations }}
+{{ toYaml $daemonset.podAnnotations | indent 8 }}
 {{- end }}
       labels:
         app.kubernetes.io/name: {{ printf "%s%s" (include "sumologic.labels.app.logs.collector.pod" $ctx) $instance | trunc 63 | trimSuffix "-" }}
@@ -70,8 +70,8 @@ spec:
 {{- if $.Values.sumologic.podLabels }}
 {{ toYaml $.Values.sumologic.podLabels | indent 8 }}
 {{- end }}
-{{- if $.Values.otellogs.daemonset.podLabels }}
-{{ toYaml $.Values.otellogs.daemonset.podLabels | indent 8 }}
+{{- if $daemonset.podLabels }}
+{{ toYaml $daemonset.podLabels | indent 8 }}
 {{- end }}
     spec:
 {{- if $nodeSelector }}
@@ -87,9 +87,9 @@ spec:
 {{ $tolerations | indent 8 }}
 {{- end }}
       securityContext:
-        {{- toYaml $.Values.otellogs.daemonset.securityContext | nindent 8 }}
-      {{- if $.Values.otellogs.daemonset.priorityClassName }}
-      priorityClassName: {{ $.Values.otellogs.daemonset.priorityClassName | quote }}
+        {{- toYaml $daemonset.securityContext | nindent 8 }}
+      {{- if $daemonset.priorityClassName }}
+      priorityClassName: {{ $daemonset.priorityClassName | quote }}
       {{- else }}
       priorityClassName: {{ include "sumologic.metadata.name.priorityclass" $ctx | quote }}
       {{- end }}
@@ -123,8 +123,8 @@ spec:
         - mountPath: /var/log/journal
           name: varlogjournal
           readOnly: true
-{{- if $.Values.otellogs.daemonset.extraVolumeMounts }}
-{{ toYaml $.Values.otellogs.daemonset.extraVolumeMounts | indent 8 }}
+{{- if $daemonset.extraVolumeMounts }}
+{{ toYaml $daemonset.extraVolumeMounts | indent 8 }}
 {{- end }}
         env:
         - name: LOGS_METADATA_SVC
@@ -136,11 +136,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-{{- if $.Values.otellogs.daemonset.extraEnvVars }}
-{{ toYaml $.Values.otellogs.daemonset.extraEnvVars | nindent 8 }}
+{{- if $daemonset.extraEnvVars }}
+{{ toYaml $daemonset.extraEnvVars | nindent 8 }}
 {{- end }}
         securityContext:
-          {{- toYaml $.Values.otellogs.daemonset.containers.otelcol.securityContext | nindent 10 }}
+          {{- toYaml $daemonset.containers.otelcol.securityContext | nindent 10 }}
         ports:
         - name: pprof
           containerPort: 1777
@@ -151,16 +151,16 @@ spec:
       initContainers: # ensure the host path is owned by the otel user group
       - name: changeowner
         # yamllint disable-line rule:line-length
-        image: {{ $.Values.otellogs.daemonset.initContainers.changeowner.image.repository }}:{{ $.Values.otellogs.daemonset.initContainers.changeowner.image.tag }}
-        imagePullPolicy: {{ $.Values.otellogs.daemonset.initContainers.changeowner.image.pullPolicy }}
+        image: {{ $daemonset.initContainers.changeowner.image.repository }}:{{ $daemonset.initContainers.changeowner.image.tag }}
+        imagePullPolicy: {{ $daemonset.initContainers.changeowner.image.pullPolicy }}
         securityContext:
-          {{- toYaml $.Values.otellogs.daemonset.initContainers.changeowner.securityContext | nindent 10 }}
+          {{- toYaml $daemonset.initContainers.changeowner.securityContext | nindent 10 }}
         command:
         - "sh"
         - "-c"
         - |
           chown -R \
-            {{ $.Values.otellogs.daemonset.securityContext.fsGroup }}:{{ $.Values.otellogs.daemonset.securityContext.fsGroup }} \
+            {{ $daemonset.securityContext.fsGroup }}:{{ $daemonset.securityContext.fsGroup }} \
             /var/lib/storage/otc
         volumeMounts:
         - mountPath: /var/lib/storage/otc
@@ -189,8 +189,8 @@ spec:
           path: /var/log/journal/
           type: ""
         name: varlogjournal
-{{- if $.Values.otellogs.daemonset.extraVolumes }}
-{{ toYaml $.Values.otellogs.daemonset.extraVolumes | indent 6 }}
+{{- if $daemonset.extraVolumes }}
+{{ toYaml $daemonset.extraVolumes | indent 6 }}
 {{- end }}
       serviceAccountName: {{ template "sumologic.metadata.name.logs.collector.serviceaccount" $ctx }}
 {{- end }}

--- a/tests/helm/testdata/goldenfile/logs_otc_daemonset/additional-complex.input.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_daemonset/additional-complex.input.yaml
@@ -1,0 +1,83 @@
+otellogs:
+  additionalDaemonSets:
+    linux:
+      nodeSelector:
+        kubernetes.io/os: linux
+      annotations:
+        name: additionalAnnotation
+      labels:
+        name: additionalLabel
+      podLabels:
+        name: additionalPodLabel
+      podAnnotations:
+        name: additionalPodAnnotation
+      securityContext:
+        fsGroup: 0
+        runAsGroup: 0
+        runAsUser: 0
+      priorityClassName: "prio"
+      ## Set securityContext for containers running in pods in log collector daemonset
+      containers:
+        otelcol:
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            privileged: true
+
+      ## Set securityContext for initContainers running in pods in log collector daemonset
+      initContainers:
+        changeowner:
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - CAP_CHOWN
+            privileged: true
+      resources:
+        requests:
+          cpu: 2
+        limits:
+          cpu: 6
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: NotIn
+                    values:
+                      - windows
+      tolerations:
+        - key: "worker"
+          operator: "Equal"
+          value: worker
+          effect: "NoSchedule"
+
+      extraEnvVars:
+        - name: VALUE_FROM_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: secret_name
+              key: secret_key
+
+      extraVolumes:
+        - name: es-certs
+          secret:
+            defaultMode: 420
+            secretName: es-certs
+      extraVolumeMounts:
+        - name: es-certs
+          mountPath: /certs
+          readOnly: true
+  daemonset:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: kubernetes.io/os
+                  operator: NotIn
+                  values:
+                    - linux

--- a/tests/helm/testdata/goldenfile/logs_otc_daemonset/additional-complex.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_daemonset/additional-complex.output.yaml
@@ -1,0 +1,170 @@
+---
+# Source: sumologic/templates/logs/collector/otelcol/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: RELEASE-NAME-sumologic-otelcol-logs-collector-linux
+  namespace: sumologic
+  annotations:
+    name: additionalAnnotation
+  labels:
+    app: RELEASE-NAME-sumologic-otelcol-logs-collector
+    chart: "sumologic-%CURRENT_CHART_VERSION%"
+    release: "RELEASE-NAME"
+    heritage: "Helm"
+    name: additionalLabel
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: RELEASE-NAME-sumologic-otelcol-logs-collector-linux
+  template:
+    metadata:
+      annotations:
+        checksum/config: "%CONFIG_CHECKSUM%"
+        name: additionalPodAnnotation
+      labels:
+        app.kubernetes.io/name: RELEASE-NAME-sumologic-otelcol-logs-collector-linux
+        app.kubernetes.io/app-name: RELEASE-NAME-sumologic-otelcol-logs-collector
+        chart: "sumologic-%CURRENT_CHART_VERSION%"
+        release: "RELEASE-NAME"
+        heritage: "Helm"
+        name: additionalPodLabel
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: NotIn
+                    values:
+                      - windows
+      tolerations:
+        - effect: NoSchedule
+          key: worker
+          operator: Equal
+          value: worker
+      securityContext:
+        fsGroup: 0
+        runAsGroup: 0
+        runAsUser: 0
+      priorityClassName: "prio"
+      containers:
+        - args:
+            - --config=/etc/otelcol/config.yaml
+          image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.92.0-sumo-0"
+          imagePullPolicy: IfNotPresent
+          name: otelcol
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+          resources:
+            limits:
+              cpu: 6
+              memory: 1Gi
+            requests:
+              cpu: 2
+              memory: 32Mi
+          volumeMounts:
+            - mountPath: /etc/otelcol
+              name: otelcol-config
+            - mountPath: /var/log/pods
+              name: varlogpods
+              readOnly: true
+            - mountPath: /var/lib/docker/containers
+              name: varlibdockercontainers
+              readOnly: true
+            - mountPath: /var/lib/storage/otc
+              name: file-storage
+            - mountPath: /var/log/journal
+              name: varlogjournal
+              readOnly: true
+            - mountPath: /certs
+              name: es-certs
+              readOnly: true
+          env:
+            - name: LOGS_METADATA_SVC
+              valueFrom:
+                configMapKeyRef:
+                  name: sumologic-configmap
+                  key: metadataLogs
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+
+            - name: VALUE_FROM_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: secret_key
+                  name: secret_name
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            privileged: true
+          ports:
+            - name: pprof
+              containerPort: 1777
+              protocol: TCP
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+      initContainers: # ensure the host path is owned by the otel user group
+        - name: changeowner
+          # yamllint disable-line rule:line-length
+          image: public.ecr.aws/docker/library/busybox:1.36.0
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            capabilities:
+              add:
+                - CAP_CHOWN
+              drop:
+                - ALL
+            privileged: true
+          command:
+            - "sh"
+            - "-c"
+            - |
+              chown -R \
+                0:0 \
+                /var/lib/storage/otc
+          volumeMounts:
+            - mountPath: /var/lib/storage/otc
+              name: file-storage
+      volumes:
+        - configMap:
+            defaultMode: 420
+            items:
+              - key: config.yaml
+                path: config.yaml
+            name: RELEASE-NAME-sumologic-otelcol-logs-collector
+          name: otelcol-config
+        - hostPath:
+            path: /var/log/pods
+            type: ""
+          name: varlogpods
+        - hostPath:
+            path: /var/lib/docker/containers
+            type: ""
+          name: varlibdockercontainers
+        - hostPath:
+            path: /var/lib/otc
+            type: DirectoryOrCreate
+          name: file-storage
+        - hostPath:
+            path: /var/log/journal/
+            type: ""
+          name: varlogjournal
+        - name: es-certs
+          secret:
+            defaultMode: 420
+            secretName: es-certs
+      serviceAccountName: RELEASE-NAME-sumologic-otelcol-logs-collector


### PR DESCRIPTION
It may be useful to create daemonsets for windows. It will still require more configuration options, but I believe now it will be more predictable for customer. It is more customizable
### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [ ] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features
