### PR TITLE
chore(setup): remove Helm templates from setup scripts

### DIFF
--- a/deploy/helm/sumologic/conf/setup/monitors.sh
+++ b/deploy/helm/sumologic/conf/setup/monitors.sh
@@ -80,7 +80,7 @@ if [[ -z "${MONITORS_FOLDER_ID}" ]]; then
   )
 
   if [ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]; then
-    NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{ printf `{{TriggerType}}` }} on {{ printf `{{Name}}` }}\",message_body=\"Triggered {{ printf `{{TriggerType}}` }} alert on {{ printf `{{Name}}` }}: {{ printf `{{QueryURL}}` }}\""
+    NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{TriggerType}} on {{Name}}\",message_body=\"Triggered {{TriggerType}} alert on {{Name}}: {{QueryURL}}\""
     NOTIFICATIONS_SETTINGS="recipients=${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
     TERRAFORM_ARGS+=(
       -var="email_notifications_critical=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Critical\", \"ResolvedCritical\"]}]"

--- a/deploy/helm/sumologic/conf/setup/setup.sh
+++ b/deploy/helm/sumologic/conf/setup/setup.sh
@@ -146,22 +146,22 @@ TF_LOG_PROVIDER=DEBUG terraform apply \
     || { echo "Error during applying Terraform changes"; exit 1; }
 
 # Setup Sumo Logic monitors if enabled
-{{- if .Values.sumologic.setup.monitors.enabled }}
-bash /etc/terraform/monitors.sh
-{{- else }}
-echo "Installation of the Sumo Logic monitors is disabled."
-echo "You can install them manually later with:"
-echo "https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor/tree/main/monitor_packages/kubernetes"
-{{- end }}
+if [ "${SUMOLOGIC_MONITORS_ENABLED}" = "true" ]; then
+    bash /etc/terraform/monitors.sh
+else
+    echo "Installation of the Sumo Logic monitors is disabled."
+    echo "You can install them manually later with:"
+    echo "https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor/tree/main/monitor_packages/kubernetes"
+fi
 
 # Setup Sumo Logic dashboards if enabled
-{{- if .Values.sumologic.setup.dashboards.enabled }}
-bash /etc/terraform/dashboards.sh
-{{- else }}
-echo "Installation of the Sumo Logic dashboards is disabled."
-echo "You can install them manually later with:"
-echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
-{{- end }}
+if [ "${SUMOLOGIC_DASHBOARDS_ENABLED}" = "true" ]; then
+    bash /etc/terraform/dashboards.sh
+else
+    echo "Installation of the Sumo Logic dashboards is disabled."
+    echo "You can install them manually later with:"
+    echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
+fi
 
 # Cleanup env variables
 export SUMOLOGIC_BASE_URL=

--- a/deploy/helm/sumologic/templates/cleanup/configmap.yaml
+++ b/deploy/helm/sumologic/templates/cleanup/configmap.yaml
@@ -10,6 +10,7 @@ metadata:
     app: {{ template "sumologic.labels.app.cleanup.configmap" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 data:
-  {{- (tpl (.Files.Glob "conf/cleanup/cleanup.sh").AsConfig .) | nindent 2 }}
-  {{- (tpl (.Files.Glob "conf/setup/*").AsConfig .) | nindent 2 }}
+  {{- (.Files.Glob "conf/cleanup/cleanup.sh").AsConfig | nindent 2 }}
+  {{- (.Files.Glob "conf/setup/*.{tf,sh}").AsConfig | nindent 2 }}
+  {{- (tpl (.Files.Glob "conf/setup/*.json").AsConfig .) | nindent 2 }}
 {{- end }}

--- a/deploy/helm/sumologic/templates/setup/configmap.yaml
+++ b/deploy/helm/sumologic/templates/setup/configmap.yaml
@@ -10,5 +10,6 @@ metadata:
     app: {{ template "sumologic.labels.app.setup.configmap" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
 data:
-  {{- (tpl (.Files.Glob "conf/setup/*").AsConfig .) | nindent 2 }}
+  {{- (.Files.Glob "conf/setup/*.{tf,sh}").AsConfig | nindent 2 }}
+  {{- (tpl (.Files.Glob "conf/setup/*.json").AsConfig .) | nindent 2 }}
 {{- end }}

--- a/deploy/helm/sumologic/templates/setup/job.yaml
+++ b/deploy/helm/sumologic/templates/setup/job.yaml
@@ -83,6 +83,10 @@ spec:
           value: "{{ template "terraform.secret.name" }}"
         - name: CHART_VERSION
           value: "{{ .Chart.Version }}"
+        - name: SUMOLOGIC_MONITORS_ENABLED
+          value: "{{ .Values.sumologic.setup.monitors.enabled }}"
+        - name: SUMOLOGIC_DASHBOARDS_ENABLED
+          value: "{{ .Values.sumologic.setup.dashboards.enabled }}"
         {{- include "proxy-env-variables" . | nindent 8 -}}
 {{- if .Values.sumologic.setup.debug }}
         - name: DEBUG_MODE

--- a/deploy/helm/sumologic/templates/setup/job.yaml
+++ b/deploy/helm/sumologic/templates/setup/job.yaml
@@ -1,3 +1,9 @@
+{{ $notificationEmails := list }}
+{{ if kindIs "string" .Values.sumologic.setup.monitors.notificationEmails }}
+{{ $notificationEmails = append $notificationEmails .Values.sumologic.setup.monitors.notificationEmails }}
+{{ else }}
+{{ $notificationEmails = concat $notificationEmails .Values.sumologic.setup.monitors.notificationEmails }}
+{{ end }}
 {{- if .Values.sumologic.setupEnabled }}
 apiVersion: batch/v1
 kind: Job
@@ -85,6 +91,13 @@ spec:
           value: "{{ .Chart.Version }}"
         - name: SUMOLOGIC_MONITORS_ENABLED
           value: "{{ .Values.sumologic.setup.monitors.enabled }}"
+        - name: SUMOLOGIC_MONITORS_STATUS
+          value: "{{ .Values.sumologic.setup.monitors.monitorStatus }}"
+{{- if not (empty $notificationEmails) }}
+        - name: SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS
+          value: |
+            {{ toRawJson $notificationEmails }}
+{{- end }}
         - name: SUMOLOGIC_DASHBOARDS_ENABLED
           value: "{{ .Values.sumologic.setup.dashboards.enabled }}"
         {{- include "proxy-env-variables" . | nindent 8 -}}

--- a/tests/helm/testdata/goldenfile/setup/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/setup/basic.output.yaml
@@ -67,6 +67,10 @@ spec:
               value: "sumologic"
             - name: CHART_VERSION
               value: "%CURRENT_CHART_VERSION%"
+            - name: SUMOLOGIC_MONITORS_ENABLED
+              value: "true"
+            - name: SUMOLOGIC_DASHBOARDS_ENABLED
+              value: "true"
 
             - name: NO_PROXY
               value: kubernetes.default.svc

--- a/tests/helm/testdata/goldenfile/setup/monitors_with_email_notifications.input.yaml
+++ b/tests/helm/testdata/goldenfile/setup/monitors_with_email_notifications.input.yaml
@@ -1,0 +1,5 @@
+sumologic:
+  setup:
+    monitors:
+      enabled: "true"
+      notificationEmails: ["test@test.lh", "email@locahost.lh"]

--- a/tests/helm/testdata/goldenfile/setup/monitors_with_email_notifications.output.yaml
+++ b/tests/helm/testdata/goldenfile/setup/monitors_with_email_notifications.output.yaml
@@ -71,6 +71,9 @@ spec:
               value: "true"
             - name: SUMOLOGIC_MONITORS_STATUS
               value: "enabled"
+            - name: SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS
+              value: |
+                ["test@test.lh","email@locahost.lh"]
             - name: SUMOLOGIC_DASHBOARDS_ENABLED
               value: "true"
 

--- a/tests/helm/testdata/goldenfile/setup/monitors_with_single_email.input.yaml
+++ b/tests/helm/testdata/goldenfile/setup/monitors_with_single_email.input.yaml
@@ -1,0 +1,5 @@
+sumologic:
+  setup:
+    monitors:
+      enabled: "true"
+      notificationEmails: "email@locahost.lh"

--- a/tests/helm/testdata/goldenfile/setup/monitors_with_single_email.output.yaml
+++ b/tests/helm/testdata/goldenfile/setup/monitors_with_single_email.output.yaml
@@ -71,6 +71,9 @@ spec:
               value: "true"
             - name: SUMOLOGIC_MONITORS_STATUS
               value: "enabled"
+            - name: SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS
+              value: |
+                ["email@locahost.lh"]
             - name: SUMOLOGIC_DASHBOARDS_ENABLED
               value: "true"
 

--- a/tests/helm/testdata/goldenfile/setup/sumologic-mock-no-secret.output.yaml
+++ b/tests/helm/testdata/goldenfile/setup/sumologic-mock-no-secret.output.yaml
@@ -69,6 +69,8 @@ spec:
               value: "%CURRENT_CHART_VERSION%"
             - name: SUMOLOGIC_MONITORS_ENABLED
               value: "true"
+            - name: SUMOLOGIC_MONITORS_STATUS
+              value: "enabled"
             - name: SUMOLOGIC_DASHBOARDS_ENABLED
               value: "true"
 

--- a/tests/helm/testdata/goldenfile/setup/sumologic-mock-no-secret.output.yaml
+++ b/tests/helm/testdata/goldenfile/setup/sumologic-mock-no-secret.output.yaml
@@ -67,6 +67,10 @@ spec:
               value: "sumologic"
             - name: CHART_VERSION
               value: "%CURRENT_CHART_VERSION%"
+            - name: SUMOLOGIC_MONITORS_ENABLED
+              value: "true"
+            - name: SUMOLOGIC_DASHBOARDS_ENABLED
+              value: "true"
 
             - name: NO_PROXY
               value: kubernetes.default.svc

--- a/tests/helm/testdata/goldenfile/setup/sumologic-mock.output.yaml
+++ b/tests/helm/testdata/goldenfile/setup/sumologic-mock.output.yaml
@@ -69,6 +69,8 @@ spec:
               value: "%CURRENT_CHART_VERSION%"
             - name: SUMOLOGIC_MONITORS_ENABLED
               value: "true"
+            - name: SUMOLOGIC_MONITORS_STATUS
+              value: "enabled"
             - name: SUMOLOGIC_DASHBOARDS_ENABLED
               value: "true"
 

--- a/tests/helm/testdata/goldenfile/setup/sumologic-mock.output.yaml
+++ b/tests/helm/testdata/goldenfile/setup/sumologic-mock.output.yaml
@@ -67,6 +67,10 @@ spec:
               value: "sumologic"
             - name: CHART_VERSION
               value: "%CURRENT_CHART_VERSION%"
+            - name: SUMOLOGIC_MONITORS_ENABLED
+              value: "true"
+            - name: SUMOLOGIC_DASHBOARDS_ENABLED
+              value: "true"
 
             - name: NO_PROXY
               value: kubernetes.default.svc

--- a/tests/helm/testdata/goldenfile/terraform/all_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/all_fields.output.yaml
@@ -249,7 +249,12 @@ data:
 
     INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
-    MONITORS_DISABLED="false"
+
+    if [ "${SUMOLOGIC_MONITORS_STATUS}" = "enabled" ]; then
+      MONITORS_DISABLED="false"
+    else
+      MONITORS_DISABLED="true"
+    fi
 
     MONITORS_ROOT_ID="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
@@ -304,14 +309,27 @@ data:
         SUMOLOGIC_ENV="us1"
       fi
 
-      TF_LOG_PROVIDER=DEBUG terraform apply \
-          -auto-approve \
-          -var="access_id=${SUMOLOGIC_ACCESSID}" \
-          -var="access_key=${SUMOLOGIC_ACCESSKEY}" \
-          -var="environment=${SUMOLOGIC_ENV}" \
-          -var="folder=${MONITORS_FOLDER_NAME}" \
-          -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}" \
-          -var="monitors_disabled=${MONITORS_DISABLED}" \
+      TERRAFORM_ARGS=(
+        -auto-approve
+        -var="access_id=${SUMOLOGIC_ACCESSID}"
+        -var="access_key=${SUMOLOGIC_ACCESSKEY}"
+        -var="environment=${SUMOLOGIC_ENV}"
+        -var="folder=${MONITORS_FOLDER_NAME}"
+        -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}"
+        -var="monitors_disabled=${MONITORS_DISABLED}"
+      )
+
+      if [ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]; then
+        NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{TriggerType}} on {{Name}}\",message_body=\"Triggered {{TriggerType}} alert on {{Name}}: {{QueryURL}}\""
+        NOTIFICATIONS_SETTINGS="recipients=${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
+        TERRAFORM_ARGS+=(
+          -var="email_notifications_critical=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Critical\", \"ResolvedCritical\"]}]"
+          -var="email_notifications_warning=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Warning\", \"ResolvedWarning\"]}]"
+          -var="email_notifications_missingdata=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"MissingData\", \"ResolvedMissingData\"]}]"
+        )
+      fi
+
+      TF_LOG_PROVIDER=DEBUG terraform apply "${TERRAFORM_ARGS[@]}" \
           || { echo "Error during applying Terraform monitors."; exit 1; }
     else
       echo "The monitors have been already installed in ${MONITORS_FOLDER_NAME}."

--- a/tests/helm/testdata/goldenfile/terraform/all_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/all_fields.output.yaml
@@ -498,10 +498,22 @@ data:
         || { echo "Error during applying Terraform changes"; exit 1; }
 
     # Setup Sumo Logic monitors if enabled
-    bash /etc/terraform/monitors.sh
+    if [ "${SUMOLOGIC_MONITORS_ENABLED}" = "true" ]; then
+        bash /etc/terraform/monitors.sh
+    else
+        echo "Installation of the Sumo Logic monitors is disabled."
+        echo "You can install them manually later with:"
+        echo "https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor/tree/main/monitor_packages/kubernetes"
+    fi
 
     # Setup Sumo Logic dashboards if enabled
-    bash /etc/terraform/dashboards.sh
+    if [ "${SUMOLOGIC_DASHBOARDS_ENABLED}" = "true" ]; then
+        bash /etc/terraform/dashboards.sh
+    else
+        echo "Installation of the Sumo Logic dashboards is disabled."
+        echo "You can install them manually later with:"
+        echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
+    fi
 
     # Cleanup env variables
     export SUMOLOGIC_BASE_URL=

--- a/tests/helm/testdata/goldenfile/terraform/collector_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/collector_fields.output.yaml
@@ -249,7 +249,12 @@ data:
 
     INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
-    MONITORS_DISABLED="false"
+
+    if [ "${SUMOLOGIC_MONITORS_STATUS}" = "enabled" ]; then
+      MONITORS_DISABLED="false"
+    else
+      MONITORS_DISABLED="true"
+    fi
 
     MONITORS_ROOT_ID="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
@@ -304,14 +309,27 @@ data:
         SUMOLOGIC_ENV="us1"
       fi
 
-      TF_LOG_PROVIDER=DEBUG terraform apply \
-          -auto-approve \
-          -var="access_id=${SUMOLOGIC_ACCESSID}" \
-          -var="access_key=${SUMOLOGIC_ACCESSKEY}" \
-          -var="environment=${SUMOLOGIC_ENV}" \
-          -var="folder=${MONITORS_FOLDER_NAME}" \
-          -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}" \
-          -var="monitors_disabled=${MONITORS_DISABLED}" \
+      TERRAFORM_ARGS=(
+        -auto-approve
+        -var="access_id=${SUMOLOGIC_ACCESSID}"
+        -var="access_key=${SUMOLOGIC_ACCESSKEY}"
+        -var="environment=${SUMOLOGIC_ENV}"
+        -var="folder=${MONITORS_FOLDER_NAME}"
+        -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}"
+        -var="monitors_disabled=${MONITORS_DISABLED}"
+      )
+
+      if [ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]; then
+        NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{TriggerType}} on {{Name}}\",message_body=\"Triggered {{TriggerType}} alert on {{Name}}: {{QueryURL}}\""
+        NOTIFICATIONS_SETTINGS="recipients=${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
+        TERRAFORM_ARGS+=(
+          -var="email_notifications_critical=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Critical\", \"ResolvedCritical\"]}]"
+          -var="email_notifications_warning=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Warning\", \"ResolvedWarning\"]}]"
+          -var="email_notifications_missingdata=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"MissingData\", \"ResolvedMissingData\"]}]"
+        )
+      fi
+
+      TF_LOG_PROVIDER=DEBUG terraform apply "${TERRAFORM_ARGS[@]}" \
           || { echo "Error during applying Terraform monitors."; exit 1; }
     else
       echo "The monitors have been already installed in ${MONITORS_FOLDER_NAME}."

--- a/tests/helm/testdata/goldenfile/terraform/collector_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/collector_fields.output.yaml
@@ -498,10 +498,22 @@ data:
         || { echo "Error during applying Terraform changes"; exit 1; }
 
     # Setup Sumo Logic monitors if enabled
-    bash /etc/terraform/monitors.sh
+    if [ "${SUMOLOGIC_MONITORS_ENABLED}" = "true" ]; then
+        bash /etc/terraform/monitors.sh
+    else
+        echo "Installation of the Sumo Logic monitors is disabled."
+        echo "You can install them manually later with:"
+        echo "https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor/tree/main/monitor_packages/kubernetes"
+    fi
 
     # Setup Sumo Logic dashboards if enabled
-    bash /etc/terraform/dashboards.sh
+    if [ "${SUMOLOGIC_DASHBOARDS_ENABLED}" = "true" ]; then
+        bash /etc/terraform/dashboards.sh
+    else
+        echo "Installation of the Sumo Logic dashboards is disabled."
+        echo "You can install them manually later with:"
+        echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
+    fi
 
     # Cleanup env variables
     export SUMOLOGIC_BASE_URL=

--- a/tests/helm/testdata/goldenfile/terraform/conditional_sources.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/conditional_sources.output.yaml
@@ -249,7 +249,12 @@ data:
 
     INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
-    MONITORS_DISABLED="false"
+
+    if [ "${SUMOLOGIC_MONITORS_STATUS}" = "enabled" ]; then
+      MONITORS_DISABLED="false"
+    else
+      MONITORS_DISABLED="true"
+    fi
 
     MONITORS_ROOT_ID="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
@@ -304,14 +309,27 @@ data:
         SUMOLOGIC_ENV="us1"
       fi
 
-      TF_LOG_PROVIDER=DEBUG terraform apply \
-          -auto-approve \
-          -var="access_id=${SUMOLOGIC_ACCESSID}" \
-          -var="access_key=${SUMOLOGIC_ACCESSKEY}" \
-          -var="environment=${SUMOLOGIC_ENV}" \
-          -var="folder=${MONITORS_FOLDER_NAME}" \
-          -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}" \
-          -var="monitors_disabled=${MONITORS_DISABLED}" \
+      TERRAFORM_ARGS=(
+        -auto-approve
+        -var="access_id=${SUMOLOGIC_ACCESSID}"
+        -var="access_key=${SUMOLOGIC_ACCESSKEY}"
+        -var="environment=${SUMOLOGIC_ENV}"
+        -var="folder=${MONITORS_FOLDER_NAME}"
+        -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}"
+        -var="monitors_disabled=${MONITORS_DISABLED}"
+      )
+
+      if [ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]; then
+        NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{TriggerType}} on {{Name}}\",message_body=\"Triggered {{TriggerType}} alert on {{Name}}: {{QueryURL}}\""
+        NOTIFICATIONS_SETTINGS="recipients=${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
+        TERRAFORM_ARGS+=(
+          -var="email_notifications_critical=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Critical\", \"ResolvedCritical\"]}]"
+          -var="email_notifications_warning=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Warning\", \"ResolvedWarning\"]}]"
+          -var="email_notifications_missingdata=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"MissingData\", \"ResolvedMissingData\"]}]"
+        )
+      fi
+
+      TF_LOG_PROVIDER=DEBUG terraform apply "${TERRAFORM_ARGS[@]}" \
           || { echo "Error during applying Terraform monitors."; exit 1; }
     else
       echo "The monitors have been already installed in ${MONITORS_FOLDER_NAME}."

--- a/tests/helm/testdata/goldenfile/terraform/conditional_sources.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/conditional_sources.output.yaml
@@ -498,10 +498,22 @@ data:
         || { echo "Error during applying Terraform changes"; exit 1; }
 
     # Setup Sumo Logic monitors if enabled
-    bash /etc/terraform/monitors.sh
+    if [ "${SUMOLOGIC_MONITORS_ENABLED}" = "true" ]; then
+        bash /etc/terraform/monitors.sh
+    else
+        echo "Installation of the Sumo Logic monitors is disabled."
+        echo "You can install them manually later with:"
+        echo "https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor/tree/main/monitor_packages/kubernetes"
+    fi
 
     # Setup Sumo Logic dashboards if enabled
-    bash /etc/terraform/dashboards.sh
+    if [ "${SUMOLOGIC_DASHBOARDS_ENABLED}" = "true" ]; then
+        bash /etc/terraform/dashboards.sh
+    else
+        echo "Installation of the Sumo Logic dashboards is disabled."
+        echo "You can install them manually later with:"
+        echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
+    fi
 
     # Cleanup env variables
     export SUMOLOGIC_BASE_URL=

--- a/tests/helm/testdata/goldenfile/terraform/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/custom.output.yaml
@@ -249,7 +249,12 @@ data:
 
     INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
-    MONITORS_DISABLED="false"
+
+    if [ "${SUMOLOGIC_MONITORS_STATUS}" = "enabled" ]; then
+      MONITORS_DISABLED="false"
+    else
+      MONITORS_DISABLED="true"
+    fi
 
     MONITORS_ROOT_ID="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
@@ -304,14 +309,27 @@ data:
         SUMOLOGIC_ENV="us1"
       fi
 
-      TF_LOG_PROVIDER=DEBUG terraform apply \
-          -auto-approve \
-          -var="access_id=${SUMOLOGIC_ACCESSID}" \
-          -var="access_key=${SUMOLOGIC_ACCESSKEY}" \
-          -var="environment=${SUMOLOGIC_ENV}" \
-          -var="folder=${MONITORS_FOLDER_NAME}" \
-          -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}" \
-          -var="monitors_disabled=${MONITORS_DISABLED}" \
+      TERRAFORM_ARGS=(
+        -auto-approve
+        -var="access_id=${SUMOLOGIC_ACCESSID}"
+        -var="access_key=${SUMOLOGIC_ACCESSKEY}"
+        -var="environment=${SUMOLOGIC_ENV}"
+        -var="folder=${MONITORS_FOLDER_NAME}"
+        -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}"
+        -var="monitors_disabled=${MONITORS_DISABLED}"
+      )
+
+      if [ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]; then
+        NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{TriggerType}} on {{Name}}\",message_body=\"Triggered {{TriggerType}} alert on {{Name}}: {{QueryURL}}\""
+        NOTIFICATIONS_SETTINGS="recipients=${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
+        TERRAFORM_ARGS+=(
+          -var="email_notifications_critical=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Critical\", \"ResolvedCritical\"]}]"
+          -var="email_notifications_warning=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Warning\", \"ResolvedWarning\"]}]"
+          -var="email_notifications_missingdata=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"MissingData\", \"ResolvedMissingData\"]}]"
+        )
+      fi
+
+      TF_LOG_PROVIDER=DEBUG terraform apply "${TERRAFORM_ARGS[@]}" \
           || { echo "Error during applying Terraform monitors."; exit 1; }
     else
       echo "The monitors have been already installed in ${MONITORS_FOLDER_NAME}."

--- a/tests/helm/testdata/goldenfile/terraform/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/custom.output.yaml
@@ -498,10 +498,22 @@ data:
         || { echo "Error during applying Terraform changes"; exit 1; }
 
     # Setup Sumo Logic monitors if enabled
-    bash /etc/terraform/monitors.sh
+    if [ "${SUMOLOGIC_MONITORS_ENABLED}" = "true" ]; then
+        bash /etc/terraform/monitors.sh
+    else
+        echo "Installation of the Sumo Logic monitors is disabled."
+        echo "You can install them manually later with:"
+        echo "https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor/tree/main/monitor_packages/kubernetes"
+    fi
 
     # Setup Sumo Logic dashboards if enabled
-    bash /etc/terraform/dashboards.sh
+    if [ "${SUMOLOGIC_DASHBOARDS_ENABLED}" = "true" ]; then
+        bash /etc/terraform/dashboards.sh
+    else
+        echo "Installation of the Sumo Logic dashboards is disabled."
+        echo "You can install them manually later with:"
+        echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
+    fi
 
     # Cleanup env variables
     export SUMOLOGIC_BASE_URL=

--- a/tests/helm/testdata/goldenfile/terraform/default.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/default.output.yaml
@@ -249,7 +249,12 @@ data:
 
     INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
-    MONITORS_DISABLED="false"
+
+    if [ "${SUMOLOGIC_MONITORS_STATUS}" = "enabled" ]; then
+      MONITORS_DISABLED="false"
+    else
+      MONITORS_DISABLED="true"
+    fi
 
     MONITORS_ROOT_ID="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
@@ -304,14 +309,27 @@ data:
         SUMOLOGIC_ENV="us1"
       fi
 
-      TF_LOG_PROVIDER=DEBUG terraform apply \
-          -auto-approve \
-          -var="access_id=${SUMOLOGIC_ACCESSID}" \
-          -var="access_key=${SUMOLOGIC_ACCESSKEY}" \
-          -var="environment=${SUMOLOGIC_ENV}" \
-          -var="folder=${MONITORS_FOLDER_NAME}" \
-          -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}" \
-          -var="monitors_disabled=${MONITORS_DISABLED}" \
+      TERRAFORM_ARGS=(
+        -auto-approve
+        -var="access_id=${SUMOLOGIC_ACCESSID}"
+        -var="access_key=${SUMOLOGIC_ACCESSKEY}"
+        -var="environment=${SUMOLOGIC_ENV}"
+        -var="folder=${MONITORS_FOLDER_NAME}"
+        -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}"
+        -var="monitors_disabled=${MONITORS_DISABLED}"
+      )
+
+      if [ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]; then
+        NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{TriggerType}} on {{Name}}\",message_body=\"Triggered {{TriggerType}} alert on {{Name}}: {{QueryURL}}\""
+        NOTIFICATIONS_SETTINGS="recipients=${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
+        TERRAFORM_ARGS+=(
+          -var="email_notifications_critical=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Critical\", \"ResolvedCritical\"]}]"
+          -var="email_notifications_warning=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Warning\", \"ResolvedWarning\"]}]"
+          -var="email_notifications_missingdata=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"MissingData\", \"ResolvedMissingData\"]}]"
+        )
+      fi
+
+      TF_LOG_PROVIDER=DEBUG terraform apply "${TERRAFORM_ARGS[@]}" \
           || { echo "Error during applying Terraform monitors."; exit 1; }
     else
       echo "The monitors have been already installed in ${MONITORS_FOLDER_NAME}."

--- a/tests/helm/testdata/goldenfile/terraform/default.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/default.output.yaml
@@ -498,10 +498,22 @@ data:
         || { echo "Error during applying Terraform changes"; exit 1; }
 
     # Setup Sumo Logic monitors if enabled
-    bash /etc/terraform/monitors.sh
+    if [ "${SUMOLOGIC_MONITORS_ENABLED}" = "true" ]; then
+        bash /etc/terraform/monitors.sh
+    else
+        echo "Installation of the Sumo Logic monitors is disabled."
+        echo "You can install them manually later with:"
+        echo "https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor/tree/main/monitor_packages/kubernetes"
+    fi
 
     # Setup Sumo Logic dashboards if enabled
-    bash /etc/terraform/dashboards.sh
+    if [ "${SUMOLOGIC_DASHBOARDS_ENABLED}" = "true" ]; then
+        bash /etc/terraform/dashboards.sh
+    else
+        echo "Installation of the Sumo Logic dashboards is disabled."
+        echo "You can install them manually later with:"
+        echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
+    fi
 
     # Cleanup env variables
     export SUMOLOGIC_BASE_URL=

--- a/tests/helm/testdata/goldenfile/terraform/disable_default_metrics.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disable_default_metrics.output.yaml
@@ -249,7 +249,12 @@ data:
 
     INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
-    MONITORS_DISABLED="false"
+
+    if [ "${SUMOLOGIC_MONITORS_STATUS}" = "enabled" ]; then
+      MONITORS_DISABLED="false"
+    else
+      MONITORS_DISABLED="true"
+    fi
 
     MONITORS_ROOT_ID="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
@@ -304,14 +309,27 @@ data:
         SUMOLOGIC_ENV="us1"
       fi
 
-      TF_LOG_PROVIDER=DEBUG terraform apply \
-          -auto-approve \
-          -var="access_id=${SUMOLOGIC_ACCESSID}" \
-          -var="access_key=${SUMOLOGIC_ACCESSKEY}" \
-          -var="environment=${SUMOLOGIC_ENV}" \
-          -var="folder=${MONITORS_FOLDER_NAME}" \
-          -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}" \
-          -var="monitors_disabled=${MONITORS_DISABLED}" \
+      TERRAFORM_ARGS=(
+        -auto-approve
+        -var="access_id=${SUMOLOGIC_ACCESSID}"
+        -var="access_key=${SUMOLOGIC_ACCESSKEY}"
+        -var="environment=${SUMOLOGIC_ENV}"
+        -var="folder=${MONITORS_FOLDER_NAME}"
+        -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}"
+        -var="monitors_disabled=${MONITORS_DISABLED}"
+      )
+
+      if [ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]; then
+        NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{TriggerType}} on {{Name}}\",message_body=\"Triggered {{TriggerType}} alert on {{Name}}: {{QueryURL}}\""
+        NOTIFICATIONS_SETTINGS="recipients=${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
+        TERRAFORM_ARGS+=(
+          -var="email_notifications_critical=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Critical\", \"ResolvedCritical\"]}]"
+          -var="email_notifications_warning=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Warning\", \"ResolvedWarning\"]}]"
+          -var="email_notifications_missingdata=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"MissingData\", \"ResolvedMissingData\"]}]"
+        )
+      fi
+
+      TF_LOG_PROVIDER=DEBUG terraform apply "${TERRAFORM_ARGS[@]}" \
           || { echo "Error during applying Terraform monitors."; exit 1; }
     else
       echo "The monitors have been already installed in ${MONITORS_FOLDER_NAME}."

--- a/tests/helm/testdata/goldenfile/terraform/disable_default_metrics.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disable_default_metrics.output.yaml
@@ -498,10 +498,22 @@ data:
         || { echo "Error during applying Terraform changes"; exit 1; }
 
     # Setup Sumo Logic monitors if enabled
-    bash /etc/terraform/monitors.sh
+    if [ "${SUMOLOGIC_MONITORS_ENABLED}" = "true" ]; then
+        bash /etc/terraform/monitors.sh
+    else
+        echo "Installation of the Sumo Logic monitors is disabled."
+        echo "You can install them manually later with:"
+        echo "https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor/tree/main/monitor_packages/kubernetes"
+    fi
 
     # Setup Sumo Logic dashboards if enabled
-    bash /etc/terraform/dashboards.sh
+    if [ "${SUMOLOGIC_DASHBOARDS_ENABLED}" = "true" ]; then
+        bash /etc/terraform/dashboards.sh
+    else
+        echo "Installation of the Sumo Logic dashboards is disabled."
+        echo "You can install them manually later with:"
+        echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
+    fi
 
     # Cleanup env variables
     export SUMOLOGIC_BASE_URL=

--- a/tests/helm/testdata/goldenfile/terraform/disabled_dashboards.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disabled_dashboards.output.yaml
@@ -498,12 +498,22 @@ data:
         || { echo "Error during applying Terraform changes"; exit 1; }
 
     # Setup Sumo Logic monitors if enabled
-    bash /etc/terraform/monitors.sh
+    if [ "${SUMOLOGIC_MONITORS_ENABLED}" = "true" ]; then
+        bash /etc/terraform/monitors.sh
+    else
+        echo "Installation of the Sumo Logic monitors is disabled."
+        echo "You can install them manually later with:"
+        echo "https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor/tree/main/monitor_packages/kubernetes"
+    fi
 
     # Setup Sumo Logic dashboards if enabled
-    echo "Installation of the Sumo Logic dashboards is disabled."
-    echo "You can install them manually later with:"
-    echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
+    if [ "${SUMOLOGIC_DASHBOARDS_ENABLED}" = "true" ]; then
+        bash /etc/terraform/dashboards.sh
+    else
+        echo "Installation of the Sumo Logic dashboards is disabled."
+        echo "You can install them manually later with:"
+        echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
+    fi
 
     # Cleanup env variables
     export SUMOLOGIC_BASE_URL=

--- a/tests/helm/testdata/goldenfile/terraform/disabled_dashboards.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disabled_dashboards.output.yaml
@@ -249,7 +249,12 @@ data:
 
     INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
-    MONITORS_DISABLED="false"
+
+    if [ "${SUMOLOGIC_MONITORS_STATUS}" = "enabled" ]; then
+      MONITORS_DISABLED="false"
+    else
+      MONITORS_DISABLED="true"
+    fi
 
     MONITORS_ROOT_ID="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
@@ -304,14 +309,27 @@ data:
         SUMOLOGIC_ENV="us1"
       fi
 
-      TF_LOG_PROVIDER=DEBUG terraform apply \
-          -auto-approve \
-          -var="access_id=${SUMOLOGIC_ACCESSID}" \
-          -var="access_key=${SUMOLOGIC_ACCESSKEY}" \
-          -var="environment=${SUMOLOGIC_ENV}" \
-          -var="folder=${MONITORS_FOLDER_NAME}" \
-          -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}" \
-          -var="monitors_disabled=${MONITORS_DISABLED}" \
+      TERRAFORM_ARGS=(
+        -auto-approve
+        -var="access_id=${SUMOLOGIC_ACCESSID}"
+        -var="access_key=${SUMOLOGIC_ACCESSKEY}"
+        -var="environment=${SUMOLOGIC_ENV}"
+        -var="folder=${MONITORS_FOLDER_NAME}"
+        -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}"
+        -var="monitors_disabled=${MONITORS_DISABLED}"
+      )
+
+      if [ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]; then
+        NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{TriggerType}} on {{Name}}\",message_body=\"Triggered {{TriggerType}} alert on {{Name}}: {{QueryURL}}\""
+        NOTIFICATIONS_SETTINGS="recipients=${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
+        TERRAFORM_ARGS+=(
+          -var="email_notifications_critical=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Critical\", \"ResolvedCritical\"]}]"
+          -var="email_notifications_warning=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Warning\", \"ResolvedWarning\"]}]"
+          -var="email_notifications_missingdata=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"MissingData\", \"ResolvedMissingData\"]}]"
+        )
+      fi
+
+      TF_LOG_PROVIDER=DEBUG terraform apply "${TERRAFORM_ARGS[@]}" \
           || { echo "Error during applying Terraform monitors."; exit 1; }
     else
       echo "The monitors have been already installed in ${MONITORS_FOLDER_NAME}."

--- a/tests/helm/testdata/goldenfile/terraform/disabled_monitors.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disabled_monitors.output.yaml
@@ -249,7 +249,12 @@ data:
 
     INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
-    MONITORS_DISABLED="true"
+
+    if [ "${SUMOLOGIC_MONITORS_STATUS}" = "enabled" ]; then
+      MONITORS_DISABLED="false"
+    else
+      MONITORS_DISABLED="true"
+    fi
 
     MONITORS_ROOT_ID="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
@@ -304,14 +309,27 @@ data:
         SUMOLOGIC_ENV="us1"
       fi
 
-      TF_LOG_PROVIDER=DEBUG terraform apply \
-          -auto-approve \
-          -var="access_id=${SUMOLOGIC_ACCESSID}" \
-          -var="access_key=${SUMOLOGIC_ACCESSKEY}" \
-          -var="environment=${SUMOLOGIC_ENV}" \
-          -var="folder=${MONITORS_FOLDER_NAME}" \
-          -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}" \
-          -var="monitors_disabled=${MONITORS_DISABLED}" \
+      TERRAFORM_ARGS=(
+        -auto-approve
+        -var="access_id=${SUMOLOGIC_ACCESSID}"
+        -var="access_key=${SUMOLOGIC_ACCESSKEY}"
+        -var="environment=${SUMOLOGIC_ENV}"
+        -var="folder=${MONITORS_FOLDER_NAME}"
+        -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}"
+        -var="monitors_disabled=${MONITORS_DISABLED}"
+      )
+
+      if [ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]; then
+        NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{TriggerType}} on {{Name}}\",message_body=\"Triggered {{TriggerType}} alert on {{Name}}: {{QueryURL}}\""
+        NOTIFICATIONS_SETTINGS="recipients=${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
+        TERRAFORM_ARGS+=(
+          -var="email_notifications_critical=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Critical\", \"ResolvedCritical\"]}]"
+          -var="email_notifications_warning=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Warning\", \"ResolvedWarning\"]}]"
+          -var="email_notifications_missingdata=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"MissingData\", \"ResolvedMissingData\"]}]"
+        )
+      fi
+
+      TF_LOG_PROVIDER=DEBUG terraform apply "${TERRAFORM_ARGS[@]}" \
           || { echo "Error during applying Terraform monitors."; exit 1; }
     else
       echo "The monitors have been already installed in ${MONITORS_FOLDER_NAME}."

--- a/tests/helm/testdata/goldenfile/terraform/disabled_monitors.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disabled_monitors.output.yaml
@@ -498,12 +498,22 @@ data:
         || { echo "Error during applying Terraform changes"; exit 1; }
 
     # Setup Sumo Logic monitors if enabled
-    echo "Installation of the Sumo Logic monitors is disabled."
-    echo "You can install them manually later with:"
-    echo "https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor/tree/main/monitor_packages/kubernetes"
+    if [ "${SUMOLOGIC_MONITORS_ENABLED}" = "true" ]; then
+        bash /etc/terraform/monitors.sh
+    else
+        echo "Installation of the Sumo Logic monitors is disabled."
+        echo "You can install them manually later with:"
+        echo "https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor/tree/main/monitor_packages/kubernetes"
+    fi
 
     # Setup Sumo Logic dashboards if enabled
-    bash /etc/terraform/dashboards.sh
+    if [ "${SUMOLOGIC_DASHBOARDS_ENABLED}" = "true" ]; then
+        bash /etc/terraform/dashboards.sh
+    else
+        echo "Installation of the Sumo Logic dashboards is disabled."
+        echo "You can install them manually later with:"
+        echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
+    fi
 
     # Cleanup env variables
     export SUMOLOGIC_BASE_URL=

--- a/tests/helm/testdata/goldenfile/terraform/logs_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/logs_fields.output.yaml
@@ -249,7 +249,12 @@ data:
 
     INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
-    MONITORS_DISABLED="false"
+
+    if [ "${SUMOLOGIC_MONITORS_STATUS}" = "enabled" ]; then
+      MONITORS_DISABLED="false"
+    else
+      MONITORS_DISABLED="true"
+    fi
 
     MONITORS_ROOT_ID="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
@@ -304,14 +309,27 @@ data:
         SUMOLOGIC_ENV="us1"
       fi
 
-      TF_LOG_PROVIDER=DEBUG terraform apply \
-          -auto-approve \
-          -var="access_id=${SUMOLOGIC_ACCESSID}" \
-          -var="access_key=${SUMOLOGIC_ACCESSKEY}" \
-          -var="environment=${SUMOLOGIC_ENV}" \
-          -var="folder=${MONITORS_FOLDER_NAME}" \
-          -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}" \
-          -var="monitors_disabled=${MONITORS_DISABLED}" \
+      TERRAFORM_ARGS=(
+        -auto-approve
+        -var="access_id=${SUMOLOGIC_ACCESSID}"
+        -var="access_key=${SUMOLOGIC_ACCESSKEY}"
+        -var="environment=${SUMOLOGIC_ENV}"
+        -var="folder=${MONITORS_FOLDER_NAME}"
+        -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}"
+        -var="monitors_disabled=${MONITORS_DISABLED}"
+      )
+
+      if [ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]; then
+        NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{TriggerType}} on {{Name}}\",message_body=\"Triggered {{TriggerType}} alert on {{Name}}: {{QueryURL}}\""
+        NOTIFICATIONS_SETTINGS="recipients=${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
+        TERRAFORM_ARGS+=(
+          -var="email_notifications_critical=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Critical\", \"ResolvedCritical\"]}]"
+          -var="email_notifications_warning=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Warning\", \"ResolvedWarning\"]}]"
+          -var="email_notifications_missingdata=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"MissingData\", \"ResolvedMissingData\"]}]"
+        )
+      fi
+
+      TF_LOG_PROVIDER=DEBUG terraform apply "${TERRAFORM_ARGS[@]}" \
           || { echo "Error during applying Terraform monitors."; exit 1; }
     else
       echo "The monitors have been already installed in ${MONITORS_FOLDER_NAME}."

--- a/tests/helm/testdata/goldenfile/terraform/logs_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/logs_fields.output.yaml
@@ -498,10 +498,22 @@ data:
         || { echo "Error during applying Terraform changes"; exit 1; }
 
     # Setup Sumo Logic monitors if enabled
-    bash /etc/terraform/monitors.sh
+    if [ "${SUMOLOGIC_MONITORS_ENABLED}" = "true" ]; then
+        bash /etc/terraform/monitors.sh
+    else
+        echo "Installation of the Sumo Logic monitors is disabled."
+        echo "You can install them manually later with:"
+        echo "https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor/tree/main/monitor_packages/kubernetes"
+    fi
 
     # Setup Sumo Logic dashboards if enabled
-    bash /etc/terraform/dashboards.sh
+    if [ "${SUMOLOGIC_DASHBOARDS_ENABLED}" = "true" ]; then
+        bash /etc/terraform/dashboards.sh
+    else
+        echo "Installation of the Sumo Logic dashboards is disabled."
+        echo "You can install them manually later with:"
+        echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
+    fi
 
     # Cleanup env variables
     export SUMOLOGIC_BASE_URL=

--- a/tests/helm/testdata/goldenfile/terraform/monitors_with_email_notifications.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/monitors_with_email_notifications.output.yaml
@@ -504,10 +504,22 @@ data:
         || { echo "Error during applying Terraform changes"; exit 1; }
 
     # Setup Sumo Logic monitors if enabled
-    bash /etc/terraform/monitors.sh
+    if [ "${SUMOLOGIC_MONITORS_ENABLED}" = "true" ]; then
+        bash /etc/terraform/monitors.sh
+    else
+        echo "Installation of the Sumo Logic monitors is disabled."
+        echo "You can install them manually later with:"
+        echo "https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor/tree/main/monitor_packages/kubernetes"
+    fi
 
     # Setup Sumo Logic dashboards if enabled
-    bash /etc/terraform/dashboards.sh
+    if [ "${SUMOLOGIC_DASHBOARDS_ENABLED}" = "true" ]; then
+        bash /etc/terraform/dashboards.sh
+    else
+        echo "Installation of the Sumo Logic dashboards is disabled."
+        echo "You can install them manually later with:"
+        echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
+    fi
 
     # Cleanup env variables
     export SUMOLOGIC_BASE_URL=

--- a/tests/helm/testdata/goldenfile/terraform/monitors_with_email_notifications.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/monitors_with_email_notifications.output.yaml
@@ -249,7 +249,12 @@ data:
 
     INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
-    MONITORS_DISABLED="false"
+
+    if [ "${SUMOLOGIC_MONITORS_STATUS}" = "enabled" ]; then
+      MONITORS_DISABLED="false"
+    else
+      MONITORS_DISABLED="true"
+    fi
 
     MONITORS_ROOT_ID="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
@@ -303,21 +308,28 @@ data:
       if [[ "${SUMOLOGIC_BASE_URL}" == "${SUMOLOGIC_ENV}" ]] ; then
         SUMOLOGIC_ENV="us1"
       fi
-      NOTIFICATIONS_RECIPIENTS='["test@test.lh","email@locahost.lh"]'
-      NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{TriggerType}} on {{Name}}\",message_body=\"Triggered {{TriggerType}} alert on {{Name}}: {{QueryURL}}\""
-      NOTIFICATIONS_SETTINGS="recipients=${NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
 
-      TF_LOG_PROVIDER=DEBUG terraform apply \
-          -auto-approve \
-          -var="access_id=${SUMOLOGIC_ACCESSID}" \
-          -var="access_key=${SUMOLOGIC_ACCESSKEY}" \
-          -var="environment=${SUMOLOGIC_ENV}" \
-          -var="folder=${MONITORS_FOLDER_NAME}" \
-          -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}" \
-          -var="monitors_disabled=${MONITORS_DISABLED}" \
-          -var="email_notifications_critical=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Critical\", \"ResolvedCritical\"]}]" \
-          -var="email_notifications_warning=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Warning\", \"ResolvedWarning\"]}]" \
-          -var="email_notifications_missingdata=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"MissingData\", \"ResolvedMissingData\"]}]" \
+      TERRAFORM_ARGS=(
+        -auto-approve
+        -var="access_id=${SUMOLOGIC_ACCESSID}"
+        -var="access_key=${SUMOLOGIC_ACCESSKEY}"
+        -var="environment=${SUMOLOGIC_ENV}"
+        -var="folder=${MONITORS_FOLDER_NAME}"
+        -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}"
+        -var="monitors_disabled=${MONITORS_DISABLED}"
+      )
+
+      if [ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]; then
+        NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{TriggerType}} on {{Name}}\",message_body=\"Triggered {{TriggerType}} alert on {{Name}}: {{QueryURL}}\""
+        NOTIFICATIONS_SETTINGS="recipients=${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
+        TERRAFORM_ARGS+=(
+          -var="email_notifications_critical=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Critical\", \"ResolvedCritical\"]}]"
+          -var="email_notifications_warning=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Warning\", \"ResolvedWarning\"]}]"
+          -var="email_notifications_missingdata=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"MissingData\", \"ResolvedMissingData\"]}]"
+        )
+      fi
+
+      TF_LOG_PROVIDER=DEBUG terraform apply "${TERRAFORM_ARGS[@]}" \
           || { echo "Error during applying Terraform monitors."; exit 1; }
     else
       echo "The monitors have been already installed in ${MONITORS_FOLDER_NAME}."

--- a/tests/helm/testdata/goldenfile/terraform/monitors_with_single_email.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/monitors_with_single_email.output.yaml
@@ -504,10 +504,22 @@ data:
         || { echo "Error during applying Terraform changes"; exit 1; }
 
     # Setup Sumo Logic monitors if enabled
-    bash /etc/terraform/monitors.sh
+    if [ "${SUMOLOGIC_MONITORS_ENABLED}" = "true" ]; then
+        bash /etc/terraform/monitors.sh
+    else
+        echo "Installation of the Sumo Logic monitors is disabled."
+        echo "You can install them manually later with:"
+        echo "https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor/tree/main/monitor_packages/kubernetes"
+    fi
 
     # Setup Sumo Logic dashboards if enabled
-    bash /etc/terraform/dashboards.sh
+    if [ "${SUMOLOGIC_DASHBOARDS_ENABLED}" = "true" ]; then
+        bash /etc/terraform/dashboards.sh
+    else
+        echo "Installation of the Sumo Logic dashboards is disabled."
+        echo "You can install them manually later with:"
+        echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
+    fi
 
     # Cleanup env variables
     export SUMOLOGIC_BASE_URL=

--- a/tests/helm/testdata/goldenfile/terraform/monitors_with_single_email.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/monitors_with_single_email.output.yaml
@@ -249,7 +249,12 @@ data:
 
     INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
-    MONITORS_DISABLED="false"
+
+    if [ "${SUMOLOGIC_MONITORS_STATUS}" = "enabled" ]; then
+      MONITORS_DISABLED="false"
+    else
+      MONITORS_DISABLED="true"
+    fi
 
     MONITORS_ROOT_ID="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
@@ -303,21 +308,28 @@ data:
       if [[ "${SUMOLOGIC_BASE_URL}" == "${SUMOLOGIC_ENV}" ]] ; then
         SUMOLOGIC_ENV="us1"
       fi
-      NOTIFICATIONS_RECIPIENTS='["email@locahost.lh"]'
-      NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{TriggerType}} on {{Name}}\",message_body=\"Triggered {{TriggerType}} alert on {{Name}}: {{QueryURL}}\""
-      NOTIFICATIONS_SETTINGS="recipients=${NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
 
-      TF_LOG_PROVIDER=DEBUG terraform apply \
-          -auto-approve \
-          -var="access_id=${SUMOLOGIC_ACCESSID}" \
-          -var="access_key=${SUMOLOGIC_ACCESSKEY}" \
-          -var="environment=${SUMOLOGIC_ENV}" \
-          -var="folder=${MONITORS_FOLDER_NAME}" \
-          -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}" \
-          -var="monitors_disabled=${MONITORS_DISABLED}" \
-          -var="email_notifications_critical=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Critical\", \"ResolvedCritical\"]}]" \
-          -var="email_notifications_warning=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Warning\", \"ResolvedWarning\"]}]" \
-          -var="email_notifications_missingdata=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"MissingData\", \"ResolvedMissingData\"]}]" \
+      TERRAFORM_ARGS=(
+        -auto-approve
+        -var="access_id=${SUMOLOGIC_ACCESSID}"
+        -var="access_key=${SUMOLOGIC_ACCESSKEY}"
+        -var="environment=${SUMOLOGIC_ENV}"
+        -var="folder=${MONITORS_FOLDER_NAME}"
+        -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}"
+        -var="monitors_disabled=${MONITORS_DISABLED}"
+      )
+
+      if [ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]; then
+        NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{TriggerType}} on {{Name}}\",message_body=\"Triggered {{TriggerType}} alert on {{Name}}: {{QueryURL}}\""
+        NOTIFICATIONS_SETTINGS="recipients=${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
+        TERRAFORM_ARGS+=(
+          -var="email_notifications_critical=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Critical\", \"ResolvedCritical\"]}]"
+          -var="email_notifications_warning=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Warning\", \"ResolvedWarning\"]}]"
+          -var="email_notifications_missingdata=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"MissingData\", \"ResolvedMissingData\"]}]"
+        )
+      fi
+
+      TF_LOG_PROVIDER=DEBUG terraform apply "${TERRAFORM_ARGS[@]}" \
           || { echo "Error during applying Terraform monitors."; exit 1; }
     else
       echo "The monitors have been already installed in ${MONITORS_FOLDER_NAME}."

--- a/tests/helm/testdata/goldenfile/terraform/strip_extrapolation.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/strip_extrapolation.output.yaml
@@ -499,10 +499,22 @@ data:
         || { echo "Error during applying Terraform changes"; exit 1; }
 
     # Setup Sumo Logic monitors if enabled
-    bash /etc/terraform/monitors.sh
+    if [ "${SUMOLOGIC_MONITORS_ENABLED}" = "true" ]; then
+        bash /etc/terraform/monitors.sh
+    else
+        echo "Installation of the Sumo Logic monitors is disabled."
+        echo "You can install them manually later with:"
+        echo "https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor/tree/main/monitor_packages/kubernetes"
+    fi
 
     # Setup Sumo Logic dashboards if enabled
-    bash /etc/terraform/dashboards.sh
+    if [ "${SUMOLOGIC_DASHBOARDS_ENABLED}" = "true" ]; then
+        bash /etc/terraform/dashboards.sh
+    else
+        echo "Installation of the Sumo Logic dashboards is disabled."
+        echo "You can install them manually later with:"
+        echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
+    fi
 
     # Cleanup env variables
     export SUMOLOGIC_BASE_URL=

--- a/tests/helm/testdata/goldenfile/terraform/strip_extrapolation.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/strip_extrapolation.output.yaml
@@ -249,7 +249,12 @@ data:
 
     INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
-    MONITORS_DISABLED="false"
+
+    if [ "${SUMOLOGIC_MONITORS_STATUS}" = "enabled" ]; then
+      MONITORS_DISABLED="false"
+    else
+      MONITORS_DISABLED="true"
+    fi
 
     MONITORS_ROOT_ID="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
@@ -304,14 +309,27 @@ data:
         SUMOLOGIC_ENV="us1"
       fi
 
-      TF_LOG_PROVIDER=DEBUG terraform apply \
-          -auto-approve \
-          -var="access_id=${SUMOLOGIC_ACCESSID}" \
-          -var="access_key=${SUMOLOGIC_ACCESSKEY}" \
-          -var="environment=${SUMOLOGIC_ENV}" \
-          -var="folder=${MONITORS_FOLDER_NAME}" \
-          -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}" \
-          -var="monitors_disabled=${MONITORS_DISABLED}" \
+      TERRAFORM_ARGS=(
+        -auto-approve
+        -var="access_id=${SUMOLOGIC_ACCESSID}"
+        -var="access_key=${SUMOLOGIC_ACCESSKEY}"
+        -var="environment=${SUMOLOGIC_ENV}"
+        -var="folder=${MONITORS_FOLDER_NAME}"
+        -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}"
+        -var="monitors_disabled=${MONITORS_DISABLED}"
+      )
+
+      if [ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]; then
+        NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{TriggerType}} on {{Name}}\",message_body=\"Triggered {{TriggerType}} alert on {{Name}}: {{QueryURL}}\""
+        NOTIFICATIONS_SETTINGS="recipients=${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
+        TERRAFORM_ARGS+=(
+          -var="email_notifications_critical=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Critical\", \"ResolvedCritical\"]}]"
+          -var="email_notifications_warning=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Warning\", \"ResolvedWarning\"]}]"
+          -var="email_notifications_missingdata=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"MissingData\", \"ResolvedMissingData\"]}]"
+        )
+      fi
+
+      TF_LOG_PROVIDER=DEBUG terraform apply "${TERRAFORM_ARGS[@]}" \
           || { echo "Error during applying Terraform monitors."; exit 1; }
     else
       echo "The monitors have been already installed in ${MONITORS_FOLDER_NAME}."

--- a/tests/helm/testdata/goldenfile/terraform/traces.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/traces.output.yaml
@@ -249,7 +249,12 @@ data:
 
     INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
-    MONITORS_DISABLED="false"
+
+    if [ "${SUMOLOGIC_MONITORS_STATUS}" = "enabled" ]; then
+      MONITORS_DISABLED="false"
+    else
+      MONITORS_DISABLED="true"
+    fi
 
     MONITORS_ROOT_ID="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
@@ -304,14 +309,27 @@ data:
         SUMOLOGIC_ENV="us1"
       fi
 
-      TF_LOG_PROVIDER=DEBUG terraform apply \
-          -auto-approve \
-          -var="access_id=${SUMOLOGIC_ACCESSID}" \
-          -var="access_key=${SUMOLOGIC_ACCESSKEY}" \
-          -var="environment=${SUMOLOGIC_ENV}" \
-          -var="folder=${MONITORS_FOLDER_NAME}" \
-          -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}" \
-          -var="monitors_disabled=${MONITORS_DISABLED}" \
+      TERRAFORM_ARGS=(
+        -auto-approve
+        -var="access_id=${SUMOLOGIC_ACCESSID}"
+        -var="access_key=${SUMOLOGIC_ACCESSKEY}"
+        -var="environment=${SUMOLOGIC_ENV}"
+        -var="folder=${MONITORS_FOLDER_NAME}"
+        -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}"
+        -var="monitors_disabled=${MONITORS_DISABLED}"
+      )
+
+      if [ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]; then
+        NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{TriggerType}} on {{Name}}\",message_body=\"Triggered {{TriggerType}} alert on {{Name}}: {{QueryURL}}\""
+        NOTIFICATIONS_SETTINGS="recipients=${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
+        TERRAFORM_ARGS+=(
+          -var="email_notifications_critical=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Critical\", \"ResolvedCritical\"]}]"
+          -var="email_notifications_warning=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Warning\", \"ResolvedWarning\"]}]"
+          -var="email_notifications_missingdata=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"MissingData\", \"ResolvedMissingData\"]}]"
+        )
+      fi
+
+      TF_LOG_PROVIDER=DEBUG terraform apply "${TERRAFORM_ARGS[@]}" \
           || { echo "Error during applying Terraform monitors."; exit 1; }
     else
       echo "The monitors have been already installed in ${MONITORS_FOLDER_NAME}."

--- a/tests/helm/testdata/goldenfile/terraform/traces.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/traces.output.yaml
@@ -498,10 +498,22 @@ data:
         || { echo "Error during applying Terraform changes"; exit 1; }
 
     # Setup Sumo Logic monitors if enabled
-    bash /etc/terraform/monitors.sh
+    if [ "${SUMOLOGIC_MONITORS_ENABLED}" = "true" ]; then
+        bash /etc/terraform/monitors.sh
+    else
+        echo "Installation of the Sumo Logic monitors is disabled."
+        echo "You can install them manually later with:"
+        echo "https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor/tree/main/monitor_packages/kubernetes"
+    fi
 
     # Setup Sumo Logic dashboards if enabled
-    bash /etc/terraform/dashboards.sh
+    if [ "${SUMOLOGIC_DASHBOARDS_ENABLED}" = "true" ]; then
+        bash /etc/terraform/dashboards.sh
+    else
+        echo "Installation of the Sumo Logic dashboards is disabled."
+        echo "You can install them manually later with:"
+        echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
+    fi
 
     # Cleanup env variables
     export SUMOLOGIC_BASE_URL=

--- a/tests/helm/testdata/goldenfile/terraform/tracing-metrics-disabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/tracing-metrics-disabled.output.yaml
@@ -249,7 +249,12 @@ data:
 
     INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
-    MONITORS_DISABLED="false"
+
+    if [ "${SUMOLOGIC_MONITORS_STATUS}" = "enabled" ]; then
+      MONITORS_DISABLED="false"
+    else
+      MONITORS_DISABLED="true"
+    fi
 
     MONITORS_ROOT_ID="$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
@@ -304,14 +309,27 @@ data:
         SUMOLOGIC_ENV="us1"
       fi
 
-      TF_LOG_PROVIDER=DEBUG terraform apply \
-          -auto-approve \
-          -var="access_id=${SUMOLOGIC_ACCESSID}" \
-          -var="access_key=${SUMOLOGIC_ACCESSKEY}" \
-          -var="environment=${SUMOLOGIC_ENV}" \
-          -var="folder=${MONITORS_FOLDER_NAME}" \
-          -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}" \
-          -var="monitors_disabled=${MONITORS_DISABLED}" \
+      TERRAFORM_ARGS=(
+        -auto-approve
+        -var="access_id=${SUMOLOGIC_ACCESSID}"
+        -var="access_key=${SUMOLOGIC_ACCESSKEY}"
+        -var="environment=${SUMOLOGIC_ENV}"
+        -var="folder=${MONITORS_FOLDER_NAME}"
+        -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}"
+        -var="monitors_disabled=${MONITORS_DISABLED}"
+      )
+
+      if [ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]; then
+        NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{TriggerType}} on {{Name}}\",message_body=\"Triggered {{TriggerType}} alert on {{Name}}: {{QueryURL}}\""
+        NOTIFICATIONS_SETTINGS="recipients=${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
+        TERRAFORM_ARGS+=(
+          -var="email_notifications_critical=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Critical\", \"ResolvedCritical\"]}]"
+          -var="email_notifications_warning=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Warning\", \"ResolvedWarning\"]}]"
+          -var="email_notifications_missingdata=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"MissingData\", \"ResolvedMissingData\"]}]"
+        )
+      fi
+
+      TF_LOG_PROVIDER=DEBUG terraform apply "${TERRAFORM_ARGS[@]}" \
           || { echo "Error during applying Terraform monitors."; exit 1; }
     else
       echo "The monitors have been already installed in ${MONITORS_FOLDER_NAME}."

--- a/tests/helm/testdata/goldenfile/terraform/tracing-metrics-disabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/tracing-metrics-disabled.output.yaml
@@ -498,10 +498,22 @@ data:
         || { echo "Error during applying Terraform changes"; exit 1; }
 
     # Setup Sumo Logic monitors if enabled
-    bash /etc/terraform/monitors.sh
+    if [ "${SUMOLOGIC_MONITORS_ENABLED}" = "true" ]; then
+        bash /etc/terraform/monitors.sh
+    else
+        echo "Installation of the Sumo Logic monitors is disabled."
+        echo "You can install them manually later with:"
+        echo "https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor/tree/main/monitor_packages/kubernetes"
+    fi
 
     # Setup Sumo Logic dashboards if enabled
-    bash /etc/terraform/dashboards.sh
+    if [ "${SUMOLOGIC_DASHBOARDS_ENABLED}" = "true" ]; then
+        bash /etc/terraform/dashboards.sh
+    else
+        echo "Installation of the Sumo Logic dashboards is disabled."
+        echo "You can install them manually later with:"
+        echo "https://help.sumologic.com/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
+    fi
 
     # Cleanup env variables
     export SUMOLOGIC_BASE_URL=


### PR DESCRIPTION
Remove remaining Helm templates from setup scripts. This mostly involves moving the values to environment variables defined on the Pod template. In the case of notification emails, this required a bit more effort.

The monitors.sh script requires literal double curly braces in a string, so I ended up just disabling templating altogether for *.sh and *.tf files.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [x] Template tests added for new features
