### PR TITLE
feat: add option to send otel metrics through otel collector

### DIFF
--- a/deploy/helm/sumologic/conf/instrumentation/otelcol.instrumentation.conf.yaml
+++ b/deploy/helm/sumologic/conf/instrumentation/otelcol.instrumentation.conf.yaml
@@ -7,6 +7,10 @@ exporters:
     verbosity: detailed
 {{- end }}
 
+{{ - if eq .Values.metricsGateway.enabled true }}
+  otlphttp/metrics:
+    endpoint: http://${METADATA_METRICS_SVC}.${NAMESPACE}.svc.{{ .Values.sumologic.clusterDNSDomain }}.:4318
+{{ - else }}
   sumologic/metrics:
     client: '{{ include "sumologic.sumo_client" . }}'
     endpoint: ${SUMO_ENDPOINT_DEFAULT_METRICS_SOURCE}
@@ -39,6 +43,7 @@ exporters:
       ## num_seconds is the number of seconds to buffer in case of a backend outage
       ## requests_per_second is the average number of requests per seconds.
       queue_size: 5000
+{{- end }}
 {{- if eq .Values.tracesGateway.enabled true }}
   otlphttp/traces:
     endpoint: 'http://{{ include "otelcolinstrumentation.exporter.endpoint" . }}:4318'
@@ -197,7 +202,11 @@ service:
       receivers: [otlp, otlp/deprecated]
       processors: [memory_limiter, k8s_tagger, source, resource, batch]
       exporters:
+{{- if eq .Values.metricsGateway.enabled true }}
+        - otlphttp/metrics
+{{- else }}
         - sumologic/metrics
+{{- end}}
 {{- if eq .Values.debug.instrumentation.otelcolInstrumentation.print true }}
         - debug
 {{- end }}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -1765,6 +1765,10 @@ metadata:
       ## To use maxUnavailable, set minAvailable to null and uncomment the below:
       # maxUnavailable: 1
 
+# Send OTEL metrics through otelcol
+metricsGateway:
+  enabled: false
+
 ## Configure traces-gateway
 ## ref: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/main/docs/opentelemetry-collector/traces.md
 tracesGateway:


### PR DESCRIPTION
Currently OTEL metrics are sent straight to sumo logic without going through the OTEL collector and any customer configured filtering and modification pipeline steps. This adds an option to send them through the collector.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [ ] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features
