### PR TITLE
chore(setup): don't use templating for Terraform imports

### DIFF
--- a/deploy/helm/sumologic/conf/cleanup/cleanup.sh
+++ b/deploy/helm/sumologic/conf/cleanup/cleanup.sh
@@ -15,6 +15,7 @@ readonly NAMESPACE="${NAMESPACE:?}"
 
 # Set variables for terraform
 export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
+export TF_VAR_secret_name="${SUMOLOGIC_SECRET_NAME}"
 export TF_VAR_chart_version="${CHART_VERSION:?}"
 export TF_VAR_namespace_name="${NAMESPACE:?}"
 

--- a/deploy/helm/sumologic/conf/setup/resources.tf
+++ b/deploy/helm/sumologic/conf/setup/resources.tf
@@ -15,4 +15,5 @@ resource "kubernetes_secret" "sumologic_collection_secret" {
   }
 
   type = "Opaque"
+  wait_for_service_account_token = false
 }

--- a/deploy/helm/sumologic/templates/cleanup/configmap.yaml
+++ b/deploy/helm/sumologic/templates/cleanup/configmap.yaml
@@ -11,5 +11,5 @@ metadata:
     {{- include "sumologic.labels.common" . | nindent 4 }}
 data:
   {{- (tpl (.Files.Glob "conf/cleanup/cleanup.sh").AsConfig .) | nindent 2 }}
-  {{- (tpl (.Files.Glob "conf/setup/{locals,main,providers,resources,variables}.tf").AsConfig .) | nindent 2 }}
+  {{- (tpl (.Files.Glob "conf/setup/*").AsConfig .) | nindent 2 }}
 {{- end }}

--- a/deploy/helm/sumologic/templates/cleanup/job.yaml
+++ b/deploy/helm/sumologic/templates/cleanup/job.yaml
@@ -50,7 +50,7 @@ spec:
           command: ["/etc/terraform/cleanup.sh"]
           envFrom:
           - secretRef:
-              name: {{ .Values.sumologic.envFromSecret | default (include "sumologic.metadata.name.setup.secret" .)}}
+              name: {{ .Values.sumologic.envFromSecret | default (include "sumologic.metadata.name.cleanup.secret" .)}}
           env:
           - name: NAMESPACE
             valueFrom:

--- a/tests/helm/testdata/goldenfile/cleanup/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/cleanup/basic.output.yaml
@@ -49,7 +49,7 @@ spec:
           command: ["/etc/terraform/cleanup.sh"]
           envFrom:
             - secretRef:
-                name: RELEASE-NAME-sumologic-setup
+                name: RELEASE-NAME-sumologic-cleanup
           env:
             - name: NAMESPACE
               valueFrom:

--- a/tests/helm/testdata/goldenfile/cleanup/sumologic-mock-no-secret.output.yaml
+++ b/tests/helm/testdata/goldenfile/cleanup/sumologic-mock-no-secret.output.yaml
@@ -49,7 +49,7 @@ spec:
           command: ["/etc/terraform/cleanup.sh"]
           envFrom:
             - secretRef:
-                name: RELEASE-NAME-sumologic-setup
+                name: RELEASE-NAME-sumologic-cleanup
           env:
             - name: NAMESPACE
               valueFrom:

--- a/tests/helm/testdata/goldenfile/cleanup/sumologic-mock.output.yaml
+++ b/tests/helm/testdata/goldenfile/cleanup/sumologic-mock.output.yaml
@@ -49,7 +49,7 @@ spec:
           command: ["/etc/terraform/cleanup.sh"]
           envFrom:
             - secretRef:
-                name: RELEASE-NAME-sumologic-setup
+                name: RELEASE-NAME-sumologic-cleanup
           env:
             - name: NAMESPACE
               valueFrom:

--- a/tests/helm/testdata/goldenfile/terraform/all_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/all_fields.output.yaml
@@ -347,6 +347,7 @@ data:
       }
 
       type = "Opaque"
+      wait_for_service_account_token = false
     }
   setup.sh: |
     #!/bin/bash

--- a/tests/helm/testdata/goldenfile/terraform/all_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/all_fields.output.yaml
@@ -482,23 +482,9 @@ data:
     # Sumo Logic Collector and HTTP sources
     # Only import sources when collector exists.
     if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
-    true  # prevent to render empty if; then
-    terraform import sumologic_http_source.default_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events"
-    terraform import sumologic_http_source.default_otlp_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events-otlp"
-    terraform import sumologic_http_source.default_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs"
-    terraform import sumologic_http_source.default_otlp_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs-otlp"
-    terraform import sumologic_http_source.apiserver_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/apiserver-metrics"
-    terraform import sumologic_http_source.control_plane_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/control-plane-metrics"
-    terraform import sumologic_http_source.controller_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-controller-manager-metrics"
-    terraform import sumologic_http_source.default_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/(default-metrics)"
-    terraform import sumologic_http_source.default_otlp_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/metrics-otlp"
-    terraform import sumologic_http_source.kubelet_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kubelet-metrics"
-    terraform import sumologic_http_source.node_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/node-exporter-metrics"
-    terraform import sumologic_http_source.scheduler_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-scheduler-metrics"
-    terraform import sumologic_http_source.state_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-state-metrics"
-    terraform import sumologic_http_source.test_source_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/(Test source)"
-    terraform import sumologic_http_source.default_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces"
-    terraform import sumologic_http_source.default_otlp_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces-otlp"
+        jq -r '.resource[] | to_entries[] | "\(.key) \(.value.name)"' sources.tf.json | while read -r resource_name source_name; do
+            terraform import "sumologic_http_source.${resource_name}" "${SUMOLOGIC_COLLECTOR_NAME}/${source_name}"
+        done
     fi
 
     # Kubernetes Secret

--- a/tests/helm/testdata/goldenfile/terraform/collector_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/collector_fields.output.yaml
@@ -347,6 +347,7 @@ data:
       }
 
       type = "Opaque"
+      wait_for_service_account_token = false
     }
   setup.sh: |
     #!/bin/bash

--- a/tests/helm/testdata/goldenfile/terraform/collector_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/collector_fields.output.yaml
@@ -482,22 +482,9 @@ data:
     # Sumo Logic Collector and HTTP sources
     # Only import sources when collector exists.
     if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
-    true  # prevent to render empty if; then
-    terraform import sumologic_http_source.default_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events"
-    terraform import sumologic_http_source.default_otlp_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events-otlp"
-    terraform import sumologic_http_source.default_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs"
-    terraform import sumologic_http_source.default_otlp_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs-otlp"
-    terraform import sumologic_http_source.apiserver_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/apiserver-metrics"
-    terraform import sumologic_http_source.control_plane_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/control-plane-metrics"
-    terraform import sumologic_http_source.controller_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-controller-manager-metrics"
-    terraform import sumologic_http_source.default_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/(default-metrics)"
-    terraform import sumologic_http_source.default_otlp_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/metrics-otlp"
-    terraform import sumologic_http_source.kubelet_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kubelet-metrics"
-    terraform import sumologic_http_source.node_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/node-exporter-metrics"
-    terraform import sumologic_http_source.scheduler_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-scheduler-metrics"
-    terraform import sumologic_http_source.state_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-state-metrics"
-    terraform import sumologic_http_source.default_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces"
-    terraform import sumologic_http_source.default_otlp_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces-otlp"
+        jq -r '.resource[] | to_entries[] | "\(.key) \(.value.name)"' sources.tf.json | while read -r resource_name source_name; do
+            terraform import "sumologic_http_source.${resource_name}" "${SUMOLOGIC_COLLECTOR_NAME}/${source_name}"
+        done
     fi
 
     # Kubernetes Secret

--- a/tests/helm/testdata/goldenfile/terraform/conditional_sources.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/conditional_sources.output.yaml
@@ -347,6 +347,7 @@ data:
       }
 
       type = "Opaque"
+      wait_for_service_account_token = false
     }
   setup.sh: |
     #!/bin/bash

--- a/tests/helm/testdata/goldenfile/terraform/conditional_sources.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/conditional_sources.output.yaml
@@ -482,7 +482,9 @@ data:
     # Sumo Logic Collector and HTTP sources
     # Only import sources when collector exists.
     if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
-    true  # prevent to render empty if; then
+        jq -r '.resource[] | to_entries[] | "\(.key) \(.value.name)"' sources.tf.json | while read -r resource_name source_name; do
+            terraform import "sumologic_http_source.${resource_name}" "${SUMOLOGIC_COLLECTOR_NAME}/${source_name}"
+        done
     fi
 
     # Kubernetes Secret

--- a/tests/helm/testdata/goldenfile/terraform/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/custom.output.yaml
@@ -347,6 +347,7 @@ data:
       }
 
       type = "Opaque"
+      wait_for_service_account_token = false
     }
   setup.sh: |
     #!/bin/bash

--- a/tests/helm/testdata/goldenfile/terraform/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/custom.output.yaml
@@ -482,7 +482,9 @@ data:
     # Sumo Logic Collector and HTTP sources
     # Only import sources when collector exists.
     if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
-    true  # prevent to render empty if; then
+        jq -r '.resource[] | to_entries[] | "\(.key) \(.value.name)"' sources.tf.json | while read -r resource_name source_name; do
+            terraform import "sumologic_http_source.${resource_name}" "${SUMOLOGIC_COLLECTOR_NAME}/${source_name}"
+        done
     fi
 
     # Kubernetes Secret

--- a/tests/helm/testdata/goldenfile/terraform/default.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/default.output.yaml
@@ -347,6 +347,7 @@ data:
       }
 
       type = "Opaque"
+      wait_for_service_account_token = false
     }
   setup.sh: |
     #!/bin/bash

--- a/tests/helm/testdata/goldenfile/terraform/default.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/default.output.yaml
@@ -482,22 +482,9 @@ data:
     # Sumo Logic Collector and HTTP sources
     # Only import sources when collector exists.
     if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
-    true  # prevent to render empty if; then
-    terraform import sumologic_http_source.default_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events"
-    terraform import sumologic_http_source.default_otlp_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events-otlp"
-    terraform import sumologic_http_source.default_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs"
-    terraform import sumologic_http_source.default_otlp_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs-otlp"
-    terraform import sumologic_http_source.apiserver_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/apiserver-metrics"
-    terraform import sumologic_http_source.control_plane_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/control-plane-metrics"
-    terraform import sumologic_http_source.controller_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-controller-manager-metrics"
-    terraform import sumologic_http_source.default_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/(default-metrics)"
-    terraform import sumologic_http_source.default_otlp_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/metrics-otlp"
-    terraform import sumologic_http_source.kubelet_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kubelet-metrics"
-    terraform import sumologic_http_source.node_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/node-exporter-metrics"
-    terraform import sumologic_http_source.scheduler_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-scheduler-metrics"
-    terraform import sumologic_http_source.state_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-state-metrics"
-    terraform import sumologic_http_source.default_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces"
-    terraform import sumologic_http_source.default_otlp_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces-otlp"
+        jq -r '.resource[] | to_entries[] | "\(.key) \(.value.name)"' sources.tf.json | while read -r resource_name source_name; do
+            terraform import "sumologic_http_source.${resource_name}" "${SUMOLOGIC_COLLECTOR_NAME}/${source_name}"
+        done
     fi
 
     # Kubernetes Secret

--- a/tests/helm/testdata/goldenfile/terraform/disable_default_metrics.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disable_default_metrics.output.yaml
@@ -347,6 +347,7 @@ data:
       }
 
       type = "Opaque"
+      wait_for_service_account_token = false
     }
   setup.sh: |
     #!/bin/bash

--- a/tests/helm/testdata/goldenfile/terraform/disable_default_metrics.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disable_default_metrics.output.yaml
@@ -482,21 +482,9 @@ data:
     # Sumo Logic Collector and HTTP sources
     # Only import sources when collector exists.
     if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
-    true  # prevent to render empty if; then
-    terraform import sumologic_http_source.default_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events"
-    terraform import sumologic_http_source.default_otlp_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events-otlp"
-    terraform import sumologic_http_source.default_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs"
-    terraform import sumologic_http_source.default_otlp_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs-otlp"
-    terraform import sumologic_http_source.apiserver_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/apiserver-metrics"
-    terraform import sumologic_http_source.control_plane_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/control-plane-metrics"
-    terraform import sumologic_http_source.controller_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-controller-manager-metrics"
-    terraform import sumologic_http_source.default_otlp_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/metrics-otlp"
-    terraform import sumologic_http_source.kubelet_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kubelet-metrics"
-    terraform import sumologic_http_source.node_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/node-exporter-metrics"
-    terraform import sumologic_http_source.scheduler_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-scheduler-metrics"
-    terraform import sumologic_http_source.state_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-state-metrics"
-    terraform import sumologic_http_source.default_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces"
-    terraform import sumologic_http_source.default_otlp_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces-otlp"
+        jq -r '.resource[] | to_entries[] | "\(.key) \(.value.name)"' sources.tf.json | while read -r resource_name source_name; do
+            terraform import "sumologic_http_source.${resource_name}" "${SUMOLOGIC_COLLECTOR_NAME}/${source_name}"
+        done
     fi
 
     # Kubernetes Secret

--- a/tests/helm/testdata/goldenfile/terraform/disabled_dashboards.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disabled_dashboards.output.yaml
@@ -347,6 +347,7 @@ data:
       }
 
       type = "Opaque"
+      wait_for_service_account_token = false
     }
   setup.sh: |
     #!/bin/bash

--- a/tests/helm/testdata/goldenfile/terraform/disabled_dashboards.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disabled_dashboards.output.yaml
@@ -482,22 +482,9 @@ data:
     # Sumo Logic Collector and HTTP sources
     # Only import sources when collector exists.
     if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
-    true  # prevent to render empty if; then
-    terraform import sumologic_http_source.default_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events"
-    terraform import sumologic_http_source.default_otlp_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events-otlp"
-    terraform import sumologic_http_source.default_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs"
-    terraform import sumologic_http_source.default_otlp_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs-otlp"
-    terraform import sumologic_http_source.apiserver_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/apiserver-metrics"
-    terraform import sumologic_http_source.control_plane_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/control-plane-metrics"
-    terraform import sumologic_http_source.controller_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-controller-manager-metrics"
-    terraform import sumologic_http_source.default_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/(default-metrics)"
-    terraform import sumologic_http_source.default_otlp_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/metrics-otlp"
-    terraform import sumologic_http_source.kubelet_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kubelet-metrics"
-    terraform import sumologic_http_source.node_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/node-exporter-metrics"
-    terraform import sumologic_http_source.scheduler_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-scheduler-metrics"
-    terraform import sumologic_http_source.state_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-state-metrics"
-    terraform import sumologic_http_source.default_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces"
-    terraform import sumologic_http_source.default_otlp_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces-otlp"
+        jq -r '.resource[] | to_entries[] | "\(.key) \(.value.name)"' sources.tf.json | while read -r resource_name source_name; do
+            terraform import "sumologic_http_source.${resource_name}" "${SUMOLOGIC_COLLECTOR_NAME}/${source_name}"
+        done
     fi
 
     # Kubernetes Secret

--- a/tests/helm/testdata/goldenfile/terraform/disabled_monitors.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disabled_monitors.output.yaml
@@ -347,6 +347,7 @@ data:
       }
 
       type = "Opaque"
+      wait_for_service_account_token = false
     }
   setup.sh: |
     #!/bin/bash

--- a/tests/helm/testdata/goldenfile/terraform/disabled_monitors.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disabled_monitors.output.yaml
@@ -482,22 +482,9 @@ data:
     # Sumo Logic Collector and HTTP sources
     # Only import sources when collector exists.
     if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
-    true  # prevent to render empty if; then
-    terraform import sumologic_http_source.default_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events"
-    terraform import sumologic_http_source.default_otlp_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events-otlp"
-    terraform import sumologic_http_source.default_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs"
-    terraform import sumologic_http_source.default_otlp_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs-otlp"
-    terraform import sumologic_http_source.apiserver_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/apiserver-metrics"
-    terraform import sumologic_http_source.control_plane_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/control-plane-metrics"
-    terraform import sumologic_http_source.controller_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-controller-manager-metrics"
-    terraform import sumologic_http_source.default_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/(default-metrics)"
-    terraform import sumologic_http_source.default_otlp_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/metrics-otlp"
-    terraform import sumologic_http_source.kubelet_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kubelet-metrics"
-    terraform import sumologic_http_source.node_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/node-exporter-metrics"
-    terraform import sumologic_http_source.scheduler_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-scheduler-metrics"
-    terraform import sumologic_http_source.state_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-state-metrics"
-    terraform import sumologic_http_source.default_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces"
-    terraform import sumologic_http_source.default_otlp_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces-otlp"
+        jq -r '.resource[] | to_entries[] | "\(.key) \(.value.name)"' sources.tf.json | while read -r resource_name source_name; do
+            terraform import "sumologic_http_source.${resource_name}" "${SUMOLOGIC_COLLECTOR_NAME}/${source_name}"
+        done
     fi
 
     # Kubernetes Secret

--- a/tests/helm/testdata/goldenfile/terraform/logs_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/logs_fields.output.yaml
@@ -347,6 +347,7 @@ data:
       }
 
       type = "Opaque"
+      wait_for_service_account_token = false
     }
   setup.sh: |
     #!/bin/bash

--- a/tests/helm/testdata/goldenfile/terraform/logs_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/logs_fields.output.yaml
@@ -482,22 +482,9 @@ data:
     # Sumo Logic Collector and HTTP sources
     # Only import sources when collector exists.
     if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
-    true  # prevent to render empty if; then
-    terraform import sumologic_http_source.default_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events"
-    terraform import sumologic_http_source.default_otlp_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events-otlp"
-    terraform import sumologic_http_source.default_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs"
-    terraform import sumologic_http_source.default_otlp_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs-otlp"
-    terraform import sumologic_http_source.apiserver_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/apiserver-metrics"
-    terraform import sumologic_http_source.control_plane_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/control-plane-metrics"
-    terraform import sumologic_http_source.controller_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-controller-manager-metrics"
-    terraform import sumologic_http_source.default_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/(default-metrics)"
-    terraform import sumologic_http_source.default_otlp_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/metrics-otlp"
-    terraform import sumologic_http_source.kubelet_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kubelet-metrics"
-    terraform import sumologic_http_source.node_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/node-exporter-metrics"
-    terraform import sumologic_http_source.scheduler_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-scheduler-metrics"
-    terraform import sumologic_http_source.state_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-state-metrics"
-    terraform import sumologic_http_source.default_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces"
-    terraform import sumologic_http_source.default_otlp_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces-otlp"
+        jq -r '.resource[] | to_entries[] | "\(.key) \(.value.name)"' sources.tf.json | while read -r resource_name source_name; do
+            terraform import "sumologic_http_source.${resource_name}" "${SUMOLOGIC_COLLECTOR_NAME}/${source_name}"
+        done
     fi
 
     # Kubernetes Secret

--- a/tests/helm/testdata/goldenfile/terraform/monitors_with_email_notifications.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/monitors_with_email_notifications.output.yaml
@@ -488,22 +488,9 @@ data:
     # Sumo Logic Collector and HTTP sources
     # Only import sources when collector exists.
     if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
-    true  # prevent to render empty if; then
-    terraform import sumologic_http_source.default_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events"
-    terraform import sumologic_http_source.default_otlp_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events-otlp"
-    terraform import sumologic_http_source.default_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs"
-    terraform import sumologic_http_source.default_otlp_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs-otlp"
-    terraform import sumologic_http_source.apiserver_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/apiserver-metrics"
-    terraform import sumologic_http_source.control_plane_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/control-plane-metrics"
-    terraform import sumologic_http_source.controller_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-controller-manager-metrics"
-    terraform import sumologic_http_source.default_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/(default-metrics)"
-    terraform import sumologic_http_source.default_otlp_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/metrics-otlp"
-    terraform import sumologic_http_source.kubelet_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kubelet-metrics"
-    terraform import sumologic_http_source.node_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/node-exporter-metrics"
-    terraform import sumologic_http_source.scheduler_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-scheduler-metrics"
-    terraform import sumologic_http_source.state_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-state-metrics"
-    terraform import sumologic_http_source.default_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces"
-    terraform import sumologic_http_source.default_otlp_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces-otlp"
+        jq -r '.resource[] | to_entries[] | "\(.key) \(.value.name)"' sources.tf.json | while read -r resource_name source_name; do
+            terraform import "sumologic_http_source.${resource_name}" "${SUMOLOGIC_COLLECTOR_NAME}/${source_name}"
+        done
     fi
 
     # Kubernetes Secret

--- a/tests/helm/testdata/goldenfile/terraform/monitors_with_email_notifications.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/monitors_with_email_notifications.output.yaml
@@ -353,6 +353,7 @@ data:
       }
 
       type = "Opaque"
+      wait_for_service_account_token = false
     }
   setup.sh: |
     #!/bin/bash

--- a/tests/helm/testdata/goldenfile/terraform/monitors_with_single_email.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/monitors_with_single_email.output.yaml
@@ -488,22 +488,9 @@ data:
     # Sumo Logic Collector and HTTP sources
     # Only import sources when collector exists.
     if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
-    true  # prevent to render empty if; then
-    terraform import sumologic_http_source.default_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events"
-    terraform import sumologic_http_source.default_otlp_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events-otlp"
-    terraform import sumologic_http_source.default_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs"
-    terraform import sumologic_http_source.default_otlp_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs-otlp"
-    terraform import sumologic_http_source.apiserver_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/apiserver-metrics"
-    terraform import sumologic_http_source.control_plane_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/control-plane-metrics"
-    terraform import sumologic_http_source.controller_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-controller-manager-metrics"
-    terraform import sumologic_http_source.default_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/(default-metrics)"
-    terraform import sumologic_http_source.default_otlp_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/metrics-otlp"
-    terraform import sumologic_http_source.kubelet_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kubelet-metrics"
-    terraform import sumologic_http_source.node_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/node-exporter-metrics"
-    terraform import sumologic_http_source.scheduler_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-scheduler-metrics"
-    terraform import sumologic_http_source.state_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-state-metrics"
-    terraform import sumologic_http_source.default_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces"
-    terraform import sumologic_http_source.default_otlp_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces-otlp"
+        jq -r '.resource[] | to_entries[] | "\(.key) \(.value.name)"' sources.tf.json | while read -r resource_name source_name; do
+            terraform import "sumologic_http_source.${resource_name}" "${SUMOLOGIC_COLLECTOR_NAME}/${source_name}"
+        done
     fi
 
     # Kubernetes Secret

--- a/tests/helm/testdata/goldenfile/terraform/monitors_with_single_email.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/monitors_with_single_email.output.yaml
@@ -353,6 +353,7 @@ data:
       }
 
       type = "Opaque"
+      wait_for_service_account_token = false
     }
   setup.sh: |
     #!/bin/bash

--- a/tests/helm/testdata/goldenfile/terraform/strip_extrapolation.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/strip_extrapolation.output.yaml
@@ -348,6 +348,7 @@ data:
       }
 
       type = "Opaque"
+      wait_for_service_account_token = false
     }
   setup.sh: |
     #!/bin/bash

--- a/tests/helm/testdata/goldenfile/terraform/strip_extrapolation.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/strip_extrapolation.output.yaml
@@ -483,22 +483,9 @@ data:
     # Sumo Logic Collector and HTTP sources
     # Only import sources when collector exists.
     if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
-    true  # prevent to render empty if; then
-    terraform import sumologic_http_source.default_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events"
-    terraform import sumologic_http_source.default_otlp_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events-otlp"
-    terraform import sumologic_http_source.default_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs"
-    terraform import sumologic_http_source.default_otlp_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs-otlp"
-    terraform import sumologic_http_source.apiserver_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/apiserver-metrics"
-    terraform import sumologic_http_source.control_plane_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/control-plane-metrics"
-    terraform import sumologic_http_source.controller_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-controller-manager-metrics"
-    terraform import sumologic_http_source.default_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/(default-metrics)"
-    terraform import sumologic_http_source.default_otlp_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/metrics-otlp"
-    terraform import sumologic_http_source.kubelet_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kubelet-metrics"
-    terraform import sumologic_http_source.node_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/node-exporter-metrics"
-    terraform import sumologic_http_source.scheduler_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-scheduler-metrics"
-    terraform import sumologic_http_source.state_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-state-metrics"
-    terraform import sumologic_http_source.default_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces"
-    terraform import sumologic_http_source.default_otlp_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces-otlp"
+        jq -r '.resource[] | to_entries[] | "\(.key) \(.value.name)"' sources.tf.json | while read -r resource_name source_name; do
+            terraform import "sumologic_http_source.${resource_name}" "${SUMOLOGIC_COLLECTOR_NAME}/${source_name}"
+        done
     fi
 
     # Kubernetes Secret

--- a/tests/helm/testdata/goldenfile/terraform/traces.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/traces.output.yaml
@@ -347,6 +347,7 @@ data:
       }
 
       type = "Opaque"
+      wait_for_service_account_token = false
     }
   setup.sh: |
     #!/bin/bash

--- a/tests/helm/testdata/goldenfile/terraform/traces.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/traces.output.yaml
@@ -482,10 +482,9 @@ data:
     # Sumo Logic Collector and HTTP sources
     # Only import sources when collector exists.
     if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
-    true  # prevent to render empty if; then
-    terraform import sumologic_http_source.default_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/(default-metrics)"
-    terraform import sumologic_http_source.default_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces"
-    terraform import sumologic_http_source.default_otlp_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces-otlp"
+        jq -r '.resource[] | to_entries[] | "\(.key) \(.value.name)"' sources.tf.json | while read -r resource_name source_name; do
+            terraform import "sumologic_http_source.${resource_name}" "${SUMOLOGIC_COLLECTOR_NAME}/${source_name}"
+        done
     fi
 
     # Kubernetes Secret

--- a/tests/helm/testdata/goldenfile/terraform/tracing-metrics-disabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/tracing-metrics-disabled.output.yaml
@@ -347,6 +347,7 @@ data:
       }
 
       type = "Opaque"
+      wait_for_service_account_token = false
     }
   setup.sh: |
     #!/bin/bash

--- a/tests/helm/testdata/goldenfile/terraform/tracing-metrics-disabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/tracing-metrics-disabled.output.yaml
@@ -482,22 +482,9 @@ data:
     # Sumo Logic Collector and HTTP sources
     # Only import sources when collector exists.
     if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
-    true  # prevent to render empty if; then
-    terraform import sumologic_http_source.default_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events"
-    terraform import sumologic_http_source.default_otlp_events_source "${SUMOLOGIC_COLLECTOR_NAME}/events-otlp"
-    terraform import sumologic_http_source.default_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs"
-    terraform import sumologic_http_source.default_otlp_logs_source "${SUMOLOGIC_COLLECTOR_NAME}/logs-otlp"
-    terraform import sumologic_http_source.apiserver_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/apiserver-metrics"
-    terraform import sumologic_http_source.control_plane_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/control-plane-metrics"
-    terraform import sumologic_http_source.controller_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-controller-manager-metrics"
-    terraform import sumologic_http_source.default_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/(default-metrics)"
-    terraform import sumologic_http_source.default_otlp_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/metrics-otlp"
-    terraform import sumologic_http_source.kubelet_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kubelet-metrics"
-    terraform import sumologic_http_source.node_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/node-exporter-metrics"
-    terraform import sumologic_http_source.scheduler_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-scheduler-metrics"
-    terraform import sumologic_http_source.state_metrics_source "${SUMOLOGIC_COLLECTOR_NAME}/kube-state-metrics"
-    terraform import sumologic_http_source.default_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces"
-    terraform import sumologic_http_source.default_otlp_traces_source "${SUMOLOGIC_COLLECTOR_NAME}/traces-otlp"
+        jq -r '.resource[] | to_entries[] | "\(.key) \(.value.name)"' sources.tf.json | while read -r resource_name source_name; do
+            terraform import "sumologic_http_source.${resource_name}" "${SUMOLOGIC_COLLECTOR_NAME}/${source_name}"
+        done
     fi
 
     # Kubernetes Secret


### PR DESCRIPTION
Import using the json file as a reference instead of templating in the bash script. This is the final part of #3761.

Also fixed a bug in cleanup, which was using the wrong Secret name. 

Finally, set an attribute on the generated Secret to align more with Kubernetes defaults.
