### PR TITLE
ci: fix dependency checker

### DIFF
--- a/ci/check_dependencies/helm_charts.py
+++ b/ci/check_dependencies/helm_charts.py
@@ -12,7 +12,7 @@ VERSION_IDX = 0
 CREATED_IDX = 1
 
 # We ignore Prometheus here, as we're locked to whatever version is CRD-compatible with OpenShift
-DEPENDENCIES_TO_IGNORE=("kube-prometheus-stack")
+DEPENDENCIES_TO_IGNORE=("kube-prometheus-stack", "falco")
 
 def get_info() -> list[str]:
     output_lines = []

--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -38,5 +38,5 @@ dependencies:
     condition: opentelemetry-operator.enabled,sumologic.metrics.collector.otelcol.enabled
   - name: prometheus-windows-exporter
     repository: https://prometheus-community.github.io/helm-charts
-    version: "0.3.*"
+    version: 0.3.1
     condition: prometheus-windows-exporter.enabled,sumologic.metrics.collector.otelcol.enabled


### PR DESCRIPTION
The dependency checker can't deal with non-pinned versions, so I pinned prometheus-windows-exporter. There isn't any reason not to keep it pinned like the rest of our dependencies, as far as I'm aware.

I've also added Falco to the ignore list, as we can only upgrade it in v5.