### PR TITLE
chore: Backport changes from 3.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 <!-- towncrier release notes start -->
 
+## [v3.19.1]
+
+### Released 2024-05-21
+
+### Changed
+
+- deps: upgrade fluent-bit subchart to `0.46.7` [#3715]
+
+[#3715]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/3715
+[v3.19.1]: https://github.com/SumoLogic/sumologic-kubernetes-collection/releases/v3.19.1
+
 ## [v3.19.0]
 
 ### Released 2024-05-14

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ release.
 | [v4.3](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v4.3/docs/README.md)   | 2024-07-24               |
 | [v4.2](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v4.2/docs/README.md)   | 2024-06-13               |
 | [v4.1](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v4.1/docs/README.md)   | 2024-05-27               |
-| [v3.19](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v3.19/docs/README.md) | 2024-08-15               |
+| [v3.19](https://github.com/SumoLogic/sumologic-kubernetes-collection/tree/release-v3.19/docs/README.md) | 2024-08-21               |
 
 ### Unsupported versions
 


### PR DESCRIPTION
Backport changes from 3.19.1 
