### PR TITLE
fix(tests): change Go version in go.mod to 1.22.0

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/SumoLogic/sumologic-kubernetes-collection/tests
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.6.1


### PR DESCRIPTION
I encountered an issue while updating tests for my changes:
```
go: download go1.22 for darwin/amd64: toolchain not available
```

More info: https://github.com/golang/go/issues/65568#issuecomment-1954876836