### PR TITLE
ci: allow backport prefix in PR names

### DIFF
--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -5,7 +5,7 @@
   },
   "CHECKS": {
     "prefixes": [],
-    "regexp": "^(Revert \"|)(docs|fix|feat|test|deps|chore|ci)(\\(.+\\)|)(\\!|): ",
+    "regexp": "^(Revert \"|\\[Backport [^ ]+\\] |)(docs|fix|feat|test|deps|chore|ci)(\\(.+\\)|)(\\!|): ",
     "regexpFlags": "i",
     "ignoreLabels" : []
   },


### PR DESCRIPTION
The PR title checker currently disallows pr title prefixes used by the backporter bot. Fix this.
