### PR TITLE
feat: update memory_limiter processor configs

### DIFF
--- a/.changelog/3630.changed.0.txt
+++ b/.changelog/3630.changed.0.txt
@@ -1,0 +1,1 @@
+feat(events): remove memory_limiter processor from the pipeline

--- a/.changelog/3630.changed.1.txt
+++ b/.changelog/3630.changed.1.txt
@@ -1,0 +1,1 @@
+feat: increase limit in memory_limiter procesor to 90%

--- a/deploy/helm/sumologic/conf/events/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/events/otelcol/config.yaml
@@ -37,10 +37,6 @@ processors:
     send_batch_max_size: 2_048
     send_batch_size: 1024
     timeout: 1s
-  memory_limiter:
-    check_interval: 1s
-    limit_percentage: 70
-    spike_limit_percentage: 20
   resource/add_cluster:
     attributes:
       - action: upsert
@@ -84,7 +80,6 @@ service:
         - sumologic/sumologic-mock
 {{- end }}
       processors:
-        - memory_limiter
         - resource/add_cluster
         - source
         - sumologic

--- a/deploy/helm/sumologic/conf/instrumentation/otelcol.instrumentation.conf.yaml
+++ b/deploy/helm/sumologic/conf/instrumentation/otelcol.instrumentation.conf.yaml
@@ -159,7 +159,7 @@ processors:
     ## Maximum amount of memory, in %, targeted to be allocated by the process heap.
     ## Note that typically the total memory usage of process will be about 50MiB higher
     ## than this value.
-    limit_percentage: 75
+    limit_percentage: 90
 
     ## Maximum spike expected between the measurements of memory usage, in %.
     spike_limit_percentage: 20

--- a/deploy/helm/sumologic/conf/instrumentation/traces.gateway.conf.yaml
+++ b/deploy/helm/sumologic/conf/instrumentation/traces.gateway.conf.yaml
@@ -39,7 +39,7 @@ processors:
     ## Maximum amount of memory, in %, targeted to be allocated by the process heap.
     ## Note that typically the total memory usage of process will be about 50MiB higher
     ## than this value.
-    limit_percentage: 75
+    limit_percentage: 90
 
     ## Maximum spike expected between the measurements of memory usage, in %.
     spike_limit_percentage: 20

--- a/deploy/helm/sumologic/conf/instrumentation/traces.sampler.conf.yaml
+++ b/deploy/helm/sumologic/conf/instrumentation/traces.sampler.conf.yaml
@@ -48,7 +48,7 @@ processors:
     ## Maximum amount of memory, in %, targeted to be allocated by the process heap.
     ## Note that typically the total memory usage of process will be about 50MiB higher
     ## than this value.
-    limit_percentage: 75
+    limit_percentage: 90
 
     ## Maximum spike expected between the measurements of memory usage, in %.
     spike_limit_percentage: 20

--- a/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
@@ -328,7 +328,7 @@ processors:
     ## it can result in unnecessary CPU consumption.
     check_interval: 5s
     ## Maximum amount of memory, in %, targeted to be allocated by the process heap.
-    limit_percentage: 75
+    limit_percentage: 90
     ## Spike limit (calculated from available memory). Must be less than limit_percentage.
     spike_limit_percentage: 20
   resource/add_cluster:

--- a/deploy/helm/sumologic/conf/metrics/otelcol/processors.yaml
+++ b/deploy/helm/sumologic/conf/metrics/otelcol/processors.yaml
@@ -62,7 +62,7 @@ memory_limiter:
   ## it can result in unnecessary CPU consumption.
   check_interval: 5s
   ## Maximum amount of memory, in %, targeted to be allocated by the process heap.
-  limit_percentage: 75
+  limit_percentage: 90
   ## Spike limit (calculated from available memory). Must be less than limit_percentage.
   spike_limit_percentage: 20
 

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/SumoLogic/sumologic-kubernetes-collection/tests
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.6.1

--- a/tests/helm/testdata/goldenfile/events_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc/basic.output.yaml
@@ -31,10 +31,6 @@ data:
         send_batch_max_size: 2048
         send_batch_size: 1024
         timeout: 1s
-      memory_limiter:
-        check_interval: 1s
-        limit_percentage: 70
-        spike_limit_percentage: 20
       resource/add_cluster:
         attributes:
         - action: upsert
@@ -66,7 +62,6 @@ data:
           exporters:
           - sumologic
           processors:
-          - memory_limiter
           - resource/add_cluster
           - source
           - sumologic

--- a/tests/helm/testdata/goldenfile/events_otc/options.output.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc/options.output.yaml
@@ -27,10 +27,6 @@ data:
         send_batch_max_size: 2048
         send_batch_size: 1024
         timeout: 1s
-      memory_limiter:
-        check_interval: 1s
-        limit_percentage: 70
-        spike_limit_percentage: 20
       resource/add_cluster:
         attributes:
         - action: upsert
@@ -61,7 +57,6 @@ data:
           exporters:
           - sumologic
           processors:
-          - memory_limiter
           - resource/add_cluster
           - source
           - sumologic

--- a/tests/helm/testdata/goldenfile/events_otc/sumologic-mock.output.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc/sumologic-mock.output.yaml
@@ -39,10 +39,6 @@ data:
         send_batch_max_size: 2048
         send_batch_size: 1024
         timeout: 1s
-      memory_limiter:
-        check_interval: 1s
-        limit_percentage: 70
-        spike_limit_percentage: 20
       resource/add_cluster:
         attributes:
         - action: upsert
@@ -76,7 +72,6 @@ data:
           - debug
           - sumologic/sumologic-mock
           processors:
-          - memory_limiter
           - resource/add_cluster
           - source
           - sumologic

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/debug.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/debug.output.yaml
@@ -180,7 +180,7 @@ data:
         - from: build_hostname
       memory_limiter:
         check_interval: 5s
-        limit_percentage: 75
+        limit_percentage: 90
         spike_limit_percentage: 20
       resource/add_cluster:
         attributes:

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/debug_with_sumologic_mock.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/debug_with_sumologic_mock.output.yaml
@@ -189,7 +189,7 @@ data:
         - from: build_hostname
       memory_limiter:
         check_interval: 5s
-        limit_percentage: 75
+        limit_percentage: 90
         spike_limit_percentage: 20
       resource/add_cluster:
         attributes:

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/debug_with_sumologic_mock_http.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/debug_with_sumologic_mock_http.output.yaml
@@ -211,7 +211,7 @@ data:
         - from: build_hostname
       memory_limiter:
         check_interval: 5s
-        limit_percentage: 75
+        limit_percentage: 90
         spike_limit_percentage: 20
       resource/add_cluster:
         attributes:

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/otel.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/otel.output.yaml
@@ -178,7 +178,7 @@ data:
         - from: build_hostname
       memory_limiter:
         check_interval: 5s
-        limit_percentage: 75
+        limit_percentage: 90
         spike_limit_percentage: 20
       resource/add_cluster:
         attributes:

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/templates.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/templates.output.yaml
@@ -178,7 +178,7 @@ data:
         - from: build_hostname
       memory_limiter:
         check_interval: 5s
-        limit_percentage: 75
+        limit_percentage: 90
         spike_limit_percentage: 20
       resource/add-resource-attribute-container:
         attributes:

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/additional_endpoints.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/additional_endpoints.output.yaml
@@ -74,7 +74,7 @@ data:
         - from: build_hostname
       memory_limiter:
         check_interval: 5s
-        limit_percentage: 75
+        limit_percentage: 90
         spike_limit_percentage: 20
       metricstransform:
         transforms:

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/basic.output.yaml
@@ -74,7 +74,7 @@ data:
         - from: build_hostname
       memory_limiter:
         check_interval: 5s
-        limit_percentage: 75
+        limit_percentage: 90
         spike_limit_percentage: 20
       metricstransform:
         transforms:

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/custom.output.yaml
@@ -151,7 +151,7 @@ data:
         - from: build_hostname
       memory_limiter:
         check_interval: 5s
-        limit_percentage: 75
+        limit_percentage: 90
         spike_limit_percentage: 20
       metricstransform:
         transforms:

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/debug.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/debug.output.yaml
@@ -76,7 +76,7 @@ data:
         - from: build_hostname
       memory_limiter:
         check_interval: 5s
-        limit_percentage: 75
+        limit_percentage: 90
         spike_limit_percentage: 20
       metricstransform:
         transforms:

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/debug_with_sumologic_mock.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/debug_with_sumologic_mock.output.yaml
@@ -99,7 +99,7 @@ data:
         - from: build_hostname
       memory_limiter:
         check_interval: 5s
-        limit_percentage: 75
+        limit_percentage: 90
         spike_limit_percentage: 20
       metricstransform:
         transforms:

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/debug_with_sumologic_mock_http.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/debug_with_sumologic_mock_http.output.yaml
@@ -176,7 +176,7 @@ data:
         - from: build_hostname
       memory_limiter:
         check_interval: 5s
-        limit_percentage: 75
+        limit_percentage: 90
         spike_limit_percentage: 20
       metricstransform:
         transforms:

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/filtered_app_metrics.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/filtered_app_metrics.output.yaml
@@ -98,7 +98,7 @@ data:
         - from: build_hostname
       memory_limiter:
         check_interval: 5s
-        limit_percentage: 75
+        limit_percentage: 90
         spike_limit_percentage: 20
       metricstransform:
         transforms:

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/config-from-merge.output.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/config-from-merge.output.yaml
@@ -70,7 +70,7 @@ data:
         passthrough: false
       memory_limiter:
         check_interval: 5s
-        limit_percentage: 75
+        limit_percentage: 90
         spike_limit_percentage: 20
       resource:
         attributes:

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/config-from-values-backward-compatibility.output.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/config-from-values-backward-compatibility.output.yaml
@@ -71,7 +71,7 @@ data:
         passthrough: false
       memory_limiter:
         check_interval: 5s
-        limit_percentage: 75
+        limit_percentage: 90
         spike_limit_percentage: 20
       resource:
         attributes:

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/traces-gateway-disabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/traces-gateway-disabled.output.yaml
@@ -82,7 +82,7 @@ data:
         passthrough: false
       memory_limiter:
         check_interval: 5s
-        limit_percentage: 75
+        limit_percentage: 90
         spike_limit_percentage: 20
       resource:
         attributes:

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/traces-gateway-disabled.sumologic-mock.output.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/traces-gateway-disabled.sumologic-mock.output.yaml
@@ -84,7 +84,7 @@ data:
         passthrough: false
       memory_limiter:
         check_interval: 5s
-        limit_percentage: 75
+        limit_percentage: 90
         spike_limit_percentage: 20
       resource:
         attributes:

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/traces-gateway-enabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/traces-gateway-enabled.output.yaml
@@ -70,7 +70,7 @@ data:
         passthrough: false
       memory_limiter:
         check_interval: 5s
-        limit_percentage: 75
+        limit_percentage: 90
         spike_limit_percentage: 20
       resource:
         attributes:

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/traces-gateway-enabled.sumologic-mock.output.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/traces-gateway-enabled.sumologic-mock.output.yaml
@@ -84,7 +84,7 @@ data:
         passthrough: false
       memory_limiter:
         check_interval: 5s
-        limit_percentage: 75
+        limit_percentage: 90
         spike_limit_percentage: 20
       resource:
         attributes:

--- a/tests/helm/testdata/goldenfile/traces-gateway-loadbalancing/config-from-merge.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-gateway-loadbalancing/config-from-merge.output.yaml
@@ -39,7 +39,7 @@ data:
         timeout: 5s
       memory_limiter:
         check_interval: 5s
-        limit_percentage: 75
+        limit_percentage: 90
         spike_limit_percentage: 20
     receivers:
       otlp:

--- a/tests/helm/testdata/goldenfile/traces-gateway-loadbalancing/config-from-values-backward-compatibility.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-gateway-loadbalancing/config-from-values-backward-compatibility.output.yaml
@@ -40,7 +40,7 @@ data:
         timeout: 5s
       memory_limiter:
         check_interval: 5s
-        limit_percentage: 75
+        limit_percentage: 90
         spike_limit_percentage: 20
     receivers:
       otlp:

--- a/tests/helm/testdata/goldenfile/traces-gateway-loadbalancing/sumologic-mock.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-gateway-loadbalancing/sumologic-mock.output.yaml
@@ -41,7 +41,7 @@ data:
         timeout: 5s
       memory_limiter:
         check_interval: 5s
-        limit_percentage: 75
+        limit_percentage: 90
         spike_limit_percentage: 20
     receivers:
       otlp:

--- a/tests/helm/testdata/goldenfile/traces-gateway-loadbalancing/traces-gateway-true.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-gateway-loadbalancing/traces-gateway-true.output.yaml
@@ -39,7 +39,7 @@ data:
         timeout: 5s
       memory_limiter:
         check_interval: 5s
-        limit_percentage: 75
+        limit_percentage: 90
         spike_limit_percentage: 20
     receivers:
       otlp:

--- a/tests/helm/testdata/goldenfile/traces-sampler/config-from-merge.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-sampler/config-from-merge.output.yaml
@@ -34,7 +34,7 @@ data:
         num_traces: 200000
       memory_limiter:
         check_interval: 5s
-        limit_percentage: 75
+        limit_percentage: 90
         spike_limit_percentage: 20
     receivers:
       otlp:

--- a/tests/helm/testdata/goldenfile/traces-sampler/config-from-values-backward-compatibility.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-sampler/config-from-values-backward-compatibility.output.yaml
@@ -35,7 +35,7 @@ data:
         num_traces: 10
       memory_limiter:
         check_interval: 5s
-        limit_percentage: 75
+        limit_percentage: 90
         spike_limit_percentage: 20
     receivers:
       otlp:

--- a/tests/helm/testdata/goldenfile/traces-sampler/httpendpoint.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-sampler/httpendpoint.output.yaml
@@ -34,7 +34,7 @@ data:
         num_traces: 200000
       memory_limiter:
         check_interval: 5s
-        limit_percentage: 75
+        limit_percentage: 90
         spike_limit_percentage: 20
     receivers:
       otlp:

--- a/tests/helm/testdata/goldenfile/traces-sampler/persistence-enabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-sampler/persistence-enabled.output.yaml
@@ -41,7 +41,7 @@ data:
         num_traces: 200000
       memory_limiter:
         check_interval: 5s
-        limit_percentage: 75
+        limit_percentage: 90
         spike_limit_percentage: 20
     receivers:
       otlp:

--- a/tests/helm/testdata/goldenfile/traces-sampler/simple.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-sampler/simple.output.yaml
@@ -34,7 +34,7 @@ data:
         num_traces: 200000
       memory_limiter:
         check_interval: 5s
-        limit_percentage: 75
+        limit_percentage: 90
         spike_limit_percentage: 20
     receivers:
       otlp:

--- a/tests/helm/testdata/goldenfile/traces-sampler/sumologic-mock.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-sampler/sumologic-mock.output.yaml
@@ -39,7 +39,7 @@ data:
         num_traces: 200000
       memory_limiter:
         check_interval: 5s
-        limit_percentage: 75
+        limit_percentage: 90
         spike_limit_percentage: 20
     receivers:
       otlp:


### PR DESCRIPTION
Change `memory_limiter` usage:

- removed in events collector, as we can allow crashes there; essentially it can be seen as a breaking change
- increased the limit to 90% in other otelcol instances

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [X] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features
