### PR TITLE
chore: update metrics-server to 6.13.1 and telegraf-operator to 1.4.0

### DIFF
--- a/.changelog/3641.changed.0.txt
+++ b/.changelog/3641.changed.0.txt
@@ -1,0 +1,1 @@
+deps: update metrics-server to 6.13.1

--- a/.changelog/3641.changed.1.txt
+++ b/.changelog/3641.changed.1.txt
@@ -1,0 +1,1 @@
+deps: update telegraf-operator to 1.4.0

--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -21,11 +21,11 @@ dependencies:
     repository: https://falcosecurity.github.io/charts
     condition: falco.enabled
   - name: metrics-server
-    version: 6.11.2
+    version: 6.13.1
     repository: https://charts.bitnami.com/bitnami
     condition: metrics-server.enabled
   - name: telegraf-operator
-    version: 1.3.12
+    version: 1.4.0
     repository: https://helm.influxdata.com/
     condition: telegraf-operator.enabled
   - name: tailing-sidecar-operator

--- a/tests/helm/testdata/goldenfile/metrics-server/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics-server/basic.output.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: metrics-server
     app.kubernetes.io/version: 0.7.0
-    helm.sh/chart: metrics-server-6.11.2
+    helm.sh/chart: metrics-server-6.13.1
 spec:
   replicas: 1
   selector:
@@ -26,9 +26,12 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: metrics-server
         app.kubernetes.io/version: 0.7.0
-        helm.sh/chart: metrics-server-6.11.2
+        helm.sh/chart: metrics-server-6.13.1
     spec:
       serviceAccountName: RELEASE-NAME-metrics-server
+      volumes:
+        - emptyDir: {}
+          name: empty-dir
       affinity:
         podAffinity:
 
@@ -47,7 +50,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
         - name: metrics-server
-          image: docker.io/bitnami/metrics-server:0.7.0-debian-12-r7
+          image: docker.io/bitnami/metrics-server:0.7.0-debian-12-r8
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false
@@ -56,6 +59,7 @@ spec:
                 - ALL
             privileged: false
             readOnlyRootFilesystem: false
+            runAsGroup: 0
             runAsNonRoot: true
             runAsUser: 1001
             seccompProfile:
@@ -91,3 +95,10 @@ spec:
               path: /readyz
               port: https
               scheme: HTTPS
+          volumeMounts:
+            - mountPath: "/tmp"
+              name: "empty-dir"
+              subPath: "tmp-dir"
+            - mountPath: "/opt/bitnami/metrics-server/apiserver.local.config"
+              name: "empty-dir"
+              subPath: "app-tmp-dir"


### PR DESCRIPTION
<!---
Describe your PR here
-->

Worth mentioning: metrics-server and falco can be upgraded to a new major version; opentelemetry-operator has some troubles when upgrading to v0.50.0 that will be solved later

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features
