### PR TITLE
test(integration): only run routing tests on latest K8s

### DIFF
--- a/tests/integration/helm_ot_routing_additional_partially_test.go
+++ b/tests/integration/helm_ot_routing_additional_partially_test.go
@@ -1,5 +1,5 @@
-//go:build allversions
-// +build allversions
+//go:build onlylatest
+// +build onlylatest
 
 package integration
 

--- a/tests/integration/helm_ot_routing_partial_test.go
+++ b/tests/integration/helm_ot_routing_partial_test.go
@@ -1,5 +1,5 @@
-//go:build allversions
-// +build allversions
+//go:build onlylatest
+// +build onlylatest
 
 package integration
 

--- a/tests/integration/helm_ot_routing_test.go
+++ b/tests/integration/helm_ot_routing_test.go
@@ -1,5 +1,5 @@
-//go:build allversions
-// +build allversions
+//go:build onlylatest
+// +build onlylatest
 
 package integration
 


### PR DESCRIPTION
It's not necessary to run these in all K8s versions.