### PR TITLE
test(integration): don't store helm release in context

### DIFF
--- a/tests/integration/features.go
+++ b/tests/integration/features.go
@@ -24,6 +24,7 @@ import (
 	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal"
 	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/ctxopts"
 	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/stepfuncs"
+	strings_internal "github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/strings"
 	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/sumologicmock"
 )
 
@@ -72,7 +73,7 @@ func GetMetricsFeature(expectedMetrics []string, metricsCollector MetricsCollect
 				// Get the receiver mock pod as metrics source
 				res := envConf.Client().Resources(ctxopts.Namespace(ctx))
 				podList := corev1.PodList{}
-				releaseName := ctxopts.HelmRelease(ctx)
+				releaseName := strings_internal.ReleaseNameFromT(t)
 				deployment := fmt.Sprintf("%s-sumologic-mock", releaseName)
 				require.NoError(t,
 					wait.For(
@@ -115,7 +116,7 @@ func GetMetricsFeature(expectedMetrics []string, metricsCollector MetricsCollect
 		).
 		Assess("expected labels are present for non-pod kube-state-metrics",
 			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
-				releaseName := ctxopts.HelmRelease(ctx)
+				releaseName := strings_internal.ReleaseNameFromT(t)
 				deployment := fmt.Sprintf("%s-sumologic-mock", releaseName)
 				metricFilters := sumologicmock.MetadataFilters{
 					"__name__":   "kube_deployment_spec_replicas",
@@ -139,7 +140,7 @@ func GetMetricsFeature(expectedMetrics []string, metricsCollector MetricsCollect
 		).
 		Assess("expected labels are present for pod kube-state-metrics",
 			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
-				releaseName := ctxopts.HelmRelease(ctx)
+				releaseName := strings_internal.ReleaseNameFromT(t)
 				deployment := fmt.Sprintf("%s-kube-state-metrics", releaseName)
 				metricFilters := sumologicmock.MetadataFilters{
 					"__name__":   "kube_pod_status_phase",
@@ -197,7 +198,7 @@ func GetTelegrafMetricsFeature(expectedMetrics []string, metricsCollector Metric
 		Assess("expected labels are present for annotation metrics",
 			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
 				metricFilters := sumologicmock.MetadataFilters{"__name__": "nginx_accepts", "job": "pod-annotations"}
-				releaseName := ctxopts.HelmRelease(ctx)
+				releaseName := strings_internal.ReleaseNameFromT(t)
 				namespace := ctxopts.Namespace(ctx)
 				expectedLabels := sumologicmock.Labels{
 					"cluster":                      "kubernetes",
@@ -1081,7 +1082,7 @@ func CheckOtelcolMetadataMetricsInstall(builder *features.FeatureBuilder) *featu
 							return true
 						},
 						resources.WithLabelSelector(
-							fmt.Sprintf("app=%s-sumologic-otelcol-metrics", ctxopts.HelmRelease(ctx)),
+							fmt.Sprintf("app=%s-sumologic-otelcol-metrics", strings_internal.ReleaseNameFromT(t)),
 						),
 					)
 				require.NoError(t,
@@ -1140,7 +1141,7 @@ func CheckOtelcolMetadataLogsInstall(builder *features.FeatureBuilder) *features
 							return true
 						},
 						resources.WithLabelSelector(
-							fmt.Sprintf("app=%s-sumologic-otelcol-logs", ctxopts.HelmRelease(ctx)),
+							fmt.Sprintf("app=%s-sumologic-otelcol-logs", strings_internal.ReleaseNameFromT(t)),
 						),
 					)
 				require.NoError(t,
@@ -1173,7 +1174,7 @@ func CheckOtelcolEventsInstall(builder *features.FeatureBuilder) *features.Featu
 		Assess("otelcol events buffers PVCs are created",
 			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
 				namespace := ctxopts.Namespace(ctx)
-				releaseName := ctxopts.HelmRelease(ctx)
+				releaseName := strings_internal.ReleaseNameFromT(t)
 				kubectlOptions := ctxopts.KubectlOptions(ctx)
 
 				t.Logf("kubeconfig: %s", kubectlOptions.ConfigPath)

--- a/tests/integration/helm_opentelemetry_operator_enabled_test.go
+++ b/tests/integration/helm_opentelemetry_operator_enabled_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/ctxopts"
+	strings_internal "github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/strings"
 )
 
 func Test_Helm_OpenTelemetry_Operator_Enabled(t *testing.T) {
@@ -74,7 +75,7 @@ func Test_Helm_OpenTelemetry_Operator_Enabled(t *testing.T) {
 		}).
 		Assess("instrumentation-cr in ot-operator-enabled-1 namespace is created", func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
 			res := envConf.Client().Resources("ot-operator-enabled-1")
-			releaseName := ctxopts.HelmRelease(ctx)
+			releaseName := strings_internal.ReleaseNameFromT(t)
 			labelSelector := fmt.Sprintf("app=%s-sumologic-ot-operator-instr", releaseName)
 			instrs := otoperatorappsv1.InstrumentationList{}
 
@@ -92,7 +93,7 @@ func Test_Helm_OpenTelemetry_Operator_Enabled(t *testing.T) {
 		}).
 		Assess("instrumentation-cr in ot-operator-enabled-2 namespace is created", func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
 			res := envConf.Client().Resources("ot-operator-enabled-2")
-			releaseName := ctxopts.HelmRelease(ctx)
+			releaseName := strings_internal.ReleaseNameFromT(t)
 			labelSelector := fmt.Sprintf("app=%s-sumologic-ot-operator-instr", releaseName)
 			instrs := otoperatorappsv1.InstrumentationList{}
 

--- a/tests/integration/helm_opentelemetry_operator_instr_test.go
+++ b/tests/integration/helm_opentelemetry_operator_instr_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/ctxopts"
+	strings_internal "github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/strings"
 )
 
 type internalCtxKey string
@@ -75,7 +76,7 @@ func Test_OpenTelemetry_Operator_Instrumentation(t *testing.T) {
 		}).
 		Assess("instrumentation-cr in ot-operator-instr-1 namespace is created", func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
 			res := envConf.Client().Resources("ot-operator-instr-1")
-			releaseName := ctxopts.HelmRelease(ctx)
+			releaseName := strings_internal.ReleaseNameFromT(t)
 			labelSelector := fmt.Sprintf("app=%s-sumologic-ot-operator-instr", releaseName)
 			instrs := otoperatorappsv1.InstrumentationList{}
 
@@ -93,7 +94,7 @@ func Test_OpenTelemetry_Operator_Instrumentation(t *testing.T) {
 		}).
 		Assess("instrumentation-cr in ot-operator-instr-2 namespace is created", func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
 			res := envConf.Client().Resources("ot-operator-instr-2")
-			releaseName := ctxopts.HelmRelease(ctx)
+			releaseName := strings_internal.ReleaseNameFromT(t)
 			labelSelector := fmt.Sprintf("app=%s-sumologic-ot-operator-instr", releaseName)
 			instrs := otoperatorappsv1.InstrumentationList{}
 

--- a/tests/integration/internal/ctxopts/context_opts.go
+++ b/tests/integration/internal/ctxopts/context_opts.go
@@ -33,12 +33,3 @@ func Namespace(ctx context.Context) string {
 	v := ctx.Value(ctxKeyNameNamespace)
 	return v.(string)
 }
-
-func WithHelmRelease(ctx context.Context, namespace string) context.Context {
-	return context.WithValue(ctx, ctxKeyNameHelmRelease, namespace)
-}
-
-func HelmRelease(ctx context.Context) string {
-	v := ctx.Value(ctxKeyNameHelmRelease)
-	return v.(string)
-}

--- a/tests/integration/internal/stepfuncs/autoscaler.go
+++ b/tests/integration/internal/stepfuncs/autoscaler.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/ctxopts"
+	strings_internal "github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/strings"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
@@ -15,7 +16,8 @@ import (
 func ChangeMinMaxStatefulsetPods(app string, newMin uint64, newMax uint64) features.Func {
 	return func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		kubectlOptions := ctxopts.KubectlOptions(ctx)
-		appName := fmt.Sprintf("%s-%s", ctxopts.HelmRelease(ctx), app)
+		strings_internal.ReleaseNameFromT(t)
+		appName := fmt.Sprintf("%s-%s", strings_internal.ReleaseNameFromT(t), app)
 
 		k8s.RunKubectl(t, kubectlOptions, "delete", "hpa", appName)
 		k8s.RunKubectl(t, kubectlOptions, "autoscale", "statefulset", appName,

--- a/tests/integration/internal/stepfuncs/helm.go
+++ b/tests/integration/internal/stepfuncs/helm.go
@@ -69,7 +69,6 @@ func HelmDependencyUpdateOpt(path string) features.Func {
 // use SetKubectlNamespaceOpt.
 func HelmInstallOpt(path string, releaseName string) features.Func {
 	return func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
-		ctx = ctxopts.WithHelmRelease(ctx, releaseName)
 		helmOptions := HelmOptionsFromT(t, ctxopts.KubectlOptions(ctx), []string{"--wait"})
 
 		err := helm.InstallE(t, helmOptions, path, releaseName)
@@ -138,7 +137,7 @@ func HelmDeleteOpt(release string) features.Func {
 // by HelmInstallTestOpt/HelmInstallOpt.
 func HelmDeleteTestOpt() features.Func {
 	return func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
-		releaseName := ctxopts.HelmRelease(ctx)
+		releaseName := strings.ReleaseNameFromT(t)
 		return HelmDeleteOpt(releaseName)(ctx, t, envConf)
 	}
 }

--- a/tests/integration/internal/stepfuncs/traces.go
+++ b/tests/integration/internal/stepfuncs/traces.go
@@ -38,6 +38,7 @@ func GenerateTraces(
 
 		deployment := tracesgenerator.GetTracesGeneratorDeployment(
 			ctx,
+			t,
 			tracesGeneratorNamespace,
 			tracesGeneratorName,
 			tracesGeneratorImage,

--- a/tests/integration/internal/strings/strings.go
+++ b/tests/integration/internal/strings/strings.go
@@ -31,7 +31,11 @@ func ValueFileFromT(t *testing.T) string {
 }
 
 func ReleaseNameFromT(t *testing.T) string {
+	fullTestName := t.Name()
+	// take only the top-level test name, so we get a consistent result in all subtests
+	parts := strings.SplitN(fullTestName, "/", 2)
+	baseTestName := parts[0]
 	h := fnv.New32a()
-	h.Write([]byte(t.Name()))
+	h.Write([]byte(baseTestName))
 	return fmt.Sprintf("rel-%d", h.Sum32())[:maxReleaseNameLength]
 }

--- a/tests/integration/internal/tracesgenerator/tracesgenerator.go
+++ b/tests/integration/internal/tracesgenerator/tracesgenerator.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"testing"
 	"time"
 
 	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/ctxopts"
+	strings_internal "github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/strings"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,6 +47,7 @@ func NewDefaultGeneratorOptions() *TracesGeneratorOptions {
 
 func GetTracesGeneratorDeployment(
 	ctx context.Context,
+	t *testing.T,
 	namespace string,
 	name string,
 	image string,
@@ -60,7 +63,7 @@ func GetTracesGeneratorDeployment(
 		Labels:    appLabels,
 	}
 
-	release := ctxopts.HelmRelease(ctx)
+	release := strings_internal.ReleaseNameFromT(t)
 	otelcolInstrumentationNamespace := ctxopts.Namespace(ctx)
 	colName := fmt.Sprintf("%s-sumologic-otelagent.%s", release, otelcolInstrumentationNamespace)
 


### PR DESCRIPTION
Instead of storing Helm release in context, we calculate it on demand based on the test name. Similar to #3748. Will make #3741 easier.

Calculating the release name requires the test object, and it wasn't passed everywhere it needed to be, so I had to modify some interfaces.