### PR TITLE
Remove reference to fluent-bit in the docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -111,8 +111,6 @@ The following table displays the currently used software versions for our Helm c
 | Falco                                     | 3.3.0   |
 | Telegraf Operator                         | 1.3.10  |
 | Tailing Sidecar Operator                  | 0.8.0   |
-| Fluentd                                   | 1.15.3  |
-| Fluent Bit                                | 2.1.6   |
 
 ### ARM support
 


### PR DESCRIPTION
fluent-bit and fluentd were removed starting with v4.