### PR TITLE
chore: make dependabot group k8s package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,12 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/tests/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      kubernetes:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
 
     labels:
       - skip-changelog


### PR DESCRIPTION
Make dependabot submit K8s package updates in one PR. I've also changed the update cadence to weekly.
