### PR TITLE
deps: bump otel-operator to 0.49.0

### DIFF
--- a/.changelog/3671.changed.txt
+++ b/.changelog/3671.changed.txt
@@ -1,0 +1,1 @@
+deps: bump otel-operator to 0.49.0

--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -33,7 +33,7 @@ dependencies:
     repository: https://sumologic.github.io/tailing-sidecar
     condition: tailing-sidecar-operator.enabled
   - name: opentelemetry-operator
-    version: 0.47.1
+    version: 0.49.0
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     condition: opentelemetry-operator.enabled,sumologic.metrics.collector.otelcol.enabled
   - name: prometheus-windows-exporter

--- a/docs/README.md
+++ b/docs/README.md
@@ -108,7 +108,7 @@ The following table displays the currently used software versions for our Helm c
 | Name                                      | Version |
 | ----------------------------------------- | ------- |
 | OpenTelemetry Collector                   | 0.92.0  |
-| OpenTelemetry Operator                    | 0.47.1  |
+| OpenTelemetry Operator                    | 0.49.0  |
 | kube-prometheus-stack/Prometheus Operator | 40.5.0  |
 | Falco                                     | 3.8.7   |
 | Telegraf Operator                         | 1.3.12  |


### PR DESCRIPTION
Can't upgrade any further for now due to https://github.com/open-telemetry/opentelemetry-helm-charts/pull/1065.

Resolves #3655, at least for now.

