### PR TITLE
fix(test/integration): only override namespace if needed

### DIFF
--- a/tests/integration/helm_ot_default_namespaceoverride_test.go
+++ b/tests/integration/helm_ot_default_namespaceoverride_test.go
@@ -10,11 +10,15 @@ import (
 	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal"
 	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/ctxopts"
 	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/stepfuncs"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 )
 
 type ctxKey string
+
+const originalNamespaceKey ctxKey = "originalNamespace"
 
 func Test_Helm_Default_OT_NamespaceOverride(t *testing.T) {
 
@@ -49,9 +53,10 @@ func Test_Helm_Default_OT_NamespaceOverride(t *testing.T) {
 
 	featTraces := GetTracesFeature()
 
-	var originalNamespaceKey ctxKey = "originalNamespace"
-
 	overrideNamespace := func(ctx context.Context, envConf *envconf.Config, t *testing.T, _ features.Feature) (context.Context, error) {
+		if !isNamespaceOverridden(t) {
+			return ctx, nil
+		}
 		originalNamespace := ctxopts.Namespace(ctx)
 		ctx = context.WithValue(ctx, originalNamespaceKey, originalNamespace)
 		kubectlOptions := ctxopts.KubectlOptions(ctx)
@@ -61,6 +66,9 @@ func Test_Helm_Default_OT_NamespaceOverride(t *testing.T) {
 		return ctx, nil
 	}
 	restoreOriginalNamespace := func(ctx context.Context, envConf *envconf.Config, t *testing.T, _ features.Feature) (context.Context, error) {
+		if !isNamespaceOverridden(t) {
+			return ctx, nil
+		}
 		originalNamespace := ctx.Value(originalNamespaceKey).(string)
 		kubectlOptions := ctxopts.KubectlOptions(ctx)
 		kubectlOptions.Namespace = originalNamespace
@@ -68,5 +76,17 @@ func Test_Helm_Default_OT_NamespaceOverride(t *testing.T) {
 		ctx = ctxopts.WithNamespace(ctx, originalNamespace)
 		return ctx, nil
 	}
+
 	testenv.BeforeEachFeature(overrideNamespace).AfterEachFeature(restoreOriginalNamespace).Test(t, featInstall, featMetrics, featLogs, featMultilineLogs, featEvents, featTraces)
+}
+
+func isNamespaceOverridden(t *testing.T) bool {
+	valuesFileBytes := stepfuncs.GetHelmValuesForT(t)
+	var values struct {
+		NamespaceOverride string `yaml:"namespaceOverride"`
+	}
+
+	err := yaml.Unmarshal(valuesFileBytes, &values)
+	require.NoError(t, err)
+	return (values.NamespaceOverride != "")
 }


### PR DESCRIPTION
Fix a bug in integration tests where the test for overriding the namespace would register pre-feature handlers that would affect the rest of the tests. The reason this doesn't affect the CI is that it runs each test in a separate cluster. We now check the values.yaml before changing the namespace.