### PR TITLE
fix(metrics): change targetallocator ServiceAccount name

### DIFF
--- a/.changelog/3604.fixed.txt
+++ b/.changelog/3604.fixed.txt
@@ -1,0 +1,1 @@
+fix(metrics): change targetallocator ServiceAccount name

--- a/deploy/helm/sumologic/templates/_helpers/_metrics.tpl
+++ b/deploy/helm/sumologic/templates/_helpers/_metrics.tpl
@@ -315,8 +315,13 @@ sumologic.com/app: otelcol
 {{ template "sumologic.metadata.name.metrics.collector.opentelemetrycollector" . }}-targetallocator
 {{- end -}}
 
+{{/*
+The `-sa` suffix at the end is needed to differentiate from the ServiceAccount created by the OpenTelemetry Operator.
+We ended up deferring to the operator on this, and then had to walk this decision back, as we needed to attach our own pull secrets to this ServiceAccount.
+However, this created a conflict where Helm didn't want to overwrite the SA created by the operator. To get around this, the name was changed.
+*/}}
 {{- define "sumologic.metadata.name.metrics.targetallocator.serviceaccount" -}}
-{{ template "sumologic.metadata.name.metrics.targetallocator.name" . }}
+{{ template "sumologic.metadata.name.metrics.targetallocator.name" . }}-sa
 {{- end -}}
 
 {{- define "sumologic.metadata.name.metrics.targetallocator.clusterrole" -}}

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
@@ -27,7 +27,7 @@ spec:
         release: RELEASE-NAME
       podMonitorSelector:
         release: RELEASE-NAME
-    serviceAccount: RELEASE-NAME-sumologic-metrics-targetallocator
+    serviceAccount: RELEASE-NAME-sumologic-metrics-targetallocator-sa
     nodeSelector:
       kubernetes.io/os: linux
     resources: {}

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
@@ -32,7 +32,7 @@ spec:
         smkey: smvalue
       podMonitorSelector:
         pmkey: pmvalue
-    serviceAccount: RELEASE-NAME-sumologic-metrics-targetallocator
+    serviceAccount: RELEASE-NAME-sumologic-metrics-targetallocator-sa
     nodeSelector:
       kubernetes.io/os: linux
       workingGroup: production

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/debug.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/debug.output.yaml
@@ -27,7 +27,7 @@ spec:
         release: RELEASE-NAME
       podMonitorSelector:
         release: RELEASE-NAME
-    serviceAccount: RELEASE-NAME-sumologic-metrics-targetallocator
+    serviceAccount: RELEASE-NAME-sumologic-metrics-targetallocator-sa
     nodeSelector:
       kubernetes.io/os: linux
     resources: {}

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/kubelet.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/kubelet.output.yaml
@@ -27,7 +27,7 @@ spec:
         release: RELEASE-NAME
       podMonitorSelector:
         release: RELEASE-NAME
-    serviceAccount: RELEASE-NAME-sumologic-metrics-targetallocator
+    serviceAccount: RELEASE-NAME-sumologic-metrics-targetallocator-sa
     nodeSelector:
       kubernetes.io/os: linux
     resources: {}


### PR DESCRIPTION
This is to avoid conflict with the operator's default. After the change, we can freely switch between the two without worrying about ownership conflicts. Helm errors if we tell it to manage a resource which already exists and is managed by the operator.

In #3515 we let the operator manage the target allocator's ServiceAccount. Then in #3539, we went back to managing it ourselves, because we needed to attach our own pull secrets to it. This results in an error when upgrading, because Helm refuses to manage a resource which is already managed by the operator, based on standard labels. Changing the name fixes this problem.

Fixes #3588. I'm also going to backport this change to v4.5 and release v4.5.2, as it currently blocks the upgrade for any user with Otel metrics enabled.

<!---
Describe your PR here
-->

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [x] Template tests added for new features
