### PR TITLE
chore(setup): pass log fields and collector fields via Terraform variables

### DIFF
--- a/deploy/helm/sumologic/conf/cleanup/cleanup.sh
+++ b/deploy/helm/sumologic/conf/cleanup/cleanup.sh
@@ -11,7 +11,11 @@ export NO_PROXY="${NO_PROXY:=""}"
 
 readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
 
-cp /etc/terraform/*.tf /terraform/
+# Set variables for terraform
+export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
+export TF_VAR_chart_version="${CHART_VERSION:?}"
+
+cp /etc/terraform/* /terraform/
 cd /terraform || exit 1
 
 # Fall back to init -upgrade to prevent:

--- a/deploy/helm/sumologic/conf/setup/fields.tf
+++ b/deploy/helm/sumologic/conf/setup/fields.tf
@@ -1,6 +1,5 @@
-{{- range $value := .Values.sumologic.logs.fields }}
-resource "sumologic_field" {{ $value | quote }} {
-  count = var.create_fields ? 1 : 0
+resource "sumologic_field" "collection_field" {
+  for_each = var.create_fields ? toset(var.fields) : toset([])
 
   lifecycle {
     # ignore changes for name and type, as older installations have been case sensitive
@@ -8,24 +7,7 @@ resource "sumologic_field" {{ $value | quote }} {
     ignore_changes = [field_name, data_type]
   }
 
-  field_name = {{ $value | quote }}
+  field_name = "${ each.key }"
   data_type = "String"
   state = "Enabled"
 }
-{{- end }}
-
-{{- range $value := .Values.sumologic.logs.additionalFields }}
-resource "sumologic_field" {{ $value | quote }} {
-  count = var.create_fields ? 1 : 0
-
-  lifecycle {
-    # ignore changes for name and type, as older installations have been case sensitive
-    # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-    ignore_changes = [field_name, data_type]
-  }
-
-  field_name = {{ $value | quote }}
-  data_type = "String"
-  state = "Enabled"
-}
-{{- end }}

--- a/deploy/helm/sumologic/conf/setup/resources.tf
+++ b/deploy/helm/sumologic/conf/setup/resources.tf
@@ -1,12 +1,7 @@
 resource "sumologic_collector" "collector" {
     name  = var.collector_name
-    description = {{ printf "Sumo Logic Kubernetes Collection\nversion: %s" .Chart.Version | quote }}
-    fields  = {
-      {{- $fields := .Values.sumologic.collector.fields }}
-      {{- range $name, $value := $fields }}
-      {{ include "terraform.generate-key" (dict "Name" $name "Value" $value "KeyLength" (include "terraform.max-key-length" $fields)) }}
-      {{- end}}
-    }
+    description = format("Sumo Logic Kubernetes Collection\nversion: %s", var.chart_version)
+    fields  = var.collector_fields
 }
 
 resource "kubernetes_secret" "sumologic_collection_secret" {

--- a/deploy/helm/sumologic/conf/setup/terraform.tfvars.json
+++ b/deploy/helm/sumologic/conf/setup/terraform.tfvars.json
@@ -1,3 +1,4 @@
 {{- $fields := concat .Values.sumologic.logs.fields .Values.sumologic.logs.additionalFields -}}
-{{- $variables := dict "fields" $fields -}}
+{{- $collectorFields := .Values.sumologic.collector.fields -}}
+{{- $variables := dict "fields" $fields "collector_fields" $collectorFields -}}
 {{- toPrettyJson $variables | nindent 2 }}

--- a/deploy/helm/sumologic/conf/setup/terraform.tfvars.json
+++ b/deploy/helm/sumologic/conf/setup/terraform.tfvars.json
@@ -1,0 +1,3 @@
+{{- $fields := concat .Values.sumologic.logs.fields .Values.sumologic.logs.additionalFields -}}
+{{- $variables := dict "fields" $fields -}}
+{{- toPrettyJson $variables | nindent 2 }}

--- a/deploy/helm/sumologic/conf/setup/variables.tf
+++ b/deploy/helm/sumologic/conf/setup/variables.tf
@@ -12,3 +12,8 @@ variable "create_fields" {
   type        = bool
   default     = true
 }
+
+variable "fields" {
+  description = "Log fields to create."
+  type = list(string)
+}

--- a/deploy/helm/sumologic/conf/setup/variables.tf
+++ b/deploy/helm/sumologic/conf/setup/variables.tf
@@ -17,3 +17,13 @@ variable "fields" {
   description = "Log fields to create."
   type = list(string)
 }
+
+variable "collector_fields" {
+  description = "Fields to set on the collector."
+  type = map(string)
+}
+
+variable "chart_version" {
+  description = "The Helm Chart version."
+  type = string
+}

--- a/deploy/helm/sumologic/templates/_helpers/_common.tpl
+++ b/deploy/helm/sumologic/templates/_helpers/_common.tpl
@@ -418,23 +418,6 @@ Example:
 
 
 {{/*
-Generate a space separated list of quoted values:
-
-Example:
-
-{{ include "helm-toolkit.utils.joinListWithSpaces" .Values.sumologic.logs.fields }}
-*/}}
-{{- define "helm-toolkit.utils.joinListWithSpaces" -}}
-{{- $local := dict "first" true -}}
-{{- range $k, $v := . -}}
-{{- if not $local.first }} {{ end -}}
-{{- $v | quote -}}
-{{- $_ := set $local "first" false -}}
-{{- end -}}
-{{- end -}}
-
-
-{{/*
 Returns kubernetes minor version as integer (without additional chars like +)
 
 Example:

--- a/deploy/helm/sumologic/templates/_helpers/_setup.tpl
+++ b/deploy/helm/sumologic/templates/_helpers/_setup.tpl
@@ -85,44 +85,6 @@ Example usage:
 {{- if .Values.sumologic.collectorName }}{{ .Values.sumologic.collectorName }}{{- else}}{{ template "sumologic.clusterNameReplaceSpaceWithDash" . }}{{- end}}
 {{- end -}}
 
-{{- define "terraform.max-key-length" -}}
-{{- $max := 0 -}}
-{{- range $key, $value := . -}}
-{{- if gt (len $key) $max -}}
-{{- $max = (len $key) -}}
-{{- end -}}
-{{- end -}}
-{{ $max }}
-{{- end -}}
-
-{{/*
-Generate key for Terraform object. Default behaviour is to print:
-
-{{ name }} = {{ value }}
-
-If this is key for list, prints only value.
-
-This template takes care about indentation using Indent key
-
-Example usage:
-
-{{- include "terraform.generate-object" (dict "Name" "my_key" "Value" "my_value" "Indent" 8 "List" true) }}
-*/}}
-{{- define "terraform.generate-key" -}}
-{{- $indent := int .Indent -}}
-{{- $name := .Name -}}
-{{- $keyLength := int .KeyLength -}}
-{{- $format := printf "%%-%ss" (toString $keyLength) -}}
-{{- $value := .Value -}}
-{{- if and ( eq (kindOf $value) "string") (not .SkipEscaping) -}}
-{{- $value = printf "\"%s\"" $value -}}
-{{- end -}}
-{{- if .SkipPadding -}}
-{{- $format = "%s" -}}
-{{- end -}}
-{{ indent (int $indent) "" }}{{ if not .SkipName }}{{ printf $format (toString $name) }} {{ if not .SkipEqual }}= {{ end }}{{ end }}{{ (toString $value) }}{{ if .AddComma }},{{ end }}
-{{- end -}}
-
 {{/*
 get configuration variable name for sources confg map
 

--- a/deploy/helm/sumologic/templates/cleanup/job.yaml
+++ b/deploy/helm/sumologic/templates/cleanup/job.yaml
@@ -60,6 +60,8 @@ spec:
 {{- end }}
           - name: SUMOLOGIC_COLLECTOR_NAME
             value: {{ include "terraform.collector.name" . }}
+          - name: CHART_VERSION
+            value: "{{ .Chart.Version }}"
           {{- include "proxy-env-variables" . | nindent 10 }}
       securityContext:
         runAsUser: 999

--- a/deploy/helm/sumologic/templates/setup/job.yaml
+++ b/deploy/helm/sumologic/templates/setup/job.yaml
@@ -75,6 +75,8 @@ spec:
 {{- end }}
         - name: SUMOLOGIC_COLLECTOR_NAME
           value: {{ include "terraform.collector.name" . }}
+        - name: CHART_VERSION
+          value: "{{ .Chart.Version }}"
         {{- include "proxy-env-variables" . | nindent 8 -}}
 {{- if .Values.sumologic.setup.debug }}
         - name: DEBUG_MODE

--- a/tests/helm/testdata/goldenfile/cleanup/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/cleanup/basic.output.yaml
@@ -55,6 +55,8 @@ spec:
               value:
             - name: SUMOLOGIC_COLLECTOR_NAME
               value: kubernetes
+            - name: CHART_VERSION
+              value: "%CURRENT_CHART_VERSION%"
 
             - name: NO_PROXY
               value: kubernetes.default.svc

--- a/tests/helm/testdata/goldenfile/cleanup/sumologic-mock-no-secret.output.yaml
+++ b/tests/helm/testdata/goldenfile/cleanup/sumologic-mock-no-secret.output.yaml
@@ -55,6 +55,8 @@ spec:
               value: http://RELEASE-NAME-sumologic-mock.sumologic.svc.cluster.local.:3000/terraform/api/
             - name: SUMOLOGIC_COLLECTOR_NAME
               value: kubernetes
+            - name: CHART_VERSION
+              value: "%CURRENT_CHART_VERSION%"
 
             - name: NO_PROXY
               value: kubernetes.default.svc

--- a/tests/helm/testdata/goldenfile/cleanup/sumologic-mock.output.yaml
+++ b/tests/helm/testdata/goldenfile/cleanup/sumologic-mock.output.yaml
@@ -55,6 +55,8 @@ spec:
               value: http://RELEASE-NAME-sumologic-mock.sumologic.svc.cluster.local.:3000/terraform/api/
             - name: SUMOLOGIC_COLLECTOR_NAME
               value: kubernetes
+            - name: CHART_VERSION
+              value: "%CURRENT_CHART_VERSION%"
 
             - name: NO_PROXY
               value: kubernetes.default.svc

--- a/tests/helm/testdata/goldenfile/setup/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/setup/basic.output.yaml
@@ -59,6 +59,8 @@ spec:
               value:
             - name: SUMOLOGIC_COLLECTOR_NAME
               value: kubernetes
+            - name: CHART_VERSION
+              value: "%CURRENT_CHART_VERSION%"
 
             - name: NO_PROXY
               value: kubernetes.default.svc

--- a/tests/helm/testdata/goldenfile/setup/sumologic-mock-no-secret.output.yaml
+++ b/tests/helm/testdata/goldenfile/setup/sumologic-mock-no-secret.output.yaml
@@ -59,6 +59,8 @@ spec:
               value: http://RELEASE-NAME-sumologic-mock.sumologic.svc.cluster.local.:3000/terraform/api/
             - name: SUMOLOGIC_COLLECTOR_NAME
               value: kubernetes
+            - name: CHART_VERSION
+              value: "%CURRENT_CHART_VERSION%"
 
             - name: NO_PROXY
               value: kubernetes.default.svc

--- a/tests/helm/testdata/goldenfile/setup/sumologic-mock.output.yaml
+++ b/tests/helm/testdata/goldenfile/setup/sumologic-mock.output.yaml
@@ -59,6 +59,8 @@ spec:
               value: http://RELEASE-NAME-sumologic-mock.sumologic.svc.cluster.local.:3000/terraform/api/
             - name: SUMOLOGIC_COLLECTOR_NAME
               value: kubernetes
+            - name: CHART_VERSION
+              value: "%CURRENT_CHART_VERSION%"
 
             - name: NO_PROXY
               value: kubernetes.default.svc

--- a/tests/helm/testdata/goldenfile/terraform/all_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/all_fields.output.yaml
@@ -211,8 +211,8 @@ data:
       echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
     fi
   fields.tf: |
-    resource "sumologic_field" "cluster" {
-      count = var.create_fields ? 1 : 0
+    resource "sumologic_field" "collection_field" {
+      for_each = var.create_fields ? toset(var.fields) : toset([])
 
       lifecycle {
         # ignore changes for name and type, as older installations have been case sensitive
@@ -220,124 +220,7 @@ data:
         ignore_changes = [field_name, data_type]
       }
 
-      field_name = "cluster"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "container" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "container"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "daemonset" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "daemonset"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "deployment" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "deployment"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "host" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "host"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "namespace" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "namespace"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "node" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "node"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "pod" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "pod"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "service" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "service"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "statefulset" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "statefulset"
+      field_name = "${ each.key }"
       data_type = "String"
       state = "Enabled"
     }
@@ -475,6 +358,7 @@ data:
 
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
+    export TF_VAR_chart_version="${CHART_VERSION:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -549,7 +433,7 @@ data:
         local REMAINING
         REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
         readonly REMAINING
-        if [[ $(( REMAINING - 10 )) -ge 10 ]] ; then
+        if [[ $(( REMAINING - ${#FIELDS} )) -ge 10 ]] ; then
             return 0
         else
             return 1
@@ -558,6 +442,8 @@ data:
 
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
+
+    declare -ra FIELDS=($(jq -r '.fields[]' terraform.tfvars.json))
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file
@@ -572,7 +458,6 @@ data:
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"
         readonly FIELDS_RESPONSE
 
-        declare -ra FIELDS=("cluster" "container" "daemonset" "deployment" "host" "namespace" "node" "pod" "service" "statefulset")
         for FIELD in "${FIELDS[@]}" ; do
             FIELD_ID=$( echo "${FIELDS_RESPONSE}" | jq -r "select(.fieldName | ascii_downcase == \"${FIELD}\") | .fieldId" )
             # Don't try to import non existing fields
@@ -582,7 +467,7 @@ data:
 
             terraform import \
                 -var="create_fields=1" \
-                sumologic_field."${FIELD}"[0] "${FIELD_ID}"
+                sumologic_field.collection_field[\"${FIELD}\"] "${FIELD_ID}"
         done
     else
         readonly CREATE_FIELDS=0
@@ -929,6 +814,21 @@ data:
         }
       }
     }
+  terraform.tfvars.json: |
+    {
+      "fields": [
+        "cluster",
+        "container",
+        "daemonset",
+        "deployment",
+        "host",
+        "namespace",
+        "node",
+        "pod",
+        "service",
+        "statefulset"
+      ]
+    }
   variables.tf: |
     variable "collector_name" {
       type  = string
@@ -943,4 +843,9 @@ data:
       description = "If set, Terraform will attempt to create fields at Sumo Logic"
       type        = bool
       default     = true
+    }
+
+    variable "fields" {
+      description = "Log fields to create."
+      type = list(string)
     }

--- a/tests/helm/testdata/goldenfile/terraform/all_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/all_fields.output.yaml
@@ -332,9 +332,8 @@ data:
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
-        description = "Sumo Logic Kubernetes Collection\nversion: %CURRENT_CHART_VERSION%"
-        fields  = {
-        }
+        description = format("Sumo Logic Kubernetes Collection\nversion: %s", var.chart_version)
+        fields  = var.collector_fields
     }
 
     resource "kubernetes_secret" "sumologic_collection_secret" {
@@ -816,6 +815,7 @@ data:
     }
   terraform.tfvars.json: |
     {
+      "collector_fields": {},
       "fields": [
         "cluster",
         "container",
@@ -848,4 +848,14 @@ data:
     variable "fields" {
       description = "Log fields to create."
       type = list(string)
+    }
+
+    variable "collector_fields" {
+      description = "Fields to set on the collector."
+      type = map(string)
+    }
+
+    variable "chart_version" {
+      description = "The Helm Chart version."
+      type = string
     }

--- a/tests/helm/testdata/goldenfile/terraform/collector_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/collector_fields.output.yaml
@@ -211,8 +211,8 @@ data:
       echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
     fi
   fields.tf: |
-    resource "sumologic_field" "cluster" {
-      count = var.create_fields ? 1 : 0
+    resource "sumologic_field" "collection_field" {
+      for_each = var.create_fields ? toset(var.fields) : toset([])
 
       lifecycle {
         # ignore changes for name and type, as older installations have been case sensitive
@@ -220,124 +220,7 @@ data:
         ignore_changes = [field_name, data_type]
       }
 
-      field_name = "cluster"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "container" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "container"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "daemonset" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "daemonset"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "deployment" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "deployment"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "host" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "host"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "namespace" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "namespace"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "node" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "node"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "pod" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "pod"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "service" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "service"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "statefulset" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "statefulset"
+      field_name = "${ each.key }"
       data_type = "String"
       state = "Enabled"
     }
@@ -477,6 +360,7 @@ data:
 
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
+    export TF_VAR_chart_version="${CHART_VERSION:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -551,7 +435,7 @@ data:
         local REMAINING
         REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
         readonly REMAINING
-        if [[ $(( REMAINING - 10 )) -ge 10 ]] ; then
+        if [[ $(( REMAINING - ${#FIELDS} )) -ge 10 ]] ; then
             return 0
         else
             return 1
@@ -560,6 +444,8 @@ data:
 
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
+
+    declare -ra FIELDS=($(jq -r '.fields[]' terraform.tfvars.json))
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file
@@ -574,7 +460,6 @@ data:
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"
         readonly FIELDS_RESPONSE
 
-        declare -ra FIELDS=("cluster" "container" "daemonset" "deployment" "host" "namespace" "node" "pod" "service" "statefulset")
         for FIELD in "${FIELDS[@]}" ; do
             FIELD_ID=$( echo "${FIELDS_RESPONSE}" | jq -r "select(.fieldName | ascii_downcase == \"${FIELD}\") | .fieldId" )
             # Don't try to import non existing fields
@@ -584,7 +469,7 @@ data:
 
             terraform import \
                 -var="create_fields=1" \
-                sumologic_field."${FIELD}"[0] "${FIELD_ID}"
+                sumologic_field.collection_field[\"${FIELD}\"] "${FIELD_ID}"
         done
     else
         readonly CREATE_FIELDS=0
@@ -831,6 +716,21 @@ data:
         }
       }
     }
+  terraform.tfvars.json: |
+    {
+      "fields": [
+        "cluster",
+        "container",
+        "daemonset",
+        "deployment",
+        "host",
+        "namespace",
+        "node",
+        "pod",
+        "service",
+        "statefulset"
+      ]
+    }
   variables.tf: |
     variable "collector_name" {
       type  = string
@@ -845,4 +745,9 @@ data:
       description = "If set, Terraform will attempt to create fields at Sumo Logic"
       type        = bool
       default     = true
+    }
+
+    variable "fields" {
+      description = "Log fields to create."
+      type = list(string)
     }

--- a/tests/helm/testdata/goldenfile/terraform/collector_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/collector_fields.output.yaml
@@ -332,11 +332,8 @@ data:
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
-        description = "Sumo Logic Kubernetes Collection\nversion: %CURRENT_CHART_VERSION%"
-        fields  = {
-          here_is_very_long_field_name = "another_value"
-          test_fields                  = "test_value"
-        }
+        description = format("Sumo Logic Kubernetes Collection\nversion: %s", var.chart_version)
+        fields  = var.collector_fields
     }
 
     resource "kubernetes_secret" "sumologic_collection_secret" {
@@ -718,6 +715,10 @@ data:
     }
   terraform.tfvars.json: |
     {
+      "collector_fields": {
+        "here_is_very_long_field_name": "another_value",
+        "test_fields": "test_value"
+      },
       "fields": [
         "cluster",
         "container",
@@ -750,4 +751,14 @@ data:
     variable "fields" {
       description = "Log fields to create."
       type = list(string)
+    }
+
+    variable "collector_fields" {
+      description = "Fields to set on the collector."
+      type = map(string)
+    }
+
+    variable "chart_version" {
+      description = "The Helm Chart version."
+      type = string
     }

--- a/tests/helm/testdata/goldenfile/terraform/conditional_sources.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/conditional_sources.output.yaml
@@ -211,8 +211,8 @@ data:
       echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
     fi
   fields.tf: |
-    resource "sumologic_field" "cluster" {
-      count = var.create_fields ? 1 : 0
+    resource "sumologic_field" "collection_field" {
+      for_each = var.create_fields ? toset(var.fields) : toset([])
 
       lifecycle {
         # ignore changes for name and type, as older installations have been case sensitive
@@ -220,124 +220,7 @@ data:
         ignore_changes = [field_name, data_type]
       }
 
-      field_name = "cluster"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "container" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "container"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "daemonset" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "daemonset"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "deployment" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "deployment"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "host" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "host"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "namespace" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "namespace"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "node" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "node"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "pod" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "pod"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "service" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "service"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "statefulset" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "statefulset"
+      field_name = "${ each.key }"
       data_type = "String"
       state = "Enabled"
     }
@@ -475,6 +358,7 @@ data:
 
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
+    export TF_VAR_chart_version="${CHART_VERSION:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -549,7 +433,7 @@ data:
         local REMAINING
         REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
         readonly REMAINING
-        if [[ $(( REMAINING - 10 )) -ge 10 ]] ; then
+        if [[ $(( REMAINING - ${#FIELDS} )) -ge 10 ]] ; then
             return 0
         else
             return 1
@@ -558,6 +442,8 @@ data:
 
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
+
+    declare -ra FIELDS=($(jq -r '.fields[]' terraform.tfvars.json))
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file
@@ -572,7 +458,6 @@ data:
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"
         readonly FIELDS_RESPONSE
 
-        declare -ra FIELDS=("cluster" "container" "daemonset" "deployment" "host" "namespace" "node" "pod" "service" "statefulset")
         for FIELD in "${FIELDS[@]}" ; do
             FIELD_ID=$( echo "${FIELDS_RESPONSE}" | jq -r "select(.fieldName | ascii_downcase == \"${FIELD}\") | .fieldId" )
             # Don't try to import non existing fields
@@ -582,7 +467,7 @@ data:
 
             terraform import \
                 -var="create_fields=1" \
-                sumologic_field."${FIELD}"[0] "${FIELD_ID}"
+                sumologic_field.collection_field[\"${FIELD}\"] "${FIELD_ID}"
         done
     else
         readonly CREATE_FIELDS=0
@@ -628,6 +513,21 @@ data:
         "sumologic_http_source": {}
       }
     }
+  terraform.tfvars.json: |
+    {
+      "fields": [
+        "cluster",
+        "container",
+        "daemonset",
+        "deployment",
+        "host",
+        "namespace",
+        "node",
+        "pod",
+        "service",
+        "statefulset"
+      ]
+    }
   variables.tf: |
     variable "collector_name" {
       type  = string
@@ -642,4 +542,9 @@ data:
       description = "If set, Terraform will attempt to create fields at Sumo Logic"
       type        = bool
       default     = true
+    }
+
+    variable "fields" {
+      description = "Log fields to create."
+      type = list(string)
     }

--- a/tests/helm/testdata/goldenfile/terraform/conditional_sources.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/conditional_sources.output.yaml
@@ -332,9 +332,8 @@ data:
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
-        description = "Sumo Logic Kubernetes Collection\nversion: %CURRENT_CHART_VERSION%"
-        fields  = {
-        }
+        description = format("Sumo Logic Kubernetes Collection\nversion: %s", var.chart_version)
+        fields  = var.collector_fields
     }
 
     resource "kubernetes_secret" "sumologic_collection_secret" {
@@ -515,6 +514,7 @@ data:
     }
   terraform.tfvars.json: |
     {
+      "collector_fields": {},
       "fields": [
         "cluster",
         "container",
@@ -547,4 +547,14 @@ data:
     variable "fields" {
       description = "Log fields to create."
       type = list(string)
+    }
+
+    variable "collector_fields" {
+      description = "Fields to set on the collector."
+      type = map(string)
+    }
+
+    variable "chart_version" {
+      description = "The Helm Chart version."
+      type = string
     }

--- a/tests/helm/testdata/goldenfile/terraform/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/custom.output.yaml
@@ -211,8 +211,8 @@ data:
       echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
     fi
   fields.tf: |
-    resource "sumologic_field" "cluster" {
-      count = var.create_fields ? 1 : 0
+    resource "sumologic_field" "collection_field" {
+      for_each = var.create_fields ? toset(var.fields) : toset([])
 
       lifecycle {
         # ignore changes for name and type, as older installations have been case sensitive
@@ -220,124 +220,7 @@ data:
         ignore_changes = [field_name, data_type]
       }
 
-      field_name = "cluster"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "container" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "container"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "daemonset" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "daemonset"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "deployment" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "deployment"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "host" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "host"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "namespace" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "namespace"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "node" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "node"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "pod" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "pod"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "service" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "service"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "statefulset" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "statefulset"
+      field_name = "${ each.key }"
       data_type = "String"
       state = "Enabled"
     }
@@ -475,6 +358,7 @@ data:
 
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
+    export TF_VAR_chart_version="${CHART_VERSION:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -549,7 +433,7 @@ data:
         local REMAINING
         REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
         readonly REMAINING
-        if [[ $(( REMAINING - 10 )) -ge 10 ]] ; then
+        if [[ $(( REMAINING - ${#FIELDS} )) -ge 10 ]] ; then
             return 0
         else
             return 1
@@ -558,6 +442,8 @@ data:
 
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
+
+    declare -ra FIELDS=($(jq -r '.fields[]' terraform.tfvars.json))
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file
@@ -572,7 +458,6 @@ data:
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"
         readonly FIELDS_RESPONSE
 
-        declare -ra FIELDS=("cluster" "container" "daemonset" "deployment" "host" "namespace" "node" "pod" "service" "statefulset")
         for FIELD in "${FIELDS[@]}" ; do
             FIELD_ID=$( echo "${FIELDS_RESPONSE}" | jq -r "select(.fieldName | ascii_downcase == \"${FIELD}\") | .fieldId" )
             # Don't try to import non existing fields
@@ -582,7 +467,7 @@ data:
 
             terraform import \
                 -var="create_fields=1" \
-                sumologic_field."${FIELD}"[0] "${FIELD_ID}"
+                sumologic_field.collection_field[\"${FIELD}\"] "${FIELD_ID}"
         done
     else
         readonly CREATE_FIELDS=0
@@ -628,6 +513,21 @@ data:
         "sumologic_http_source": {}
       }
     }
+  terraform.tfvars.json: |
+    {
+      "fields": [
+        "cluster",
+        "container",
+        "daemonset",
+        "deployment",
+        "host",
+        "namespace",
+        "node",
+        "pod",
+        "service",
+        "statefulset"
+      ]
+    }
   variables.tf: |
     variable "collector_name" {
       type  = string
@@ -642,4 +542,9 @@ data:
       description = "If set, Terraform will attempt to create fields at Sumo Logic"
       type        = bool
       default     = true
+    }
+
+    variable "fields" {
+      description = "Log fields to create."
+      type = list(string)
     }

--- a/tests/helm/testdata/goldenfile/terraform/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/custom.output.yaml
@@ -332,9 +332,8 @@ data:
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
-        description = "Sumo Logic Kubernetes Collection\nversion: %CURRENT_CHART_VERSION%"
-        fields  = {
-        }
+        description = format("Sumo Logic Kubernetes Collection\nversion: %s", var.chart_version)
+        fields  = var.collector_fields
     }
 
     resource "kubernetes_secret" "sumologic_collection_secret" {
@@ -515,6 +514,7 @@ data:
     }
   terraform.tfvars.json: |
     {
+      "collector_fields": {},
       "fields": [
         "cluster",
         "container",
@@ -547,4 +547,14 @@ data:
     variable "fields" {
       description = "Log fields to create."
       type = list(string)
+    }
+
+    variable "collector_fields" {
+      description = "Fields to set on the collector."
+      type = map(string)
+    }
+
+    variable "chart_version" {
+      description = "The Helm Chart version."
+      type = string
     }

--- a/tests/helm/testdata/goldenfile/terraform/default.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/default.output.yaml
@@ -211,8 +211,8 @@ data:
       echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
     fi
   fields.tf: |
-    resource "sumologic_field" "cluster" {
-      count = var.create_fields ? 1 : 0
+    resource "sumologic_field" "collection_field" {
+      for_each = var.create_fields ? toset(var.fields) : toset([])
 
       lifecycle {
         # ignore changes for name and type, as older installations have been case sensitive
@@ -220,124 +220,7 @@ data:
         ignore_changes = [field_name, data_type]
       }
 
-      field_name = "cluster"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "container" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "container"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "daemonset" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "daemonset"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "deployment" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "deployment"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "host" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "host"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "namespace" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "namespace"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "node" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "node"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "pod" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "pod"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "service" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "service"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "statefulset" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "statefulset"
+      field_name = "${ each.key }"
       data_type = "String"
       state = "Enabled"
     }
@@ -475,6 +358,7 @@ data:
 
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
+    export TF_VAR_chart_version="${CHART_VERSION:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -549,7 +433,7 @@ data:
         local REMAINING
         REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
         readonly REMAINING
-        if [[ $(( REMAINING - 10 )) -ge 10 ]] ; then
+        if [[ $(( REMAINING - ${#FIELDS} )) -ge 10 ]] ; then
             return 0
         else
             return 1
@@ -558,6 +442,8 @@ data:
 
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
+
+    declare -ra FIELDS=($(jq -r '.fields[]' terraform.tfvars.json))
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file
@@ -572,7 +458,6 @@ data:
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"
         readonly FIELDS_RESPONSE
 
-        declare -ra FIELDS=("cluster" "container" "daemonset" "deployment" "host" "namespace" "node" "pod" "service" "statefulset")
         for FIELD in "${FIELDS[@]}" ; do
             FIELD_ID=$( echo "${FIELDS_RESPONSE}" | jq -r "select(.fieldName | ascii_downcase == \"${FIELD}\") | .fieldId" )
             # Don't try to import non existing fields
@@ -582,7 +467,7 @@ data:
 
             terraform import \
                 -var="create_fields=1" \
-                sumologic_field."${FIELD}"[0] "${FIELD_ID}"
+                sumologic_field.collection_field[\"${FIELD}\"] "${FIELD_ID}"
         done
     else
         readonly CREATE_FIELDS=0
@@ -829,6 +714,21 @@ data:
         }
       }
     }
+  terraform.tfvars.json: |
+    {
+      "fields": [
+        "cluster",
+        "container",
+        "daemonset",
+        "deployment",
+        "host",
+        "namespace",
+        "node",
+        "pod",
+        "service",
+        "statefulset"
+      ]
+    }
   variables.tf: |
     variable "collector_name" {
       type  = string
@@ -843,4 +743,9 @@ data:
       description = "If set, Terraform will attempt to create fields at Sumo Logic"
       type        = bool
       default     = true
+    }
+
+    variable "fields" {
+      description = "Log fields to create."
+      type = list(string)
     }

--- a/tests/helm/testdata/goldenfile/terraform/default.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/default.output.yaml
@@ -332,9 +332,8 @@ data:
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
-        description = "Sumo Logic Kubernetes Collection\nversion: %CURRENT_CHART_VERSION%"
-        fields  = {
-        }
+        description = format("Sumo Logic Kubernetes Collection\nversion: %s", var.chart_version)
+        fields  = var.collector_fields
     }
 
     resource "kubernetes_secret" "sumologic_collection_secret" {
@@ -716,6 +715,7 @@ data:
     }
   terraform.tfvars.json: |
     {
+      "collector_fields": {},
       "fields": [
         "cluster",
         "container",
@@ -748,4 +748,14 @@ data:
     variable "fields" {
       description = "Log fields to create."
       type = list(string)
+    }
+
+    variable "collector_fields" {
+      description = "Fields to set on the collector."
+      type = map(string)
+    }
+
+    variable "chart_version" {
+      description = "The Helm Chart version."
+      type = string
     }

--- a/tests/helm/testdata/goldenfile/terraform/disable_default_metrics.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disable_default_metrics.output.yaml
@@ -211,8 +211,8 @@ data:
       echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
     fi
   fields.tf: |
-    resource "sumologic_field" "cluster" {
-      count = var.create_fields ? 1 : 0
+    resource "sumologic_field" "collection_field" {
+      for_each = var.create_fields ? toset(var.fields) : toset([])
 
       lifecycle {
         # ignore changes for name and type, as older installations have been case sensitive
@@ -220,124 +220,7 @@ data:
         ignore_changes = [field_name, data_type]
       }
 
-      field_name = "cluster"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "container" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "container"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "daemonset" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "daemonset"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "deployment" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "deployment"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "host" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "host"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "namespace" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "namespace"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "node" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "node"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "pod" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "pod"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "service" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "service"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "statefulset" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "statefulset"
+      field_name = "${ each.key }"
       data_type = "String"
       state = "Enabled"
     }
@@ -475,6 +358,7 @@ data:
 
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
+    export TF_VAR_chart_version="${CHART_VERSION:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -549,7 +433,7 @@ data:
         local REMAINING
         REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
         readonly REMAINING
-        if [[ $(( REMAINING - 10 )) -ge 10 ]] ; then
+        if [[ $(( REMAINING - ${#FIELDS} )) -ge 10 ]] ; then
             return 0
         else
             return 1
@@ -558,6 +442,8 @@ data:
 
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
+
+    declare -ra FIELDS=($(jq -r '.fields[]' terraform.tfvars.json))
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file
@@ -572,7 +458,6 @@ data:
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"
         readonly FIELDS_RESPONSE
 
-        declare -ra FIELDS=("cluster" "container" "daemonset" "deployment" "host" "namespace" "node" "pod" "service" "statefulset")
         for FIELD in "${FIELDS[@]}" ; do
             FIELD_ID=$( echo "${FIELDS_RESPONSE}" | jq -r "select(.fieldName | ascii_downcase == \"${FIELD}\") | .fieldId" )
             # Don't try to import non existing fields
@@ -582,7 +467,7 @@ data:
 
             terraform import \
                 -var="create_fields=1" \
-                sumologic_field."${FIELD}"[0] "${FIELD_ID}"
+                sumologic_field.collection_field[\"${FIELD}\"] "${FIELD_ID}"
         done
     else
         readonly CREATE_FIELDS=0
@@ -819,6 +704,21 @@ data:
         }
       }
     }
+  terraform.tfvars.json: |
+    {
+      "fields": [
+        "cluster",
+        "container",
+        "daemonset",
+        "deployment",
+        "host",
+        "namespace",
+        "node",
+        "pod",
+        "service",
+        "statefulset"
+      ]
+    }
   variables.tf: |
     variable "collector_name" {
       type  = string
@@ -833,4 +733,9 @@ data:
       description = "If set, Terraform will attempt to create fields at Sumo Logic"
       type        = bool
       default     = true
+    }
+
+    variable "fields" {
+      description = "Log fields to create."
+      type = list(string)
     }

--- a/tests/helm/testdata/goldenfile/terraform/disable_default_metrics.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disable_default_metrics.output.yaml
@@ -332,9 +332,8 @@ data:
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
-        description = "Sumo Logic Kubernetes Collection\nversion: %CURRENT_CHART_VERSION%"
-        fields  = {
-        }
+        description = format("Sumo Logic Kubernetes Collection\nversion: %s", var.chart_version)
+        fields  = var.collector_fields
     }
 
     resource "kubernetes_secret" "sumologic_collection_secret" {
@@ -706,6 +705,7 @@ data:
     }
   terraform.tfvars.json: |
     {
+      "collector_fields": {},
       "fields": [
         "cluster",
         "container",
@@ -738,4 +738,14 @@ data:
     variable "fields" {
       description = "Log fields to create."
       type = list(string)
+    }
+
+    variable "collector_fields" {
+      description = "Fields to set on the collector."
+      type = map(string)
+    }
+
+    variable "chart_version" {
+      description = "The Helm Chart version."
+      type = string
     }

--- a/tests/helm/testdata/goldenfile/terraform/disabled_dashboards.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disabled_dashboards.output.yaml
@@ -332,9 +332,8 @@ data:
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
-        description = "Sumo Logic Kubernetes Collection\nversion: %CURRENT_CHART_VERSION%"
-        fields  = {
-        }
+        description = format("Sumo Logic Kubernetes Collection\nversion: %s", var.chart_version)
+        fields  = var.collector_fields
     }
 
     resource "kubernetes_secret" "sumologic_collection_secret" {
@@ -718,6 +717,7 @@ data:
     }
   terraform.tfvars.json: |
     {
+      "collector_fields": {},
       "fields": [
         "cluster",
         "container",
@@ -750,4 +750,14 @@ data:
     variable "fields" {
       description = "Log fields to create."
       type = list(string)
+    }
+
+    variable "collector_fields" {
+      description = "Fields to set on the collector."
+      type = map(string)
+    }
+
+    variable "chart_version" {
+      description = "The Helm Chart version."
+      type = string
     }

--- a/tests/helm/testdata/goldenfile/terraform/disabled_dashboards.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disabled_dashboards.output.yaml
@@ -211,8 +211,8 @@ data:
       echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
     fi
   fields.tf: |
-    resource "sumologic_field" "cluster" {
-      count = var.create_fields ? 1 : 0
+    resource "sumologic_field" "collection_field" {
+      for_each = var.create_fields ? toset(var.fields) : toset([])
 
       lifecycle {
         # ignore changes for name and type, as older installations have been case sensitive
@@ -220,124 +220,7 @@ data:
         ignore_changes = [field_name, data_type]
       }
 
-      field_name = "cluster"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "container" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "container"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "daemonset" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "daemonset"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "deployment" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "deployment"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "host" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "host"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "namespace" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "namespace"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "node" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "node"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "pod" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "pod"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "service" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "service"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "statefulset" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "statefulset"
+      field_name = "${ each.key }"
       data_type = "String"
       state = "Enabled"
     }
@@ -475,6 +358,7 @@ data:
 
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
+    export TF_VAR_chart_version="${CHART_VERSION:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -549,7 +433,7 @@ data:
         local REMAINING
         REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
         readonly REMAINING
-        if [[ $(( REMAINING - 10 )) -ge 10 ]] ; then
+        if [[ $(( REMAINING - ${#FIELDS} )) -ge 10 ]] ; then
             return 0
         else
             return 1
@@ -558,6 +442,8 @@ data:
 
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
+
+    declare -ra FIELDS=($(jq -r '.fields[]' terraform.tfvars.json))
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file
@@ -572,7 +458,6 @@ data:
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"
         readonly FIELDS_RESPONSE
 
-        declare -ra FIELDS=("cluster" "container" "daemonset" "deployment" "host" "namespace" "node" "pod" "service" "statefulset")
         for FIELD in "${FIELDS[@]}" ; do
             FIELD_ID=$( echo "${FIELDS_RESPONSE}" | jq -r "select(.fieldName | ascii_downcase == \"${FIELD}\") | .fieldId" )
             # Don't try to import non existing fields
@@ -582,7 +467,7 @@ data:
 
             terraform import \
                 -var="create_fields=1" \
-                sumologic_field."${FIELD}"[0] "${FIELD_ID}"
+                sumologic_field.collection_field[\"${FIELD}\"] "${FIELD_ID}"
         done
     else
         readonly CREATE_FIELDS=0
@@ -831,6 +716,21 @@ data:
         }
       }
     }
+  terraform.tfvars.json: |
+    {
+      "fields": [
+        "cluster",
+        "container",
+        "daemonset",
+        "deployment",
+        "host",
+        "namespace",
+        "node",
+        "pod",
+        "service",
+        "statefulset"
+      ]
+    }
   variables.tf: |
     variable "collector_name" {
       type  = string
@@ -845,4 +745,9 @@ data:
       description = "If set, Terraform will attempt to create fields at Sumo Logic"
       type        = bool
       default     = true
+    }
+
+    variable "fields" {
+      description = "Log fields to create."
+      type = list(string)
     }

--- a/tests/helm/testdata/goldenfile/terraform/disabled_monitors.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disabled_monitors.output.yaml
@@ -332,9 +332,8 @@ data:
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
-        description = "Sumo Logic Kubernetes Collection\nversion: %CURRENT_CHART_VERSION%"
-        fields  = {
-        }
+        description = format("Sumo Logic Kubernetes Collection\nversion: %s", var.chart_version)
+        fields  = var.collector_fields
     }
 
     resource "kubernetes_secret" "sumologic_collection_secret" {
@@ -718,6 +717,7 @@ data:
     }
   terraform.tfvars.json: |
     {
+      "collector_fields": {},
       "fields": [
         "cluster",
         "container",
@@ -750,4 +750,14 @@ data:
     variable "fields" {
       description = "Log fields to create."
       type = list(string)
+    }
+
+    variable "collector_fields" {
+      description = "Fields to set on the collector."
+      type = map(string)
+    }
+
+    variable "chart_version" {
+      description = "The Helm Chart version."
+      type = string
     }

--- a/tests/helm/testdata/goldenfile/terraform/disabled_monitors.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disabled_monitors.output.yaml
@@ -211,8 +211,8 @@ data:
       echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
     fi
   fields.tf: |
-    resource "sumologic_field" "cluster" {
-      count = var.create_fields ? 1 : 0
+    resource "sumologic_field" "collection_field" {
+      for_each = var.create_fields ? toset(var.fields) : toset([])
 
       lifecycle {
         # ignore changes for name and type, as older installations have been case sensitive
@@ -220,124 +220,7 @@ data:
         ignore_changes = [field_name, data_type]
       }
 
-      field_name = "cluster"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "container" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "container"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "daemonset" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "daemonset"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "deployment" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "deployment"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "host" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "host"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "namespace" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "namespace"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "node" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "node"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "pod" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "pod"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "service" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "service"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "statefulset" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "statefulset"
+      field_name = "${ each.key }"
       data_type = "String"
       state = "Enabled"
     }
@@ -475,6 +358,7 @@ data:
 
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
+    export TF_VAR_chart_version="${CHART_VERSION:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -549,7 +433,7 @@ data:
         local REMAINING
         REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
         readonly REMAINING
-        if [[ $(( REMAINING - 10 )) -ge 10 ]] ; then
+        if [[ $(( REMAINING - ${#FIELDS} )) -ge 10 ]] ; then
             return 0
         else
             return 1
@@ -558,6 +442,8 @@ data:
 
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
+
+    declare -ra FIELDS=($(jq -r '.fields[]' terraform.tfvars.json))
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file
@@ -572,7 +458,6 @@ data:
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"
         readonly FIELDS_RESPONSE
 
-        declare -ra FIELDS=("cluster" "container" "daemonset" "deployment" "host" "namespace" "node" "pod" "service" "statefulset")
         for FIELD in "${FIELDS[@]}" ; do
             FIELD_ID=$( echo "${FIELDS_RESPONSE}" | jq -r "select(.fieldName | ascii_downcase == \"${FIELD}\") | .fieldId" )
             # Don't try to import non existing fields
@@ -582,7 +467,7 @@ data:
 
             terraform import \
                 -var="create_fields=1" \
-                sumologic_field."${FIELD}"[0] "${FIELD_ID}"
+                sumologic_field.collection_field[\"${FIELD}\"] "${FIELD_ID}"
         done
     else
         readonly CREATE_FIELDS=0
@@ -831,6 +716,21 @@ data:
         }
       }
     }
+  terraform.tfvars.json: |
+    {
+      "fields": [
+        "cluster",
+        "container",
+        "daemonset",
+        "deployment",
+        "host",
+        "namespace",
+        "node",
+        "pod",
+        "service",
+        "statefulset"
+      ]
+    }
   variables.tf: |
     variable "collector_name" {
       type  = string
@@ -845,4 +745,9 @@ data:
       description = "If set, Terraform will attempt to create fields at Sumo Logic"
       type        = bool
       default     = true
+    }
+
+    variable "fields" {
+      description = "Log fields to create."
+      type = list(string)
     }

--- a/tests/helm/testdata/goldenfile/terraform/logs_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/logs_fields.output.yaml
@@ -332,9 +332,8 @@ data:
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
-        description = "Sumo Logic Kubernetes Collection\nversion: %CURRENT_CHART_VERSION%"
-        fields  = {
-        }
+        description = format("Sumo Logic Kubernetes Collection\nversion: %s", var.chart_version)
+        fields  = var.collector_fields
     }
 
     resource "kubernetes_secret" "sumologic_collection_secret" {
@@ -716,6 +715,7 @@ data:
     }
   terraform.tfvars.json: |
     {
+      "collector_fields": {},
       "fields": [
         "cluster",
         "container",
@@ -750,4 +750,14 @@ data:
     variable "fields" {
       description = "Log fields to create."
       type = list(string)
+    }
+
+    variable "collector_fields" {
+      description = "Fields to set on the collector."
+      type = map(string)
+    }
+
+    variable "chart_version" {
+      description = "The Helm Chart version."
+      type = string
     }

--- a/tests/helm/testdata/goldenfile/terraform/logs_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/logs_fields.output.yaml
@@ -211,8 +211,8 @@ data:
       echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
     fi
   fields.tf: |
-    resource "sumologic_field" "cluster" {
-      count = var.create_fields ? 1 : 0
+    resource "sumologic_field" "collection_field" {
+      for_each = var.create_fields ? toset(var.fields) : toset([])
 
       lifecycle {
         # ignore changes for name and type, as older installations have been case sensitive
@@ -220,150 +220,7 @@ data:
         ignore_changes = [field_name, data_type]
       }
 
-      field_name = "cluster"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "container" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "container"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "daemonset" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "daemonset"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "deployment" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "deployment"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "host" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "host"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "namespace" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "namespace"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "node" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "node"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "pod" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "pod"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "service" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "service"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "statefulset" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "statefulset"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "addfield1" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "addfield1"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "addfield2" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "addfield2"
+      field_name = "${ each.key }"
       data_type = "String"
       state = "Enabled"
     }
@@ -501,6 +358,7 @@ data:
 
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
+    export TF_VAR_chart_version="${CHART_VERSION:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -575,7 +433,7 @@ data:
         local REMAINING
         REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
         readonly REMAINING
-        if [[ $(( REMAINING - 10 )) -ge 10 ]] ; then
+        if [[ $(( REMAINING - ${#FIELDS} )) -ge 10 ]] ; then
             return 0
         else
             return 1
@@ -584,6 +442,8 @@ data:
 
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
+
+    declare -ra FIELDS=($(jq -r '.fields[]' terraform.tfvars.json))
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file
@@ -598,7 +458,6 @@ data:
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"
         readonly FIELDS_RESPONSE
 
-        declare -ra FIELDS=("cluster" "container" "daemonset" "deployment" "host" "namespace" "node" "pod" "service" "statefulset")
         for FIELD in "${FIELDS[@]}" ; do
             FIELD_ID=$( echo "${FIELDS_RESPONSE}" | jq -r "select(.fieldName | ascii_downcase == \"${FIELD}\") | .fieldId" )
             # Don't try to import non existing fields
@@ -608,7 +467,7 @@ data:
 
             terraform import \
                 -var="create_fields=1" \
-                sumologic_field."${FIELD}"[0] "${FIELD_ID}"
+                sumologic_field.collection_field[\"${FIELD}\"] "${FIELD_ID}"
         done
     else
         readonly CREATE_FIELDS=0
@@ -855,6 +714,23 @@ data:
         }
       }
     }
+  terraform.tfvars.json: |
+    {
+      "fields": [
+        "cluster",
+        "container",
+        "daemonset",
+        "deployment",
+        "host",
+        "namespace",
+        "node",
+        "pod",
+        "service",
+        "statefulset",
+        "addfield1",
+        "addfield2"
+      ]
+    }
   variables.tf: |
     variable "collector_name" {
       type  = string
@@ -869,4 +745,9 @@ data:
       description = "If set, Terraform will attempt to create fields at Sumo Logic"
       type        = bool
       default     = true
+    }
+
+    variable "fields" {
+      description = "Log fields to create."
+      type = list(string)
     }

--- a/tests/helm/testdata/goldenfile/terraform/monitors_with_email_notifications.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/monitors_with_email_notifications.output.yaml
@@ -338,9 +338,8 @@ data:
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
-        description = "Sumo Logic Kubernetes Collection\nversion: %CURRENT_CHART_VERSION%"
-        fields  = {
-        }
+        description = format("Sumo Logic Kubernetes Collection\nversion: %s", var.chart_version)
+        fields  = var.collector_fields
     }
 
     resource "kubernetes_secret" "sumologic_collection_secret" {
@@ -722,6 +721,7 @@ data:
     }
   terraform.tfvars.json: |
     {
+      "collector_fields": {},
       "fields": [
         "cluster",
         "container",
@@ -754,4 +754,14 @@ data:
     variable "fields" {
       description = "Log fields to create."
       type = list(string)
+    }
+
+    variable "collector_fields" {
+      description = "Fields to set on the collector."
+      type = map(string)
+    }
+
+    variable "chart_version" {
+      description = "The Helm Chart version."
+      type = string
     }

--- a/tests/helm/testdata/goldenfile/terraform/monitors_with_email_notifications.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/monitors_with_email_notifications.output.yaml
@@ -211,8 +211,8 @@ data:
       echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
     fi
   fields.tf: |
-    resource "sumologic_field" "cluster" {
-      count = var.create_fields ? 1 : 0
+    resource "sumologic_field" "collection_field" {
+      for_each = var.create_fields ? toset(var.fields) : toset([])
 
       lifecycle {
         # ignore changes for name and type, as older installations have been case sensitive
@@ -220,124 +220,7 @@ data:
         ignore_changes = [field_name, data_type]
       }
 
-      field_name = "cluster"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "container" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "container"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "daemonset" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "daemonset"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "deployment" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "deployment"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "host" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "host"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "namespace" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "namespace"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "node" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "node"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "pod" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "pod"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "service" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "service"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "statefulset" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "statefulset"
+      field_name = "${ each.key }"
       data_type = "String"
       state = "Enabled"
     }
@@ -481,6 +364,7 @@ data:
 
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
+    export TF_VAR_chart_version="${CHART_VERSION:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -555,7 +439,7 @@ data:
         local REMAINING
         REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
         readonly REMAINING
-        if [[ $(( REMAINING - 10 )) -ge 10 ]] ; then
+        if [[ $(( REMAINING - ${#FIELDS} )) -ge 10 ]] ; then
             return 0
         else
             return 1
@@ -564,6 +448,8 @@ data:
 
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
+
+    declare -ra FIELDS=($(jq -r '.fields[]' terraform.tfvars.json))
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file
@@ -578,7 +464,6 @@ data:
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"
         readonly FIELDS_RESPONSE
 
-        declare -ra FIELDS=("cluster" "container" "daemonset" "deployment" "host" "namespace" "node" "pod" "service" "statefulset")
         for FIELD in "${FIELDS[@]}" ; do
             FIELD_ID=$( echo "${FIELDS_RESPONSE}" | jq -r "select(.fieldName | ascii_downcase == \"${FIELD}\") | .fieldId" )
             # Don't try to import non existing fields
@@ -588,7 +473,7 @@ data:
 
             terraform import \
                 -var="create_fields=1" \
-                sumologic_field."${FIELD}"[0] "${FIELD_ID}"
+                sumologic_field.collection_field[\"${FIELD}\"] "${FIELD_ID}"
         done
     else
         readonly CREATE_FIELDS=0
@@ -835,6 +720,21 @@ data:
         }
       }
     }
+  terraform.tfvars.json: |
+    {
+      "fields": [
+        "cluster",
+        "container",
+        "daemonset",
+        "deployment",
+        "host",
+        "namespace",
+        "node",
+        "pod",
+        "service",
+        "statefulset"
+      ]
+    }
   variables.tf: |
     variable "collector_name" {
       type  = string
@@ -849,4 +749,9 @@ data:
       description = "If set, Terraform will attempt to create fields at Sumo Logic"
       type        = bool
       default     = true
+    }
+
+    variable "fields" {
+      description = "Log fields to create."
+      type = list(string)
     }

--- a/tests/helm/testdata/goldenfile/terraform/monitors_with_single_email.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/monitors_with_single_email.output.yaml
@@ -338,9 +338,8 @@ data:
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
-        description = "Sumo Logic Kubernetes Collection\nversion: %CURRENT_CHART_VERSION%"
-        fields  = {
-        }
+        description = format("Sumo Logic Kubernetes Collection\nversion: %s", var.chart_version)
+        fields  = var.collector_fields
     }
 
     resource "kubernetes_secret" "sumologic_collection_secret" {
@@ -722,6 +721,7 @@ data:
     }
   terraform.tfvars.json: |
     {
+      "collector_fields": {},
       "fields": [
         "cluster",
         "container",
@@ -754,4 +754,14 @@ data:
     variable "fields" {
       description = "Log fields to create."
       type = list(string)
+    }
+
+    variable "collector_fields" {
+      description = "Fields to set on the collector."
+      type = map(string)
+    }
+
+    variable "chart_version" {
+      description = "The Helm Chart version."
+      type = string
     }

--- a/tests/helm/testdata/goldenfile/terraform/monitors_with_single_email.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/monitors_with_single_email.output.yaml
@@ -211,8 +211,8 @@ data:
       echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
     fi
   fields.tf: |
-    resource "sumologic_field" "cluster" {
-      count = var.create_fields ? 1 : 0
+    resource "sumologic_field" "collection_field" {
+      for_each = var.create_fields ? toset(var.fields) : toset([])
 
       lifecycle {
         # ignore changes for name and type, as older installations have been case sensitive
@@ -220,124 +220,7 @@ data:
         ignore_changes = [field_name, data_type]
       }
 
-      field_name = "cluster"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "container" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "container"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "daemonset" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "daemonset"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "deployment" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "deployment"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "host" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "host"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "namespace" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "namespace"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "node" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "node"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "pod" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "pod"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "service" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "service"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "statefulset" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "statefulset"
+      field_name = "${ each.key }"
       data_type = "String"
       state = "Enabled"
     }
@@ -481,6 +364,7 @@ data:
 
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
+    export TF_VAR_chart_version="${CHART_VERSION:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -555,7 +439,7 @@ data:
         local REMAINING
         REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
         readonly REMAINING
-        if [[ $(( REMAINING - 10 )) -ge 10 ]] ; then
+        if [[ $(( REMAINING - ${#FIELDS} )) -ge 10 ]] ; then
             return 0
         else
             return 1
@@ -564,6 +448,8 @@ data:
 
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
+
+    declare -ra FIELDS=($(jq -r '.fields[]' terraform.tfvars.json))
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file
@@ -578,7 +464,6 @@ data:
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"
         readonly FIELDS_RESPONSE
 
-        declare -ra FIELDS=("cluster" "container" "daemonset" "deployment" "host" "namespace" "node" "pod" "service" "statefulset")
         for FIELD in "${FIELDS[@]}" ; do
             FIELD_ID=$( echo "${FIELDS_RESPONSE}" | jq -r "select(.fieldName | ascii_downcase == \"${FIELD}\") | .fieldId" )
             # Don't try to import non existing fields
@@ -588,7 +473,7 @@ data:
 
             terraform import \
                 -var="create_fields=1" \
-                sumologic_field."${FIELD}"[0] "${FIELD_ID}"
+                sumologic_field.collection_field[\"${FIELD}\"] "${FIELD_ID}"
         done
     else
         readonly CREATE_FIELDS=0
@@ -835,6 +720,21 @@ data:
         }
       }
     }
+  terraform.tfvars.json: |
+    {
+      "fields": [
+        "cluster",
+        "container",
+        "daemonset",
+        "deployment",
+        "host",
+        "namespace",
+        "node",
+        "pod",
+        "service",
+        "statefulset"
+      ]
+    }
   variables.tf: |
     variable "collector_name" {
       type  = string
@@ -849,4 +749,9 @@ data:
       description = "If set, Terraform will attempt to create fields at Sumo Logic"
       type        = bool
       default     = true
+    }
+
+    variable "fields" {
+      description = "Log fields to create."
+      type = list(string)
     }

--- a/tests/helm/testdata/goldenfile/terraform/strip_extrapolation.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/strip_extrapolation.output.yaml
@@ -211,8 +211,8 @@ data:
       echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
     fi
   fields.tf: |
-    resource "sumologic_field" "cluster" {
-      count = var.create_fields ? 1 : 0
+    resource "sumologic_field" "collection_field" {
+      for_each = var.create_fields ? toset(var.fields) : toset([])
 
       lifecycle {
         # ignore changes for name and type, as older installations have been case sensitive
@@ -220,124 +220,7 @@ data:
         ignore_changes = [field_name, data_type]
       }
 
-      field_name = "cluster"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "container" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "container"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "daemonset" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "daemonset"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "deployment" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "deployment"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "host" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "host"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "namespace" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "namespace"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "node" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "node"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "pod" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "pod"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "service" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "service"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "statefulset" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "statefulset"
+      field_name = "${ each.key }"
       data_type = "String"
       state = "Enabled"
     }
@@ -476,6 +359,7 @@ data:
 
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
+    export TF_VAR_chart_version="${CHART_VERSION:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -550,7 +434,7 @@ data:
         local REMAINING
         REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
         readonly REMAINING
-        if [[ $(( REMAINING - 10 )) -ge 10 ]] ; then
+        if [[ $(( REMAINING - ${#FIELDS} )) -ge 10 ]] ; then
             return 0
         else
             return 1
@@ -559,6 +443,8 @@ data:
 
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
+
+    declare -ra FIELDS=($(jq -r '.fields[]' terraform.tfvars.json))
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file
@@ -573,7 +459,6 @@ data:
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"
         readonly FIELDS_RESPONSE
 
-        declare -ra FIELDS=("cluster" "container" "daemonset" "deployment" "host" "namespace" "node" "pod" "service" "statefulset")
         for FIELD in "${FIELDS[@]}" ; do
             FIELD_ID=$( echo "${FIELDS_RESPONSE}" | jq -r "select(.fieldName | ascii_downcase == \"${FIELD}\") | .fieldId" )
             # Don't try to import non existing fields
@@ -583,7 +468,7 @@ data:
 
             terraform import \
                 -var="create_fields=1" \
-                sumologic_field."${FIELD}"[0] "${FIELD_ID}"
+                sumologic_field.collection_field[\"${FIELD}\"] "${FIELD_ID}"
         done
     else
         readonly CREATE_FIELDS=0
@@ -830,6 +715,21 @@ data:
         }
       }
     }
+  terraform.tfvars.json: |
+    {
+      "fields": [
+        "cluster",
+        "container",
+        "daemonset",
+        "deployment",
+        "host",
+        "namespace",
+        "node",
+        "pod",
+        "service",
+        "statefulset"
+      ]
+    }
   variables.tf: |
     variable "collector_name" {
       type  = string
@@ -844,4 +744,9 @@ data:
       description = "If set, Terraform will attempt to create fields at Sumo Logic"
       type        = bool
       default     = true
+    }
+
+    variable "fields" {
+      description = "Log fields to create."
+      type = list(string)
     }

--- a/tests/helm/testdata/goldenfile/terraform/strip_extrapolation.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/strip_extrapolation.output.yaml
@@ -333,9 +333,8 @@ data:
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
-        description = "Sumo Logic Kubernetes Collection\nversion: %CURRENT_CHART_VERSION%"
-        fields  = {
-        }
+        description = format("Sumo Logic Kubernetes Collection\nversion: %s", var.chart_version)
+        fields  = var.collector_fields
     }
 
     resource "kubernetes_secret" "sumologic_collection_secret" {
@@ -717,6 +716,7 @@ data:
     }
   terraform.tfvars.json: |
     {
+      "collector_fields": {},
       "fields": [
         "cluster",
         "container",
@@ -749,4 +749,14 @@ data:
     variable "fields" {
       description = "Log fields to create."
       type = list(string)
+    }
+
+    variable "collector_fields" {
+      description = "Fields to set on the collector."
+      type = map(string)
+    }
+
+    variable "chart_version" {
+      description = "The Helm Chart version."
+      type = string
     }

--- a/tests/helm/testdata/goldenfile/terraform/traces.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/traces.output.yaml
@@ -211,8 +211,8 @@ data:
       echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
     fi
   fields.tf: |
-    resource "sumologic_field" "cluster" {
-      count = var.create_fields ? 1 : 0
+    resource "sumologic_field" "collection_field" {
+      for_each = var.create_fields ? toset(var.fields) : toset([])
 
       lifecycle {
         # ignore changes for name and type, as older installations have been case sensitive
@@ -220,124 +220,7 @@ data:
         ignore_changes = [field_name, data_type]
       }
 
-      field_name = "cluster"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "container" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "container"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "daemonset" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "daemonset"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "deployment" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "deployment"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "host" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "host"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "namespace" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "namespace"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "node" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "node"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "pod" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "pod"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "service" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "service"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "statefulset" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "statefulset"
+      field_name = "${ each.key }"
       data_type = "String"
       state = "Enabled"
     }
@@ -475,6 +358,7 @@ data:
 
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
+    export TF_VAR_chart_version="${CHART_VERSION:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -549,7 +433,7 @@ data:
         local REMAINING
         REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
         readonly REMAINING
-        if [[ $(( REMAINING - 10 )) -ge 10 ]] ; then
+        if [[ $(( REMAINING - ${#FIELDS} )) -ge 10 ]] ; then
             return 0
         else
             return 1
@@ -558,6 +442,8 @@ data:
 
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
+
+    declare -ra FIELDS=($(jq -r '.fields[]' terraform.tfvars.json))
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file
@@ -572,7 +458,6 @@ data:
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"
         readonly FIELDS_RESPONSE
 
-        declare -ra FIELDS=("cluster" "container" "daemonset" "deployment" "host" "namespace" "node" "pod" "service" "statefulset")
         for FIELD in "${FIELDS[@]}" ; do
             FIELD_ID=$( echo "${FIELDS_RESPONSE}" | jq -r "select(.fieldName | ascii_downcase == \"${FIELD}\") | .fieldId" )
             # Don't try to import non existing fields
@@ -582,7 +467,7 @@ data:
 
             terraform import \
                 -var="create_fields=1" \
-                sumologic_field."${FIELD}"[0] "${FIELD_ID}"
+                sumologic_field.collection_field[\"${FIELD}\"] "${FIELD_ID}"
         done
     else
         readonly CREATE_FIELDS=0
@@ -669,6 +554,21 @@ data:
         }
       }
     }
+  terraform.tfvars.json: |
+    {
+      "fields": [
+        "cluster",
+        "container",
+        "daemonset",
+        "deployment",
+        "host",
+        "namespace",
+        "node",
+        "pod",
+        "service",
+        "statefulset"
+      ]
+    }
   variables.tf: |
     variable "collector_name" {
       type  = string
@@ -683,4 +583,9 @@ data:
       description = "If set, Terraform will attempt to create fields at Sumo Logic"
       type        = bool
       default     = true
+    }
+
+    variable "fields" {
+      description = "Log fields to create."
+      type = list(string)
     }

--- a/tests/helm/testdata/goldenfile/terraform/traces.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/traces.output.yaml
@@ -332,9 +332,8 @@ data:
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
-        description = "Sumo Logic Kubernetes Collection\nversion: %CURRENT_CHART_VERSION%"
-        fields  = {
-        }
+        description = format("Sumo Logic Kubernetes Collection\nversion: %s", var.chart_version)
+        fields  = var.collector_fields
     }
 
     resource "kubernetes_secret" "sumologic_collection_secret" {
@@ -556,6 +555,7 @@ data:
     }
   terraform.tfvars.json: |
     {
+      "collector_fields": {},
       "fields": [
         "cluster",
         "container",
@@ -588,4 +588,14 @@ data:
     variable "fields" {
       description = "Log fields to create."
       type = list(string)
+    }
+
+    variable "collector_fields" {
+      description = "Fields to set on the collector."
+      type = map(string)
+    }
+
+    variable "chart_version" {
+      description = "The Helm Chart version."
+      type = string
     }

--- a/tests/helm/testdata/goldenfile/terraform/tracing-metrics-disabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/tracing-metrics-disabled.output.yaml
@@ -211,8 +211,8 @@ data:
       echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
     fi
   fields.tf: |
-    resource "sumologic_field" "cluster" {
-      count = var.create_fields ? 1 : 0
+    resource "sumologic_field" "collection_field" {
+      for_each = var.create_fields ? toset(var.fields) : toset([])
 
       lifecycle {
         # ignore changes for name and type, as older installations have been case sensitive
@@ -220,124 +220,7 @@ data:
         ignore_changes = [field_name, data_type]
       }
 
-      field_name = "cluster"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "container" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "container"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "daemonset" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "daemonset"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "deployment" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "deployment"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "host" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "host"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "namespace" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "namespace"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "node" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "node"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "pod" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "pod"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "service" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "service"
-      data_type = "String"
-      state = "Enabled"
-    }
-    resource "sumologic_field" "statefulset" {
-      count = var.create_fields ? 1 : 0
-
-      lifecycle {
-        # ignore changes for name and type, as older installations have been case sensitive
-        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
-        ignore_changes = [field_name, data_type]
-      }
-
-      field_name = "statefulset"
+      field_name = "${ each.key }"
       data_type = "String"
       state = "Enabled"
     }
@@ -475,6 +358,7 @@ data:
 
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
+    export TF_VAR_chart_version="${CHART_VERSION:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -549,7 +433,7 @@ data:
         local REMAINING
         REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
         readonly REMAINING
-        if [[ $(( REMAINING - 10 )) -ge 10 ]] ; then
+        if [[ $(( REMAINING - ${#FIELDS} )) -ge 10 ]] ; then
             return 0
         else
             return 1
@@ -558,6 +442,8 @@ data:
 
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
+
+    declare -ra FIELDS=($(jq -r '.fields[]' terraform.tfvars.json))
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file
@@ -572,7 +458,6 @@ data:
             "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"
         readonly FIELDS_RESPONSE
 
-        declare -ra FIELDS=("cluster" "container" "daemonset" "deployment" "host" "namespace" "node" "pod" "service" "statefulset")
         for FIELD in "${FIELDS[@]}" ; do
             FIELD_ID=$( echo "${FIELDS_RESPONSE}" | jq -r "select(.fieldName | ascii_downcase == \"${FIELD}\") | .fieldId" )
             # Don't try to import non existing fields
@@ -582,7 +467,7 @@ data:
 
             terraform import \
                 -var="create_fields=1" \
-                sumologic_field."${FIELD}"[0] "${FIELD_ID}"
+                sumologic_field.collection_field[\"${FIELD}\"] "${FIELD_ID}"
         done
     else
         readonly CREATE_FIELDS=0
@@ -829,6 +714,21 @@ data:
         }
       }
     }
+  terraform.tfvars.json: |
+    {
+      "fields": [
+        "cluster",
+        "container",
+        "daemonset",
+        "deployment",
+        "host",
+        "namespace",
+        "node",
+        "pod",
+        "service",
+        "statefulset"
+      ]
+    }
   variables.tf: |
     variable "collector_name" {
       type  = string
@@ -843,4 +743,9 @@ data:
       description = "If set, Terraform will attempt to create fields at Sumo Logic"
       type        = bool
       default     = true
+    }
+
+    variable "fields" {
+      description = "Log fields to create."
+      type = list(string)
     }

--- a/tests/helm/testdata/goldenfile/terraform/tracing-metrics-disabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/tracing-metrics-disabled.output.yaml
@@ -332,9 +332,8 @@ data:
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
-        description = "Sumo Logic Kubernetes Collection\nversion: %CURRENT_CHART_VERSION%"
-        fields  = {
-        }
+        description = format("Sumo Logic Kubernetes Collection\nversion: %s", var.chart_version)
+        fields  = var.collector_fields
     }
 
     resource "kubernetes_secret" "sumologic_collection_secret" {
@@ -716,6 +715,7 @@ data:
     }
   terraform.tfvars.json: |
     {
+      "collector_fields": {},
       "fields": [
         "cluster",
         "container",
@@ -748,4 +748,14 @@ data:
     variable "fields" {
       description = "Log fields to create."
       type = list(string)
+    }
+
+    variable "collector_fields" {
+      description = "Fields to set on the collector."
+      type = map(string)
+    }
+
+    variable "chart_version" {
+      description = "The Helm Chart version."
+      type = string
     }


### PR DESCRIPTION
Pass these as Terraform variables. Define the values in a `terraform.tfvars.json` file, which Terraform loads automatically.

Collector fields require that we know the Helm Chart version, so pass that in as an environment variable.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
