### PR TITLE
test(integration): force delete fixed namespaces

### DIFF
--- a/tests/integration/features.go
+++ b/tests/integration/features.go
@@ -465,7 +465,7 @@ func GetAllLogsFeature(waitFunction stepfuncs.WaitForLogs, generate bool) featur
 		feature = feature.
 			Teardown(removeLogsDeployment).
 			Teardown(removeLogsDaemonset).
-			Teardown(stepfuncs.KubectlDeleteNamespaceOpt(internal.LogsGeneratorNamespace))
+			Teardown(stepfuncs.KubectlDeleteNamespaceOpt(internal.LogsGeneratorNamespace, true))
 	}
 
 	return feature.Feature()
@@ -576,7 +576,7 @@ func GetPartialLogsFeature() features.Feature {
 		)).
 		Teardown(removeLogsDeployment).
 		Teardown(removeLogsDaemonset).
-		Teardown(stepfuncs.KubectlDeleteNamespaceOpt(internal.LogsGeneratorNamespace)).
+		Teardown(stepfuncs.KubectlDeleteNamespaceOpt(internal.LogsGeneratorNamespace, true)).
 		Feature()
 }
 
@@ -847,7 +847,7 @@ func GetCurlAppFeature() features.Feature {
 			waitDuration,
 			tickDuration,
 		)).
-		Teardown(stepfuncs.KubectlDeleteNamespaceOpt(internal.InstrumentationAppsNamespace)).
+		Teardown(stepfuncs.KubectlDeleteNamespaceOpt(internal.InstrumentationAppsNamespace, true)).
 		Feature()
 }
 
@@ -949,7 +949,7 @@ func GetTracesFeature() features.Feature {
 			terrak8s.RunKubectl(t, &opts, "delete", "deployment", internal.TracesGeneratorName)
 			return ctx
 		}).
-		Teardown(stepfuncs.KubectlDeleteNamespaceOpt(internal.TracesGeneratorNamespace)).
+		Teardown(stepfuncs.KubectlDeleteNamespaceOpt(internal.TracesGeneratorNamespace, true)).
 		Feature()
 }
 

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -99,7 +99,7 @@ func ConfigureTestEnv(testenv env.Environment) {
 		stepfuncs.HelmDeleteTestOpt(),
 		stepfuncs.KubectlDeleteOverrideNamespaceOpt(),
 		stepfuncs.KubectlDeleteOperatorNamespacesOpt(),
-		stepfuncs.KubectlDeleteNamespaceTestOpt(),
+		stepfuncs.KubectlDeleteNamespaceTestOpt(false),
 	) {
 		testenv.AfterEachTest(f)
 	}


### PR DESCRIPTION
Namespace deletion can be slow in K8s due to finalizers. This can be a problem for fixed namespaces which are the same for each test that uses them. This change tries to improve this by explicitly disabling finalizers before deleting the namespace.

