### PR TITLE
feat(test/integration): use a single cluster

### DIFF
--- a/tests/integration/Makefile
+++ b/tests/integration/Makefile
@@ -22,7 +22,7 @@ delete-cluster:
 .PHONY: test
 test:
 	KIND_NODE_IMAGE=$(KIND_NODE_IMAGE) \
-		go test -timeout 30m -v -count 1 -tags=$(GOTAGS) -run=$(TEST_NAME) . -args $(TEST_ARGS)
+		go test -timeout 60m -v -count 1 -tags=$(GOTAGS) -run=$(TEST_NAME) . -args $(TEST_ARGS)
 
 .PHONY: create-image-archive
 create-image-archive:

--- a/tests/integration/features.go
+++ b/tests/integration/features.go
@@ -464,8 +464,7 @@ func GetAllLogsFeature(waitFunction stepfuncs.WaitForLogs, generate bool) featur
 	if generate {
 		feature = feature.
 			Teardown(removeLogsDeployment).
-			Teardown(removeLogsDaemonset).
-			Teardown(stepfuncs.KubectlDeleteNamespaceOpt(internal.LogsGeneratorNamespace, true))
+			Teardown(removeLogsDaemonset)
 	}
 
 	return feature.Feature()
@@ -576,7 +575,6 @@ func GetPartialLogsFeature() features.Feature {
 		)).
 		Teardown(removeLogsDeployment).
 		Teardown(removeLogsDaemonset).
-		Teardown(stepfuncs.KubectlDeleteNamespaceOpt(internal.LogsGeneratorNamespace, true)).
 		Feature()
 }
 

--- a/tests/integration/internal/ctxopts/context_opts.go
+++ b/tests/integration/internal/ctxopts/context_opts.go
@@ -52,34 +52,3 @@ func HelmRelease(ctx context.Context) string {
 	v := ctx.Value(ctxKeyNameHelmRelease)
 	return v.(string)
 }
-
-func Clusters(ctx context.Context) []string {
-	v := ctx.Value(ctxKeyNameKindClusters)
-	if v == nil {
-		return []string{}
-	}
-	return v.([]string)
-}
-
-func WithCluster(ctx context.Context, clusterName string) context.Context {
-	clusters := Clusters(ctx)
-	clusters = append(clusters, clusterName)
-	return context.WithValue(ctx, ctxKeyNameKindClusters, clusters)
-}
-
-func WithoutCluster(ctx context.Context, clusterName string) context.Context {
-	clusters := Clusters(ctx)
-	index := -1
-	for i, cluster := range clusters {
-		if cluster == clusterName {
-			index = i
-		}
-	}
-	if index == -1 {
-		return ctx
-	}
-
-	clusters[index] = clusters[len(clusters)-1]
-	clusters = clusters[:len(clusters)-1]
-	return context.WithValue(ctx, ctxKeyNameKindClusters, clusters)
-}

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -69,6 +69,9 @@ func TestMain(m *testing.M) {
 func ConfigureTestEnv(testenv env.Environment) {
 
 	// Before
+
+	testenv.Setup(envfuncs.CreateNamespace(internal.LogsGeneratorNamespace))
+
 	for _, f := range stepfuncs.IntoTestEnvFuncs(
 		// Needed for OpenTelemetry Operator test
 		// TODO: Create namespaces only for specific tests
@@ -113,6 +116,7 @@ func ConfigureTestEnv(testenv env.Environment) {
 			return envfuncs.DeleteNamespace(namespace)(ctx, envConf)
 		},
 		envfuncs.DeleteNamespace(internal.OverrideNamespace),
+		envfuncs.DeleteNamespace(internal.LogsGeneratorNamespace),
 	)
 }
 


### PR DESCRIPTION
We currently create a new cluster for each test by default. This approach becomes a lot more annoying in e2e_framework 0.3.0, which I'd like to upgrade to here: #3741. Instead, use one cluster to run all the tests. Note that this doesn't affect E2E tests - those run each test in a separate job, which also means a separate cluster.

To make running all the tests in a single cluster less flaky, I've also moved log generator namespace creation and deletion to environment setup. Creating and deleting this namespace per-test is annoying, as namespace deletion can take some time in K8s. When running multiple tests in sequence in the same cluster, you sometimes get conflicts from trying to
create the log generator namespace while it's still being deleted.
