### PR TITLE
chore: update Sumo Logic Terraform Provider to 2.28.3

### DIFF
--- a/.changelog/3592.changed.txt
+++ b/.changelog/3592.changed.txt
@@ -1,0 +1,1 @@
+chore: update Sumo Logic Terraform Provider to 2.28.3

--- a/deploy/helm/sumologic/conf/setup/main.tf
+++ b/deploy/helm/sumologic/conf/setup/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     sumologic = {
       source  = "sumologic/sumologic"
-      version = "~> 2.18"
+      version = ">= 2.28.3, < 3.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/tests/helm/testdata/goldenfile/terraform/all_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/all_fields.output.yaml
@@ -365,7 +365,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.18"
+          version = ">= 2.28.3, < 3.0.0"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/testdata/goldenfile/terraform/collector_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/collector_fields.output.yaml
@@ -364,7 +364,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.18"
+          version = ">= 2.28.3, < 3.0.0"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/testdata/goldenfile/terraform/conditional_sources.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/conditional_sources.output.yaml
@@ -349,7 +349,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.18"
+          version = ">= 2.28.3, < 3.0.0"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/testdata/goldenfile/terraform/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/custom.output.yaml
@@ -349,7 +349,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.18"
+          version = ">= 2.28.3, < 3.0.0"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/testdata/goldenfile/terraform/default.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/default.output.yaml
@@ -364,7 +364,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.18"
+          version = ">= 2.28.3, < 3.0.0"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/testdata/goldenfile/terraform/disable_default_metrics.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disable_default_metrics.output.yaml
@@ -363,7 +363,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.18"
+          version = ">= 2.28.3, < 3.0.0"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/testdata/goldenfile/terraform/disabled_dashboards.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disabled_dashboards.output.yaml
@@ -364,7 +364,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.18"
+          version = ">= 2.28.3, < 3.0.0"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/testdata/goldenfile/terraform/disabled_monitors.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disabled_monitors.output.yaml
@@ -364,7 +364,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.18"
+          version = ">= 2.28.3, < 3.0.0"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/testdata/goldenfile/terraform/logs_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/logs_fields.output.yaml
@@ -390,7 +390,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.18"
+          version = ">= 2.28.3, < 3.0.0"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/testdata/goldenfile/terraform/monitors_with_email_notifications.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/monitors_with_email_notifications.output.yaml
@@ -364,7 +364,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.18"
+          version = ">= 2.28.3, < 3.0.0"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/testdata/goldenfile/terraform/monitors_with_single_email.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/monitors_with_single_email.output.yaml
@@ -364,7 +364,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.18"
+          version = ">= 2.28.3, < 3.0.0"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/testdata/goldenfile/terraform/strip_extrapolation.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/strip_extrapolation.output.yaml
@@ -364,7 +364,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.18"
+          version = ">= 2.28.3, < 3.0.0"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/testdata/goldenfile/terraform/traces.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/traces.output.yaml
@@ -352,7 +352,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.18"
+          version = ">= 2.28.3, < 3.0.0"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"

--- a/tests/helm/testdata/goldenfile/terraform/tracing-metrics-disabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/tracing-metrics-disabled.output.yaml
@@ -364,7 +364,7 @@ data:
       required_providers {
         sumologic = {
           source  = "sumologic/sumologic"
-          version = "~> 2.18"
+          version = ">= 2.28.3, < 3.0.0"
         }
         kubernetes = {
           source  = "hashicorp/kubernetes"


### PR DESCRIPTION
Fixes vulnerabilities reported in v2.27.0 and v2.28.0.