### PR TITLE
chore(setup): use consistent collector name

### DIFF
--- a/deploy/helm/sumologic/conf/cleanup/cleanup.sh
+++ b/deploy/helm/sumologic/conf/cleanup/cleanup.sh
@@ -9,6 +9,8 @@ export HTTP_PROXY="${HTTP_PROXY:=""}"
 export HTTPS_PROXY="${HTTPS_PROXY:=""}"
 export NO_PROXY="${NO_PROXY:=""}"
 
+readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
+
 cp /etc/terraform/*.tf /terraform/
 cd /terraform || exit 1
 
@@ -17,7 +19,7 @@ cd /terraform || exit 1
 terraform init -input=false -get=false || terraform init -input=false -upgrade
 
 # shellcheck disable=SC1083
-terraform import sumologic_collector.collector {{ template "terraform.collector.name" . }}
+terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"
 # shellcheck disable=SC1083
 terraform import kubernetes_secret.sumologic_collection_secret {{ template "terraform.secret.fullname" . }}
 

--- a/deploy/helm/sumologic/conf/setup/variables.tf
+++ b/deploy/helm/sumologic/conf/setup/variables.tf
@@ -1,10 +1,5 @@
 variable "collector_name" {
   type  = string
-  {{- if .Values.sumologic.collectorName }}
-  default = "{{ .Values.sumologic.collectorName }}"
-  {{- else }}
-  default = "{{ template "sumologic.clusterNameReplaceSpaceWithDash" . }}"
-  {{- end }}
 }
 
 variable "namespace_name" {

--- a/deploy/helm/sumologic/templates/_helpers/_setup.tpl
+++ b/deploy/helm/sumologic/templates/_helpers/_setup.tpl
@@ -82,7 +82,7 @@ Example usage:
 
 */}}
 {{- define "terraform.collector.name" -}}
-{{- if .Values.sumologic.collectorName }}{{ .Values.sumologic.collectorName }}{{- else}}{{ .Values.sumologic.clusterName }}{{- end}}
+{{- if .Values.sumologic.collectorName }}{{ .Values.sumologic.collectorName }}{{- else}}{{ template "sumologic.clusterNameReplaceSpaceWithDash" . }}{{- end}}
 {{- end -}}
 
 {{/*

--- a/deploy/helm/sumologic/templates/cleanup/job.yaml
+++ b/deploy/helm/sumologic/templates/cleanup/job.yaml
@@ -58,6 +58,8 @@ spec:
 {{- else }}
             value: {{ .Values.sumologic.endpoint }}
 {{- end }}
+          - name: SUMOLOGIC_COLLECTOR_NAME
+            value: {{ include "terraform.collector.name" . }}
           {{- include "proxy-env-variables" . | nindent 10 }}
       securityContext:
         runAsUser: 999

--- a/deploy/helm/sumologic/templates/setup/job.yaml
+++ b/deploy/helm/sumologic/templates/setup/job.yaml
@@ -73,6 +73,8 @@ spec:
 {{- else }}
           value: {{ .Values.sumologic.endpoint }}
 {{- end }}
+        - name: SUMOLOGIC_COLLECTOR_NAME
+          value: {{ include "terraform.collector.name" . }}
         {{- include "proxy-env-variables" . | nindent 8 -}}
 {{- if .Values.sumologic.setup.debug }}
         - name: DEBUG_MODE

--- a/tests/helm/testdata/goldenfile/cleanup/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/cleanup/basic.output.yaml
@@ -53,6 +53,8 @@ spec:
           env:
             - name: SUMOLOGIC_BASE_URL
               value:
+            - name: SUMOLOGIC_COLLECTOR_NAME
+              value: kubernetes
 
             - name: NO_PROXY
               value: kubernetes.default.svc

--- a/tests/helm/testdata/goldenfile/cleanup/sumologic-mock-no-secret.output.yaml
+++ b/tests/helm/testdata/goldenfile/cleanup/sumologic-mock-no-secret.output.yaml
@@ -53,6 +53,8 @@ spec:
           env:
             - name: SUMOLOGIC_BASE_URL
               value: http://RELEASE-NAME-sumologic-mock.sumologic.svc.cluster.local.:3000/terraform/api/
+            - name: SUMOLOGIC_COLLECTOR_NAME
+              value: kubernetes
 
             - name: NO_PROXY
               value: kubernetes.default.svc

--- a/tests/helm/testdata/goldenfile/cleanup/sumologic-mock.output.yaml
+++ b/tests/helm/testdata/goldenfile/cleanup/sumologic-mock.output.yaml
@@ -53,6 +53,8 @@ spec:
           env:
             - name: SUMOLOGIC_BASE_URL
               value: http://RELEASE-NAME-sumologic-mock.sumologic.svc.cluster.local.:3000/terraform/api/
+            - name: SUMOLOGIC_COLLECTOR_NAME
+              value: kubernetes
 
             - name: NO_PROXY
               value: kubernetes.default.svc

--- a/tests/helm/testdata/goldenfile/setup/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/setup/basic.output.yaml
@@ -57,6 +57,8 @@ spec:
           env:
             - name: SUMOLOGIC_BASE_URL
               value:
+            - name: SUMOLOGIC_COLLECTOR_NAME
+              value: kubernetes
 
             - name: NO_PROXY
               value: kubernetes.default.svc

--- a/tests/helm/testdata/goldenfile/setup/sumologic-mock-no-secret.output.yaml
+++ b/tests/helm/testdata/goldenfile/setup/sumologic-mock-no-secret.output.yaml
@@ -57,6 +57,8 @@ spec:
           env:
             - name: SUMOLOGIC_BASE_URL
               value: http://RELEASE-NAME-sumologic-mock.sumologic.svc.cluster.local.:3000/terraform/api/
+            - name: SUMOLOGIC_COLLECTOR_NAME
+              value: kubernetes
 
             - name: NO_PROXY
               value: kubernetes.default.svc

--- a/tests/helm/testdata/goldenfile/setup/sumologic-mock.output.yaml
+++ b/tests/helm/testdata/goldenfile/setup/sumologic-mock.output.yaml
@@ -57,6 +57,8 @@ spec:
           env:
             - name: SUMOLOGIC_BASE_URL
               value: http://RELEASE-NAME-sumologic-mock.sumologic.svc.cluster.local.:3000/terraform/api/
+            - name: SUMOLOGIC_COLLECTOR_NAME
+              value: kubernetes
 
             - name: NO_PROXY
               value: kubernetes.default.svc

--- a/tests/helm/testdata/goldenfile/terraform/all_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/all_fields.output.yaml
@@ -636,6 +636,10 @@ data:
 
     readonly DEBUG_MODE=${DEBUG_MODE:="false"}
     readonly DEBUG_MODE_ENABLED_FLAG="true"
+    readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
+
+    # Set variables for terraform
+    export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -752,28 +756,26 @@ data:
         echo "Please refer to https://help.sumologic.com/docs/manage/fields/ to manually create the fields after you have removed unused fields to free up capacity."
     fi
 
-    readonly COLLECTOR_NAME="kubernetes"
-
     # Sumo Logic Collector and HTTP sources
     # Only import sources when collector exists.
-    if terraform import sumologic_collector.collector "${COLLECTOR_NAME}"; then
+    if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
     true  # prevent to render empty if; then
-    terraform import sumologic_http_source.default_events_source "${COLLECTOR_NAME}/events"
-    terraform import sumologic_http_source.default_otlp_events_source "${COLLECTOR_NAME}/events-otlp"
-    terraform import sumologic_http_source.default_logs_source "${COLLECTOR_NAME}/logs"
-    terraform import sumologic_http_source.default_otlp_logs_source "${COLLECTOR_NAME}/logs-otlp"
-    terraform import sumologic_http_source.apiserver_metrics_source "${COLLECTOR_NAME}/apiserver-metrics"
-    terraform import sumologic_http_source.control_plane_metrics_source "${COLLECTOR_NAME}/control-plane-metrics"
-    terraform import sumologic_http_source.controller_metrics_source "${COLLECTOR_NAME}/kube-controller-manager-metrics"
-    terraform import sumologic_http_source.default_metrics_source "${COLLECTOR_NAME}/(default-metrics)"
-    terraform import sumologic_http_source.default_otlp_metrics_source "${COLLECTOR_NAME}/metrics-otlp"
-    terraform import sumologic_http_source.kubelet_metrics_source "${COLLECTOR_NAME}/kubelet-metrics"
-    terraform import sumologic_http_source.node_metrics_source "${COLLECTOR_NAME}/node-exporter-metrics"
-    terraform import sumologic_http_source.scheduler_metrics_source "${COLLECTOR_NAME}/kube-scheduler-metrics"
-    terraform import sumologic_http_source.state_metrics_source "${COLLECTOR_NAME}/kube-state-metrics"
-    terraform import sumologic_http_source.test_source_metrics_source "${COLLECTOR_NAME}/(Test source)"
-    terraform import sumologic_http_source.default_traces_source "${COLLECTOR_NAME}/traces"
-    terraform import sumologic_http_source.default_otlp_traces_source "${COLLECTOR_NAME}/traces-otlp"
+    terraform import sumologic_http_source.default_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events"
+    terraform import sumologic_http_source.default_otlp_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events-otlp"
+    terraform import sumologic_http_source.default_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs"
+    terraform import sumologic_http_source.default_otlp_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs-otlp"
+    terraform import sumologic_http_source.apiserver_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/apiserver-metrics"
+    terraform import sumologic_http_source.control_plane_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/control-plane-metrics"
+    terraform import sumologic_http_source.controller_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-controller-manager-metrics"
+    terraform import sumologic_http_source.default_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/(default-metrics)"
+    terraform import sumologic_http_source.default_otlp_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/metrics-otlp"
+    terraform import sumologic_http_source.kubelet_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kubelet-metrics"
+    terraform import sumologic_http_source.node_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/node-exporter-metrics"
+    terraform import sumologic_http_source.scheduler_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-scheduler-metrics"
+    terraform import sumologic_http_source.state_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-state-metrics"
+    terraform import sumologic_http_source.test_source_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/(Test source)"
+    terraform import sumologic_http_source.default_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces"
+    terraform import sumologic_http_source.default_otlp_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces-otlp"
     fi
 
     # Kubernetes Secret
@@ -800,7 +802,6 @@ data:
   variables.tf: |
     variable "collector_name" {
       type  = string
-      default = "kubernetes"
     }
 
     variable "namespace_name" {

--- a/tests/helm/testdata/goldenfile/terraform/collector_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/collector_fields.output.yaml
@@ -591,6 +591,10 @@ data:
 
     readonly DEBUG_MODE=${DEBUG_MODE:="false"}
     readonly DEBUG_MODE_ENABLED_FLAG="true"
+    readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
+
+    # Set variables for terraform
+    export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -707,27 +711,25 @@ data:
         echo "Please refer to https://help.sumologic.com/docs/manage/fields/ to manually create the fields after you have removed unused fields to free up capacity."
     fi
 
-    readonly COLLECTOR_NAME="kubernetes"
-
     # Sumo Logic Collector and HTTP sources
     # Only import sources when collector exists.
-    if terraform import sumologic_collector.collector "${COLLECTOR_NAME}"; then
+    if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
     true  # prevent to render empty if; then
-    terraform import sumologic_http_source.default_events_source "${COLLECTOR_NAME}/events"
-    terraform import sumologic_http_source.default_otlp_events_source "${COLLECTOR_NAME}/events-otlp"
-    terraform import sumologic_http_source.default_logs_source "${COLLECTOR_NAME}/logs"
-    terraform import sumologic_http_source.default_otlp_logs_source "${COLLECTOR_NAME}/logs-otlp"
-    terraform import sumologic_http_source.apiserver_metrics_source "${COLLECTOR_NAME}/apiserver-metrics"
-    terraform import sumologic_http_source.control_plane_metrics_source "${COLLECTOR_NAME}/control-plane-metrics"
-    terraform import sumologic_http_source.controller_metrics_source "${COLLECTOR_NAME}/kube-controller-manager-metrics"
-    terraform import sumologic_http_source.default_metrics_source "${COLLECTOR_NAME}/(default-metrics)"
-    terraform import sumologic_http_source.default_otlp_metrics_source "${COLLECTOR_NAME}/metrics-otlp"
-    terraform import sumologic_http_source.kubelet_metrics_source "${COLLECTOR_NAME}/kubelet-metrics"
-    terraform import sumologic_http_source.node_metrics_source "${COLLECTOR_NAME}/node-exporter-metrics"
-    terraform import sumologic_http_source.scheduler_metrics_source "${COLLECTOR_NAME}/kube-scheduler-metrics"
-    terraform import sumologic_http_source.state_metrics_source "${COLLECTOR_NAME}/kube-state-metrics"
-    terraform import sumologic_http_source.default_traces_source "${COLLECTOR_NAME}/traces"
-    terraform import sumologic_http_source.default_otlp_traces_source "${COLLECTOR_NAME}/traces-otlp"
+    terraform import sumologic_http_source.default_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events"
+    terraform import sumologic_http_source.default_otlp_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events-otlp"
+    terraform import sumologic_http_source.default_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs"
+    terraform import sumologic_http_source.default_otlp_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs-otlp"
+    terraform import sumologic_http_source.apiserver_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/apiserver-metrics"
+    terraform import sumologic_http_source.control_plane_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/control-plane-metrics"
+    terraform import sumologic_http_source.controller_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-controller-manager-metrics"
+    terraform import sumologic_http_source.default_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/(default-metrics)"
+    terraform import sumologic_http_source.default_otlp_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/metrics-otlp"
+    terraform import sumologic_http_source.kubelet_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kubelet-metrics"
+    terraform import sumologic_http_source.node_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/node-exporter-metrics"
+    terraform import sumologic_http_source.scheduler_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-scheduler-metrics"
+    terraform import sumologic_http_source.state_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-state-metrics"
+    terraform import sumologic_http_source.default_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces"
+    terraform import sumologic_http_source.default_otlp_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces-otlp"
     fi
 
     # Kubernetes Secret
@@ -754,7 +756,6 @@ data:
   variables.tf: |
     variable "collector_name" {
       type  = string
-      default = "kubernetes"
     }
 
     variable "namespace_name" {

--- a/tests/helm/testdata/goldenfile/terraform/conditional_sources.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/conditional_sources.output.yaml
@@ -471,6 +471,10 @@ data:
 
     readonly DEBUG_MODE=${DEBUG_MODE:="false"}
     readonly DEBUG_MODE_ENABLED_FLAG="true"
+    readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
+
+    # Set variables for terraform
+    export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -587,11 +591,9 @@ data:
         echo "Please refer to https://help.sumologic.com/docs/manage/fields/ to manually create the fields after you have removed unused fields to free up capacity."
     fi
 
-    readonly COLLECTOR_NAME="kubernetes"
-
     # Sumo Logic Collector and HTTP sources
     # Only import sources when collector exists.
-    if terraform import sumologic_collector.collector "${COLLECTOR_NAME}"; then
+    if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
     true  # prevent to render empty if; then
     fi
 
@@ -619,7 +621,6 @@ data:
   variables.tf: |
     variable "collector_name" {
       type  = string
-      default = "kubernetes"
     }
 
     variable "namespace_name" {

--- a/tests/helm/testdata/goldenfile/terraform/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/custom.output.yaml
@@ -471,6 +471,10 @@ data:
 
     readonly DEBUG_MODE=${DEBUG_MODE:="false"}
     readonly DEBUG_MODE_ENABLED_FLAG="true"
+    readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
+
+    # Set variables for terraform
+    export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -587,11 +591,9 @@ data:
         echo "Please refer to https://help.sumologic.com/docs/manage/fields/ to manually create the fields after you have removed unused fields to free up capacity."
     fi
 
-    readonly COLLECTOR_NAME="kubernetes"
-
     # Sumo Logic Collector and HTTP sources
     # Only import sources when collector exists.
-    if terraform import sumologic_collector.collector "${COLLECTOR_NAME}"; then
+    if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
     true  # prevent to render empty if; then
     fi
 
@@ -619,7 +621,6 @@ data:
   variables.tf: |
     variable "collector_name" {
       type  = string
-      default = "kubernetes"
     }
 
     variable "namespace_name" {

--- a/tests/helm/testdata/goldenfile/terraform/default.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/default.output.yaml
@@ -589,6 +589,10 @@ data:
 
     readonly DEBUG_MODE=${DEBUG_MODE:="false"}
     readonly DEBUG_MODE_ENABLED_FLAG="true"
+    readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
+
+    # Set variables for terraform
+    export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -705,27 +709,25 @@ data:
         echo "Please refer to https://help.sumologic.com/docs/manage/fields/ to manually create the fields after you have removed unused fields to free up capacity."
     fi
 
-    readonly COLLECTOR_NAME="kubernetes"
-
     # Sumo Logic Collector and HTTP sources
     # Only import sources when collector exists.
-    if terraform import sumologic_collector.collector "${COLLECTOR_NAME}"; then
+    if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
     true  # prevent to render empty if; then
-    terraform import sumologic_http_source.default_events_source "${COLLECTOR_NAME}/events"
-    terraform import sumologic_http_source.default_otlp_events_source "${COLLECTOR_NAME}/events-otlp"
-    terraform import sumologic_http_source.default_logs_source "${COLLECTOR_NAME}/logs"
-    terraform import sumologic_http_source.default_otlp_logs_source "${COLLECTOR_NAME}/logs-otlp"
-    terraform import sumologic_http_source.apiserver_metrics_source "${COLLECTOR_NAME}/apiserver-metrics"
-    terraform import sumologic_http_source.control_plane_metrics_source "${COLLECTOR_NAME}/control-plane-metrics"
-    terraform import sumologic_http_source.controller_metrics_source "${COLLECTOR_NAME}/kube-controller-manager-metrics"
-    terraform import sumologic_http_source.default_metrics_source "${COLLECTOR_NAME}/(default-metrics)"
-    terraform import sumologic_http_source.default_otlp_metrics_source "${COLLECTOR_NAME}/metrics-otlp"
-    terraform import sumologic_http_source.kubelet_metrics_source "${COLLECTOR_NAME}/kubelet-metrics"
-    terraform import sumologic_http_source.node_metrics_source "${COLLECTOR_NAME}/node-exporter-metrics"
-    terraform import sumologic_http_source.scheduler_metrics_source "${COLLECTOR_NAME}/kube-scheduler-metrics"
-    terraform import sumologic_http_source.state_metrics_source "${COLLECTOR_NAME}/kube-state-metrics"
-    terraform import sumologic_http_source.default_traces_source "${COLLECTOR_NAME}/traces"
-    terraform import sumologic_http_source.default_otlp_traces_source "${COLLECTOR_NAME}/traces-otlp"
+    terraform import sumologic_http_source.default_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events"
+    terraform import sumologic_http_source.default_otlp_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events-otlp"
+    terraform import sumologic_http_source.default_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs"
+    terraform import sumologic_http_source.default_otlp_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs-otlp"
+    terraform import sumologic_http_source.apiserver_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/apiserver-metrics"
+    terraform import sumologic_http_source.control_plane_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/control-plane-metrics"
+    terraform import sumologic_http_source.controller_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-controller-manager-metrics"
+    terraform import sumologic_http_source.default_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/(default-metrics)"
+    terraform import sumologic_http_source.default_otlp_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/metrics-otlp"
+    terraform import sumologic_http_source.kubelet_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kubelet-metrics"
+    terraform import sumologic_http_source.node_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/node-exporter-metrics"
+    terraform import sumologic_http_source.scheduler_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-scheduler-metrics"
+    terraform import sumologic_http_source.state_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-state-metrics"
+    terraform import sumologic_http_source.default_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces"
+    terraform import sumologic_http_source.default_otlp_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces-otlp"
     fi
 
     # Kubernetes Secret
@@ -752,7 +754,6 @@ data:
   variables.tf: |
     variable "collector_name" {
       type  = string
-      default = "kubernetes"
     }
 
     variable "namespace_name" {

--- a/tests/helm/testdata/goldenfile/terraform/disable_default_metrics.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disable_default_metrics.output.yaml
@@ -582,6 +582,10 @@ data:
 
     readonly DEBUG_MODE=${DEBUG_MODE:="false"}
     readonly DEBUG_MODE_ENABLED_FLAG="true"
+    readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
+
+    # Set variables for terraform
+    export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -698,26 +702,24 @@ data:
         echo "Please refer to https://help.sumologic.com/docs/manage/fields/ to manually create the fields after you have removed unused fields to free up capacity."
     fi
 
-    readonly COLLECTOR_NAME="kubernetes"
-
     # Sumo Logic Collector and HTTP sources
     # Only import sources when collector exists.
-    if terraform import sumologic_collector.collector "${COLLECTOR_NAME}"; then
+    if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
     true  # prevent to render empty if; then
-    terraform import sumologic_http_source.default_events_source "${COLLECTOR_NAME}/events"
-    terraform import sumologic_http_source.default_otlp_events_source "${COLLECTOR_NAME}/events-otlp"
-    terraform import sumologic_http_source.default_logs_source "${COLLECTOR_NAME}/logs"
-    terraform import sumologic_http_source.default_otlp_logs_source "${COLLECTOR_NAME}/logs-otlp"
-    terraform import sumologic_http_source.apiserver_metrics_source "${COLLECTOR_NAME}/apiserver-metrics"
-    terraform import sumologic_http_source.control_plane_metrics_source "${COLLECTOR_NAME}/control-plane-metrics"
-    terraform import sumologic_http_source.controller_metrics_source "${COLLECTOR_NAME}/kube-controller-manager-metrics"
-    terraform import sumologic_http_source.default_otlp_metrics_source "${COLLECTOR_NAME}/metrics-otlp"
-    terraform import sumologic_http_source.kubelet_metrics_source "${COLLECTOR_NAME}/kubelet-metrics"
-    terraform import sumologic_http_source.node_metrics_source "${COLLECTOR_NAME}/node-exporter-metrics"
-    terraform import sumologic_http_source.scheduler_metrics_source "${COLLECTOR_NAME}/kube-scheduler-metrics"
-    terraform import sumologic_http_source.state_metrics_source "${COLLECTOR_NAME}/kube-state-metrics"
-    terraform import sumologic_http_source.default_traces_source "${COLLECTOR_NAME}/traces"
-    terraform import sumologic_http_source.default_otlp_traces_source "${COLLECTOR_NAME}/traces-otlp"
+    terraform import sumologic_http_source.default_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events"
+    terraform import sumologic_http_source.default_otlp_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events-otlp"
+    terraform import sumologic_http_source.default_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs"
+    terraform import sumologic_http_source.default_otlp_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs-otlp"
+    terraform import sumologic_http_source.apiserver_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/apiserver-metrics"
+    terraform import sumologic_http_source.control_plane_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/control-plane-metrics"
+    terraform import sumologic_http_source.controller_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-controller-manager-metrics"
+    terraform import sumologic_http_source.default_otlp_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/metrics-otlp"
+    terraform import sumologic_http_source.kubelet_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kubelet-metrics"
+    terraform import sumologic_http_source.node_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/node-exporter-metrics"
+    terraform import sumologic_http_source.scheduler_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-scheduler-metrics"
+    terraform import sumologic_http_source.state_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-state-metrics"
+    terraform import sumologic_http_source.default_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces"
+    terraform import sumologic_http_source.default_otlp_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces-otlp"
     fi
 
     # Kubernetes Secret
@@ -744,7 +746,6 @@ data:
   variables.tf: |
     variable "collector_name" {
       type  = string
-      default = "kubernetes"
     }
 
     variable "namespace_name" {

--- a/tests/helm/testdata/goldenfile/terraform/disabled_dashboards.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disabled_dashboards.output.yaml
@@ -589,6 +589,10 @@ data:
 
     readonly DEBUG_MODE=${DEBUG_MODE:="false"}
     readonly DEBUG_MODE_ENABLED_FLAG="true"
+    readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
+
+    # Set variables for terraform
+    export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -705,27 +709,25 @@ data:
         echo "Please refer to https://help.sumologic.com/docs/manage/fields/ to manually create the fields after you have removed unused fields to free up capacity."
     fi
 
-    readonly COLLECTOR_NAME="kubernetes"
-
     # Sumo Logic Collector and HTTP sources
     # Only import sources when collector exists.
-    if terraform import sumologic_collector.collector "${COLLECTOR_NAME}"; then
+    if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
     true  # prevent to render empty if; then
-    terraform import sumologic_http_source.default_events_source "${COLLECTOR_NAME}/events"
-    terraform import sumologic_http_source.default_otlp_events_source "${COLLECTOR_NAME}/events-otlp"
-    terraform import sumologic_http_source.default_logs_source "${COLLECTOR_NAME}/logs"
-    terraform import sumologic_http_source.default_otlp_logs_source "${COLLECTOR_NAME}/logs-otlp"
-    terraform import sumologic_http_source.apiserver_metrics_source "${COLLECTOR_NAME}/apiserver-metrics"
-    terraform import sumologic_http_source.control_plane_metrics_source "${COLLECTOR_NAME}/control-plane-metrics"
-    terraform import sumologic_http_source.controller_metrics_source "${COLLECTOR_NAME}/kube-controller-manager-metrics"
-    terraform import sumologic_http_source.default_metrics_source "${COLLECTOR_NAME}/(default-metrics)"
-    terraform import sumologic_http_source.default_otlp_metrics_source "${COLLECTOR_NAME}/metrics-otlp"
-    terraform import sumologic_http_source.kubelet_metrics_source "${COLLECTOR_NAME}/kubelet-metrics"
-    terraform import sumologic_http_source.node_metrics_source "${COLLECTOR_NAME}/node-exporter-metrics"
-    terraform import sumologic_http_source.scheduler_metrics_source "${COLLECTOR_NAME}/kube-scheduler-metrics"
-    terraform import sumologic_http_source.state_metrics_source "${COLLECTOR_NAME}/kube-state-metrics"
-    terraform import sumologic_http_source.default_traces_source "${COLLECTOR_NAME}/traces"
-    terraform import sumologic_http_source.default_otlp_traces_source "${COLLECTOR_NAME}/traces-otlp"
+    terraform import sumologic_http_source.default_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events"
+    terraform import sumologic_http_source.default_otlp_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events-otlp"
+    terraform import sumologic_http_source.default_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs"
+    terraform import sumologic_http_source.default_otlp_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs-otlp"
+    terraform import sumologic_http_source.apiserver_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/apiserver-metrics"
+    terraform import sumologic_http_source.control_plane_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/control-plane-metrics"
+    terraform import sumologic_http_source.controller_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-controller-manager-metrics"
+    terraform import sumologic_http_source.default_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/(default-metrics)"
+    terraform import sumologic_http_source.default_otlp_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/metrics-otlp"
+    terraform import sumologic_http_source.kubelet_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kubelet-metrics"
+    terraform import sumologic_http_source.node_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/node-exporter-metrics"
+    terraform import sumologic_http_source.scheduler_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-scheduler-metrics"
+    terraform import sumologic_http_source.state_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-state-metrics"
+    terraform import sumologic_http_source.default_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces"
+    terraform import sumologic_http_source.default_otlp_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces-otlp"
     fi
 
     # Kubernetes Secret
@@ -754,7 +756,6 @@ data:
   variables.tf: |
     variable "collector_name" {
       type  = string
-      default = "kubernetes"
     }
 
     variable "namespace_name" {

--- a/tests/helm/testdata/goldenfile/terraform/disabled_monitors.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disabled_monitors.output.yaml
@@ -589,6 +589,10 @@ data:
 
     readonly DEBUG_MODE=${DEBUG_MODE:="false"}
     readonly DEBUG_MODE_ENABLED_FLAG="true"
+    readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
+
+    # Set variables for terraform
+    export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -705,27 +709,25 @@ data:
         echo "Please refer to https://help.sumologic.com/docs/manage/fields/ to manually create the fields after you have removed unused fields to free up capacity."
     fi
 
-    readonly COLLECTOR_NAME="kubernetes"
-
     # Sumo Logic Collector and HTTP sources
     # Only import sources when collector exists.
-    if terraform import sumologic_collector.collector "${COLLECTOR_NAME}"; then
+    if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
     true  # prevent to render empty if; then
-    terraform import sumologic_http_source.default_events_source "${COLLECTOR_NAME}/events"
-    terraform import sumologic_http_source.default_otlp_events_source "${COLLECTOR_NAME}/events-otlp"
-    terraform import sumologic_http_source.default_logs_source "${COLLECTOR_NAME}/logs"
-    terraform import sumologic_http_source.default_otlp_logs_source "${COLLECTOR_NAME}/logs-otlp"
-    terraform import sumologic_http_source.apiserver_metrics_source "${COLLECTOR_NAME}/apiserver-metrics"
-    terraform import sumologic_http_source.control_plane_metrics_source "${COLLECTOR_NAME}/control-plane-metrics"
-    terraform import sumologic_http_source.controller_metrics_source "${COLLECTOR_NAME}/kube-controller-manager-metrics"
-    terraform import sumologic_http_source.default_metrics_source "${COLLECTOR_NAME}/(default-metrics)"
-    terraform import sumologic_http_source.default_otlp_metrics_source "${COLLECTOR_NAME}/metrics-otlp"
-    terraform import sumologic_http_source.kubelet_metrics_source "${COLLECTOR_NAME}/kubelet-metrics"
-    terraform import sumologic_http_source.node_metrics_source "${COLLECTOR_NAME}/node-exporter-metrics"
-    terraform import sumologic_http_source.scheduler_metrics_source "${COLLECTOR_NAME}/kube-scheduler-metrics"
-    terraform import sumologic_http_source.state_metrics_source "${COLLECTOR_NAME}/kube-state-metrics"
-    terraform import sumologic_http_source.default_traces_source "${COLLECTOR_NAME}/traces"
-    terraform import sumologic_http_source.default_otlp_traces_source "${COLLECTOR_NAME}/traces-otlp"
+    terraform import sumologic_http_source.default_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events"
+    terraform import sumologic_http_source.default_otlp_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events-otlp"
+    terraform import sumologic_http_source.default_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs"
+    terraform import sumologic_http_source.default_otlp_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs-otlp"
+    terraform import sumologic_http_source.apiserver_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/apiserver-metrics"
+    terraform import sumologic_http_source.control_plane_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/control-plane-metrics"
+    terraform import sumologic_http_source.controller_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-controller-manager-metrics"
+    terraform import sumologic_http_source.default_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/(default-metrics)"
+    terraform import sumologic_http_source.default_otlp_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/metrics-otlp"
+    terraform import sumologic_http_source.kubelet_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kubelet-metrics"
+    terraform import sumologic_http_source.node_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/node-exporter-metrics"
+    terraform import sumologic_http_source.scheduler_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-scheduler-metrics"
+    terraform import sumologic_http_source.state_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-state-metrics"
+    terraform import sumologic_http_source.default_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces"
+    terraform import sumologic_http_source.default_otlp_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces-otlp"
     fi
 
     # Kubernetes Secret
@@ -754,7 +756,6 @@ data:
   variables.tf: |
     variable "collector_name" {
       type  = string
-      default = "kubernetes"
     }
 
     variable "namespace_name" {

--- a/tests/helm/testdata/goldenfile/terraform/logs_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/logs_fields.output.yaml
@@ -615,6 +615,10 @@ data:
 
     readonly DEBUG_MODE=${DEBUG_MODE:="false"}
     readonly DEBUG_MODE_ENABLED_FLAG="true"
+    readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
+
+    # Set variables for terraform
+    export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -731,27 +735,25 @@ data:
         echo "Please refer to https://help.sumologic.com/docs/manage/fields/ to manually create the fields after you have removed unused fields to free up capacity."
     fi
 
-    readonly COLLECTOR_NAME="kubernetes"
-
     # Sumo Logic Collector and HTTP sources
     # Only import sources when collector exists.
-    if terraform import sumologic_collector.collector "${COLLECTOR_NAME}"; then
+    if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
     true  # prevent to render empty if; then
-    terraform import sumologic_http_source.default_events_source "${COLLECTOR_NAME}/events"
-    terraform import sumologic_http_source.default_otlp_events_source "${COLLECTOR_NAME}/events-otlp"
-    terraform import sumologic_http_source.default_logs_source "${COLLECTOR_NAME}/logs"
-    terraform import sumologic_http_source.default_otlp_logs_source "${COLLECTOR_NAME}/logs-otlp"
-    terraform import sumologic_http_source.apiserver_metrics_source "${COLLECTOR_NAME}/apiserver-metrics"
-    terraform import sumologic_http_source.control_plane_metrics_source "${COLLECTOR_NAME}/control-plane-metrics"
-    terraform import sumologic_http_source.controller_metrics_source "${COLLECTOR_NAME}/kube-controller-manager-metrics"
-    terraform import sumologic_http_source.default_metrics_source "${COLLECTOR_NAME}/(default-metrics)"
-    terraform import sumologic_http_source.default_otlp_metrics_source "${COLLECTOR_NAME}/metrics-otlp"
-    terraform import sumologic_http_source.kubelet_metrics_source "${COLLECTOR_NAME}/kubelet-metrics"
-    terraform import sumologic_http_source.node_metrics_source "${COLLECTOR_NAME}/node-exporter-metrics"
-    terraform import sumologic_http_source.scheduler_metrics_source "${COLLECTOR_NAME}/kube-scheduler-metrics"
-    terraform import sumologic_http_source.state_metrics_source "${COLLECTOR_NAME}/kube-state-metrics"
-    terraform import sumologic_http_source.default_traces_source "${COLLECTOR_NAME}/traces"
-    terraform import sumologic_http_source.default_otlp_traces_source "${COLLECTOR_NAME}/traces-otlp"
+    terraform import sumologic_http_source.default_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events"
+    terraform import sumologic_http_source.default_otlp_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events-otlp"
+    terraform import sumologic_http_source.default_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs"
+    terraform import sumologic_http_source.default_otlp_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs-otlp"
+    terraform import sumologic_http_source.apiserver_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/apiserver-metrics"
+    terraform import sumologic_http_source.control_plane_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/control-plane-metrics"
+    terraform import sumologic_http_source.controller_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-controller-manager-metrics"
+    terraform import sumologic_http_source.default_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/(default-metrics)"
+    terraform import sumologic_http_source.default_otlp_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/metrics-otlp"
+    terraform import sumologic_http_source.kubelet_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kubelet-metrics"
+    terraform import sumologic_http_source.node_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/node-exporter-metrics"
+    terraform import sumologic_http_source.scheduler_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-scheduler-metrics"
+    terraform import sumologic_http_source.state_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-state-metrics"
+    terraform import sumologic_http_source.default_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces"
+    terraform import sumologic_http_source.default_otlp_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces-otlp"
     fi
 
     # Kubernetes Secret
@@ -778,7 +780,6 @@ data:
   variables.tf: |
     variable "collector_name" {
       type  = string
-      default = "kubernetes"
     }
 
     variable "namespace_name" {

--- a/tests/helm/testdata/goldenfile/terraform/monitors_with_email_notifications.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/monitors_with_email_notifications.output.yaml
@@ -595,6 +595,10 @@ data:
 
     readonly DEBUG_MODE=${DEBUG_MODE:="false"}
     readonly DEBUG_MODE_ENABLED_FLAG="true"
+    readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
+
+    # Set variables for terraform
+    export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -711,27 +715,25 @@ data:
         echo "Please refer to https://help.sumologic.com/docs/manage/fields/ to manually create the fields after you have removed unused fields to free up capacity."
     fi
 
-    readonly COLLECTOR_NAME="kubernetes"
-
     # Sumo Logic Collector and HTTP sources
     # Only import sources when collector exists.
-    if terraform import sumologic_collector.collector "${COLLECTOR_NAME}"; then
+    if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
     true  # prevent to render empty if; then
-    terraform import sumologic_http_source.default_events_source "${COLLECTOR_NAME}/events"
-    terraform import sumologic_http_source.default_otlp_events_source "${COLLECTOR_NAME}/events-otlp"
-    terraform import sumologic_http_source.default_logs_source "${COLLECTOR_NAME}/logs"
-    terraform import sumologic_http_source.default_otlp_logs_source "${COLLECTOR_NAME}/logs-otlp"
-    terraform import sumologic_http_source.apiserver_metrics_source "${COLLECTOR_NAME}/apiserver-metrics"
-    terraform import sumologic_http_source.control_plane_metrics_source "${COLLECTOR_NAME}/control-plane-metrics"
-    terraform import sumologic_http_source.controller_metrics_source "${COLLECTOR_NAME}/kube-controller-manager-metrics"
-    terraform import sumologic_http_source.default_metrics_source "${COLLECTOR_NAME}/(default-metrics)"
-    terraform import sumologic_http_source.default_otlp_metrics_source "${COLLECTOR_NAME}/metrics-otlp"
-    terraform import sumologic_http_source.kubelet_metrics_source "${COLLECTOR_NAME}/kubelet-metrics"
-    terraform import sumologic_http_source.node_metrics_source "${COLLECTOR_NAME}/node-exporter-metrics"
-    terraform import sumologic_http_source.scheduler_metrics_source "${COLLECTOR_NAME}/kube-scheduler-metrics"
-    terraform import sumologic_http_source.state_metrics_source "${COLLECTOR_NAME}/kube-state-metrics"
-    terraform import sumologic_http_source.default_traces_source "${COLLECTOR_NAME}/traces"
-    terraform import sumologic_http_source.default_otlp_traces_source "${COLLECTOR_NAME}/traces-otlp"
+    terraform import sumologic_http_source.default_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events"
+    terraform import sumologic_http_source.default_otlp_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events-otlp"
+    terraform import sumologic_http_source.default_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs"
+    terraform import sumologic_http_source.default_otlp_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs-otlp"
+    terraform import sumologic_http_source.apiserver_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/apiserver-metrics"
+    terraform import sumologic_http_source.control_plane_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/control-plane-metrics"
+    terraform import sumologic_http_source.controller_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-controller-manager-metrics"
+    terraform import sumologic_http_source.default_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/(default-metrics)"
+    terraform import sumologic_http_source.default_otlp_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/metrics-otlp"
+    terraform import sumologic_http_source.kubelet_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kubelet-metrics"
+    terraform import sumologic_http_source.node_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/node-exporter-metrics"
+    terraform import sumologic_http_source.scheduler_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-scheduler-metrics"
+    terraform import sumologic_http_source.state_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-state-metrics"
+    terraform import sumologic_http_source.default_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces"
+    terraform import sumologic_http_source.default_otlp_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces-otlp"
     fi
 
     # Kubernetes Secret
@@ -758,7 +760,6 @@ data:
   variables.tf: |
     variable "collector_name" {
       type  = string
-      default = "kubernetes"
     }
 
     variable "namespace_name" {

--- a/tests/helm/testdata/goldenfile/terraform/monitors_with_single_email.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/monitors_with_single_email.output.yaml
@@ -595,6 +595,10 @@ data:
 
     readonly DEBUG_MODE=${DEBUG_MODE:="false"}
     readonly DEBUG_MODE_ENABLED_FLAG="true"
+    readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
+
+    # Set variables for terraform
+    export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -711,27 +715,25 @@ data:
         echo "Please refer to https://help.sumologic.com/docs/manage/fields/ to manually create the fields after you have removed unused fields to free up capacity."
     fi
 
-    readonly COLLECTOR_NAME="kubernetes"
-
     # Sumo Logic Collector and HTTP sources
     # Only import sources when collector exists.
-    if terraform import sumologic_collector.collector "${COLLECTOR_NAME}"; then
+    if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
     true  # prevent to render empty if; then
-    terraform import sumologic_http_source.default_events_source "${COLLECTOR_NAME}/events"
-    terraform import sumologic_http_source.default_otlp_events_source "${COLLECTOR_NAME}/events-otlp"
-    terraform import sumologic_http_source.default_logs_source "${COLLECTOR_NAME}/logs"
-    terraform import sumologic_http_source.default_otlp_logs_source "${COLLECTOR_NAME}/logs-otlp"
-    terraform import sumologic_http_source.apiserver_metrics_source "${COLLECTOR_NAME}/apiserver-metrics"
-    terraform import sumologic_http_source.control_plane_metrics_source "${COLLECTOR_NAME}/control-plane-metrics"
-    terraform import sumologic_http_source.controller_metrics_source "${COLLECTOR_NAME}/kube-controller-manager-metrics"
-    terraform import sumologic_http_source.default_metrics_source "${COLLECTOR_NAME}/(default-metrics)"
-    terraform import sumologic_http_source.default_otlp_metrics_source "${COLLECTOR_NAME}/metrics-otlp"
-    terraform import sumologic_http_source.kubelet_metrics_source "${COLLECTOR_NAME}/kubelet-metrics"
-    terraform import sumologic_http_source.node_metrics_source "${COLLECTOR_NAME}/node-exporter-metrics"
-    terraform import sumologic_http_source.scheduler_metrics_source "${COLLECTOR_NAME}/kube-scheduler-metrics"
-    terraform import sumologic_http_source.state_metrics_source "${COLLECTOR_NAME}/kube-state-metrics"
-    terraform import sumologic_http_source.default_traces_source "${COLLECTOR_NAME}/traces"
-    terraform import sumologic_http_source.default_otlp_traces_source "${COLLECTOR_NAME}/traces-otlp"
+    terraform import sumologic_http_source.default_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events"
+    terraform import sumologic_http_source.default_otlp_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events-otlp"
+    terraform import sumologic_http_source.default_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs"
+    terraform import sumologic_http_source.default_otlp_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs-otlp"
+    terraform import sumologic_http_source.apiserver_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/apiserver-metrics"
+    terraform import sumologic_http_source.control_plane_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/control-plane-metrics"
+    terraform import sumologic_http_source.controller_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-controller-manager-metrics"
+    terraform import sumologic_http_source.default_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/(default-metrics)"
+    terraform import sumologic_http_source.default_otlp_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/metrics-otlp"
+    terraform import sumologic_http_source.kubelet_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kubelet-metrics"
+    terraform import sumologic_http_source.node_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/node-exporter-metrics"
+    terraform import sumologic_http_source.scheduler_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-scheduler-metrics"
+    terraform import sumologic_http_source.state_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-state-metrics"
+    terraform import sumologic_http_source.default_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces"
+    terraform import sumologic_http_source.default_otlp_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces-otlp"
     fi
 
     # Kubernetes Secret
@@ -758,7 +760,6 @@ data:
   variables.tf: |
     variable "collector_name" {
       type  = string
-      default = "kubernetes"
     }
 
     variable "namespace_name" {

--- a/tests/helm/testdata/goldenfile/terraform/strip_extrapolation.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/strip_extrapolation.output.yaml
@@ -590,6 +590,10 @@ data:
 
     readonly DEBUG_MODE=${DEBUG_MODE:="false"}
     readonly DEBUG_MODE_ENABLED_FLAG="true"
+    readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
+
+    # Set variables for terraform
+    export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -706,27 +710,25 @@ data:
         echo "Please refer to https://help.sumologic.com/docs/manage/fields/ to manually create the fields after you have removed unused fields to free up capacity."
     fi
 
-    readonly COLLECTOR_NAME="kubernetes"
-
     # Sumo Logic Collector and HTTP sources
     # Only import sources when collector exists.
-    if terraform import sumologic_collector.collector "${COLLECTOR_NAME}"; then
+    if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
     true  # prevent to render empty if; then
-    terraform import sumologic_http_source.default_events_source "${COLLECTOR_NAME}/events"
-    terraform import sumologic_http_source.default_otlp_events_source "${COLLECTOR_NAME}/events-otlp"
-    terraform import sumologic_http_source.default_logs_source "${COLLECTOR_NAME}/logs"
-    terraform import sumologic_http_source.default_otlp_logs_source "${COLLECTOR_NAME}/logs-otlp"
-    terraform import sumologic_http_source.apiserver_metrics_source "${COLLECTOR_NAME}/apiserver-metrics"
-    terraform import sumologic_http_source.control_plane_metrics_source "${COLLECTOR_NAME}/control-plane-metrics"
-    terraform import sumologic_http_source.controller_metrics_source "${COLLECTOR_NAME}/kube-controller-manager-metrics"
-    terraform import sumologic_http_source.default_metrics_source "${COLLECTOR_NAME}/(default-metrics)"
-    terraform import sumologic_http_source.default_otlp_metrics_source "${COLLECTOR_NAME}/metrics-otlp"
-    terraform import sumologic_http_source.kubelet_metrics_source "${COLLECTOR_NAME}/kubelet-metrics"
-    terraform import sumologic_http_source.node_metrics_source "${COLLECTOR_NAME}/node-exporter-metrics"
-    terraform import sumologic_http_source.scheduler_metrics_source "${COLLECTOR_NAME}/kube-scheduler-metrics"
-    terraform import sumologic_http_source.state_metrics_source "${COLLECTOR_NAME}/kube-state-metrics"
-    terraform import sumologic_http_source.default_traces_source "${COLLECTOR_NAME}/traces"
-    terraform import sumologic_http_source.default_otlp_traces_source "${COLLECTOR_NAME}/traces-otlp"
+    terraform import sumologic_http_source.default_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events"
+    terraform import sumologic_http_source.default_otlp_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events-otlp"
+    terraform import sumologic_http_source.default_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs"
+    terraform import sumologic_http_source.default_otlp_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs-otlp"
+    terraform import sumologic_http_source.apiserver_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/apiserver-metrics"
+    terraform import sumologic_http_source.control_plane_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/control-plane-metrics"
+    terraform import sumologic_http_source.controller_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-controller-manager-metrics"
+    terraform import sumologic_http_source.default_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/(default-metrics)"
+    terraform import sumologic_http_source.default_otlp_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/metrics-otlp"
+    terraform import sumologic_http_source.kubelet_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kubelet-metrics"
+    terraform import sumologic_http_source.node_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/node-exporter-metrics"
+    terraform import sumologic_http_source.scheduler_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-scheduler-metrics"
+    terraform import sumologic_http_source.state_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-state-metrics"
+    terraform import sumologic_http_source.default_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces"
+    terraform import sumologic_http_source.default_otlp_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces-otlp"
     fi
 
     # Kubernetes Secret
@@ -753,7 +755,6 @@ data:
   variables.tf: |
     variable "collector_name" {
       type  = string
-      default = "kubernetes"
     }
 
     variable "namespace_name" {

--- a/tests/helm/testdata/goldenfile/terraform/traces.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/traces.output.yaml
@@ -494,6 +494,10 @@ data:
 
     readonly DEBUG_MODE=${DEBUG_MODE:="false"}
     readonly DEBUG_MODE_ENABLED_FLAG="true"
+    readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
+
+    # Set variables for terraform
+    export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -610,15 +614,13 @@ data:
         echo "Please refer to https://help.sumologic.com/docs/manage/fields/ to manually create the fields after you have removed unused fields to free up capacity."
     fi
 
-    readonly COLLECTOR_NAME="kubernetes"
-
     # Sumo Logic Collector and HTTP sources
     # Only import sources when collector exists.
-    if terraform import sumologic_collector.collector "${COLLECTOR_NAME}"; then
+    if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
     true  # prevent to render empty if; then
-    terraform import sumologic_http_source.default_metrics_source "${COLLECTOR_NAME}/(default-metrics)"
-    terraform import sumologic_http_source.default_traces_source "${COLLECTOR_NAME}/traces"
-    terraform import sumologic_http_source.default_otlp_traces_source "${COLLECTOR_NAME}/traces-otlp"
+    terraform import sumologic_http_source.default_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/(default-metrics)"
+    terraform import sumologic_http_source.default_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces"
+    terraform import sumologic_http_source.default_otlp_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces-otlp"
     fi
 
     # Kubernetes Secret
@@ -645,7 +647,6 @@ data:
   variables.tf: |
     variable "collector_name" {
       type  = string
-      default = "kubernetes"
     }
 
     variable "namespace_name" {

--- a/tests/helm/testdata/goldenfile/terraform/tracing-metrics-disabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/tracing-metrics-disabled.output.yaml
@@ -589,6 +589,10 @@ data:
 
     readonly DEBUG_MODE=${DEBUG_MODE:="false"}
     readonly DEBUG_MODE_ENABLED_FLAG="true"
+    readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
+
+    # Set variables for terraform
+    export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -705,27 +709,25 @@ data:
         echo "Please refer to https://help.sumologic.com/docs/manage/fields/ to manually create the fields after you have removed unused fields to free up capacity."
     fi
 
-    readonly COLLECTOR_NAME="kubernetes"
-
     # Sumo Logic Collector and HTTP sources
     # Only import sources when collector exists.
-    if terraform import sumologic_collector.collector "${COLLECTOR_NAME}"; then
+    if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
     true  # prevent to render empty if; then
-    terraform import sumologic_http_source.default_events_source "${COLLECTOR_NAME}/events"
-    terraform import sumologic_http_source.default_otlp_events_source "${COLLECTOR_NAME}/events-otlp"
-    terraform import sumologic_http_source.default_logs_source "${COLLECTOR_NAME}/logs"
-    terraform import sumologic_http_source.default_otlp_logs_source "${COLLECTOR_NAME}/logs-otlp"
-    terraform import sumologic_http_source.apiserver_metrics_source "${COLLECTOR_NAME}/apiserver-metrics"
-    terraform import sumologic_http_source.control_plane_metrics_source "${COLLECTOR_NAME}/control-plane-metrics"
-    terraform import sumologic_http_source.controller_metrics_source "${COLLECTOR_NAME}/kube-controller-manager-metrics"
-    terraform import sumologic_http_source.default_metrics_source "${COLLECTOR_NAME}/(default-metrics)"
-    terraform import sumologic_http_source.default_otlp_metrics_source "${COLLECTOR_NAME}/metrics-otlp"
-    terraform import sumologic_http_source.kubelet_metrics_source "${COLLECTOR_NAME}/kubelet-metrics"
-    terraform import sumologic_http_source.node_metrics_source "${COLLECTOR_NAME}/node-exporter-metrics"
-    terraform import sumologic_http_source.scheduler_metrics_source "${COLLECTOR_NAME}/kube-scheduler-metrics"
-    terraform import sumologic_http_source.state_metrics_source "${COLLECTOR_NAME}/kube-state-metrics"
-    terraform import sumologic_http_source.default_traces_source "${COLLECTOR_NAME}/traces"
-    terraform import sumologic_http_source.default_otlp_traces_source "${COLLECTOR_NAME}/traces-otlp"
+    terraform import sumologic_http_source.default_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events"
+    terraform import sumologic_http_source.default_otlp_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events-otlp"
+    terraform import sumologic_http_source.default_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs"
+    terraform import sumologic_http_source.default_otlp_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs-otlp"
+    terraform import sumologic_http_source.apiserver_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/apiserver-metrics"
+    terraform import sumologic_http_source.control_plane_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/control-plane-metrics"
+    terraform import sumologic_http_source.controller_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-controller-manager-metrics"
+    terraform import sumologic_http_source.default_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/(default-metrics)"
+    terraform import sumologic_http_source.default_otlp_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/metrics-otlp"
+    terraform import sumologic_http_source.kubelet_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kubelet-metrics"
+    terraform import sumologic_http_source.node_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/node-exporter-metrics"
+    terraform import sumologic_http_source.scheduler_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-scheduler-metrics"
+    terraform import sumologic_http_source.state_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-state-metrics"
+    terraform import sumologic_http_source.default_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces"
+    terraform import sumologic_http_source.default_otlp_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces-otlp"
     fi
 
     # Kubernetes Secret
@@ -752,7 +754,6 @@ data:
   variables.tf: |
     variable "collector_name" {
       type  = string
-      default = "kubernetes"
     }
 
     variable "namespace_name" {


### PR DESCRIPTION
Collector name was determined slightly differently in the setup/cleanup bash scripts and the Terraform manifests. This PR makes it consistently the same.

I've also moved collector name determination to the Job template. This is part of an effort to eventually do no templating in bash scripts and Terraform manifests. For Terraform, I removed defaults from the variable, and it's now set via a `TF_VAR_` environment variable.

<!---
Describe your PR here
-->

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
