### PR TITLE
docs(filtering): Fix Documentation for Metrics Filtering

### DIFF
--- a/docs/filtering.md
+++ b/docs/filtering.md
@@ -312,7 +312,7 @@ sumologic:
             metrics:
               metric:
                 ## Exclude all metrics from "sumologic" namespace
-                - `resource.attributes["k8s.namespace.name"] == "sumologic"`
+                - 'resource.attributes["k8s.namespace.name"] == "sumologic"'
 ```
 
 #### Drop metric datapoints with unspecified type


### PR DESCRIPTION
Fixing the surrounding quotes in the documented example of filtering metrics using a k8s namespace.

The current usage of starting the string with backticks instead of single quotes is invalid YAML.

### Checklist

- [ ] Changelog updated or skip changelog label added
- [X] Documentation updated
- [X] Template tests added for new features - N/A
- [X] Integration tests added or modified for major features - N/A
