### PR TITLE
deps(test): upgrade e2e-framework to 0.3.0

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -15,7 +15,7 @@ require (
 	k8s.io/apimachinery v0.30.1
 	k8s.io/klog/v2 v2.120.1
 	k8s.io/kube-aggregator v0.30.1
-	sigs.k8s.io/e2e-framework v0.2.0
+	sigs.k8s.io/e2e-framework v0.3.0
 )
 
 require (

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -276,8 +276,8 @@ k8s.io/utils v0.0.0-20240310230437-4693a0247e57 h1:gbqbevonBh57eILzModw6mrkbwM0g
 k8s.io/utils v0.0.0-20240310230437-4693a0247e57/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/controller-runtime v0.18.2 h1:RqVW6Kpeaji67CY5nPEfRz6ZfFMk0lWQlNrLqlNpx+Q=
 sigs.k8s.io/controller-runtime v0.18.2/go.mod h1:tuAt1+wbVsXIT8lPtk5RURxqAnq7xkpv2Mhttslg7Hw=
-sigs.k8s.io/e2e-framework v0.2.0 h1:gD6AWWAHFcHibI69E9TgkNFhh0mVwWtRCHy2RU057jQ=
-sigs.k8s.io/e2e-framework v0.2.0/go.mod h1:E6JXj/V4PIlb95jsn2WrNKG+Shb45xaaI7C0+BH4PL8=
+sigs.k8s.io/e2e-framework v0.3.0 h1:eqQALBtPCth8+ulTs6lcPK7ytV5rZSSHJzQHZph4O7U=
+sigs.k8s.io/e2e-framework v0.3.0/go.mod h1:C+ef37/D90Dc7Xq1jQnNbJYscrUGpxrWog9bx2KIa+c=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+sGiqlzvrtq4=

--- a/tests/integration/internal/ctxopts/context_opts.go
+++ b/tests/integration/internal/ctxopts/context_opts.go
@@ -31,5 +31,8 @@ func WithNamespace(ctx context.Context, namespace string) context.Context {
 
 func Namespace(ctx context.Context) string {
 	v := ctx.Value(ctxKeyNameNamespace)
+	if v == nil {
+		return ""
+	}
 	return v.(string)
 }

--- a/tests/integration/internal/stepfuncs/helm.go
+++ b/tests/integration/internal/stepfuncs/helm.go
@@ -115,6 +115,9 @@ func HelmInstallOpt(path string, releaseName string) features.Func {
 func HelmInstallTestOpt(path string) features.Func {
 	return func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
 		releaseName := strings.ReleaseNameFromT(t)
+		// create the namespace here so it can be propagated in the context
+		// only the final before test action gets to modify the context
+		ctx = KubectlCreateNamespaceTestOpt()(ctx, t, envConf)
 		return HelmInstallOpt(path, releaseName)(ctx, t, envConf)
 	}
 }

--- a/tests/integration/internal/stepfuncs/kubectl.go
+++ b/tests/integration/internal/stepfuncs/kubectl.go
@@ -23,6 +23,8 @@ import (
 func KubectlDeleteNamespaceTestOpt(force bool) features.Func {
 	return func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
 		namespace := ctxopts.Namespace(ctx)
+		kubectlOptions := ctxopts.KubectlOptions(ctx)
+		kubectlOptions.Namespace = ""
 		return KubectlDeleteNamespaceOpt(namespace, force)(ctx, t, envConf)
 	}
 }
@@ -50,6 +52,7 @@ func KubectlCreateNamespaceOpt(namespace string) features.Func {
 	return func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
 		kubectlOptions := ctxopts.KubectlOptions(ctx)
 		kubectlOptions.Namespace = namespace
+		ctx = ctxopts.WithKubectlOptions(ctx, kubectlOptions)
 		k8s.CreateNamespace(t, kubectlOptions, namespace)
 		return ctxopts.WithNamespace(ctx, namespace)
 	}


### PR DESCRIPTION
Update to [e2e_framework 0.3.0](https://github.com/kubernetes-sigs/e2e-framework/releases/tag/v0.3.0). Changes:
* creating the kind cluster is now a bit different, as it's part of a broader framework of cluster providers
* context is not actually passed between pre-test actions, so all changes need to be made in the final action

I plan to do some more cleanups of the context handling in a follow-up.
