### PR TITLE
chore(setup): pass secret name and namespace as TF variables

### DIFF
--- a/deploy/helm/sumologic/conf/cleanup/cleanup.sh
+++ b/deploy/helm/sumologic/conf/cleanup/cleanup.sh
@@ -14,6 +14,7 @@ readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
 # Set variables for terraform
 export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
 export TF_VAR_chart_version="${CHART_VERSION:?}"
+export TF_VAR_namespace_name="${NAMESPACE:?}"
 
 cp /etc/terraform/* /terraform/
 cd /terraform || exit 1

--- a/deploy/helm/sumologic/conf/cleanup/cleanup.sh
+++ b/deploy/helm/sumologic/conf/cleanup/cleanup.sh
@@ -10,6 +10,8 @@ export HTTPS_PROXY="${HTTPS_PROXY:=""}"
 export NO_PROXY="${NO_PROXY:=""}"
 
 readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
+readonly SUMOLOGIC_SECRET_NAME="${SUMOLOGIC_SECRET_NAME:?}"
+readonly NAMESPACE="${NAMESPACE:?}"
 
 # Set variables for terraform
 export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
@@ -26,7 +28,7 @@ terraform init -input=false -get=false || terraform init -input=false -upgrade
 # shellcheck disable=SC1083
 terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"
 # shellcheck disable=SC1083
-terraform import kubernetes_secret.sumologic_collection_secret {{ template "terraform.secret.fullname" . }}
+terraform import kubernetes_secret.sumologic_collection_secret "${NAMESPACE}/${SUMOLOGIC_SECRET_NAME}"
 
 terraform destroy -auto-approve
 

--- a/deploy/helm/sumologic/conf/setup/resources.tf
+++ b/deploy/helm/sumologic/conf/setup/resources.tf
@@ -6,7 +6,7 @@ resource "sumologic_collector" "collector" {
 
 resource "kubernetes_secret" "sumologic_collection_secret" {
   metadata {
-    name = "{{ template "terraform.secret.name" }}"
+    name = var.secret_name
     namespace = var.namespace_name
   }
 

--- a/deploy/helm/sumologic/conf/setup/setup.sh
+++ b/deploy/helm/sumologic/conf/setup/setup.sh
@@ -7,6 +7,7 @@ readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
 # Set variables for terraform
 export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
 export TF_VAR_chart_version="${CHART_VERSION:?}"
+export TF_VAR_namespace_name="${NAMESPACE:?}"
 
 # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
 # so that we don't have to deal with True vs true vs TRUE

--- a/deploy/helm/sumologic/conf/setup/setup.sh
+++ b/deploy/helm/sumologic/conf/setup/setup.sh
@@ -3,11 +3,14 @@
 readonly DEBUG_MODE=${DEBUG_MODE:="false"}
 readonly DEBUG_MODE_ENABLED_FLAG="true"
 readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
+readonly NAMESPACE="${NAMESPACE:?}"
+readonly SUMOLOGIC_SECRET_NAME="${SUMOLOGIC_SECRET_NAME:?}"
 
 # Set variables for terraform
 export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
+export TF_VAR_namespace_name="${NAMESPACE}"
+export TF_VAR_secret_name="${SUMOLOGIC_SECRET_NAME}"
 export TF_VAR_chart_version="${CHART_VERSION:?}"
-export TF_VAR_namespace_name="${NAMESPACE:?}"
 
 # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
 # so that we don't have to deal with True vs true vs TRUE
@@ -149,7 +152,7 @@ terraform import sumologic_http_source.{{ template "terraform.sources.name" (dic
 fi
 
 # Kubernetes Secret
-terraform import kubernetes_secret.sumologic_collection_secret {{ template "terraform.secret.fullname" . }}
+terraform import kubernetes_secret.sumologic_collection_secret "${NAMESPACE}/${SUMOLOGIC_SECRET_NAME}"
 
 # Apply planned changes
 TF_LOG_PROVIDER=DEBUG terraform apply \

--- a/deploy/helm/sumologic/conf/setup/variables.tf
+++ b/deploy/helm/sumologic/conf/setup/variables.tf
@@ -6,6 +6,10 @@ variable "namespace_name" {
   type  = string
 }
 
+variable "secret_name" {
+  type = string
+}
+
 variable "create_fields" {
   description = "If set, Terraform will attempt to create fields at Sumo Logic"
   type        = bool

--- a/deploy/helm/sumologic/conf/setup/variables.tf
+++ b/deploy/helm/sumologic/conf/setup/variables.tf
@@ -4,7 +4,6 @@ variable "collector_name" {
 
 variable "namespace_name" {
   type  = string
-  default = "{{ template "sumologic.namespace" . }}"
 }
 
 variable "create_fields" {

--- a/deploy/helm/sumologic/templates/_helpers/_setup.tpl
+++ b/deploy/helm/sumologic/templates/_helpers/_setup.tpl
@@ -11,18 +11,6 @@ Example usage:
 {{- end -}}
 
 {{/*
-Returns the name of Kubernetes secret prefixed with release namespace.
-
-Example usage:
-
-{{ include "terraform.secret.fullname" }}
-
-*/}}
-{{- define "terraform.secret.fullname" -}}
-{{ template "sumologic.namespace" . }}/{{ template "terraform.secret.name" . }}
-{{- end -}}
-
-{{/*
 Convert source name to Terraform metric name:
  * converts all `-` to `_`
  * adds `_$type_source` suffix

--- a/deploy/helm/sumologic/templates/cleanup/job.yaml
+++ b/deploy/helm/sumologic/templates/cleanup/job.yaml
@@ -52,6 +52,10 @@ spec:
           - secretRef:
               name: {{ .Values.sumologic.envFromSecret | default (include "sumologic.metadata.name.setup.secret" .)}}
           env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
           - name: SUMOLOGIC_BASE_URL
 {{- if eq (include "sumologic-mock.local-mode-enabled" .) "true" }}
             value: http://{{ template "sumologic-mock.hostname" . }}:{{ template "sumologic-mock.port" . }}/terraform/api/

--- a/deploy/helm/sumologic/templates/cleanup/job.yaml
+++ b/deploy/helm/sumologic/templates/cleanup/job.yaml
@@ -66,6 +66,8 @@ spec:
             value: {{ include "terraform.collector.name" . }}
           - name: CHART_VERSION
             value: "{{ .Chart.Version }}"
+          - name: SUMOLOGIC_SECRET_NAME
+            value: "{{ template "terraform.secret.name" }}"
           {{- include "proxy-env-variables" . | nindent 10 }}
       securityContext:
         runAsUser: 999

--- a/deploy/helm/sumologic/templates/setup/job.yaml
+++ b/deploy/helm/sumologic/templates/setup/job.yaml
@@ -67,6 +67,10 @@ spec:
         - secretRef:
             name: {{ .Values.sumologic.envFromSecret | default (include "sumologic.metadata.name.setup.secret" .)}}
         env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: SUMOLOGIC_BASE_URL
 {{- if eq (include "sumologic-mock.local-mode-enabled" .) "true" }}
           value: http://{{ template "sumologic-mock.hostname" . }}:{{ template "sumologic-mock.port" . }}/terraform/api/

--- a/deploy/helm/sumologic/templates/setup/job.yaml
+++ b/deploy/helm/sumologic/templates/setup/job.yaml
@@ -79,6 +79,8 @@ spec:
 {{- end }}
         - name: SUMOLOGIC_COLLECTOR_NAME
           value: {{ include "terraform.collector.name" . }}
+        - name: SUMOLOGIC_SECRET_NAME
+          value: "{{ template "terraform.secret.name" }}"
         - name: CHART_VERSION
           value: "{{ .Chart.Version }}"
         {{- include "proxy-env-variables" . | nindent 8 -}}

--- a/tests/helm/testdata/goldenfile/cleanup/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/cleanup/basic.output.yaml
@@ -51,6 +51,10 @@ spec:
             - secretRef:
                 name: RELEASE-NAME-sumologic-setup
           env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: SUMOLOGIC_BASE_URL
               value:
             - name: SUMOLOGIC_COLLECTOR_NAME

--- a/tests/helm/testdata/goldenfile/cleanup/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/cleanup/basic.output.yaml
@@ -61,6 +61,8 @@ spec:
               value: kubernetes
             - name: CHART_VERSION
               value: "%CURRENT_CHART_VERSION%"
+            - name: SUMOLOGIC_SECRET_NAME
+              value: "sumologic"
 
             - name: NO_PROXY
               value: kubernetes.default.svc

--- a/tests/helm/testdata/goldenfile/cleanup/sumologic-mock-no-secret.output.yaml
+++ b/tests/helm/testdata/goldenfile/cleanup/sumologic-mock-no-secret.output.yaml
@@ -51,6 +51,10 @@ spec:
             - secretRef:
                 name: RELEASE-NAME-sumologic-setup
           env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: SUMOLOGIC_BASE_URL
               value: http://RELEASE-NAME-sumologic-mock.sumologic.svc.cluster.local.:3000/terraform/api/
             - name: SUMOLOGIC_COLLECTOR_NAME

--- a/tests/helm/testdata/goldenfile/cleanup/sumologic-mock-no-secret.output.yaml
+++ b/tests/helm/testdata/goldenfile/cleanup/sumologic-mock-no-secret.output.yaml
@@ -61,6 +61,8 @@ spec:
               value: kubernetes
             - name: CHART_VERSION
               value: "%CURRENT_CHART_VERSION%"
+            - name: SUMOLOGIC_SECRET_NAME
+              value: "sumologic"
 
             - name: NO_PROXY
               value: kubernetes.default.svc

--- a/tests/helm/testdata/goldenfile/cleanup/sumologic-mock.output.yaml
+++ b/tests/helm/testdata/goldenfile/cleanup/sumologic-mock.output.yaml
@@ -51,6 +51,10 @@ spec:
             - secretRef:
                 name: RELEASE-NAME-sumologic-setup
           env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: SUMOLOGIC_BASE_URL
               value: http://RELEASE-NAME-sumologic-mock.sumologic.svc.cluster.local.:3000/terraform/api/
             - name: SUMOLOGIC_COLLECTOR_NAME

--- a/tests/helm/testdata/goldenfile/cleanup/sumologic-mock.output.yaml
+++ b/tests/helm/testdata/goldenfile/cleanup/sumologic-mock.output.yaml
@@ -61,6 +61,8 @@ spec:
               value: kubernetes
             - name: CHART_VERSION
               value: "%CURRENT_CHART_VERSION%"
+            - name: SUMOLOGIC_SECRET_NAME
+              value: "sumologic"
 
             - name: NO_PROXY
               value: kubernetes.default.svc

--- a/tests/helm/testdata/goldenfile/setup/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/setup/basic.output.yaml
@@ -63,6 +63,8 @@ spec:
               value:
             - name: SUMOLOGIC_COLLECTOR_NAME
               value: kubernetes
+            - name: SUMOLOGIC_SECRET_NAME
+              value: "sumologic"
             - name: CHART_VERSION
               value: "%CURRENT_CHART_VERSION%"
 

--- a/tests/helm/testdata/goldenfile/setup/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/setup/basic.output.yaml
@@ -55,6 +55,10 @@ spec:
             - secretRef:
                 name: RELEASE-NAME-sumologic-setup
           env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: SUMOLOGIC_BASE_URL
               value:
             - name: SUMOLOGIC_COLLECTOR_NAME

--- a/tests/helm/testdata/goldenfile/setup/sumologic-mock-no-secret.output.yaml
+++ b/tests/helm/testdata/goldenfile/setup/sumologic-mock-no-secret.output.yaml
@@ -55,6 +55,10 @@ spec:
             - secretRef:
                 name: RELEASE-NAME-sumologic-setup
           env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: SUMOLOGIC_BASE_URL
               value: http://RELEASE-NAME-sumologic-mock.sumologic.svc.cluster.local.:3000/terraform/api/
             - name: SUMOLOGIC_COLLECTOR_NAME

--- a/tests/helm/testdata/goldenfile/setup/sumologic-mock-no-secret.output.yaml
+++ b/tests/helm/testdata/goldenfile/setup/sumologic-mock-no-secret.output.yaml
@@ -63,6 +63,8 @@ spec:
               value: http://RELEASE-NAME-sumologic-mock.sumologic.svc.cluster.local.:3000/terraform/api/
             - name: SUMOLOGIC_COLLECTOR_NAME
               value: kubernetes
+            - name: SUMOLOGIC_SECRET_NAME
+              value: "sumologic"
             - name: CHART_VERSION
               value: "%CURRENT_CHART_VERSION%"
 

--- a/tests/helm/testdata/goldenfile/setup/sumologic-mock.output.yaml
+++ b/tests/helm/testdata/goldenfile/setup/sumologic-mock.output.yaml
@@ -55,6 +55,10 @@ spec:
             - secretRef:
                 name: RELEASE-NAME-sumologic-setup
           env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: SUMOLOGIC_BASE_URL
               value: http://RELEASE-NAME-sumologic-mock.sumologic.svc.cluster.local.:3000/terraform/api/
             - name: SUMOLOGIC_COLLECTOR_NAME

--- a/tests/helm/testdata/goldenfile/setup/sumologic-mock.output.yaml
+++ b/tests/helm/testdata/goldenfile/setup/sumologic-mock.output.yaml
@@ -63,6 +63,8 @@ spec:
               value: http://RELEASE-NAME-sumologic-mock.sumologic.svc.cluster.local.:3000/terraform/api/
             - name: SUMOLOGIC_COLLECTOR_NAME
               value: kubernetes
+            - name: SUMOLOGIC_SECRET_NAME
+              value: "sumologic"
             - name: CHART_VERSION
               value: "%CURRENT_CHART_VERSION%"
 

--- a/tests/helm/testdata/goldenfile/terraform/all_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/all_fields.output.yaml
@@ -338,7 +338,7 @@ data:
 
     resource "kubernetes_secret" "sumologic_collection_secret" {
       metadata {
-        name = "sumologic"
+        name = var.secret_name
         namespace = var.namespace_name
       }
 
@@ -354,11 +354,14 @@ data:
     readonly DEBUG_MODE=${DEBUG_MODE:="false"}
     readonly DEBUG_MODE_ENABLED_FLAG="true"
     readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
+    readonly NAMESPACE="${NAMESPACE:?}"
+    readonly SUMOLOGIC_SECRET_NAME="${SUMOLOGIC_SECRET_NAME:?}"
 
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
+    export TF_VAR_namespace_name="${NAMESPACE}"
+    export TF_VAR_secret_name="${SUMOLOGIC_SECRET_NAME}"
     export TF_VAR_chart_version="${CHART_VERSION:?}"
-    export TF_VAR_namespace_name="${NAMESPACE:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -499,7 +502,7 @@ data:
     fi
 
     # Kubernetes Secret
-    terraform import kubernetes_secret.sumologic_collection_secret sumologic/sumologic
+    terraform import kubernetes_secret.sumologic_collection_secret "${NAMESPACE}/${SUMOLOGIC_SECRET_NAME}"
 
     # Apply planned changes
     TF_LOG_PROVIDER=DEBUG terraform apply \
@@ -837,6 +840,10 @@ data:
 
     variable "namespace_name" {
       type  = string
+    }
+
+    variable "secret_name" {
+      type = string
     }
 
     variable "create_fields" {

--- a/tests/helm/testdata/goldenfile/terraform/all_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/all_fields.output.yaml
@@ -358,6 +358,7 @@ data:
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
     export TF_VAR_chart_version="${CHART_VERSION:?}"
+    export TF_VAR_namespace_name="${NAMESPACE:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -836,7 +837,6 @@ data:
 
     variable "namespace_name" {
       type  = string
-      default = "sumologic"
     }
 
     variable "create_fields" {

--- a/tests/helm/testdata/goldenfile/terraform/collector_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/collector_fields.output.yaml
@@ -338,7 +338,7 @@ data:
 
     resource "kubernetes_secret" "sumologic_collection_secret" {
       metadata {
-        name = "sumologic"
+        name = var.secret_name
         namespace = var.namespace_name
       }
 
@@ -354,11 +354,14 @@ data:
     readonly DEBUG_MODE=${DEBUG_MODE:="false"}
     readonly DEBUG_MODE_ENABLED_FLAG="true"
     readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
+    readonly NAMESPACE="${NAMESPACE:?}"
+    readonly SUMOLOGIC_SECRET_NAME="${SUMOLOGIC_SECRET_NAME:?}"
 
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
+    export TF_VAR_namespace_name="${NAMESPACE}"
+    export TF_VAR_secret_name="${SUMOLOGIC_SECRET_NAME}"
     export TF_VAR_chart_version="${CHART_VERSION:?}"
-    export TF_VAR_namespace_name="${NAMESPACE:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -498,7 +501,7 @@ data:
     fi
 
     # Kubernetes Secret
-    terraform import kubernetes_secret.sumologic_collection_secret sumologic/sumologic
+    terraform import kubernetes_secret.sumologic_collection_secret "${NAMESPACE}/${SUMOLOGIC_SECRET_NAME}"
 
     # Apply planned changes
     TF_LOG_PROVIDER=DEBUG terraform apply \
@@ -740,6 +743,10 @@ data:
 
     variable "namespace_name" {
       type  = string
+    }
+
+    variable "secret_name" {
+      type = string
     }
 
     variable "create_fields" {

--- a/tests/helm/testdata/goldenfile/terraform/collector_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/collector_fields.output.yaml
@@ -358,6 +358,7 @@ data:
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
     export TF_VAR_chart_version="${CHART_VERSION:?}"
+    export TF_VAR_namespace_name="${NAMESPACE:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -739,7 +740,6 @@ data:
 
     variable "namespace_name" {
       type  = string
-      default = "sumologic"
     }
 
     variable "create_fields" {

--- a/tests/helm/testdata/goldenfile/terraform/conditional_sources.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/conditional_sources.output.yaml
@@ -358,6 +358,7 @@ data:
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
     export TF_VAR_chart_version="${CHART_VERSION:?}"
+    export TF_VAR_namespace_name="${NAMESPACE:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -535,7 +536,6 @@ data:
 
     variable "namespace_name" {
       type  = string
-      default = "sumologic"
     }
 
     variable "create_fields" {

--- a/tests/helm/testdata/goldenfile/terraform/conditional_sources.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/conditional_sources.output.yaml
@@ -338,7 +338,7 @@ data:
 
     resource "kubernetes_secret" "sumologic_collection_secret" {
       metadata {
-        name = "sumologic"
+        name = var.secret_name
         namespace = var.namespace_name
       }
 
@@ -354,11 +354,14 @@ data:
     readonly DEBUG_MODE=${DEBUG_MODE:="false"}
     readonly DEBUG_MODE_ENABLED_FLAG="true"
     readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
+    readonly NAMESPACE="${NAMESPACE:?}"
+    readonly SUMOLOGIC_SECRET_NAME="${SUMOLOGIC_SECRET_NAME:?}"
 
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
+    export TF_VAR_namespace_name="${NAMESPACE}"
+    export TF_VAR_secret_name="${SUMOLOGIC_SECRET_NAME}"
     export TF_VAR_chart_version="${CHART_VERSION:?}"
-    export TF_VAR_namespace_name="${NAMESPACE:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -483,7 +486,7 @@ data:
     fi
 
     # Kubernetes Secret
-    terraform import kubernetes_secret.sumologic_collection_secret sumologic/sumologic
+    terraform import kubernetes_secret.sumologic_collection_secret "${NAMESPACE}/${SUMOLOGIC_SECRET_NAME}"
 
     # Apply planned changes
     TF_LOG_PROVIDER=DEBUG terraform apply \
@@ -536,6 +539,10 @@ data:
 
     variable "namespace_name" {
       type  = string
+    }
+
+    variable "secret_name" {
+      type = string
     }
 
     variable "create_fields" {

--- a/tests/helm/testdata/goldenfile/terraform/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/custom.output.yaml
@@ -358,6 +358,7 @@ data:
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
     export TF_VAR_chart_version="${CHART_VERSION:?}"
+    export TF_VAR_namespace_name="${NAMESPACE:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -535,7 +536,6 @@ data:
 
     variable "namespace_name" {
       type  = string
-      default = "sumologic"
     }
 
     variable "create_fields" {

--- a/tests/helm/testdata/goldenfile/terraform/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/custom.output.yaml
@@ -338,7 +338,7 @@ data:
 
     resource "kubernetes_secret" "sumologic_collection_secret" {
       metadata {
-        name = "sumologic"
+        name = var.secret_name
         namespace = var.namespace_name
       }
 
@@ -354,11 +354,14 @@ data:
     readonly DEBUG_MODE=${DEBUG_MODE:="false"}
     readonly DEBUG_MODE_ENABLED_FLAG="true"
     readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
+    readonly NAMESPACE="${NAMESPACE:?}"
+    readonly SUMOLOGIC_SECRET_NAME="${SUMOLOGIC_SECRET_NAME:?}"
 
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
+    export TF_VAR_namespace_name="${NAMESPACE}"
+    export TF_VAR_secret_name="${SUMOLOGIC_SECRET_NAME}"
     export TF_VAR_chart_version="${CHART_VERSION:?}"
-    export TF_VAR_namespace_name="${NAMESPACE:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -483,7 +486,7 @@ data:
     fi
 
     # Kubernetes Secret
-    terraform import kubernetes_secret.sumologic_collection_secret sumologic/sumologic
+    terraform import kubernetes_secret.sumologic_collection_secret "${NAMESPACE}/${SUMOLOGIC_SECRET_NAME}"
 
     # Apply planned changes
     TF_LOG_PROVIDER=DEBUG terraform apply \
@@ -536,6 +539,10 @@ data:
 
     variable "namespace_name" {
       type  = string
+    }
+
+    variable "secret_name" {
+      type = string
     }
 
     variable "create_fields" {

--- a/tests/helm/testdata/goldenfile/terraform/default.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/default.output.yaml
@@ -358,6 +358,7 @@ data:
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
     export TF_VAR_chart_version="${CHART_VERSION:?}"
+    export TF_VAR_namespace_name="${NAMESPACE:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -736,7 +737,6 @@ data:
 
     variable "namespace_name" {
       type  = string
-      default = "sumologic"
     }
 
     variable "create_fields" {

--- a/tests/helm/testdata/goldenfile/terraform/default.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/default.output.yaml
@@ -338,7 +338,7 @@ data:
 
     resource "kubernetes_secret" "sumologic_collection_secret" {
       metadata {
-        name = "sumologic"
+        name = var.secret_name
         namespace = var.namespace_name
       }
 
@@ -354,11 +354,14 @@ data:
     readonly DEBUG_MODE=${DEBUG_MODE:="false"}
     readonly DEBUG_MODE_ENABLED_FLAG="true"
     readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
+    readonly NAMESPACE="${NAMESPACE:?}"
+    readonly SUMOLOGIC_SECRET_NAME="${SUMOLOGIC_SECRET_NAME:?}"
 
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
+    export TF_VAR_namespace_name="${NAMESPACE}"
+    export TF_VAR_secret_name="${SUMOLOGIC_SECRET_NAME}"
     export TF_VAR_chart_version="${CHART_VERSION:?}"
-    export TF_VAR_namespace_name="${NAMESPACE:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -498,7 +501,7 @@ data:
     fi
 
     # Kubernetes Secret
-    terraform import kubernetes_secret.sumologic_collection_secret sumologic/sumologic
+    terraform import kubernetes_secret.sumologic_collection_secret "${NAMESPACE}/${SUMOLOGIC_SECRET_NAME}"
 
     # Apply planned changes
     TF_LOG_PROVIDER=DEBUG terraform apply \
@@ -737,6 +740,10 @@ data:
 
     variable "namespace_name" {
       type  = string
+    }
+
+    variable "secret_name" {
+      type = string
     }
 
     variable "create_fields" {

--- a/tests/helm/testdata/goldenfile/terraform/disable_default_metrics.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disable_default_metrics.output.yaml
@@ -358,6 +358,7 @@ data:
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
     export TF_VAR_chart_version="${CHART_VERSION:?}"
+    export TF_VAR_namespace_name="${NAMESPACE:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -726,7 +727,6 @@ data:
 
     variable "namespace_name" {
       type  = string
-      default = "sumologic"
     }
 
     variable "create_fields" {

--- a/tests/helm/testdata/goldenfile/terraform/disable_default_metrics.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disable_default_metrics.output.yaml
@@ -338,7 +338,7 @@ data:
 
     resource "kubernetes_secret" "sumologic_collection_secret" {
       metadata {
-        name = "sumologic"
+        name = var.secret_name
         namespace = var.namespace_name
       }
 
@@ -354,11 +354,14 @@ data:
     readonly DEBUG_MODE=${DEBUG_MODE:="false"}
     readonly DEBUG_MODE_ENABLED_FLAG="true"
     readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
+    readonly NAMESPACE="${NAMESPACE:?}"
+    readonly SUMOLOGIC_SECRET_NAME="${SUMOLOGIC_SECRET_NAME:?}"
 
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
+    export TF_VAR_namespace_name="${NAMESPACE}"
+    export TF_VAR_secret_name="${SUMOLOGIC_SECRET_NAME}"
     export TF_VAR_chart_version="${CHART_VERSION:?}"
-    export TF_VAR_namespace_name="${NAMESPACE:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -497,7 +500,7 @@ data:
     fi
 
     # Kubernetes Secret
-    terraform import kubernetes_secret.sumologic_collection_secret sumologic/sumologic
+    terraform import kubernetes_secret.sumologic_collection_secret "${NAMESPACE}/${SUMOLOGIC_SECRET_NAME}"
 
     # Apply planned changes
     TF_LOG_PROVIDER=DEBUG terraform apply \
@@ -727,6 +730,10 @@ data:
 
     variable "namespace_name" {
       type  = string
+    }
+
+    variable "secret_name" {
+      type = string
     }
 
     variable "create_fields" {

--- a/tests/helm/testdata/goldenfile/terraform/disabled_dashboards.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disabled_dashboards.output.yaml
@@ -358,6 +358,7 @@ data:
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
     export TF_VAR_chart_version="${CHART_VERSION:?}"
+    export TF_VAR_namespace_name="${NAMESPACE:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -738,7 +739,6 @@ data:
 
     variable "namespace_name" {
       type  = string
-      default = "sumologic"
     }
 
     variable "create_fields" {

--- a/tests/helm/testdata/goldenfile/terraform/disabled_dashboards.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disabled_dashboards.output.yaml
@@ -338,7 +338,7 @@ data:
 
     resource "kubernetes_secret" "sumologic_collection_secret" {
       metadata {
-        name = "sumologic"
+        name = var.secret_name
         namespace = var.namespace_name
       }
 
@@ -354,11 +354,14 @@ data:
     readonly DEBUG_MODE=${DEBUG_MODE:="false"}
     readonly DEBUG_MODE_ENABLED_FLAG="true"
     readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
+    readonly NAMESPACE="${NAMESPACE:?}"
+    readonly SUMOLOGIC_SECRET_NAME="${SUMOLOGIC_SECRET_NAME:?}"
 
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
+    export TF_VAR_namespace_name="${NAMESPACE}"
+    export TF_VAR_secret_name="${SUMOLOGIC_SECRET_NAME}"
     export TF_VAR_chart_version="${CHART_VERSION:?}"
-    export TF_VAR_namespace_name="${NAMESPACE:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -498,7 +501,7 @@ data:
     fi
 
     # Kubernetes Secret
-    terraform import kubernetes_secret.sumologic_collection_secret sumologic/sumologic
+    terraform import kubernetes_secret.sumologic_collection_secret "${NAMESPACE}/${SUMOLOGIC_SECRET_NAME}"
 
     # Apply planned changes
     TF_LOG_PROVIDER=DEBUG terraform apply \
@@ -739,6 +742,10 @@ data:
 
     variable "namespace_name" {
       type  = string
+    }
+
+    variable "secret_name" {
+      type = string
     }
 
     variable "create_fields" {

--- a/tests/helm/testdata/goldenfile/terraform/disabled_monitors.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disabled_monitors.output.yaml
@@ -358,6 +358,7 @@ data:
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
     export TF_VAR_chart_version="${CHART_VERSION:?}"
+    export TF_VAR_namespace_name="${NAMESPACE:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -738,7 +739,6 @@ data:
 
     variable "namespace_name" {
       type  = string
-      default = "sumologic"
     }
 
     variable "create_fields" {

--- a/tests/helm/testdata/goldenfile/terraform/disabled_monitors.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disabled_monitors.output.yaml
@@ -338,7 +338,7 @@ data:
 
     resource "kubernetes_secret" "sumologic_collection_secret" {
       metadata {
-        name = "sumologic"
+        name = var.secret_name
         namespace = var.namespace_name
       }
 
@@ -354,11 +354,14 @@ data:
     readonly DEBUG_MODE=${DEBUG_MODE:="false"}
     readonly DEBUG_MODE_ENABLED_FLAG="true"
     readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
+    readonly NAMESPACE="${NAMESPACE:?}"
+    readonly SUMOLOGIC_SECRET_NAME="${SUMOLOGIC_SECRET_NAME:?}"
 
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
+    export TF_VAR_namespace_name="${NAMESPACE}"
+    export TF_VAR_secret_name="${SUMOLOGIC_SECRET_NAME}"
     export TF_VAR_chart_version="${CHART_VERSION:?}"
-    export TF_VAR_namespace_name="${NAMESPACE:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -498,7 +501,7 @@ data:
     fi
 
     # Kubernetes Secret
-    terraform import kubernetes_secret.sumologic_collection_secret sumologic/sumologic
+    terraform import kubernetes_secret.sumologic_collection_secret "${NAMESPACE}/${SUMOLOGIC_SECRET_NAME}"
 
     # Apply planned changes
     TF_LOG_PROVIDER=DEBUG terraform apply \
@@ -739,6 +742,10 @@ data:
 
     variable "namespace_name" {
       type  = string
+    }
+
+    variable "secret_name" {
+      type = string
     }
 
     variable "create_fields" {

--- a/tests/helm/testdata/goldenfile/terraform/logs_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/logs_fields.output.yaml
@@ -358,6 +358,7 @@ data:
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
     export TF_VAR_chart_version="${CHART_VERSION:?}"
+    export TF_VAR_namespace_name="${NAMESPACE:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -738,7 +739,6 @@ data:
 
     variable "namespace_name" {
       type  = string
-      default = "sumologic"
     }
 
     variable "create_fields" {

--- a/tests/helm/testdata/goldenfile/terraform/logs_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/logs_fields.output.yaml
@@ -338,7 +338,7 @@ data:
 
     resource "kubernetes_secret" "sumologic_collection_secret" {
       metadata {
-        name = "sumologic"
+        name = var.secret_name
         namespace = var.namespace_name
       }
 
@@ -354,11 +354,14 @@ data:
     readonly DEBUG_MODE=${DEBUG_MODE:="false"}
     readonly DEBUG_MODE_ENABLED_FLAG="true"
     readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
+    readonly NAMESPACE="${NAMESPACE:?}"
+    readonly SUMOLOGIC_SECRET_NAME="${SUMOLOGIC_SECRET_NAME:?}"
 
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
+    export TF_VAR_namespace_name="${NAMESPACE}"
+    export TF_VAR_secret_name="${SUMOLOGIC_SECRET_NAME}"
     export TF_VAR_chart_version="${CHART_VERSION:?}"
-    export TF_VAR_namespace_name="${NAMESPACE:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -498,7 +501,7 @@ data:
     fi
 
     # Kubernetes Secret
-    terraform import kubernetes_secret.sumologic_collection_secret sumologic/sumologic
+    terraform import kubernetes_secret.sumologic_collection_secret "${NAMESPACE}/${SUMOLOGIC_SECRET_NAME}"
 
     # Apply planned changes
     TF_LOG_PROVIDER=DEBUG terraform apply \
@@ -739,6 +742,10 @@ data:
 
     variable "namespace_name" {
       type  = string
+    }
+
+    variable "secret_name" {
+      type = string
     }
 
     variable "create_fields" {

--- a/tests/helm/testdata/goldenfile/terraform/monitors_with_email_notifications.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/monitors_with_email_notifications.output.yaml
@@ -364,6 +364,7 @@ data:
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
     export TF_VAR_chart_version="${CHART_VERSION:?}"
+    export TF_VAR_namespace_name="${NAMESPACE:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -742,7 +743,6 @@ data:
 
     variable "namespace_name" {
       type  = string
-      default = "sumologic"
     }
 
     variable "create_fields" {

--- a/tests/helm/testdata/goldenfile/terraform/monitors_with_email_notifications.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/monitors_with_email_notifications.output.yaml
@@ -344,7 +344,7 @@ data:
 
     resource "kubernetes_secret" "sumologic_collection_secret" {
       metadata {
-        name = "sumologic"
+        name = var.secret_name
         namespace = var.namespace_name
       }
 
@@ -360,11 +360,14 @@ data:
     readonly DEBUG_MODE=${DEBUG_MODE:="false"}
     readonly DEBUG_MODE_ENABLED_FLAG="true"
     readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
+    readonly NAMESPACE="${NAMESPACE:?}"
+    readonly SUMOLOGIC_SECRET_NAME="${SUMOLOGIC_SECRET_NAME:?}"
 
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
+    export TF_VAR_namespace_name="${NAMESPACE}"
+    export TF_VAR_secret_name="${SUMOLOGIC_SECRET_NAME}"
     export TF_VAR_chart_version="${CHART_VERSION:?}"
-    export TF_VAR_namespace_name="${NAMESPACE:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -504,7 +507,7 @@ data:
     fi
 
     # Kubernetes Secret
-    terraform import kubernetes_secret.sumologic_collection_secret sumologic/sumologic
+    terraform import kubernetes_secret.sumologic_collection_secret "${NAMESPACE}/${SUMOLOGIC_SECRET_NAME}"
 
     # Apply planned changes
     TF_LOG_PROVIDER=DEBUG terraform apply \
@@ -743,6 +746,10 @@ data:
 
     variable "namespace_name" {
       type  = string
+    }
+
+    variable "secret_name" {
+      type = string
     }
 
     variable "create_fields" {

--- a/tests/helm/testdata/goldenfile/terraform/monitors_with_single_email.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/monitors_with_single_email.output.yaml
@@ -364,6 +364,7 @@ data:
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
     export TF_VAR_chart_version="${CHART_VERSION:?}"
+    export TF_VAR_namespace_name="${NAMESPACE:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -742,7 +743,6 @@ data:
 
     variable "namespace_name" {
       type  = string
-      default = "sumologic"
     }
 
     variable "create_fields" {

--- a/tests/helm/testdata/goldenfile/terraform/monitors_with_single_email.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/monitors_with_single_email.output.yaml
@@ -344,7 +344,7 @@ data:
 
     resource "kubernetes_secret" "sumologic_collection_secret" {
       metadata {
-        name = "sumologic"
+        name = var.secret_name
         namespace = var.namespace_name
       }
 
@@ -360,11 +360,14 @@ data:
     readonly DEBUG_MODE=${DEBUG_MODE:="false"}
     readonly DEBUG_MODE_ENABLED_FLAG="true"
     readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
+    readonly NAMESPACE="${NAMESPACE:?}"
+    readonly SUMOLOGIC_SECRET_NAME="${SUMOLOGIC_SECRET_NAME:?}"
 
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
+    export TF_VAR_namespace_name="${NAMESPACE}"
+    export TF_VAR_secret_name="${SUMOLOGIC_SECRET_NAME}"
     export TF_VAR_chart_version="${CHART_VERSION:?}"
-    export TF_VAR_namespace_name="${NAMESPACE:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -504,7 +507,7 @@ data:
     fi
 
     # Kubernetes Secret
-    terraform import kubernetes_secret.sumologic_collection_secret sumologic/sumologic
+    terraform import kubernetes_secret.sumologic_collection_secret "${NAMESPACE}/${SUMOLOGIC_SECRET_NAME}"
 
     # Apply planned changes
     TF_LOG_PROVIDER=DEBUG terraform apply \
@@ -743,6 +746,10 @@ data:
 
     variable "namespace_name" {
       type  = string
+    }
+
+    variable "secret_name" {
+      type = string
     }
 
     variable "create_fields" {

--- a/tests/helm/testdata/goldenfile/terraform/strip_extrapolation.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/strip_extrapolation.output.yaml
@@ -359,6 +359,7 @@ data:
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
     export TF_VAR_chart_version="${CHART_VERSION:?}"
+    export TF_VAR_namespace_name="${NAMESPACE:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -737,7 +738,6 @@ data:
 
     variable "namespace_name" {
       type  = string
-      default = "sumologic"
     }
 
     variable "create_fields" {

--- a/tests/helm/testdata/goldenfile/terraform/strip_extrapolation.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/strip_extrapolation.output.yaml
@@ -339,7 +339,7 @@ data:
 
     resource "kubernetes_secret" "sumologic_collection_secret" {
       metadata {
-        name = "sumologic"
+        name = var.secret_name
         namespace = var.namespace_name
       }
 
@@ -355,11 +355,14 @@ data:
     readonly DEBUG_MODE=${DEBUG_MODE:="false"}
     readonly DEBUG_MODE_ENABLED_FLAG="true"
     readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
+    readonly NAMESPACE="${NAMESPACE:?}"
+    readonly SUMOLOGIC_SECRET_NAME="${SUMOLOGIC_SECRET_NAME:?}"
 
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
+    export TF_VAR_namespace_name="${NAMESPACE}"
+    export TF_VAR_secret_name="${SUMOLOGIC_SECRET_NAME}"
     export TF_VAR_chart_version="${CHART_VERSION:?}"
-    export TF_VAR_namespace_name="${NAMESPACE:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -499,7 +502,7 @@ data:
     fi
 
     # Kubernetes Secret
-    terraform import kubernetes_secret.sumologic_collection_secret sumologic/sumologic
+    terraform import kubernetes_secret.sumologic_collection_secret "${NAMESPACE}/${SUMOLOGIC_SECRET_NAME}"
 
     # Apply planned changes
     TF_LOG_PROVIDER=DEBUG terraform apply \
@@ -738,6 +741,10 @@ data:
 
     variable "namespace_name" {
       type  = string
+    }
+
+    variable "secret_name" {
+      type = string
     }
 
     variable "create_fields" {

--- a/tests/helm/testdata/goldenfile/terraform/traces.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/traces.output.yaml
@@ -338,7 +338,7 @@ data:
 
     resource "kubernetes_secret" "sumologic_collection_secret" {
       metadata {
-        name = "sumologic"
+        name = var.secret_name
         namespace = var.namespace_name
       }
 
@@ -354,11 +354,14 @@ data:
     readonly DEBUG_MODE=${DEBUG_MODE:="false"}
     readonly DEBUG_MODE_ENABLED_FLAG="true"
     readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
+    readonly NAMESPACE="${NAMESPACE:?}"
+    readonly SUMOLOGIC_SECRET_NAME="${SUMOLOGIC_SECRET_NAME:?}"
 
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
+    export TF_VAR_namespace_name="${NAMESPACE}"
+    export TF_VAR_secret_name="${SUMOLOGIC_SECRET_NAME}"
     export TF_VAR_chart_version="${CHART_VERSION:?}"
-    export TF_VAR_namespace_name="${NAMESPACE:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -486,7 +489,7 @@ data:
     fi
 
     # Kubernetes Secret
-    terraform import kubernetes_secret.sumologic_collection_secret sumologic/sumologic
+    terraform import kubernetes_secret.sumologic_collection_secret "${NAMESPACE}/${SUMOLOGIC_SECRET_NAME}"
 
     # Apply planned changes
     TF_LOG_PROVIDER=DEBUG terraform apply \
@@ -577,6 +580,10 @@ data:
 
     variable "namespace_name" {
       type  = string
+    }
+
+    variable "secret_name" {
+      type = string
     }
 
     variable "create_fields" {

--- a/tests/helm/testdata/goldenfile/terraform/traces.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/traces.output.yaml
@@ -358,6 +358,7 @@ data:
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
     export TF_VAR_chart_version="${CHART_VERSION:?}"
+    export TF_VAR_namespace_name="${NAMESPACE:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -576,7 +577,6 @@ data:
 
     variable "namespace_name" {
       type  = string
-      default = "sumologic"
     }
 
     variable "create_fields" {

--- a/tests/helm/testdata/goldenfile/terraform/tracing-metrics-disabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/tracing-metrics-disabled.output.yaml
@@ -358,6 +358,7 @@ data:
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
     export TF_VAR_chart_version="${CHART_VERSION:?}"
+    export TF_VAR_namespace_name="${NAMESPACE:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -736,7 +737,6 @@ data:
 
     variable "namespace_name" {
       type  = string
-      default = "sumologic"
     }
 
     variable "create_fields" {

--- a/tests/helm/testdata/goldenfile/terraform/tracing-metrics-disabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/tracing-metrics-disabled.output.yaml
@@ -338,7 +338,7 @@ data:
 
     resource "kubernetes_secret" "sumologic_collection_secret" {
       metadata {
-        name = "sumologic"
+        name = var.secret_name
         namespace = var.namespace_name
       }
 
@@ -354,11 +354,14 @@ data:
     readonly DEBUG_MODE=${DEBUG_MODE:="false"}
     readonly DEBUG_MODE_ENABLED_FLAG="true"
     readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
+    readonly NAMESPACE="${NAMESPACE:?}"
+    readonly SUMOLOGIC_SECRET_NAME="${SUMOLOGIC_SECRET_NAME:?}"
 
     # Set variables for terraform
     export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
+    export TF_VAR_namespace_name="${NAMESPACE}"
+    export TF_VAR_secret_name="${SUMOLOGIC_SECRET_NAME}"
     export TF_VAR_chart_version="${CHART_VERSION:?}"
-    export TF_VAR_namespace_name="${NAMESPACE:?}"
 
     # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
     # so that we don't have to deal with True vs true vs TRUE
@@ -498,7 +501,7 @@ data:
     fi
 
     # Kubernetes Secret
-    terraform import kubernetes_secret.sumologic_collection_secret sumologic/sumologic
+    terraform import kubernetes_secret.sumologic_collection_secret "${NAMESPACE}/${SUMOLOGIC_SECRET_NAME}"
 
     # Apply planned changes
     TF_LOG_PROVIDER=DEBUG terraform apply \
@@ -737,6 +740,10 @@ data:
 
     variable "namespace_name" {
       type  = string
+    }
+
+    variable "secret_name" {
+      type = string
     }
 
     variable "create_fields" {


### PR DESCRIPTION
Pass secret name and namespace as variables instead of templating. Namespace we get from downward API, and secret name from a template.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
