### PR TITLE
chore: Backport release v4.7.1 (#3726)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 <!-- towncrier release notes start -->
 
+## [v4.7.1]
+
+### Released 2024-05-22
+
+- chore: Upgrading tailing-sidecar to v0.13.0 [#3725]
+
+[#3725]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/3725
+[v4.7.1]: https://github.com/SumoLogic/sumologic-kubernetes-collection/releases/v4.7.1
+
 ## [v3.19.2]
 
 ### Released 2024-05-22

--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sumologic
-version: 4.7.0
-appVersion: 4.7.0
+version: 4.7.1
+appVersion: 4.7.1
 description: A Helm chart for collecting Kubernetes logs, metrics, traces and events into Sumo Logic.
 type: application
 keywords:


### PR DESCRIPTION
(cherry picked from commit 1d42a8bd80ca92a5025a3aff880a1ba027bbf57c)

[Backport main] release v4.7.1 (#3726)

- [x] Documentation updated
