### PR TITLE
chore: prepare release 3.19.0

### DIFF
--- a/.changelog/3595.changed.txt
+++ b/.changelog/3595.changed.txt
@@ -1,1 +1,0 @@
-chore(setup): upgrade setup job from 3.11.0 to 3.14.0

--- a/.changelog/3695.changed.0.txt
+++ b/.changelog/3695.changed.0.txt
@@ -1,1 +1,0 @@
-deps: upgrade `opentelemetry-operator` subchart to `v0.49.0` 

--- a/.changelog/3695.changed.1.txt
+++ b/.changelog/3695.changed.1.txt
@@ -1,1 +1,0 @@
-deps: upgrade falco subchart to '3.8.7`

--- a/.changelog/3695.changed.2.txt
+++ b/.changelog/3695.changed.2.txt
@@ -1,1 +1,0 @@
-deps: upgrade metrics-server subchart to `6.13.1`

--- a/.changelog/3695.changed.3.txt
+++ b/.changelog/3695.changed.3.txt
@@ -1,1 +1,0 @@
-deps: upgrade telegraf-operator subchart to `1.4.0`

--- a/.changelog/3695.changed.4.txt
+++ b/.changelog/3695.changed.4.txt
@@ -1,1 +1,0 @@
-deps: upgrade tailing-sidecar-operator subchart to `0.12.0`

--- a/.changelog/3695.changed.5.txt
+++ b/.changelog/3695.changed.5.txt
@@ -1,1 +1,0 @@
-deps: upgrade fluent-bit subchart to `0.46.5`

--- a/.changelog/3696.changed.txt
+++ b/.changelog/3696.changed.txt
@@ -1,1 +1,0 @@
-chore: update OpenTelemetry Collector to v0.99.0-sumo-0

--- a/.changelog/3698.changed.txt
+++ b/.changelog/3698.changed.txt
@@ -1,1 +1,0 @@
-chore: update nginx image to 1.26.0-sumo-0

--- a/.changelog/3700.changed.txt
+++ b/.changelog/3700.changed.txt
@@ -1,1 +1,0 @@
-chore(setup): upgrade setup job from 3.11.0 to 3.14.0

--- a/.changelog/3701.changed.txt
+++ b/.changelog/3701.changed.txt
@@ -1,1 +1,0 @@
-chore: update fluentd image to 1.16.5-sumo-0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 <!-- towncrier release notes start -->
 
+## [v3.19.0]
+
+### Released 2024-05-14
+
+### Changed
+
+- deps(setup): upgrade setup job from 3.11.0 to 3.14.0 [#3595], [#3700]
+- deps: upgrade telegraf-operator subchart to `1.4.0` [#3695]
+- deps: upgrade fluent-bit subchart to `0.46.5` [#3695]
+- deps: upgrade tailing-sidecar-operator subchart to `0.12.0` [#3695]
+- deps: upgrade `opentelemetry-operator` subchart to `v0.49.0` [#3695]
+- deps: upgrade metrics-server subchart to `6.13.1` [#3695]
+- deps: upgrade falco subchart to '3.8.7` [#3695]
+- deps: update OpenTelemetry Collector to v0.99.0-sumo-0 [#3696]
+- deps: update nginx image to 1.26.0-sumo-0 [#3698]
+- deps: update fluentd image to 1.16.5-sumo-0 [#3701]
+
+[#3595]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/3595
+[#3700]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/3700
+[#3695]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/3695
+[#3696]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/3696
+[#3698]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/3698
+[#3701]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/3701
+[v3.19.0]: https://github.com/SumoLogic/sumologic-kubernetes-collection/releases/v3.19.0
+
 ## [v3.18.0]
 
 ### Released 2024-01-24

--- a/README.md
+++ b/README.md
@@ -22,18 +22,19 @@ release.
 
 | version                                                                                                 | planned end of life date |
 | ------------------------------------------------------------------------------------------------------- | ------------------------ |
-| [v3.18](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v3.18/docs/README.md) | 2024-04-20               |
-| [v3.17](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v3.17/docs/README.md) | 2024-04-20               |
-| [v3.16](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v3.16/docs/README.md) | 2024-04-20               |
-| [v3.15](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v3.15/docs/README.md) | 2024-04-18               |
-| [v3.14](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v3.14/docs/README.md) | 2024-03-18               |
-| [v3.13](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v3.13/docs/README.md) | 2024-03-01               |
-| [v3.12](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v3.12/docs/README.md) | 2024-02-21               |
+| [v3.19](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v3.19/docs/README.md) | 2024-08-15               |
 
 ### Unsupported versions
 
 | version                                                                                                   | end of life date |
 | --------------------------------------------------------------------------------------------------------- | ---------------- |
+| [v3.18](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v3.18/docs/README.md)   | 2024-04-20       |
+| [v3.17](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v3.17/docs/README.md)   | 2024-04-20       |
+| [v3.16](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v3.16/docs/README.md)   | 2024-04-20       |
+| [v3.15](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v3.15/docs/README.md)   | 2024-04-18       |
+| [v3.14](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v3.14/docs/README.md)   | 2024-03-18       |
+| [v3.13](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v3.13/docs/README.md)   | 2024-03-01       |
+| [v3.12](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v3.12/docs/README.md)   | 2024-02-21       |
 | [v3.11](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v3.11/docs/README.md)   | 2024-02-07       |
 | [v3.10](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v3.10/docs/README.md)   | 2024-01-28       |
 | [v3.9](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v3.9/docs/README.md)     | 2024-01-06       |

--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sumologic
-version: 3.18.0
-appVersion: 3.18.0
+version: 3.19.0
+appVersion: 3.19.0
 description: A Helm chart for collecting Kubernetes logs, metrics, traces and events into Sumo Logic.
 type: application
 keywords:


### PR DESCRIPTION
This is the final release of the v3 line. I've set the end of support date to mid-August to give users a bit more time to upgrade.

<!---
Describe your PR here
-->

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [x] Documentation updated
