### PR TITLE
fix(test): get rid of unsafe regular expression for chart version replacing

### DIFF
--- a/tests/helm/goldenfile_test.go
+++ b/tests/helm/goldenfile_test.go
@@ -132,10 +132,10 @@ func runGoldenFileTest(t *testing.T, valuesFileName string, outputFileName strin
 // expected templates
 func fixupRenderedYaml(yaml string, chartVersion string) string {
 	checksumRegex := regexp.MustCompile("checksum/config: [a-z0-9]{64}")
-	chartsRegex := regexp.MustCompile("([^kubernetes-setup:])" + chartVersion)
+
 	output := yaml
 	output = strings.ReplaceAll(output, releaseName, "RELEASE-NAME")
-	output = chartsRegex.ReplaceAllString(output, "$1%CURRENT_CHART_VERSION%")
+	output = strings.ReplaceAll(output, chartVersion, "%CURRENT_CHART_VERSION%")
 	output = checksumRegex.ReplaceAllLiteralString(output, "checksum/config: '%CONFIG_CHECKSUM%'")
 	output = strings.TrimSuffix(output, "\n")
 	return output


### PR DESCRIPTION
This reverts changes in template tests from https://github.com/SumoLogic/sumologic-kubernetes-collection/commit/f6e9329b54adc0865b51bd9bfe7bae1cfe75c75f

regular expression could replace random characters


<img width="1120" alt="Screenshot 2024-03-29 at 13 13 38" src="https://github.com/SumoLogic/sumologic-kubernetes-collection/assets/73836361/405e3d55-15b6-4f11-b159-1c6e6136ff7f">

what seems to happen in https://github.com/SumoLogic/sumologic-kubernetes-collection/actions/runs/8479476276/job/23233572027

```
    	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -27,3 +27,3 @@
        	            	      (string) (len=11) "annotations": (map[string]interface {}) (len=2) {
        	            	-      (string) (len=15) "checksum/config": (string) (len=17) "%CONFIG_CHECKSUM%",
        	            	+      (string) (len=15) "checksum/config": (string) (len=82) "cbd6863a1bb9610%CURRENT_CHART_VERSION%0a88dd6a9b21781a5cbbe4c9076848d3d521f672b50a",
```



### Checklist

- [x] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features
