### PR TITLE
test(integration): use different namespaces for instrumentation tests

### DIFF
--- a/tests/integration/helm_opentelemetry_operator_enabled_test.go
+++ b/tests/integration/helm_opentelemetry_operator_enabled_test.go
@@ -72,8 +72,8 @@ func Test_Helm_OpenTelemetry_Operator_Enabled(t *testing.T) {
 			)
 			return ctx
 		}).
-		Assess("instrumentation-cr in ot-operator1 namespace is created", func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
-			res := envConf.Client().Resources("ot-operator1")
+		Assess("instrumentation-cr in ot-operator-enabled-1 namespace is created", func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
+			res := envConf.Client().Resources("ot-operator-enabled-1")
 			releaseName := ctxopts.HelmRelease(ctx)
 			labelSelector := fmt.Sprintf("app=%s-sumologic-ot-operator-instr", releaseName)
 			instrs := otoperatorappsv1.InstrumentationList{}
@@ -90,8 +90,8 @@ func Test_Helm_OpenTelemetry_Operator_Enabled(t *testing.T) {
 			)
 			return ctx
 		}).
-		Assess("instrumentation-cr in ot-operator2 namespace is created", func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
-			res := envConf.Client().Resources("ot-operator2")
+		Assess("instrumentation-cr in ot-operator-enabled-2 namespace is created", func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
+			res := envConf.Client().Resources("ot-operator-enabled-2")
 			releaseName := ctxopts.HelmRelease(ctx)
 			labelSelector := fmt.Sprintf("app=%s-sumologic-ot-operator-instr", releaseName)
 			instrs := otoperatorappsv1.InstrumentationList{}

--- a/tests/integration/helm_opentelemetry_operator_instr_test.go
+++ b/tests/integration/helm_opentelemetry_operator_instr_test.go
@@ -33,8 +33,6 @@ func Test_OpenTelemetry_Operator_Instrumentation(t *testing.T) {
 		waitDuration = time.Minute * 2
 	)
 
-	var originalNamespaceKey internalCtxKey = "originalNamespace"
-
 	installChecks := []featureCheck{
 		CheckSumologicSecret(3),
 		CheckTracesWithoutGatewayInstall,
@@ -75,8 +73,8 @@ func Test_OpenTelemetry_Operator_Instrumentation(t *testing.T) {
 			)
 			return ctx
 		}).
-		Assess("instrumentation-cr in ot-operator1 namespace is created", func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
-			res := envConf.Client().Resources("ot-operator1")
+		Assess("instrumentation-cr in ot-operator-instr-1 namespace is created", func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
+			res := envConf.Client().Resources("ot-operator-instr-1")
 			releaseName := ctxopts.HelmRelease(ctx)
 			labelSelector := fmt.Sprintf("app=%s-sumologic-ot-operator-instr", releaseName)
 			instrs := otoperatorappsv1.InstrumentationList{}
@@ -93,8 +91,8 @@ func Test_OpenTelemetry_Operator_Instrumentation(t *testing.T) {
 			)
 			return ctx
 		}).
-		Assess("instrumentation-cr in ot-operator2 namespace is created", func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
-			res := envConf.Client().Resources("ot-operator2")
+		Assess("instrumentation-cr in ot-operator-instr-2 namespace is created", func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
+			res := envConf.Client().Resources("ot-operator-instr-2")
 			releaseName := ctxopts.HelmRelease(ctx)
 			labelSelector := fmt.Sprintf("app=%s-sumologic-ot-operator-instr", releaseName)
 			instrs := otoperatorappsv1.InstrumentationList{}
@@ -121,24 +119,5 @@ func Test_OpenTelemetry_Operator_Instrumentation(t *testing.T) {
 
 	curlApp := GetCurlAppFeature()
 
-	useDefaultNs := func(ctx context.Context, envConf *envconf.Config, t *testing.T, _ features.Feature) (context.Context, error) {
-		originalNamespace := ctxopts.Namespace(ctx)
-		ctx = context.WithValue(ctx, originalNamespaceKey, originalNamespace)
-		kubectlOptions := ctxopts.KubectlOptions(ctx)
-		kubectlOptions.Namespace = originalNamespace
-		ctx = ctxopts.WithKubectlOptions(ctx, kubectlOptions)
-		ctx = ctxopts.WithNamespace(ctx, originalNamespace)
-		return ctx, nil
-	}
-
-	restoreOriginalNamespace := func(ctx context.Context, envConf *envconf.Config, t *testing.T, _ features.Feature) (context.Context, error) {
-		originalNamespace := ctx.Value(originalNamespaceKey).(string)
-		kubectlOptions := ctxopts.KubectlOptions(ctx)
-		kubectlOptions.Namespace = originalNamespace
-		ctx = ctxopts.WithKubectlOptions(ctx, kubectlOptions)
-		ctx = ctxopts.WithNamespace(ctx, originalNamespace)
-		return ctx, nil
-	}
-
-	testenv.BeforeEachFeature(useDefaultNs).AfterEachFeature(restoreOriginalNamespace).Test(t, featInstall, featOpenTelemetryOperator, featDotnetApp, featJavaApp, featNodeJSApp, featPythonApp, curlApp)
+	testenv.Test(t, featInstall, featOpenTelemetryOperator, featDotnetApp, featJavaApp, featNodeJSApp, featPythonApp, curlApp)
 }

--- a/tests/integration/internal/k8s/pods.go
+++ b/tests/integration/internal/k8s/pods.go
@@ -81,7 +81,8 @@ func WaitUntilSumologicMockAvailable(
 	waitDuration time.Duration,
 	tickDuration time.Duration,
 ) {
-	k8s.WaitUntilServiceAvailable(t, ctxopts.KubectlOptions(ctx), serviceName, int(waitDuration), tickDuration)
+	retries := waitDuration / tickDuration
+	k8s.WaitUntilServiceAvailable(t, ctxopts.KubectlOptions(ctx), serviceName, int(retries), tickDuration)
 }
 
 func formatSelectors(listOptions v1.ListOptions) string {

--- a/tests/integration/internal/stepfuncs/assess_funcs.go
+++ b/tests/integration/internal/stepfuncs/assess_funcs.go
@@ -12,7 +12,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	log "k8s.io/klog/v2"
 	"sigs.k8s.io/e2e-framework/klient/k8s"
 	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
@@ -49,10 +48,10 @@ func WaitUntilPodsAvailable(listOptions metav1.ListOptions, count int, wait time
 // `wait` and `tick` times as well as the provided list options and the desired count.
 func WaitUntilPodsAvailableCustomNS(listOptions metav1.ListOptions, count int, wait time.Duration, tick time.Duration, namespace string) features.Func {
 	return func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
-		opts := ctxopts.KubectlOptions(ctx)
+		opts := *ctxopts.KubectlOptions(ctx)
 		opts.Namespace = namespace
 
-		k8s_internal.WaitUntilPodsAvailable(t, opts,
+		k8s_internal.WaitUntilPodsAvailable(t, &opts,
 			listOptions, count, wait, tick,
 		)
 		return ctx
@@ -506,7 +505,7 @@ func WaitUntilStatefulSetIsReady(
 ) features.Func {
 	return func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
 		sts := appsv1.StatefulSet{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ctxopts.Namespace(ctx),
 			},
 		}
@@ -557,7 +556,7 @@ func WaitUntilDaemonSetIsReady(
 ) features.Func {
 	return func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
 		ds := appsv1.DaemonSet{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ctxopts.Namespace(ctx),
 			},
 		}
@@ -608,7 +607,7 @@ func WaitUntilDeploymentIsReady(
 ) features.Func {
 	return func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
 		deps := appsv1.Deployment{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ctxopts.Namespace(ctx),
 			},
 		}

--- a/tests/integration/values/values_helm_opentelemetry_operator_enabled.yaml
+++ b/tests/integration/values/values_helm_opentelemetry_operator_enabled.yaml
@@ -10,7 +10,7 @@ sumologic:
 opentelemetry-operator:
   enabled: true
   createDefaultInstrumentation: true
-  instrumentationNamespaces: "ot-operator1,ot-operator2"
+  instrumentationNamespaces: "ot-operator-enabled-1,ot-operator-enabled-2"
   manager:
     resources:
       requests:

--- a/tests/integration/values/values_opentelemetry_operator_instrumentation.yaml
+++ b/tests/integration/values/values_opentelemetry_operator_instrumentation.yaml
@@ -10,7 +10,7 @@ sumologic:
 opentelemetry-operator:
   enabled: true
   createDefaultInstrumentation: true
-  instrumentationNamespaces: "ot-operator1,ot-operator2,test-apps"
+  instrumentationNamespaces: "ot-operator-instr-1,ot-operator-instr-2,test-apps"
   manager:
     resources:
       requests:


### PR DESCRIPTION
Use different namespaces for different instrumentation tests. This makes conflicts less likely when running the tests in the same cluster.