### PR TITLE
chore: prepare 4.6.1 release

### DIFF
--- a/.changelog/3618.fixed.txt
+++ b/.changelog/3618.fixed.txt
@@ -1,1 +1,0 @@
-fix(metrics): use namespaceSelector from configuration for additionalServiceMonitors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 <!-- towncrier release notes start -->
 
+## [v4.6.1]
+
+### Released 2024-03-29
+
+### Fixed
+
+- fix(metrics): use namespaceSelector from configuration for additionalServiceMonitors [#3618]
+
+[#3618]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/3618
+[v4.6.1]: https://github.com/SumoLogic/sumologic-kubernetes-collection/releases/v4.6.1
+
 ## [v4.6.0]
 
 ### Released 2024-03-27

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,3 +1,3 @@
-# Deployment Guide for unreleased version
+# Deployment Guide for v4.6
 
 Moved to [/docs/README.md](/docs/README.md)

--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sumologic
-version: 4.6.0
-appVersion: 4.6.0
+version: 4.6.1
+appVersion: 4.6.1
 description: A Helm chart for collecting Kubernetes logs, metrics, traces and events into Sumo Logic.
 type: application
 keywords:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,10 @@
-# Deployment Guide for 4.6
+# Deployment Guide for v4.6
 
 This page has instructions for collecting Kubernetes logs, metrics, and events; enriching them with deployment, pod, and service level
 metadata; and sending them to Sumo Logic. See our [documentation guide](https://help.sumologic.com/docs/observability/kubernetes/) for
 details on our Kubernetes Solution.
 
-- [Deployment Guide for unreleased version](#deployment-guide-for-unreleased-version)
+- [Deployment Guide for v4.6](#deployment-guide-for-v46)
   - [Solution overview](#solution-overview)
     - [Log Collection](#log-collection)
     - [Metrics Collection](#metrics-collection)

--- a/tests/helm/goldenfile_test.go
+++ b/tests/helm/goldenfile_test.go
@@ -132,10 +132,10 @@ func runGoldenFileTest(t *testing.T, valuesFileName string, outputFileName strin
 // expected templates
 func fixupRenderedYaml(yaml string, chartVersion string) string {
 	checksumRegex := regexp.MustCompile("checksum/config: [a-z0-9]{64}")
-	chartsRegex := regexp.MustCompile("([^kubernetes-setup:])" + chartVersion)
+
 	output := yaml
 	output = strings.ReplaceAll(output, releaseName, "RELEASE-NAME")
-	output = chartsRegex.ReplaceAllString(output, "$1%CURRENT_CHART_VERSION%")
+	output = strings.ReplaceAll(output, chartVersion, "%CURRENT_CHART_VERSION%")
 	output = checksumRegex.ReplaceAllLiteralString(output, "checksum/config: '%CONFIG_CHECKSUM%'")
 	output = strings.TrimSuffix(output, "\n")
 	return output


### PR DESCRIPTION
- chore: prepare 4.6.1 release
- fix docs: change headers `Deployment Guide for unreleased version` to `Deployment Guide for v4.6`
- backport of #3626 