### PR TITLE
Upgrade fluent-bit helm chart

### DIFF
--- a/.changelog/3715.changed.0.txt
+++ b/.changelog/3715.changed.0.txt
@@ -1,0 +1,1 @@
+deps: upgrade fluent-bit subchart to `0.46.7`

--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -13,7 +13,7 @@ sources:
   - https://github.com/SumoLogic/sumologic-kubernetes-collection
 dependencies:
   - name: fluent-bit
-    version: 0.46.5
+    version: 0.46.7
     repository: https://fluent.github.io/helm-charts
     condition: fluent-bit.enabled,sumologic.logs.enabled
   - name: kube-prometheus-stack


### PR DESCRIPTION
v0.46.7 of the fluent-bit helm chart addresses CVE-2024-4323