### PR TITLE
test(integration): don't store kubectl options in context

### DIFF
--- a/tests/integration/features.go
+++ b/tests/integration/features.go
@@ -410,14 +410,14 @@ func checkKubeletLogs(count uint, strict bool, waitFunction stepfuncs.WaitForLog
 }
 
 func removeLogsDeployment(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
-	opts := *ctxopts.KubectlOptions(ctx)
+	opts := *ctxopts.KubectlOptions(ctx, envConf)
 	opts.Namespace = internal.LogsGeneratorNamespace
 	terrak8s.RunKubectl(t, &opts, "delete", "deployment", internal.LogsGeneratorName)
 	return ctx
 }
 
 func removeLogsDaemonset(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
-	opts := *ctxopts.KubectlOptions(ctx)
+	opts := *ctxopts.KubectlOptions(ctx, envConf)
 	opts.Namespace = internal.LogsGeneratorNamespace
 	terrak8s.RunKubectl(t, &opts, "delete", "daemonset", internal.LogsGeneratorName)
 	return ctx
@@ -943,7 +943,7 @@ func GetTracesFeature() features.Feature {
 			tickDuration,
 		)).
 		Teardown(func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
-			opts := *ctxopts.KubectlOptions(ctx)
+			opts := *ctxopts.KubectlOptions(ctx, envConf)
 			opts.Namespace = internal.TracesGeneratorNamespace
 			terrak8s.RunKubectl(t, &opts, "delete", "deployment", internal.TracesGeneratorName)
 			return ctx
@@ -1041,8 +1041,8 @@ func CheckSumologicSecret(endpointCount int) featureCheck {
 	return func(builder *features.FeatureBuilder) *features.FeatureBuilder {
 		return builder.Assess("sumologic secret is created with endpoints",
 			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
-				terrak8s.WaitUntilSecretAvailable(t, ctxopts.KubectlOptions(ctx), "sumologic", 60, tickDuration)
-				secret := terrak8s.GetSecret(t, ctxopts.KubectlOptions(ctx), "sumologic")
+				terrak8s.WaitUntilSecretAvailable(t, ctxopts.KubectlOptions(ctx, envConf), "sumologic", 60, tickDuration)
+				secret := terrak8s.GetSecret(t, ctxopts.KubectlOptions(ctx, envConf), "sumologic")
 				require.Len(t, secret.Data, endpointCount, "Secret has incorrect number of endpoints")
 				return ctx
 			})
@@ -1175,7 +1175,7 @@ func CheckOtelcolEventsInstall(builder *features.FeatureBuilder) *features.Featu
 			func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
 				namespace := ctxopts.Namespace(ctx)
 				releaseName := strings_internal.ReleaseNameFromT(t)
-				kubectlOptions := ctxopts.KubectlOptions(ctx)
+				kubectlOptions := ctxopts.KubectlOptions(ctx, envConf)
 
 				t.Logf("kubeconfig: %s", kubectlOptions.ConfigPath)
 				cl, err := terrak8s.GetKubernetesClientFromOptionsE(t, kubectlOptions)

--- a/tests/integration/helm_ot_default_namespaceoverride_test.go
+++ b/tests/integration/helm_ot_default_namespaceoverride_test.go
@@ -59,9 +59,6 @@ func Test_Helm_Default_OT_NamespaceOverride(t *testing.T) {
 		}
 		originalNamespace := ctxopts.Namespace(ctx)
 		ctx = context.WithValue(ctx, originalNamespaceKey, originalNamespace)
-		kubectlOptions := ctxopts.KubectlOptions(ctx)
-		kubectlOptions.Namespace = internal.OverrideNamespace
-		ctx = ctxopts.WithKubectlOptions(ctx, kubectlOptions)
 		ctx = ctxopts.WithNamespace(ctx, internal.OverrideNamespace)
 		return ctx, nil
 	}
@@ -70,9 +67,6 @@ func Test_Helm_Default_OT_NamespaceOverride(t *testing.T) {
 			return ctx, nil
 		}
 		originalNamespace := ctx.Value(originalNamespaceKey).(string)
-		kubectlOptions := ctxopts.KubectlOptions(ctx)
-		kubectlOptions.Namespace = originalNamespace
-		ctx = ctxopts.WithKubectlOptions(ctx, kubectlOptions)
 		ctx = ctxopts.WithNamespace(ctx, originalNamespace)
 		return ctx, nil
 	}

--- a/tests/integration/internal/ctxopts/context_opts.go
+++ b/tests/integration/internal/ctxopts/context_opts.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/gruntwork-io/terratest/modules/k8s"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
 )
 
 type ctxKey string
@@ -16,15 +17,13 @@ const (
 	ctxKeyNameKindClusters   ctxKey = "kindClusters"
 )
 
-func WithKubectlOptions(ctx context.Context, kubectlOptions *k8s.KubectlOptions) context.Context {
-	return context.WithValue(ctx, ctxKeyNameKubectlOptions, kubectlOptions)
+func KubectlOptions(ctx context.Context, envConf *envconf.Config) *k8s.KubectlOptions {
+	namespace := Namespace(ctx)
+	return k8s.NewKubectlOptions("", envConf.KubeContext(), namespace)
 }
 
-func KubectlOptions(ctx context.Context) *k8s.KubectlOptions {
-	v := ctx.Value(ctxKeyNameKubectlOptions)
-	return v.(*k8s.KubectlOptions)
-}
-
+// NOTE: It's possible to put the namespace in the environment config instead, but this makes running tests in parallel impossible.
+// Each test gets its own copy of the context, but they use the same environment config.
 func WithNamespace(ctx context.Context, namespace string) context.Context {
 	return context.WithValue(ctx, ctxKeyNameNamespace, namespace)
 }

--- a/tests/integration/internal/k8s/pods.go
+++ b/tests/integration/internal/k8s/pods.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
 )
 
 // Same as WaitUntilPodsAvailableE, but terminates the test instead of returning an error.
@@ -76,13 +77,14 @@ func WaitUntilPodsAvailableE(
 
 func WaitUntilSumologicMockAvailable(
 	ctx context.Context,
+	envConf *envconf.Config,
 	t *testing.T,
 	serviceName string,
 	waitDuration time.Duration,
 	tickDuration time.Duration,
 ) {
 	retries := waitDuration / tickDuration
-	k8s.WaitUntilServiceAvailable(t, ctxopts.KubectlOptions(ctx), serviceName, int(retries), tickDuration)
+	k8s.WaitUntilServiceAvailable(t, ctxopts.KubectlOptions(ctx, envConf), serviceName, int(retries), tickDuration)
 }
 
 func formatSelectors(listOptions v1.ListOptions) string {

--- a/tests/integration/internal/k8s/tunnel.go
+++ b/tests/integration/internal/k8s/tunnel.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	terrak8s "github.com/gruntwork-io/terratest/modules/k8s"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
 
 	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal"
 	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/ctxopts"
@@ -13,10 +14,11 @@ import (
 // TunnelForSumologicMock creates a tunnel with port forward to sumologic-mock service.
 func TunnelForSumologicMock(
 	ctx context.Context,
+	envConf *envconf.Config,
 	t *testing.T,
 	serviceName string,
 ) *terrak8s.Tunnel {
-	kubectlOptions := *ctxopts.KubectlOptions(ctx)
+	kubectlOptions := *ctxopts.KubectlOptions(ctx, envConf)
 	kubectlOptions.Namespace = ctxopts.Namespace(ctx)
 
 	tunnel := terrak8s.NewTunnel(

--- a/tests/integration/internal/stepfuncs/autoscaler.go
+++ b/tests/integration/internal/stepfuncs/autoscaler.go
@@ -15,7 +15,7 @@ import (
 
 func ChangeMinMaxStatefulsetPods(app string, newMin uint64, newMax uint64) features.Func {
 	return func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-		kubectlOptions := ctxopts.KubectlOptions(ctx)
+		kubectlOptions := ctxopts.KubectlOptions(ctx, c)
 		strings_internal.ReleaseNameFromT(t)
 		appName := fmt.Sprintf("%s-%s", strings_internal.ReleaseNameFromT(t), app)
 

--- a/tests/integration/internal/stepfuncs/debug.go
+++ b/tests/integration/internal/stepfuncs/debug.go
@@ -23,14 +23,14 @@ import (
 func PrintClusterStateOpt(force ...bool) features.Func {
 	return func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
 		if (len(force) == 1 && force[0]) || t.Failed() {
-			kubectlOptions := *ctxopts.KubectlOptions(ctx)
+			kubectlOptions := *ctxopts.KubectlOptions(ctx, envConf)
 			kubectlOptions.Namespace = ctxopts.Namespace(ctx)
 			k8s.RunKubectl(t, &kubectlOptions,
 				"logs", "-lapp=sumoloigic-mock", "--tail=1000",
 			)
 
-			k8s.RunKubectl(t, ctxopts.KubectlOptions(ctx), "get", "all")
-			k8s.RunKubectl(t, ctxopts.KubectlOptions(ctx), "get", "events")
+			k8s.RunKubectl(t, ctxopts.KubectlOptions(ctx, envConf), "get", "all")
+			k8s.RunKubectl(t, ctxopts.KubectlOptions(ctx, envConf), "get", "events")
 		}
 
 		return ctx

--- a/tests/integration/internal/stepfuncs/helm.go
+++ b/tests/integration/internal/stepfuncs/helm.go
@@ -31,7 +31,7 @@ const (
 // HelmVersion returns a features.Func that will run helm version
 func HelmVersionOpt() features.Func {
 	return func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
-		helmOptions := HelmOptionsFromT(t, ctxopts.KubectlOptions(ctx), []string{})
+		helmOptions := HelmOptionsFromT(t, ctxopts.KubectlOptions(ctx, envConf), []string{})
 		_, err := helm.RunHelmCommandAndGetOutputE(t, helmOptions, "version")
 		require.NoError(t, err)
 
@@ -53,7 +53,7 @@ func HelmDependencyUpdateOpt(path string) features.Func {
 			)
 			return ctx
 		}
-		helmOptions := HelmOptionsFromT(t, ctxopts.KubectlOptions(ctx), []string{})
+		helmOptions := HelmOptionsFromT(t, ctxopts.KubectlOptions(ctx, envConf), []string{})
 		_, err := helm.RunHelmCommandAndGetOutputE(t, helmOptions, "dependency", "update", path)
 		require.NoError(t, err)
 
@@ -69,11 +69,11 @@ func HelmDependencyUpdateOpt(path string) features.Func {
 // use SetKubectlNamespaceOpt.
 func HelmInstallOpt(path string, releaseName string) features.Func {
 	return func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
-		helmOptions := HelmOptionsFromT(t, ctxopts.KubectlOptions(ctx), []string{"--wait"})
+		helmOptions := HelmOptionsFromT(t, ctxopts.KubectlOptions(ctx, envConf), []string{"--wait"})
 
 		err := helm.InstallE(t, helmOptions, path, releaseName)
 		if err != nil {
-			kubectlOptions := ctxopts.KubectlOptions(ctx)
+			kubectlOptions := ctxopts.KubectlOptions(ctx, envConf)
 
 			// Print setup job logs if installation failed.
 			k8s.RunKubectl(t, kubectlOptions,
@@ -130,7 +130,7 @@ func HelmInstallTestOpt(path string) features.Func {
 // use SetKubectlNamespaceOpt.
 func HelmDeleteOpt(release string) features.Func {
 	return func(ctx context.Context, t *testing.T, envConf *envconf.Config) context.Context {
-		helmOptions := HelmOptionsFromT(t, ctxopts.KubectlOptions(ctx), []string{"--wait"})
+		helmOptions := HelmOptionsFromT(t, ctxopts.KubectlOptions(ctx, envConf), []string{"--wait"})
 		helm.Delete(t, helmOptions, release, true)
 		return ctx
 	}

--- a/tests/integration/internal/sumologicmock/receiver_mock.go
+++ b/tests/integration/internal/sumologicmock/receiver_mock.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
 
 	"github.com/SumoLogic/sumologic-kubernetes-collection/tests/integration/internal/k8s"
 )
@@ -37,10 +38,11 @@ func NewClient(t *testing.T, baseUrl url.URL) *SumologicMockClient {
 // by the caller when they're done with it.
 func NewClientWithK8sTunnel(
 	ctx context.Context,
+	envConf *envconf.Config,
 	t *testing.T,
 	serviceName string,
 ) (*SumologicMockClient, func()) {
-	tunnel := k8s.TunnelForSumologicMock(ctx, t, serviceName)
+	tunnel := k8s.TunnelForSumologicMock(ctx, envConf, t, serviceName)
 	baseUrl := url.URL{
 		Scheme: "http",
 		Host:   tunnel.Endpoint(),


### PR DESCRIPTION
Instead just create the struct on the fly based on the environment and context. This lets us get rid of a bunch of custom test code, and also makes it easier to run the tests in parallel if need be.