### PR TITLE
chore: prepare release v3.19.4

### DIFF
--- a/.changelog/3738.changed.txt
+++ b/.changelog/3738.changed.txt
@@ -1,1 +1,0 @@
-deps: update OpenTelemetry Collector to v0.100.0-sumo-0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 <!-- towncrier release notes start -->
 
+## [v3.19.4]
+
+### Released 2024-05-27
+
+### Changed
+
+- deps: update OpenTelemetry Collector to v0.100.0-sumo-0 [#3738]
+
+[#3738]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/3738
+[v3.19.4]: https://github.com/SumoLogic/sumologic-kubernetes-collection/releases/v3.19.4
+
 ## [v3.19.3]
 
 ### Released 2024-05-23

--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sumologic
-version: 3.19.3
-appVersion: 3.19.3
+version: 3.19.4
+appVersion: 3.19.4
 description: A Helm chart for collecting Kubernetes logs, metrics, traces and events into Sumo Logic.
 type: application
 keywords:


### PR DESCRIPTION
Prepare v3.19.4 with upgraded otel collector. This is primarily so we can have a v3 release that includes the fix for https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32170, which appears to be affecting several customers.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [x] Documentation updated
