### PR TITLE
ci: run shellcheck directly on scripts

### DIFF
--- a/ci/shellcheck.sh
+++ b/ci/shellcheck.sh
@@ -3,37 +3,9 @@
 set -euo pipefail
 
 echo "Checking the bash scripts with shellcheck..."
-find . ! -path '*deploy/helm/sumologic/conf/setup/setup.sh' ! -path '*deploy/helm/sumologic/conf/setup/monitors.sh' ! -path "*/tmp/*" -name '*.sh' -type 'f' -print |
+find . -name '*.sh' -type 'f' -print |
     while read -r file; do
         # Run tests in their own context
         echo "Checking ${file} with shellcheck"
         shellcheck --enable all --external-sources --exclude SC2155 "${file}"
-    done
-
-find . -path '*tests/helm/terraform/static/*.output.yaml' -type 'f' -print |
-    while read -r file; do
-        # Run tests in their own context
-        echo "Checking ${file} (setup.sh) with shellcheck"
-        yq '.data."setup.sh"' "${file}" | shellcheck --enable all --external-sources --exclude SC2155 -
-    done
-
-find . -path '*tests/helm/terraform/static/*.output.yaml' -type 'f' -print |
-    while read -r file; do
-        # Run tests in their own context
-        echo "Checking ${file} (monitors.sh) with shellcheck"
-        yq '.data."monitors.sh"' "${file}" | shellcheck --enable all --external-sources --exclude SC2155 --exclude SC2312 -
-    done
-
-find . -path '*tests/helm/terraform/static/*.output.yaml' -type 'f' -print |
-    while read -r file; do
-        # Run tests in their own context
-        echo "Checking ${file} (dashboards.sh) with shellcheck"
-        yq '.data."dashboards.sh"' "${file}" | shellcheck --enable all --external-sources --exclude SC2155 -
-    done
-
-find . -path '*tests/helm/terraform_custom/static/*.output.yaml' ! -path "./tests/helm/terraform_custom/static/empty.output.yaml" -type 'f' -print |
-    while read -r file; do
-        # Run tests in their own context
-        echo "Checking ${file} (custom_setup.sh) with shellcheck"
-        yq '.data."custom_setup.sh"' "${file}" | shellcheck --enable all --external-sources --exclude SC2155 -
     done

--- a/deploy/helm/sumologic/conf/setup/setup.sh
+++ b/deploy/helm/sumologic/conf/setup/setup.sh
@@ -95,7 +95,7 @@ function should_create_fields() {
 cp /etc/terraform/* /terraform/
 cd /terraform || exit 1
 
-declare -ra FIELDS=($(jq -r '.fields[]' terraform.tfvars.json))
+declare -ra FIELDS=("$(jq -r '.fields[]' terraform.tfvars.json)")
 
 # Fall back to init -upgrade to prevent:
 # Error: Inconsistent dependency lock file
@@ -119,7 +119,7 @@ if should_create_fields ; then
 
         terraform import \
             -var="create_fields=1" \
-            sumologic_field.collection_field[\"${FIELD}\"] "${FIELD_ID}"
+            sumologic_field.collection_field[\""${FIELD}"\"] "${FIELD_ID}"
     done
 else
     readonly CREATE_FIELDS=0
@@ -133,7 +133,7 @@ fi
 if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
     jq -r '.resource[] | to_entries[] | "\(.key) \(.value.name)"' sources.tf.json | while read -r resource_name source_name; do
         terraform import "sumologic_http_source.${resource_name}" "${SUMOLOGIC_COLLECTOR_NAME}/${source_name}"
-    done
+    done || true
 fi
 
 # Kubernetes Secret
@@ -146,7 +146,7 @@ TF_LOG_PROVIDER=DEBUG terraform apply \
     || { echo "Error during applying Terraform changes"; exit 1; }
 
 # Setup Sumo Logic monitors if enabled
-if [ "${SUMOLOGIC_MONITORS_ENABLED}" = "true" ]; then
+if [[ "${SUMOLOGIC_MONITORS_ENABLED:?}" = "true" ]]; then
     bash /etc/terraform/monitors.sh
 else
     echo "Installation of the Sumo Logic monitors is disabled."
@@ -155,7 +155,7 @@ else
 fi
 
 # Setup Sumo Logic dashboards if enabled
-if [ "${SUMOLOGIC_DASHBOARDS_ENABLED}" = "true" ]; then
+if [[ "${SUMOLOGIC_DASHBOARDS_ENABLED:?}" = "true" ]]; then
     bash /etc/terraform/dashboards.sh
 else
     echo "Installation of the Sumo Logic dashboards is disabled."

--- a/tests/helm/testdata/goldenfile/terraform/all_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/all_fields.output.yaml
@@ -250,23 +250,24 @@ data:
     INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
 
-    if [ "${SUMOLOGIC_MONITORS_STATUS}" = "enabled" ]; then
+    if [[ "${SUMOLOGIC_MONITORS_STATUS:?}" = "enabled" ]]; then
       MONITORS_DISABLED="false"
     else
       MONITORS_DISABLED="true"
     fi
 
-    MONITORS_ROOT_ID="$(curl -XGET -s \
+    MONITORS_CURL_RESPONSE=$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/root)
+    MONITORS_ROOT_ID="$(echo "${MONITORS_CURL_RESPONSE}" | jq -r '.id' )"
     readonly MONITORS_ROOT_ID
 
     # verify if the integrations folder already exists
-    INTEGRATIONS_RESPONSE="$(curl -XGET -s -G \
+    INTEGRATIONS_CURL_RESPONSE=$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
-            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}" | \
-            jq '.[]' )"
+            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}")
+    INTEGRATIONS_RESPONSE="$(echo "${INTEGRATIONS_CURL_RESPONSE}" | jq '.[]' )"
     readonly INTEGRATIONS_RESPONSE
 
     INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
@@ -274,20 +275,20 @@ data:
 
     # and create it if necessary
     if [[ -z "${INTEGRATIONS_FOLDER_ID}" ]]; then
-      INTEGRATIONS_FOLDER_ID="$(curl -XPOST -s \
+      INTEGRATIONS_FOLDER_CURL_RESPONSE=$(curl -XPOST -s \
                   -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
                   -H "Content-Type: application/json" \
                   -d "{\"name\":\"${INTEGRATIONS_FOLDER_NAME}\",\"type\":\"MonitorsLibraryFolder\",\"description\":\"Monitors provided by the Sumo Logic integrations.\"}" \
-                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}" | \
-                  jq -r " .id" )"
+                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}")
+      INTEGRATIONS_FOLDER_ID="$(echo "${INTEGRATIONS_FOLDER_CURL_RESPONSE}" | jq -r " .id" )"
     fi
 
     # verify if the k8s monitors folder already exists
-    MONITORS_RESPONSE="$(curl -XGET -s -G \
+    MONITORS_CURL_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
-            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}" | \
-            jq '.[]' )"
+            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}")"
+    MONITORS_RESPONSE="$(echo "${MONITORS_CURL_RESPONSE}" | jq '.[]' )"
     readonly MONITORS_RESPONSE
 
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \
@@ -319,7 +320,7 @@ data:
         -var="monitors_disabled=${MONITORS_DISABLED}"
       )
 
-      if [ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]; then
+      if [[ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]]; then
         NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{TriggerType}} on {{Name}}\",message_body=\"Triggered {{TriggerType}} alert on {{Name}}: {{QueryURL}}\""
         NOTIFICATIONS_SETTINGS="recipients=${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
         TERRAFORM_ARGS+=(
@@ -336,17 +337,6 @@ data:
       echo "You can (re)install them manually with:"
       echo "https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor/tree/main/monitor_packages/kubernetes"
     fi
-  providers.tf.json: |
-    {
-      "provider": {
-        "kubernetes": {
-          "cluster_ca_certificate": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt\")}",
-          "host": "https://kubernetes.default.svc",
-          "token": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/token\")}"
-        },
-        "sumologic": {}
-      }
-    }
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
@@ -465,7 +455,7 @@ data:
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
 
-    declare -ra FIELDS=($(jq -r '.fields[]' terraform.tfvars.json))
+    declare -ra FIELDS=("$(jq -r '.fields[]' terraform.tfvars.json)")
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file
@@ -489,7 +479,7 @@ data:
 
             terraform import \
                 -var="create_fields=1" \
-                sumologic_field.collection_field[\"${FIELD}\"] "${FIELD_ID}"
+                sumologic_field.collection_field[\""${FIELD}"\"] "${FIELD_ID}"
         done
     else
         readonly CREATE_FIELDS=0
@@ -503,7 +493,7 @@ data:
     if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
         jq -r '.resource[] | to_entries[] | "\(.key) \(.value.name)"' sources.tf.json | while read -r resource_name source_name; do
             terraform import "sumologic_http_source.${resource_name}" "${SUMOLOGIC_COLLECTOR_NAME}/${source_name}"
-        done
+        done || true
     fi
 
     # Kubernetes Secret
@@ -516,7 +506,7 @@ data:
         || { echo "Error during applying Terraform changes"; exit 1; }
 
     # Setup Sumo Logic monitors if enabled
-    if [ "${SUMOLOGIC_MONITORS_ENABLED}" = "true" ]; then
+    if [[ "${SUMOLOGIC_MONITORS_ENABLED:?}" = "true" ]]; then
         bash /etc/terraform/monitors.sh
     else
         echo "Installation of the Sumo Logic monitors is disabled."
@@ -525,7 +515,7 @@ data:
     fi
 
     # Setup Sumo Logic dashboards if enabled
-    if [ "${SUMOLOGIC_DASHBOARDS_ENABLED}" = "true" ]; then
+    if [[ "${SUMOLOGIC_DASHBOARDS_ENABLED:?}" = "true" ]]; then
         bash /etc/terraform/dashboards.sh
     else
         echo "Installation of the Sumo Logic dashboards is disabled."
@@ -539,6 +529,50 @@ data:
     export SUMOLOGIC_ACCESSID=
 
     bash /etc/terraform/custom.sh
+  variables.tf: |
+    variable "collector_name" {
+      type  = string
+    }
+
+    variable "namespace_name" {
+      type  = string
+    }
+
+    variable "secret_name" {
+      type = string
+    }
+
+    variable "create_fields" {
+      description = "If set, Terraform will attempt to create fields at Sumo Logic"
+      type        = bool
+      default     = true
+    }
+
+    variable "fields" {
+      description = "Log fields to create."
+      type = list(string)
+    }
+
+    variable "collector_fields" {
+      description = "Fields to set on the collector."
+      type = map(string)
+    }
+
+    variable "chart_version" {
+      description = "The Helm Chart version."
+      type = string
+    }
+  providers.tf.json: |
+    {
+      "provider": {
+        "kubernetes": {
+          "cluster_ca_certificate": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt\")}",
+          "host": "https://kubernetes.default.svc",
+          "token": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/token\")}"
+        },
+        "sumologic": {}
+      }
+    }
   sources.tf.json: |
     {
       "locals": {
@@ -849,37 +883,4 @@ data:
         "service",
         "statefulset"
       ]
-    }
-  variables.tf: |
-    variable "collector_name" {
-      type  = string
-    }
-
-    variable "namespace_name" {
-      type  = string
-    }
-
-    variable "secret_name" {
-      type = string
-    }
-
-    variable "create_fields" {
-      description = "If set, Terraform will attempt to create fields at Sumo Logic"
-      type        = bool
-      default     = true
-    }
-
-    variable "fields" {
-      description = "Log fields to create."
-      type = list(string)
-    }
-
-    variable "collector_fields" {
-      description = "Fields to set on the collector."
-      type = map(string)
-    }
-
-    variable "chart_version" {
-      description = "The Helm Chart version."
-      type = string
     }

--- a/tests/helm/testdata/goldenfile/terraform/collector_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/collector_fields.output.yaml
@@ -250,23 +250,24 @@ data:
     INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
 
-    if [ "${SUMOLOGIC_MONITORS_STATUS}" = "enabled" ]; then
+    if [[ "${SUMOLOGIC_MONITORS_STATUS:?}" = "enabled" ]]; then
       MONITORS_DISABLED="false"
     else
       MONITORS_DISABLED="true"
     fi
 
-    MONITORS_ROOT_ID="$(curl -XGET -s \
+    MONITORS_CURL_RESPONSE=$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/root)
+    MONITORS_ROOT_ID="$(echo "${MONITORS_CURL_RESPONSE}" | jq -r '.id' )"
     readonly MONITORS_ROOT_ID
 
     # verify if the integrations folder already exists
-    INTEGRATIONS_RESPONSE="$(curl -XGET -s -G \
+    INTEGRATIONS_CURL_RESPONSE=$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
-            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}" | \
-            jq '.[]' )"
+            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}")
+    INTEGRATIONS_RESPONSE="$(echo "${INTEGRATIONS_CURL_RESPONSE}" | jq '.[]' )"
     readonly INTEGRATIONS_RESPONSE
 
     INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
@@ -274,20 +275,20 @@ data:
 
     # and create it if necessary
     if [[ -z "${INTEGRATIONS_FOLDER_ID}" ]]; then
-      INTEGRATIONS_FOLDER_ID="$(curl -XPOST -s \
+      INTEGRATIONS_FOLDER_CURL_RESPONSE=$(curl -XPOST -s \
                   -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
                   -H "Content-Type: application/json" \
                   -d "{\"name\":\"${INTEGRATIONS_FOLDER_NAME}\",\"type\":\"MonitorsLibraryFolder\",\"description\":\"Monitors provided by the Sumo Logic integrations.\"}" \
-                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}" | \
-                  jq -r " .id" )"
+                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}")
+      INTEGRATIONS_FOLDER_ID="$(echo "${INTEGRATIONS_FOLDER_CURL_RESPONSE}" | jq -r " .id" )"
     fi
 
     # verify if the k8s monitors folder already exists
-    MONITORS_RESPONSE="$(curl -XGET -s -G \
+    MONITORS_CURL_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
-            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}" | \
-            jq '.[]' )"
+            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}")"
+    MONITORS_RESPONSE="$(echo "${MONITORS_CURL_RESPONSE}" | jq '.[]' )"
     readonly MONITORS_RESPONSE
 
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \
@@ -319,7 +320,7 @@ data:
         -var="monitors_disabled=${MONITORS_DISABLED}"
       )
 
-      if [ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]; then
+      if [[ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]]; then
         NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{TriggerType}} on {{Name}}\",message_body=\"Triggered {{TriggerType}} alert on {{Name}}: {{QueryURL}}\""
         NOTIFICATIONS_SETTINGS="recipients=${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
         TERRAFORM_ARGS+=(
@@ -336,17 +337,6 @@ data:
       echo "You can (re)install them manually with:"
       echo "https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor/tree/main/monitor_packages/kubernetes"
     fi
-  providers.tf.json: |
-    {
-      "provider": {
-        "kubernetes": {
-          "cluster_ca_certificate": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt\")}",
-          "host": "https://kubernetes.default.svc",
-          "token": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/token\")}"
-        },
-        "sumologic": {}
-      }
-    }
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
@@ -465,7 +455,7 @@ data:
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
 
-    declare -ra FIELDS=($(jq -r '.fields[]' terraform.tfvars.json))
+    declare -ra FIELDS=("$(jq -r '.fields[]' terraform.tfvars.json)")
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file
@@ -489,7 +479,7 @@ data:
 
             terraform import \
                 -var="create_fields=1" \
-                sumologic_field.collection_field[\"${FIELD}\"] "${FIELD_ID}"
+                sumologic_field.collection_field[\""${FIELD}"\"] "${FIELD_ID}"
         done
     else
         readonly CREATE_FIELDS=0
@@ -503,7 +493,7 @@ data:
     if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
         jq -r '.resource[] | to_entries[] | "\(.key) \(.value.name)"' sources.tf.json | while read -r resource_name source_name; do
             terraform import "sumologic_http_source.${resource_name}" "${SUMOLOGIC_COLLECTOR_NAME}/${source_name}"
-        done
+        done || true
     fi
 
     # Kubernetes Secret
@@ -516,7 +506,7 @@ data:
         || { echo "Error during applying Terraform changes"; exit 1; }
 
     # Setup Sumo Logic monitors if enabled
-    if [ "${SUMOLOGIC_MONITORS_ENABLED}" = "true" ]; then
+    if [[ "${SUMOLOGIC_MONITORS_ENABLED:?}" = "true" ]]; then
         bash /etc/terraform/monitors.sh
     else
         echo "Installation of the Sumo Logic monitors is disabled."
@@ -525,7 +515,7 @@ data:
     fi
 
     # Setup Sumo Logic dashboards if enabled
-    if [ "${SUMOLOGIC_DASHBOARDS_ENABLED}" = "true" ]; then
+    if [[ "${SUMOLOGIC_DASHBOARDS_ENABLED:?}" = "true" ]]; then
         bash /etc/terraform/dashboards.sh
     else
         echo "Installation of the Sumo Logic dashboards is disabled."
@@ -539,6 +529,50 @@ data:
     export SUMOLOGIC_ACCESSID=
 
     bash /etc/terraform/custom.sh
+  variables.tf: |
+    variable "collector_name" {
+      type  = string
+    }
+
+    variable "namespace_name" {
+      type  = string
+    }
+
+    variable "secret_name" {
+      type = string
+    }
+
+    variable "create_fields" {
+      description = "If set, Terraform will attempt to create fields at Sumo Logic"
+      type        = bool
+      default     = true
+    }
+
+    variable "fields" {
+      description = "Log fields to create."
+      type = list(string)
+    }
+
+    variable "collector_fields" {
+      description = "Fields to set on the collector."
+      type = map(string)
+    }
+
+    variable "chart_version" {
+      description = "The Helm Chart version."
+      type = string
+    }
+  providers.tf.json: |
+    {
+      "provider": {
+        "kubernetes": {
+          "cluster_ca_certificate": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt\")}",
+          "host": "https://kubernetes.default.svc",
+          "token": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/token\")}"
+        },
+        "sumologic": {}
+      }
+    }
   sources.tf.json: |
     {
       "locals": {
@@ -753,37 +787,4 @@ data:
         "service",
         "statefulset"
       ]
-    }
-  variables.tf: |
-    variable "collector_name" {
-      type  = string
-    }
-
-    variable "namespace_name" {
-      type  = string
-    }
-
-    variable "secret_name" {
-      type = string
-    }
-
-    variable "create_fields" {
-      description = "If set, Terraform will attempt to create fields at Sumo Logic"
-      type        = bool
-      default     = true
-    }
-
-    variable "fields" {
-      description = "Log fields to create."
-      type = list(string)
-    }
-
-    variable "collector_fields" {
-      description = "Fields to set on the collector."
-      type = map(string)
-    }
-
-    variable "chart_version" {
-      description = "The Helm Chart version."
-      type = string
     }

--- a/tests/helm/testdata/goldenfile/terraform/conditional_sources.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/conditional_sources.output.yaml
@@ -250,23 +250,24 @@ data:
     INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
 
-    if [ "${SUMOLOGIC_MONITORS_STATUS}" = "enabled" ]; then
+    if [[ "${SUMOLOGIC_MONITORS_STATUS:?}" = "enabled" ]]; then
       MONITORS_DISABLED="false"
     else
       MONITORS_DISABLED="true"
     fi
 
-    MONITORS_ROOT_ID="$(curl -XGET -s \
+    MONITORS_CURL_RESPONSE=$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/root)
+    MONITORS_ROOT_ID="$(echo "${MONITORS_CURL_RESPONSE}" | jq -r '.id' )"
     readonly MONITORS_ROOT_ID
 
     # verify if the integrations folder already exists
-    INTEGRATIONS_RESPONSE="$(curl -XGET -s -G \
+    INTEGRATIONS_CURL_RESPONSE=$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
-            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}" | \
-            jq '.[]' )"
+            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}")
+    INTEGRATIONS_RESPONSE="$(echo "${INTEGRATIONS_CURL_RESPONSE}" | jq '.[]' )"
     readonly INTEGRATIONS_RESPONSE
 
     INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
@@ -274,20 +275,20 @@ data:
 
     # and create it if necessary
     if [[ -z "${INTEGRATIONS_FOLDER_ID}" ]]; then
-      INTEGRATIONS_FOLDER_ID="$(curl -XPOST -s \
+      INTEGRATIONS_FOLDER_CURL_RESPONSE=$(curl -XPOST -s \
                   -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
                   -H "Content-Type: application/json" \
                   -d "{\"name\":\"${INTEGRATIONS_FOLDER_NAME}\",\"type\":\"MonitorsLibraryFolder\",\"description\":\"Monitors provided by the Sumo Logic integrations.\"}" \
-                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}" | \
-                  jq -r " .id" )"
+                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}")
+      INTEGRATIONS_FOLDER_ID="$(echo "${INTEGRATIONS_FOLDER_CURL_RESPONSE}" | jq -r " .id" )"
     fi
 
     # verify if the k8s monitors folder already exists
-    MONITORS_RESPONSE="$(curl -XGET -s -G \
+    MONITORS_CURL_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
-            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}" | \
-            jq '.[]' )"
+            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}")"
+    MONITORS_RESPONSE="$(echo "${MONITORS_CURL_RESPONSE}" | jq '.[]' )"
     readonly MONITORS_RESPONSE
 
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \
@@ -319,7 +320,7 @@ data:
         -var="monitors_disabled=${MONITORS_DISABLED}"
       )
 
-      if [ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]; then
+      if [[ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]]; then
         NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{TriggerType}} on {{Name}}\",message_body=\"Triggered {{TriggerType}} alert on {{Name}}: {{QueryURL}}\""
         NOTIFICATIONS_SETTINGS="recipients=${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
         TERRAFORM_ARGS+=(
@@ -336,17 +337,6 @@ data:
       echo "You can (re)install them manually with:"
       echo "https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor/tree/main/monitor_packages/kubernetes"
     fi
-  providers.tf.json: |
-    {
-      "provider": {
-        "kubernetes": {
-          "cluster_ca_certificate": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt\")}",
-          "host": "https://kubernetes.default.svc",
-          "token": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/token\")}"
-        },
-        "sumologic": {}
-      }
-    }
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
@@ -465,7 +455,7 @@ data:
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
 
-    declare -ra FIELDS=($(jq -r '.fields[]' terraform.tfvars.json))
+    declare -ra FIELDS=("$(jq -r '.fields[]' terraform.tfvars.json)")
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file
@@ -489,7 +479,7 @@ data:
 
             terraform import \
                 -var="create_fields=1" \
-                sumologic_field.collection_field[\"${FIELD}\"] "${FIELD_ID}"
+                sumologic_field.collection_field[\""${FIELD}"\"] "${FIELD_ID}"
         done
     else
         readonly CREATE_FIELDS=0
@@ -503,7 +493,7 @@ data:
     if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
         jq -r '.resource[] | to_entries[] | "\(.key) \(.value.name)"' sources.tf.json | while read -r resource_name source_name; do
             terraform import "sumologic_http_source.${resource_name}" "${SUMOLOGIC_COLLECTOR_NAME}/${source_name}"
-        done
+        done || true
     fi
 
     # Kubernetes Secret
@@ -516,7 +506,7 @@ data:
         || { echo "Error during applying Terraform changes"; exit 1; }
 
     # Setup Sumo Logic monitors if enabled
-    if [ "${SUMOLOGIC_MONITORS_ENABLED}" = "true" ]; then
+    if [[ "${SUMOLOGIC_MONITORS_ENABLED:?}" = "true" ]]; then
         bash /etc/terraform/monitors.sh
     else
         echo "Installation of the Sumo Logic monitors is disabled."
@@ -525,7 +515,7 @@ data:
     fi
 
     # Setup Sumo Logic dashboards if enabled
-    if [ "${SUMOLOGIC_DASHBOARDS_ENABLED}" = "true" ]; then
+    if [[ "${SUMOLOGIC_DASHBOARDS_ENABLED:?}" = "true" ]]; then
         bash /etc/terraform/dashboards.sh
     else
         echo "Installation of the Sumo Logic dashboards is disabled."
@@ -539,32 +529,6 @@ data:
     export SUMOLOGIC_ACCESSID=
 
     bash /etc/terraform/custom.sh
-  sources.tf.json: |
-    {
-      "locals": {
-        "source_configs": {},
-        "sources": {}
-      },
-      "resource": {
-        "sumologic_http_source": {}
-      }
-    }
-  terraform.tfvars.json: |
-    {
-      "collector_fields": {},
-      "fields": [
-        "cluster",
-        "container",
-        "daemonset",
-        "deployment",
-        "host",
-        "namespace",
-        "node",
-        "pod",
-        "service",
-        "statefulset"
-      ]
-    }
   variables.tf: |
     variable "collector_name" {
       type  = string
@@ -597,4 +561,41 @@ data:
     variable "chart_version" {
       description = "The Helm Chart version."
       type = string
+    }
+  providers.tf.json: |
+    {
+      "provider": {
+        "kubernetes": {
+          "cluster_ca_certificate": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt\")}",
+          "host": "https://kubernetes.default.svc",
+          "token": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/token\")}"
+        },
+        "sumologic": {}
+      }
+    }
+  sources.tf.json: |
+    {
+      "locals": {
+        "source_configs": {},
+        "sources": {}
+      },
+      "resource": {
+        "sumologic_http_source": {}
+      }
+    }
+  terraform.tfvars.json: |
+    {
+      "collector_fields": {},
+      "fields": [
+        "cluster",
+        "container",
+        "daemonset",
+        "deployment",
+        "host",
+        "namespace",
+        "node",
+        "pod",
+        "service",
+        "statefulset"
+      ]
     }

--- a/tests/helm/testdata/goldenfile/terraform/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/custom.output.yaml
@@ -250,23 +250,24 @@ data:
     INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
 
-    if [ "${SUMOLOGIC_MONITORS_STATUS}" = "enabled" ]; then
+    if [[ "${SUMOLOGIC_MONITORS_STATUS:?}" = "enabled" ]]; then
       MONITORS_DISABLED="false"
     else
       MONITORS_DISABLED="true"
     fi
 
-    MONITORS_ROOT_ID="$(curl -XGET -s \
+    MONITORS_CURL_RESPONSE=$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/root)
+    MONITORS_ROOT_ID="$(echo "${MONITORS_CURL_RESPONSE}" | jq -r '.id' )"
     readonly MONITORS_ROOT_ID
 
     # verify if the integrations folder already exists
-    INTEGRATIONS_RESPONSE="$(curl -XGET -s -G \
+    INTEGRATIONS_CURL_RESPONSE=$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
-            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}" | \
-            jq '.[]' )"
+            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}")
+    INTEGRATIONS_RESPONSE="$(echo "${INTEGRATIONS_CURL_RESPONSE}" | jq '.[]' )"
     readonly INTEGRATIONS_RESPONSE
 
     INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
@@ -274,20 +275,20 @@ data:
 
     # and create it if necessary
     if [[ -z "${INTEGRATIONS_FOLDER_ID}" ]]; then
-      INTEGRATIONS_FOLDER_ID="$(curl -XPOST -s \
+      INTEGRATIONS_FOLDER_CURL_RESPONSE=$(curl -XPOST -s \
                   -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
                   -H "Content-Type: application/json" \
                   -d "{\"name\":\"${INTEGRATIONS_FOLDER_NAME}\",\"type\":\"MonitorsLibraryFolder\",\"description\":\"Monitors provided by the Sumo Logic integrations.\"}" \
-                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}" | \
-                  jq -r " .id" )"
+                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}")
+      INTEGRATIONS_FOLDER_ID="$(echo "${INTEGRATIONS_FOLDER_CURL_RESPONSE}" | jq -r " .id" )"
     fi
 
     # verify if the k8s monitors folder already exists
-    MONITORS_RESPONSE="$(curl -XGET -s -G \
+    MONITORS_CURL_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
-            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}" | \
-            jq '.[]' )"
+            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}")"
+    MONITORS_RESPONSE="$(echo "${MONITORS_CURL_RESPONSE}" | jq '.[]' )"
     readonly MONITORS_RESPONSE
 
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \
@@ -319,7 +320,7 @@ data:
         -var="monitors_disabled=${MONITORS_DISABLED}"
       )
 
-      if [ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]; then
+      if [[ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]]; then
         NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{TriggerType}} on {{Name}}\",message_body=\"Triggered {{TriggerType}} alert on {{Name}}: {{QueryURL}}\""
         NOTIFICATIONS_SETTINGS="recipients=${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
         TERRAFORM_ARGS+=(
@@ -336,17 +337,6 @@ data:
       echo "You can (re)install them manually with:"
       echo "https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor/tree/main/monitor_packages/kubernetes"
     fi
-  providers.tf.json: |
-    {
-      "provider": {
-        "kubernetes": {
-          "cluster_ca_certificate": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt\")}",
-          "host": "https://kubernetes.default.svc",
-          "token": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/token\")}"
-        },
-        "sumologic": {}
-      }
-    }
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
@@ -465,7 +455,7 @@ data:
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
 
-    declare -ra FIELDS=($(jq -r '.fields[]' terraform.tfvars.json))
+    declare -ra FIELDS=("$(jq -r '.fields[]' terraform.tfvars.json)")
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file
@@ -489,7 +479,7 @@ data:
 
             terraform import \
                 -var="create_fields=1" \
-                sumologic_field.collection_field[\"${FIELD}\"] "${FIELD_ID}"
+                sumologic_field.collection_field[\""${FIELD}"\"] "${FIELD_ID}"
         done
     else
         readonly CREATE_FIELDS=0
@@ -503,7 +493,7 @@ data:
     if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
         jq -r '.resource[] | to_entries[] | "\(.key) \(.value.name)"' sources.tf.json | while read -r resource_name source_name; do
             terraform import "sumologic_http_source.${resource_name}" "${SUMOLOGIC_COLLECTOR_NAME}/${source_name}"
-        done
+        done || true
     fi
 
     # Kubernetes Secret
@@ -516,7 +506,7 @@ data:
         || { echo "Error during applying Terraform changes"; exit 1; }
 
     # Setup Sumo Logic monitors if enabled
-    if [ "${SUMOLOGIC_MONITORS_ENABLED}" = "true" ]; then
+    if [[ "${SUMOLOGIC_MONITORS_ENABLED:?}" = "true" ]]; then
         bash /etc/terraform/monitors.sh
     else
         echo "Installation of the Sumo Logic monitors is disabled."
@@ -525,7 +515,7 @@ data:
     fi
 
     # Setup Sumo Logic dashboards if enabled
-    if [ "${SUMOLOGIC_DASHBOARDS_ENABLED}" = "true" ]; then
+    if [[ "${SUMOLOGIC_DASHBOARDS_ENABLED:?}" = "true" ]]; then
         bash /etc/terraform/dashboards.sh
     else
         echo "Installation of the Sumo Logic dashboards is disabled."
@@ -539,32 +529,6 @@ data:
     export SUMOLOGIC_ACCESSID=
 
     bash /etc/terraform/custom.sh
-  sources.tf.json: |
-    {
-      "locals": {
-        "source_configs": {},
-        "sources": {}
-      },
-      "resource": {
-        "sumologic_http_source": {}
-      }
-    }
-  terraform.tfvars.json: |
-    {
-      "collector_fields": {},
-      "fields": [
-        "cluster",
-        "container",
-        "daemonset",
-        "deployment",
-        "host",
-        "namespace",
-        "node",
-        "pod",
-        "service",
-        "statefulset"
-      ]
-    }
   variables.tf: |
     variable "collector_name" {
       type  = string
@@ -597,4 +561,41 @@ data:
     variable "chart_version" {
       description = "The Helm Chart version."
       type = string
+    }
+  providers.tf.json: |
+    {
+      "provider": {
+        "kubernetes": {
+          "cluster_ca_certificate": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt\")}",
+          "host": "https://kubernetes.default.svc",
+          "token": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/token\")}"
+        },
+        "sumologic": {}
+      }
+    }
+  sources.tf.json: |
+    {
+      "locals": {
+        "source_configs": {},
+        "sources": {}
+      },
+      "resource": {
+        "sumologic_http_source": {}
+      }
+    }
+  terraform.tfvars.json: |
+    {
+      "collector_fields": {},
+      "fields": [
+        "cluster",
+        "container",
+        "daemonset",
+        "deployment",
+        "host",
+        "namespace",
+        "node",
+        "pod",
+        "service",
+        "statefulset"
+      ]
     }

--- a/tests/helm/testdata/goldenfile/terraform/default.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/default.output.yaml
@@ -250,23 +250,24 @@ data:
     INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
 
-    if [ "${SUMOLOGIC_MONITORS_STATUS}" = "enabled" ]; then
+    if [[ "${SUMOLOGIC_MONITORS_STATUS:?}" = "enabled" ]]; then
       MONITORS_DISABLED="false"
     else
       MONITORS_DISABLED="true"
     fi
 
-    MONITORS_ROOT_ID="$(curl -XGET -s \
+    MONITORS_CURL_RESPONSE=$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/root)
+    MONITORS_ROOT_ID="$(echo "${MONITORS_CURL_RESPONSE}" | jq -r '.id' )"
     readonly MONITORS_ROOT_ID
 
     # verify if the integrations folder already exists
-    INTEGRATIONS_RESPONSE="$(curl -XGET -s -G \
+    INTEGRATIONS_CURL_RESPONSE=$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
-            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}" | \
-            jq '.[]' )"
+            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}")
+    INTEGRATIONS_RESPONSE="$(echo "${INTEGRATIONS_CURL_RESPONSE}" | jq '.[]' )"
     readonly INTEGRATIONS_RESPONSE
 
     INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
@@ -274,20 +275,20 @@ data:
 
     # and create it if necessary
     if [[ -z "${INTEGRATIONS_FOLDER_ID}" ]]; then
-      INTEGRATIONS_FOLDER_ID="$(curl -XPOST -s \
+      INTEGRATIONS_FOLDER_CURL_RESPONSE=$(curl -XPOST -s \
                   -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
                   -H "Content-Type: application/json" \
                   -d "{\"name\":\"${INTEGRATIONS_FOLDER_NAME}\",\"type\":\"MonitorsLibraryFolder\",\"description\":\"Monitors provided by the Sumo Logic integrations.\"}" \
-                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}" | \
-                  jq -r " .id" )"
+                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}")
+      INTEGRATIONS_FOLDER_ID="$(echo "${INTEGRATIONS_FOLDER_CURL_RESPONSE}" | jq -r " .id" )"
     fi
 
     # verify if the k8s monitors folder already exists
-    MONITORS_RESPONSE="$(curl -XGET -s -G \
+    MONITORS_CURL_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
-            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}" | \
-            jq '.[]' )"
+            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}")"
+    MONITORS_RESPONSE="$(echo "${MONITORS_CURL_RESPONSE}" | jq '.[]' )"
     readonly MONITORS_RESPONSE
 
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \
@@ -319,7 +320,7 @@ data:
         -var="monitors_disabled=${MONITORS_DISABLED}"
       )
 
-      if [ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]; then
+      if [[ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]]; then
         NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{TriggerType}} on {{Name}}\",message_body=\"Triggered {{TriggerType}} alert on {{Name}}: {{QueryURL}}\""
         NOTIFICATIONS_SETTINGS="recipients=${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
         TERRAFORM_ARGS+=(
@@ -336,17 +337,6 @@ data:
       echo "You can (re)install them manually with:"
       echo "https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor/tree/main/monitor_packages/kubernetes"
     fi
-  providers.tf.json: |
-    {
-      "provider": {
-        "kubernetes": {
-          "cluster_ca_certificate": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt\")}",
-          "host": "https://kubernetes.default.svc",
-          "token": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/token\")}"
-        },
-        "sumologic": {}
-      }
-    }
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
@@ -465,7 +455,7 @@ data:
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
 
-    declare -ra FIELDS=($(jq -r '.fields[]' terraform.tfvars.json))
+    declare -ra FIELDS=("$(jq -r '.fields[]' terraform.tfvars.json)")
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file
@@ -489,7 +479,7 @@ data:
 
             terraform import \
                 -var="create_fields=1" \
-                sumologic_field.collection_field[\"${FIELD}\"] "${FIELD_ID}"
+                sumologic_field.collection_field[\""${FIELD}"\"] "${FIELD_ID}"
         done
     else
         readonly CREATE_FIELDS=0
@@ -503,7 +493,7 @@ data:
     if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
         jq -r '.resource[] | to_entries[] | "\(.key) \(.value.name)"' sources.tf.json | while read -r resource_name source_name; do
             terraform import "sumologic_http_source.${resource_name}" "${SUMOLOGIC_COLLECTOR_NAME}/${source_name}"
-        done
+        done || true
     fi
 
     # Kubernetes Secret
@@ -516,7 +506,7 @@ data:
         || { echo "Error during applying Terraform changes"; exit 1; }
 
     # Setup Sumo Logic monitors if enabled
-    if [ "${SUMOLOGIC_MONITORS_ENABLED}" = "true" ]; then
+    if [[ "${SUMOLOGIC_MONITORS_ENABLED:?}" = "true" ]]; then
         bash /etc/terraform/monitors.sh
     else
         echo "Installation of the Sumo Logic monitors is disabled."
@@ -525,7 +515,7 @@ data:
     fi
 
     # Setup Sumo Logic dashboards if enabled
-    if [ "${SUMOLOGIC_DASHBOARDS_ENABLED}" = "true" ]; then
+    if [[ "${SUMOLOGIC_DASHBOARDS_ENABLED:?}" = "true" ]]; then
         bash /etc/terraform/dashboards.sh
     else
         echo "Installation of the Sumo Logic dashboards is disabled."
@@ -539,6 +529,50 @@ data:
     export SUMOLOGIC_ACCESSID=
 
     bash /etc/terraform/custom.sh
+  variables.tf: |
+    variable "collector_name" {
+      type  = string
+    }
+
+    variable "namespace_name" {
+      type  = string
+    }
+
+    variable "secret_name" {
+      type = string
+    }
+
+    variable "create_fields" {
+      description = "If set, Terraform will attempt to create fields at Sumo Logic"
+      type        = bool
+      default     = true
+    }
+
+    variable "fields" {
+      description = "Log fields to create."
+      type = list(string)
+    }
+
+    variable "collector_fields" {
+      description = "Fields to set on the collector."
+      type = map(string)
+    }
+
+    variable "chart_version" {
+      description = "The Helm Chart version."
+      type = string
+    }
+  providers.tf.json: |
+    {
+      "provider": {
+        "kubernetes": {
+          "cluster_ca_certificate": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt\")}",
+          "host": "https://kubernetes.default.svc",
+          "token": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/token\")}"
+        },
+        "sumologic": {}
+      }
+    }
   sources.tf.json: |
     {
       "locals": {
@@ -750,37 +784,4 @@ data:
         "service",
         "statefulset"
       ]
-    }
-  variables.tf: |
-    variable "collector_name" {
-      type  = string
-    }
-
-    variable "namespace_name" {
-      type  = string
-    }
-
-    variable "secret_name" {
-      type = string
-    }
-
-    variable "create_fields" {
-      description = "If set, Terraform will attempt to create fields at Sumo Logic"
-      type        = bool
-      default     = true
-    }
-
-    variable "fields" {
-      description = "Log fields to create."
-      type = list(string)
-    }
-
-    variable "collector_fields" {
-      description = "Fields to set on the collector."
-      type = map(string)
-    }
-
-    variable "chart_version" {
-      description = "The Helm Chart version."
-      type = string
     }

--- a/tests/helm/testdata/goldenfile/terraform/disable_default_metrics.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disable_default_metrics.output.yaml
@@ -250,23 +250,24 @@ data:
     INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
 
-    if [ "${SUMOLOGIC_MONITORS_STATUS}" = "enabled" ]; then
+    if [[ "${SUMOLOGIC_MONITORS_STATUS:?}" = "enabled" ]]; then
       MONITORS_DISABLED="false"
     else
       MONITORS_DISABLED="true"
     fi
 
-    MONITORS_ROOT_ID="$(curl -XGET -s \
+    MONITORS_CURL_RESPONSE=$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/root)
+    MONITORS_ROOT_ID="$(echo "${MONITORS_CURL_RESPONSE}" | jq -r '.id' )"
     readonly MONITORS_ROOT_ID
 
     # verify if the integrations folder already exists
-    INTEGRATIONS_RESPONSE="$(curl -XGET -s -G \
+    INTEGRATIONS_CURL_RESPONSE=$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
-            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}" | \
-            jq '.[]' )"
+            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}")
+    INTEGRATIONS_RESPONSE="$(echo "${INTEGRATIONS_CURL_RESPONSE}" | jq '.[]' )"
     readonly INTEGRATIONS_RESPONSE
 
     INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
@@ -274,20 +275,20 @@ data:
 
     # and create it if necessary
     if [[ -z "${INTEGRATIONS_FOLDER_ID}" ]]; then
-      INTEGRATIONS_FOLDER_ID="$(curl -XPOST -s \
+      INTEGRATIONS_FOLDER_CURL_RESPONSE=$(curl -XPOST -s \
                   -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
                   -H "Content-Type: application/json" \
                   -d "{\"name\":\"${INTEGRATIONS_FOLDER_NAME}\",\"type\":\"MonitorsLibraryFolder\",\"description\":\"Monitors provided by the Sumo Logic integrations.\"}" \
-                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}" | \
-                  jq -r " .id" )"
+                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}")
+      INTEGRATIONS_FOLDER_ID="$(echo "${INTEGRATIONS_FOLDER_CURL_RESPONSE}" | jq -r " .id" )"
     fi
 
     # verify if the k8s monitors folder already exists
-    MONITORS_RESPONSE="$(curl -XGET -s -G \
+    MONITORS_CURL_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
-            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}" | \
-            jq '.[]' )"
+            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}")"
+    MONITORS_RESPONSE="$(echo "${MONITORS_CURL_RESPONSE}" | jq '.[]' )"
     readonly MONITORS_RESPONSE
 
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \
@@ -319,7 +320,7 @@ data:
         -var="monitors_disabled=${MONITORS_DISABLED}"
       )
 
-      if [ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]; then
+      if [[ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]]; then
         NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{TriggerType}} on {{Name}}\",message_body=\"Triggered {{TriggerType}} alert on {{Name}}: {{QueryURL}}\""
         NOTIFICATIONS_SETTINGS="recipients=${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
         TERRAFORM_ARGS+=(
@@ -336,17 +337,6 @@ data:
       echo "You can (re)install them manually with:"
       echo "https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor/tree/main/monitor_packages/kubernetes"
     fi
-  providers.tf.json: |
-    {
-      "provider": {
-        "kubernetes": {
-          "cluster_ca_certificate": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt\")}",
-          "host": "https://kubernetes.default.svc",
-          "token": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/token\")}"
-        },
-        "sumologic": {}
-      }
-    }
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
@@ -465,7 +455,7 @@ data:
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
 
-    declare -ra FIELDS=($(jq -r '.fields[]' terraform.tfvars.json))
+    declare -ra FIELDS=("$(jq -r '.fields[]' terraform.tfvars.json)")
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file
@@ -489,7 +479,7 @@ data:
 
             terraform import \
                 -var="create_fields=1" \
-                sumologic_field.collection_field[\"${FIELD}\"] "${FIELD_ID}"
+                sumologic_field.collection_field[\""${FIELD}"\"] "${FIELD_ID}"
         done
     else
         readonly CREATE_FIELDS=0
@@ -503,7 +493,7 @@ data:
     if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
         jq -r '.resource[] | to_entries[] | "\(.key) \(.value.name)"' sources.tf.json | while read -r resource_name source_name; do
             terraform import "sumologic_http_source.${resource_name}" "${SUMOLOGIC_COLLECTOR_NAME}/${source_name}"
-        done
+        done || true
     fi
 
     # Kubernetes Secret
@@ -516,7 +506,7 @@ data:
         || { echo "Error during applying Terraform changes"; exit 1; }
 
     # Setup Sumo Logic monitors if enabled
-    if [ "${SUMOLOGIC_MONITORS_ENABLED}" = "true" ]; then
+    if [[ "${SUMOLOGIC_MONITORS_ENABLED:?}" = "true" ]]; then
         bash /etc/terraform/monitors.sh
     else
         echo "Installation of the Sumo Logic monitors is disabled."
@@ -525,7 +515,7 @@ data:
     fi
 
     # Setup Sumo Logic dashboards if enabled
-    if [ "${SUMOLOGIC_DASHBOARDS_ENABLED}" = "true" ]; then
+    if [[ "${SUMOLOGIC_DASHBOARDS_ENABLED:?}" = "true" ]]; then
         bash /etc/terraform/dashboards.sh
     else
         echo "Installation of the Sumo Logic dashboards is disabled."
@@ -539,6 +529,50 @@ data:
     export SUMOLOGIC_ACCESSID=
 
     bash /etc/terraform/custom.sh
+  variables.tf: |
+    variable "collector_name" {
+      type  = string
+    }
+
+    variable "namespace_name" {
+      type  = string
+    }
+
+    variable "secret_name" {
+      type = string
+    }
+
+    variable "create_fields" {
+      description = "If set, Terraform will attempt to create fields at Sumo Logic"
+      type        = bool
+      default     = true
+    }
+
+    variable "fields" {
+      description = "Log fields to create."
+      type = list(string)
+    }
+
+    variable "collector_fields" {
+      description = "Fields to set on the collector."
+      type = map(string)
+    }
+
+    variable "chart_version" {
+      description = "The Helm Chart version."
+      type = string
+    }
+  providers.tf.json: |
+    {
+      "provider": {
+        "kubernetes": {
+          "cluster_ca_certificate": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt\")}",
+          "host": "https://kubernetes.default.svc",
+          "token": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/token\")}"
+        },
+        "sumologic": {}
+      }
+    }
   sources.tf.json: |
     {
       "locals": {
@@ -741,37 +775,4 @@ data:
         "service",
         "statefulset"
       ]
-    }
-  variables.tf: |
-    variable "collector_name" {
-      type  = string
-    }
-
-    variable "namespace_name" {
-      type  = string
-    }
-
-    variable "secret_name" {
-      type = string
-    }
-
-    variable "create_fields" {
-      description = "If set, Terraform will attempt to create fields at Sumo Logic"
-      type        = bool
-      default     = true
-    }
-
-    variable "fields" {
-      description = "Log fields to create."
-      type = list(string)
-    }
-
-    variable "collector_fields" {
-      description = "Fields to set on the collector."
-      type = map(string)
-    }
-
-    variable "chart_version" {
-      description = "The Helm Chart version."
-      type = string
     }

--- a/tests/helm/testdata/goldenfile/terraform/disabled_dashboards.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disabled_dashboards.output.yaml
@@ -250,23 +250,24 @@ data:
     INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
 
-    if [ "${SUMOLOGIC_MONITORS_STATUS}" = "enabled" ]; then
+    if [[ "${SUMOLOGIC_MONITORS_STATUS:?}" = "enabled" ]]; then
       MONITORS_DISABLED="false"
     else
       MONITORS_DISABLED="true"
     fi
 
-    MONITORS_ROOT_ID="$(curl -XGET -s \
+    MONITORS_CURL_RESPONSE=$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/root)
+    MONITORS_ROOT_ID="$(echo "${MONITORS_CURL_RESPONSE}" | jq -r '.id' )"
     readonly MONITORS_ROOT_ID
 
     # verify if the integrations folder already exists
-    INTEGRATIONS_RESPONSE="$(curl -XGET -s -G \
+    INTEGRATIONS_CURL_RESPONSE=$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
-            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}" | \
-            jq '.[]' )"
+            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}")
+    INTEGRATIONS_RESPONSE="$(echo "${INTEGRATIONS_CURL_RESPONSE}" | jq '.[]' )"
     readonly INTEGRATIONS_RESPONSE
 
     INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
@@ -274,20 +275,20 @@ data:
 
     # and create it if necessary
     if [[ -z "${INTEGRATIONS_FOLDER_ID}" ]]; then
-      INTEGRATIONS_FOLDER_ID="$(curl -XPOST -s \
+      INTEGRATIONS_FOLDER_CURL_RESPONSE=$(curl -XPOST -s \
                   -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
                   -H "Content-Type: application/json" \
                   -d "{\"name\":\"${INTEGRATIONS_FOLDER_NAME}\",\"type\":\"MonitorsLibraryFolder\",\"description\":\"Monitors provided by the Sumo Logic integrations.\"}" \
-                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}" | \
-                  jq -r " .id" )"
+                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}")
+      INTEGRATIONS_FOLDER_ID="$(echo "${INTEGRATIONS_FOLDER_CURL_RESPONSE}" | jq -r " .id" )"
     fi
 
     # verify if the k8s monitors folder already exists
-    MONITORS_RESPONSE="$(curl -XGET -s -G \
+    MONITORS_CURL_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
-            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}" | \
-            jq '.[]' )"
+            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}")"
+    MONITORS_RESPONSE="$(echo "${MONITORS_CURL_RESPONSE}" | jq '.[]' )"
     readonly MONITORS_RESPONSE
 
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \
@@ -319,7 +320,7 @@ data:
         -var="monitors_disabled=${MONITORS_DISABLED}"
       )
 
-      if [ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]; then
+      if [[ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]]; then
         NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{TriggerType}} on {{Name}}\",message_body=\"Triggered {{TriggerType}} alert on {{Name}}: {{QueryURL}}\""
         NOTIFICATIONS_SETTINGS="recipients=${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
         TERRAFORM_ARGS+=(
@@ -336,17 +337,6 @@ data:
       echo "You can (re)install them manually with:"
       echo "https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor/tree/main/monitor_packages/kubernetes"
     fi
-  providers.tf.json: |
-    {
-      "provider": {
-        "kubernetes": {
-          "cluster_ca_certificate": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt\")}",
-          "host": "https://kubernetes.default.svc",
-          "token": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/token\")}"
-        },
-        "sumologic": {}
-      }
-    }
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
@@ -465,7 +455,7 @@ data:
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
 
-    declare -ra FIELDS=($(jq -r '.fields[]' terraform.tfvars.json))
+    declare -ra FIELDS=("$(jq -r '.fields[]' terraform.tfvars.json)")
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file
@@ -489,7 +479,7 @@ data:
 
             terraform import \
                 -var="create_fields=1" \
-                sumologic_field.collection_field[\"${FIELD}\"] "${FIELD_ID}"
+                sumologic_field.collection_field[\""${FIELD}"\"] "${FIELD_ID}"
         done
     else
         readonly CREATE_FIELDS=0
@@ -503,7 +493,7 @@ data:
     if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
         jq -r '.resource[] | to_entries[] | "\(.key) \(.value.name)"' sources.tf.json | while read -r resource_name source_name; do
             terraform import "sumologic_http_source.${resource_name}" "${SUMOLOGIC_COLLECTOR_NAME}/${source_name}"
-        done
+        done || true
     fi
 
     # Kubernetes Secret
@@ -516,7 +506,7 @@ data:
         || { echo "Error during applying Terraform changes"; exit 1; }
 
     # Setup Sumo Logic monitors if enabled
-    if [ "${SUMOLOGIC_MONITORS_ENABLED}" = "true" ]; then
+    if [[ "${SUMOLOGIC_MONITORS_ENABLED:?}" = "true" ]]; then
         bash /etc/terraform/monitors.sh
     else
         echo "Installation of the Sumo Logic monitors is disabled."
@@ -525,7 +515,7 @@ data:
     fi
 
     # Setup Sumo Logic dashboards if enabled
-    if [ "${SUMOLOGIC_DASHBOARDS_ENABLED}" = "true" ]; then
+    if [[ "${SUMOLOGIC_DASHBOARDS_ENABLED:?}" = "true" ]]; then
         bash /etc/terraform/dashboards.sh
     else
         echo "Installation of the Sumo Logic dashboards is disabled."
@@ -539,6 +529,50 @@ data:
     export SUMOLOGIC_ACCESSID=
 
     bash /etc/terraform/custom.sh
+  variables.tf: |
+    variable "collector_name" {
+      type  = string
+    }
+
+    variable "namespace_name" {
+      type  = string
+    }
+
+    variable "secret_name" {
+      type = string
+    }
+
+    variable "create_fields" {
+      description = "If set, Terraform will attempt to create fields at Sumo Logic"
+      type        = bool
+      default     = true
+    }
+
+    variable "fields" {
+      description = "Log fields to create."
+      type = list(string)
+    }
+
+    variable "collector_fields" {
+      description = "Fields to set on the collector."
+      type = map(string)
+    }
+
+    variable "chart_version" {
+      description = "The Helm Chart version."
+      type = string
+    }
+  providers.tf.json: |
+    {
+      "provider": {
+        "kubernetes": {
+          "cluster_ca_certificate": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt\")}",
+          "host": "https://kubernetes.default.svc",
+          "token": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/token\")}"
+        },
+        "sumologic": {}
+      }
+    }
   sources.tf.json: |
     {
       "locals": {
@@ -750,37 +784,4 @@ data:
         "service",
         "statefulset"
       ]
-    }
-  variables.tf: |
-    variable "collector_name" {
-      type  = string
-    }
-
-    variable "namespace_name" {
-      type  = string
-    }
-
-    variable "secret_name" {
-      type = string
-    }
-
-    variable "create_fields" {
-      description = "If set, Terraform will attempt to create fields at Sumo Logic"
-      type        = bool
-      default     = true
-    }
-
-    variable "fields" {
-      description = "Log fields to create."
-      type = list(string)
-    }
-
-    variable "collector_fields" {
-      description = "Fields to set on the collector."
-      type = map(string)
-    }
-
-    variable "chart_version" {
-      description = "The Helm Chart version."
-      type = string
     }

--- a/tests/helm/testdata/goldenfile/terraform/disabled_monitors.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disabled_monitors.output.yaml
@@ -250,23 +250,24 @@ data:
     INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
 
-    if [ "${SUMOLOGIC_MONITORS_STATUS}" = "enabled" ]; then
+    if [[ "${SUMOLOGIC_MONITORS_STATUS:?}" = "enabled" ]]; then
       MONITORS_DISABLED="false"
     else
       MONITORS_DISABLED="true"
     fi
 
-    MONITORS_ROOT_ID="$(curl -XGET -s \
+    MONITORS_CURL_RESPONSE=$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/root)
+    MONITORS_ROOT_ID="$(echo "${MONITORS_CURL_RESPONSE}" | jq -r '.id' )"
     readonly MONITORS_ROOT_ID
 
     # verify if the integrations folder already exists
-    INTEGRATIONS_RESPONSE="$(curl -XGET -s -G \
+    INTEGRATIONS_CURL_RESPONSE=$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
-            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}" | \
-            jq '.[]' )"
+            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}")
+    INTEGRATIONS_RESPONSE="$(echo "${INTEGRATIONS_CURL_RESPONSE}" | jq '.[]' )"
     readonly INTEGRATIONS_RESPONSE
 
     INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
@@ -274,20 +275,20 @@ data:
 
     # and create it if necessary
     if [[ -z "${INTEGRATIONS_FOLDER_ID}" ]]; then
-      INTEGRATIONS_FOLDER_ID="$(curl -XPOST -s \
+      INTEGRATIONS_FOLDER_CURL_RESPONSE=$(curl -XPOST -s \
                   -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
                   -H "Content-Type: application/json" \
                   -d "{\"name\":\"${INTEGRATIONS_FOLDER_NAME}\",\"type\":\"MonitorsLibraryFolder\",\"description\":\"Monitors provided by the Sumo Logic integrations.\"}" \
-                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}" | \
-                  jq -r " .id" )"
+                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}")
+      INTEGRATIONS_FOLDER_ID="$(echo "${INTEGRATIONS_FOLDER_CURL_RESPONSE}" | jq -r " .id" )"
     fi
 
     # verify if the k8s monitors folder already exists
-    MONITORS_RESPONSE="$(curl -XGET -s -G \
+    MONITORS_CURL_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
-            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}" | \
-            jq '.[]' )"
+            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}")"
+    MONITORS_RESPONSE="$(echo "${MONITORS_CURL_RESPONSE}" | jq '.[]' )"
     readonly MONITORS_RESPONSE
 
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \
@@ -319,7 +320,7 @@ data:
         -var="monitors_disabled=${MONITORS_DISABLED}"
       )
 
-      if [ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]; then
+      if [[ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]]; then
         NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{TriggerType}} on {{Name}}\",message_body=\"Triggered {{TriggerType}} alert on {{Name}}: {{QueryURL}}\""
         NOTIFICATIONS_SETTINGS="recipients=${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
         TERRAFORM_ARGS+=(
@@ -336,17 +337,6 @@ data:
       echo "You can (re)install them manually with:"
       echo "https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor/tree/main/monitor_packages/kubernetes"
     fi
-  providers.tf.json: |
-    {
-      "provider": {
-        "kubernetes": {
-          "cluster_ca_certificate": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt\")}",
-          "host": "https://kubernetes.default.svc",
-          "token": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/token\")}"
-        },
-        "sumologic": {}
-      }
-    }
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
@@ -465,7 +455,7 @@ data:
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
 
-    declare -ra FIELDS=($(jq -r '.fields[]' terraform.tfvars.json))
+    declare -ra FIELDS=("$(jq -r '.fields[]' terraform.tfvars.json)")
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file
@@ -489,7 +479,7 @@ data:
 
             terraform import \
                 -var="create_fields=1" \
-                sumologic_field.collection_field[\"${FIELD}\"] "${FIELD_ID}"
+                sumologic_field.collection_field[\""${FIELD}"\"] "${FIELD_ID}"
         done
     else
         readonly CREATE_FIELDS=0
@@ -503,7 +493,7 @@ data:
     if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
         jq -r '.resource[] | to_entries[] | "\(.key) \(.value.name)"' sources.tf.json | while read -r resource_name source_name; do
             terraform import "sumologic_http_source.${resource_name}" "${SUMOLOGIC_COLLECTOR_NAME}/${source_name}"
-        done
+        done || true
     fi
 
     # Kubernetes Secret
@@ -516,7 +506,7 @@ data:
         || { echo "Error during applying Terraform changes"; exit 1; }
 
     # Setup Sumo Logic monitors if enabled
-    if [ "${SUMOLOGIC_MONITORS_ENABLED}" = "true" ]; then
+    if [[ "${SUMOLOGIC_MONITORS_ENABLED:?}" = "true" ]]; then
         bash /etc/terraform/monitors.sh
     else
         echo "Installation of the Sumo Logic monitors is disabled."
@@ -525,7 +515,7 @@ data:
     fi
 
     # Setup Sumo Logic dashboards if enabled
-    if [ "${SUMOLOGIC_DASHBOARDS_ENABLED}" = "true" ]; then
+    if [[ "${SUMOLOGIC_DASHBOARDS_ENABLED:?}" = "true" ]]; then
         bash /etc/terraform/dashboards.sh
     else
         echo "Installation of the Sumo Logic dashboards is disabled."
@@ -539,6 +529,50 @@ data:
     export SUMOLOGIC_ACCESSID=
 
     bash /etc/terraform/custom.sh
+  variables.tf: |
+    variable "collector_name" {
+      type  = string
+    }
+
+    variable "namespace_name" {
+      type  = string
+    }
+
+    variable "secret_name" {
+      type = string
+    }
+
+    variable "create_fields" {
+      description = "If set, Terraform will attempt to create fields at Sumo Logic"
+      type        = bool
+      default     = true
+    }
+
+    variable "fields" {
+      description = "Log fields to create."
+      type = list(string)
+    }
+
+    variable "collector_fields" {
+      description = "Fields to set on the collector."
+      type = map(string)
+    }
+
+    variable "chart_version" {
+      description = "The Helm Chart version."
+      type = string
+    }
+  providers.tf.json: |
+    {
+      "provider": {
+        "kubernetes": {
+          "cluster_ca_certificate": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt\")}",
+          "host": "https://kubernetes.default.svc",
+          "token": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/token\")}"
+        },
+        "sumologic": {}
+      }
+    }
   sources.tf.json: |
     {
       "locals": {
@@ -750,37 +784,4 @@ data:
         "service",
         "statefulset"
       ]
-    }
-  variables.tf: |
-    variable "collector_name" {
-      type  = string
-    }
-
-    variable "namespace_name" {
-      type  = string
-    }
-
-    variable "secret_name" {
-      type = string
-    }
-
-    variable "create_fields" {
-      description = "If set, Terraform will attempt to create fields at Sumo Logic"
-      type        = bool
-      default     = true
-    }
-
-    variable "fields" {
-      description = "Log fields to create."
-      type = list(string)
-    }
-
-    variable "collector_fields" {
-      description = "Fields to set on the collector."
-      type = map(string)
-    }
-
-    variable "chart_version" {
-      description = "The Helm Chart version."
-      type = string
     }

--- a/tests/helm/testdata/goldenfile/terraform/logs_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/logs_fields.output.yaml
@@ -250,23 +250,24 @@ data:
     INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
 
-    if [ "${SUMOLOGIC_MONITORS_STATUS}" = "enabled" ]; then
+    if [[ "${SUMOLOGIC_MONITORS_STATUS:?}" = "enabled" ]]; then
       MONITORS_DISABLED="false"
     else
       MONITORS_DISABLED="true"
     fi
 
-    MONITORS_ROOT_ID="$(curl -XGET -s \
+    MONITORS_CURL_RESPONSE=$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/root)
+    MONITORS_ROOT_ID="$(echo "${MONITORS_CURL_RESPONSE}" | jq -r '.id' )"
     readonly MONITORS_ROOT_ID
 
     # verify if the integrations folder already exists
-    INTEGRATIONS_RESPONSE="$(curl -XGET -s -G \
+    INTEGRATIONS_CURL_RESPONSE=$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
-            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}" | \
-            jq '.[]' )"
+            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}")
+    INTEGRATIONS_RESPONSE="$(echo "${INTEGRATIONS_CURL_RESPONSE}" | jq '.[]' )"
     readonly INTEGRATIONS_RESPONSE
 
     INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
@@ -274,20 +275,20 @@ data:
 
     # and create it if necessary
     if [[ -z "${INTEGRATIONS_FOLDER_ID}" ]]; then
-      INTEGRATIONS_FOLDER_ID="$(curl -XPOST -s \
+      INTEGRATIONS_FOLDER_CURL_RESPONSE=$(curl -XPOST -s \
                   -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
                   -H "Content-Type: application/json" \
                   -d "{\"name\":\"${INTEGRATIONS_FOLDER_NAME}\",\"type\":\"MonitorsLibraryFolder\",\"description\":\"Monitors provided by the Sumo Logic integrations.\"}" \
-                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}" | \
-                  jq -r " .id" )"
+                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}")
+      INTEGRATIONS_FOLDER_ID="$(echo "${INTEGRATIONS_FOLDER_CURL_RESPONSE}" | jq -r " .id" )"
     fi
 
     # verify if the k8s monitors folder already exists
-    MONITORS_RESPONSE="$(curl -XGET -s -G \
+    MONITORS_CURL_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
-            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}" | \
-            jq '.[]' )"
+            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}")"
+    MONITORS_RESPONSE="$(echo "${MONITORS_CURL_RESPONSE}" | jq '.[]' )"
     readonly MONITORS_RESPONSE
 
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \
@@ -319,7 +320,7 @@ data:
         -var="monitors_disabled=${MONITORS_DISABLED}"
       )
 
-      if [ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]; then
+      if [[ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]]; then
         NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{TriggerType}} on {{Name}}\",message_body=\"Triggered {{TriggerType}} alert on {{Name}}: {{QueryURL}}\""
         NOTIFICATIONS_SETTINGS="recipients=${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
         TERRAFORM_ARGS+=(
@@ -336,17 +337,6 @@ data:
       echo "You can (re)install them manually with:"
       echo "https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor/tree/main/monitor_packages/kubernetes"
     fi
-  providers.tf.json: |
-    {
-      "provider": {
-        "kubernetes": {
-          "cluster_ca_certificate": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt\")}",
-          "host": "https://kubernetes.default.svc",
-          "token": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/token\")}"
-        },
-        "sumologic": {}
-      }
-    }
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
@@ -465,7 +455,7 @@ data:
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
 
-    declare -ra FIELDS=($(jq -r '.fields[]' terraform.tfvars.json))
+    declare -ra FIELDS=("$(jq -r '.fields[]' terraform.tfvars.json)")
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file
@@ -489,7 +479,7 @@ data:
 
             terraform import \
                 -var="create_fields=1" \
-                sumologic_field.collection_field[\"${FIELD}\"] "${FIELD_ID}"
+                sumologic_field.collection_field[\""${FIELD}"\"] "${FIELD_ID}"
         done
     else
         readonly CREATE_FIELDS=0
@@ -503,7 +493,7 @@ data:
     if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
         jq -r '.resource[] | to_entries[] | "\(.key) \(.value.name)"' sources.tf.json | while read -r resource_name source_name; do
             terraform import "sumologic_http_source.${resource_name}" "${SUMOLOGIC_COLLECTOR_NAME}/${source_name}"
-        done
+        done || true
     fi
 
     # Kubernetes Secret
@@ -516,7 +506,7 @@ data:
         || { echo "Error during applying Terraform changes"; exit 1; }
 
     # Setup Sumo Logic monitors if enabled
-    if [ "${SUMOLOGIC_MONITORS_ENABLED}" = "true" ]; then
+    if [[ "${SUMOLOGIC_MONITORS_ENABLED:?}" = "true" ]]; then
         bash /etc/terraform/monitors.sh
     else
         echo "Installation of the Sumo Logic monitors is disabled."
@@ -525,7 +515,7 @@ data:
     fi
 
     # Setup Sumo Logic dashboards if enabled
-    if [ "${SUMOLOGIC_DASHBOARDS_ENABLED}" = "true" ]; then
+    if [[ "${SUMOLOGIC_DASHBOARDS_ENABLED:?}" = "true" ]]; then
         bash /etc/terraform/dashboards.sh
     else
         echo "Installation of the Sumo Logic dashboards is disabled."
@@ -539,6 +529,50 @@ data:
     export SUMOLOGIC_ACCESSID=
 
     bash /etc/terraform/custom.sh
+  variables.tf: |
+    variable "collector_name" {
+      type  = string
+    }
+
+    variable "namespace_name" {
+      type  = string
+    }
+
+    variable "secret_name" {
+      type = string
+    }
+
+    variable "create_fields" {
+      description = "If set, Terraform will attempt to create fields at Sumo Logic"
+      type        = bool
+      default     = true
+    }
+
+    variable "fields" {
+      description = "Log fields to create."
+      type = list(string)
+    }
+
+    variable "collector_fields" {
+      description = "Fields to set on the collector."
+      type = map(string)
+    }
+
+    variable "chart_version" {
+      description = "The Helm Chart version."
+      type = string
+    }
+  providers.tf.json: |
+    {
+      "provider": {
+        "kubernetes": {
+          "cluster_ca_certificate": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt\")}",
+          "host": "https://kubernetes.default.svc",
+          "token": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/token\")}"
+        },
+        "sumologic": {}
+      }
+    }
   sources.tf.json: |
     {
       "locals": {
@@ -752,37 +786,4 @@ data:
         "addfield1",
         "addfield2"
       ]
-    }
-  variables.tf: |
-    variable "collector_name" {
-      type  = string
-    }
-
-    variable "namespace_name" {
-      type  = string
-    }
-
-    variable "secret_name" {
-      type = string
-    }
-
-    variable "create_fields" {
-      description = "If set, Terraform will attempt to create fields at Sumo Logic"
-      type        = bool
-      default     = true
-    }
-
-    variable "fields" {
-      description = "Log fields to create."
-      type = list(string)
-    }
-
-    variable "collector_fields" {
-      description = "Fields to set on the collector."
-      type = map(string)
-    }
-
-    variable "chart_version" {
-      description = "The Helm Chart version."
-      type = string
     }

--- a/tests/helm/testdata/goldenfile/terraform/monitors_with_email_notifications.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/monitors_with_email_notifications.output.yaml
@@ -250,23 +250,24 @@ data:
     INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
 
-    if [ "${SUMOLOGIC_MONITORS_STATUS}" = "enabled" ]; then
+    if [[ "${SUMOLOGIC_MONITORS_STATUS:?}" = "enabled" ]]; then
       MONITORS_DISABLED="false"
     else
       MONITORS_DISABLED="true"
     fi
 
-    MONITORS_ROOT_ID="$(curl -XGET -s \
+    MONITORS_CURL_RESPONSE=$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/root)
+    MONITORS_ROOT_ID="$(echo "${MONITORS_CURL_RESPONSE}" | jq -r '.id' )"
     readonly MONITORS_ROOT_ID
 
     # verify if the integrations folder already exists
-    INTEGRATIONS_RESPONSE="$(curl -XGET -s -G \
+    INTEGRATIONS_CURL_RESPONSE=$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
-            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}" | \
-            jq '.[]' )"
+            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}")
+    INTEGRATIONS_RESPONSE="$(echo "${INTEGRATIONS_CURL_RESPONSE}" | jq '.[]' )"
     readonly INTEGRATIONS_RESPONSE
 
     INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
@@ -274,20 +275,20 @@ data:
 
     # and create it if necessary
     if [[ -z "${INTEGRATIONS_FOLDER_ID}" ]]; then
-      INTEGRATIONS_FOLDER_ID="$(curl -XPOST -s \
+      INTEGRATIONS_FOLDER_CURL_RESPONSE=$(curl -XPOST -s \
                   -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
                   -H "Content-Type: application/json" \
                   -d "{\"name\":\"${INTEGRATIONS_FOLDER_NAME}\",\"type\":\"MonitorsLibraryFolder\",\"description\":\"Monitors provided by the Sumo Logic integrations.\"}" \
-                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}" | \
-                  jq -r " .id" )"
+                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}")
+      INTEGRATIONS_FOLDER_ID="$(echo "${INTEGRATIONS_FOLDER_CURL_RESPONSE}" | jq -r " .id" )"
     fi
 
     # verify if the k8s monitors folder already exists
-    MONITORS_RESPONSE="$(curl -XGET -s -G \
+    MONITORS_CURL_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
-            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}" | \
-            jq '.[]' )"
+            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}")"
+    MONITORS_RESPONSE="$(echo "${MONITORS_CURL_RESPONSE}" | jq '.[]' )"
     readonly MONITORS_RESPONSE
 
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \
@@ -319,7 +320,7 @@ data:
         -var="monitors_disabled=${MONITORS_DISABLED}"
       )
 
-      if [ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]; then
+      if [[ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]]; then
         NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{TriggerType}} on {{Name}}\",message_body=\"Triggered {{TriggerType}} alert on {{Name}}: {{QueryURL}}\""
         NOTIFICATIONS_SETTINGS="recipients=${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
         TERRAFORM_ARGS+=(
@@ -336,17 +337,6 @@ data:
       echo "You can (re)install them manually with:"
       echo "https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor/tree/main/monitor_packages/kubernetes"
     fi
-  providers.tf.json: |
-    {
-      "provider": {
-        "kubernetes": {
-          "cluster_ca_certificate": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt\")}",
-          "host": "https://kubernetes.default.svc",
-          "token": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/token\")}"
-        },
-        "sumologic": {}
-      }
-    }
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
@@ -465,7 +455,7 @@ data:
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
 
-    declare -ra FIELDS=($(jq -r '.fields[]' terraform.tfvars.json))
+    declare -ra FIELDS=("$(jq -r '.fields[]' terraform.tfvars.json)")
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file
@@ -489,7 +479,7 @@ data:
 
             terraform import \
                 -var="create_fields=1" \
-                sumologic_field.collection_field[\"${FIELD}\"] "${FIELD_ID}"
+                sumologic_field.collection_field[\""${FIELD}"\"] "${FIELD_ID}"
         done
     else
         readonly CREATE_FIELDS=0
@@ -503,7 +493,7 @@ data:
     if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
         jq -r '.resource[] | to_entries[] | "\(.key) \(.value.name)"' sources.tf.json | while read -r resource_name source_name; do
             terraform import "sumologic_http_source.${resource_name}" "${SUMOLOGIC_COLLECTOR_NAME}/${source_name}"
-        done
+        done || true
     fi
 
     # Kubernetes Secret
@@ -516,7 +506,7 @@ data:
         || { echo "Error during applying Terraform changes"; exit 1; }
 
     # Setup Sumo Logic monitors if enabled
-    if [ "${SUMOLOGIC_MONITORS_ENABLED}" = "true" ]; then
+    if [[ "${SUMOLOGIC_MONITORS_ENABLED:?}" = "true" ]]; then
         bash /etc/terraform/monitors.sh
     else
         echo "Installation of the Sumo Logic monitors is disabled."
@@ -525,7 +515,7 @@ data:
     fi
 
     # Setup Sumo Logic dashboards if enabled
-    if [ "${SUMOLOGIC_DASHBOARDS_ENABLED}" = "true" ]; then
+    if [[ "${SUMOLOGIC_DASHBOARDS_ENABLED:?}" = "true" ]]; then
         bash /etc/terraform/dashboards.sh
     else
         echo "Installation of the Sumo Logic dashboards is disabled."
@@ -539,6 +529,50 @@ data:
     export SUMOLOGIC_ACCESSID=
 
     bash /etc/terraform/custom.sh
+  variables.tf: |
+    variable "collector_name" {
+      type  = string
+    }
+
+    variable "namespace_name" {
+      type  = string
+    }
+
+    variable "secret_name" {
+      type = string
+    }
+
+    variable "create_fields" {
+      description = "If set, Terraform will attempt to create fields at Sumo Logic"
+      type        = bool
+      default     = true
+    }
+
+    variable "fields" {
+      description = "Log fields to create."
+      type = list(string)
+    }
+
+    variable "collector_fields" {
+      description = "Fields to set on the collector."
+      type = map(string)
+    }
+
+    variable "chart_version" {
+      description = "The Helm Chart version."
+      type = string
+    }
+  providers.tf.json: |
+    {
+      "provider": {
+        "kubernetes": {
+          "cluster_ca_certificate": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt\")}",
+          "host": "https://kubernetes.default.svc",
+          "token": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/token\")}"
+        },
+        "sumologic": {}
+      }
+    }
   sources.tf.json: |
     {
       "locals": {
@@ -750,37 +784,4 @@ data:
         "service",
         "statefulset"
       ]
-    }
-  variables.tf: |
-    variable "collector_name" {
-      type  = string
-    }
-
-    variable "namespace_name" {
-      type  = string
-    }
-
-    variable "secret_name" {
-      type = string
-    }
-
-    variable "create_fields" {
-      description = "If set, Terraform will attempt to create fields at Sumo Logic"
-      type        = bool
-      default     = true
-    }
-
-    variable "fields" {
-      description = "Log fields to create."
-      type = list(string)
-    }
-
-    variable "collector_fields" {
-      description = "Fields to set on the collector."
-      type = map(string)
-    }
-
-    variable "chart_version" {
-      description = "The Helm Chart version."
-      type = string
     }

--- a/tests/helm/testdata/goldenfile/terraform/monitors_with_single_email.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/monitors_with_single_email.output.yaml
@@ -250,23 +250,24 @@ data:
     INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
 
-    if [ "${SUMOLOGIC_MONITORS_STATUS}" = "enabled" ]; then
+    if [[ "${SUMOLOGIC_MONITORS_STATUS:?}" = "enabled" ]]; then
       MONITORS_DISABLED="false"
     else
       MONITORS_DISABLED="true"
     fi
 
-    MONITORS_ROOT_ID="$(curl -XGET -s \
+    MONITORS_CURL_RESPONSE=$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/root)
+    MONITORS_ROOT_ID="$(echo "${MONITORS_CURL_RESPONSE}" | jq -r '.id' )"
     readonly MONITORS_ROOT_ID
 
     # verify if the integrations folder already exists
-    INTEGRATIONS_RESPONSE="$(curl -XGET -s -G \
+    INTEGRATIONS_CURL_RESPONSE=$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
-            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}" | \
-            jq '.[]' )"
+            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}")
+    INTEGRATIONS_RESPONSE="$(echo "${INTEGRATIONS_CURL_RESPONSE}" | jq '.[]' )"
     readonly INTEGRATIONS_RESPONSE
 
     INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
@@ -274,20 +275,20 @@ data:
 
     # and create it if necessary
     if [[ -z "${INTEGRATIONS_FOLDER_ID}" ]]; then
-      INTEGRATIONS_FOLDER_ID="$(curl -XPOST -s \
+      INTEGRATIONS_FOLDER_CURL_RESPONSE=$(curl -XPOST -s \
                   -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
                   -H "Content-Type: application/json" \
                   -d "{\"name\":\"${INTEGRATIONS_FOLDER_NAME}\",\"type\":\"MonitorsLibraryFolder\",\"description\":\"Monitors provided by the Sumo Logic integrations.\"}" \
-                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}" | \
-                  jq -r " .id" )"
+                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}")
+      INTEGRATIONS_FOLDER_ID="$(echo "${INTEGRATIONS_FOLDER_CURL_RESPONSE}" | jq -r " .id" )"
     fi
 
     # verify if the k8s monitors folder already exists
-    MONITORS_RESPONSE="$(curl -XGET -s -G \
+    MONITORS_CURL_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
-            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}" | \
-            jq '.[]' )"
+            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}")"
+    MONITORS_RESPONSE="$(echo "${MONITORS_CURL_RESPONSE}" | jq '.[]' )"
     readonly MONITORS_RESPONSE
 
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \
@@ -319,7 +320,7 @@ data:
         -var="monitors_disabled=${MONITORS_DISABLED}"
       )
 
-      if [ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]; then
+      if [[ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]]; then
         NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{TriggerType}} on {{Name}}\",message_body=\"Triggered {{TriggerType}} alert on {{Name}}: {{QueryURL}}\""
         NOTIFICATIONS_SETTINGS="recipients=${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
         TERRAFORM_ARGS+=(
@@ -336,17 +337,6 @@ data:
       echo "You can (re)install them manually with:"
       echo "https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor/tree/main/monitor_packages/kubernetes"
     fi
-  providers.tf.json: |
-    {
-      "provider": {
-        "kubernetes": {
-          "cluster_ca_certificate": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt\")}",
-          "host": "https://kubernetes.default.svc",
-          "token": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/token\")}"
-        },
-        "sumologic": {}
-      }
-    }
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
@@ -465,7 +455,7 @@ data:
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
 
-    declare -ra FIELDS=($(jq -r '.fields[]' terraform.tfvars.json))
+    declare -ra FIELDS=("$(jq -r '.fields[]' terraform.tfvars.json)")
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file
@@ -489,7 +479,7 @@ data:
 
             terraform import \
                 -var="create_fields=1" \
-                sumologic_field.collection_field[\"${FIELD}\"] "${FIELD_ID}"
+                sumologic_field.collection_field[\""${FIELD}"\"] "${FIELD_ID}"
         done
     else
         readonly CREATE_FIELDS=0
@@ -503,7 +493,7 @@ data:
     if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
         jq -r '.resource[] | to_entries[] | "\(.key) \(.value.name)"' sources.tf.json | while read -r resource_name source_name; do
             terraform import "sumologic_http_source.${resource_name}" "${SUMOLOGIC_COLLECTOR_NAME}/${source_name}"
-        done
+        done || true
     fi
 
     # Kubernetes Secret
@@ -516,7 +506,7 @@ data:
         || { echo "Error during applying Terraform changes"; exit 1; }
 
     # Setup Sumo Logic monitors if enabled
-    if [ "${SUMOLOGIC_MONITORS_ENABLED}" = "true" ]; then
+    if [[ "${SUMOLOGIC_MONITORS_ENABLED:?}" = "true" ]]; then
         bash /etc/terraform/monitors.sh
     else
         echo "Installation of the Sumo Logic monitors is disabled."
@@ -525,7 +515,7 @@ data:
     fi
 
     # Setup Sumo Logic dashboards if enabled
-    if [ "${SUMOLOGIC_DASHBOARDS_ENABLED}" = "true" ]; then
+    if [[ "${SUMOLOGIC_DASHBOARDS_ENABLED:?}" = "true" ]]; then
         bash /etc/terraform/dashboards.sh
     else
         echo "Installation of the Sumo Logic dashboards is disabled."
@@ -539,6 +529,50 @@ data:
     export SUMOLOGIC_ACCESSID=
 
     bash /etc/terraform/custom.sh
+  variables.tf: |
+    variable "collector_name" {
+      type  = string
+    }
+
+    variable "namespace_name" {
+      type  = string
+    }
+
+    variable "secret_name" {
+      type = string
+    }
+
+    variable "create_fields" {
+      description = "If set, Terraform will attempt to create fields at Sumo Logic"
+      type        = bool
+      default     = true
+    }
+
+    variable "fields" {
+      description = "Log fields to create."
+      type = list(string)
+    }
+
+    variable "collector_fields" {
+      description = "Fields to set on the collector."
+      type = map(string)
+    }
+
+    variable "chart_version" {
+      description = "The Helm Chart version."
+      type = string
+    }
+  providers.tf.json: |
+    {
+      "provider": {
+        "kubernetes": {
+          "cluster_ca_certificate": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt\")}",
+          "host": "https://kubernetes.default.svc",
+          "token": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/token\")}"
+        },
+        "sumologic": {}
+      }
+    }
   sources.tf.json: |
     {
       "locals": {
@@ -750,37 +784,4 @@ data:
         "service",
         "statefulset"
       ]
-    }
-  variables.tf: |
-    variable "collector_name" {
-      type  = string
-    }
-
-    variable "namespace_name" {
-      type  = string
-    }
-
-    variable "secret_name" {
-      type = string
-    }
-
-    variable "create_fields" {
-      description = "If set, Terraform will attempt to create fields at Sumo Logic"
-      type        = bool
-      default     = true
-    }
-
-    variable "fields" {
-      description = "Log fields to create."
-      type = list(string)
-    }
-
-    variable "collector_fields" {
-      description = "Fields to set on the collector."
-      type = map(string)
-    }
-
-    variable "chart_version" {
-      description = "The Helm Chart version."
-      type = string
     }

--- a/tests/helm/testdata/goldenfile/terraform/strip_extrapolation.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/strip_extrapolation.output.yaml
@@ -250,23 +250,24 @@ data:
     INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
 
-    if [ "${SUMOLOGIC_MONITORS_STATUS}" = "enabled" ]; then
+    if [[ "${SUMOLOGIC_MONITORS_STATUS:?}" = "enabled" ]]; then
       MONITORS_DISABLED="false"
     else
       MONITORS_DISABLED="true"
     fi
 
-    MONITORS_ROOT_ID="$(curl -XGET -s \
+    MONITORS_CURL_RESPONSE=$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/root)
+    MONITORS_ROOT_ID="$(echo "${MONITORS_CURL_RESPONSE}" | jq -r '.id' )"
     readonly MONITORS_ROOT_ID
 
     # verify if the integrations folder already exists
-    INTEGRATIONS_RESPONSE="$(curl -XGET -s -G \
+    INTEGRATIONS_CURL_RESPONSE=$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
-            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}" | \
-            jq '.[]' )"
+            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}")
+    INTEGRATIONS_RESPONSE="$(echo "${INTEGRATIONS_CURL_RESPONSE}" | jq '.[]' )"
     readonly INTEGRATIONS_RESPONSE
 
     INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
@@ -274,20 +275,20 @@ data:
 
     # and create it if necessary
     if [[ -z "${INTEGRATIONS_FOLDER_ID}" ]]; then
-      INTEGRATIONS_FOLDER_ID="$(curl -XPOST -s \
+      INTEGRATIONS_FOLDER_CURL_RESPONSE=$(curl -XPOST -s \
                   -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
                   -H "Content-Type: application/json" \
                   -d "{\"name\":\"${INTEGRATIONS_FOLDER_NAME}\",\"type\":\"MonitorsLibraryFolder\",\"description\":\"Monitors provided by the Sumo Logic integrations.\"}" \
-                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}" | \
-                  jq -r " .id" )"
+                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}")
+      INTEGRATIONS_FOLDER_ID="$(echo "${INTEGRATIONS_FOLDER_CURL_RESPONSE}" | jq -r " .id" )"
     fi
 
     # verify if the k8s monitors folder already exists
-    MONITORS_RESPONSE="$(curl -XGET -s -G \
+    MONITORS_CURL_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
-            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}" | \
-            jq '.[]' )"
+            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}")"
+    MONITORS_RESPONSE="$(echo "${MONITORS_CURL_RESPONSE}" | jq '.[]' )"
     readonly MONITORS_RESPONSE
 
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \
@@ -319,7 +320,7 @@ data:
         -var="monitors_disabled=${MONITORS_DISABLED}"
       )
 
-      if [ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]; then
+      if [[ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]]; then
         NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{TriggerType}} on {{Name}}\",message_body=\"Triggered {{TriggerType}} alert on {{Name}}: {{QueryURL}}\""
         NOTIFICATIONS_SETTINGS="recipients=${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
         TERRAFORM_ARGS+=(
@@ -336,18 +337,6 @@ data:
       echo "You can (re)install them manually with:"
       echo "https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor/tree/main/monitor_packages/kubernetes"
     fi
-  providers.tf.json: |
-    {
-      "provider": {
-        "kubernetes": {
-          "cluster_ca_certificate": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt\")}",
-          "extrapolation": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/token\")}/${test}",
-          "host": "https://kubernetes.default.svc",
-          "token": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/token\")}"
-        },
-        "sumologic": {}
-      }
-    }
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
@@ -466,7 +455,7 @@ data:
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
 
-    declare -ra FIELDS=($(jq -r '.fields[]' terraform.tfvars.json))
+    declare -ra FIELDS=("$(jq -r '.fields[]' terraform.tfvars.json)")
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file
@@ -490,7 +479,7 @@ data:
 
             terraform import \
                 -var="create_fields=1" \
-                sumologic_field.collection_field[\"${FIELD}\"] "${FIELD_ID}"
+                sumologic_field.collection_field[\""${FIELD}"\"] "${FIELD_ID}"
         done
     else
         readonly CREATE_FIELDS=0
@@ -504,7 +493,7 @@ data:
     if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
         jq -r '.resource[] | to_entries[] | "\(.key) \(.value.name)"' sources.tf.json | while read -r resource_name source_name; do
             terraform import "sumologic_http_source.${resource_name}" "${SUMOLOGIC_COLLECTOR_NAME}/${source_name}"
-        done
+        done || true
     fi
 
     # Kubernetes Secret
@@ -517,7 +506,7 @@ data:
         || { echo "Error during applying Terraform changes"; exit 1; }
 
     # Setup Sumo Logic monitors if enabled
-    if [ "${SUMOLOGIC_MONITORS_ENABLED}" = "true" ]; then
+    if [[ "${SUMOLOGIC_MONITORS_ENABLED:?}" = "true" ]]; then
         bash /etc/terraform/monitors.sh
     else
         echo "Installation of the Sumo Logic monitors is disabled."
@@ -526,7 +515,7 @@ data:
     fi
 
     # Setup Sumo Logic dashboards if enabled
-    if [ "${SUMOLOGIC_DASHBOARDS_ENABLED}" = "true" ]; then
+    if [[ "${SUMOLOGIC_DASHBOARDS_ENABLED:?}" = "true" ]]; then
         bash /etc/terraform/dashboards.sh
     else
         echo "Installation of the Sumo Logic dashboards is disabled."
@@ -540,6 +529,51 @@ data:
     export SUMOLOGIC_ACCESSID=
 
     bash /etc/terraform/custom.sh
+  variables.tf: |
+    variable "collector_name" {
+      type  = string
+    }
+
+    variable "namespace_name" {
+      type  = string
+    }
+
+    variable "secret_name" {
+      type = string
+    }
+
+    variable "create_fields" {
+      description = "If set, Terraform will attempt to create fields at Sumo Logic"
+      type        = bool
+      default     = true
+    }
+
+    variable "fields" {
+      description = "Log fields to create."
+      type = list(string)
+    }
+
+    variable "collector_fields" {
+      description = "Fields to set on the collector."
+      type = map(string)
+    }
+
+    variable "chart_version" {
+      description = "The Helm Chart version."
+      type = string
+    }
+  providers.tf.json: |
+    {
+      "provider": {
+        "kubernetes": {
+          "cluster_ca_certificate": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt\")}",
+          "extrapolation": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/token\")}/${test}",
+          "host": "https://kubernetes.default.svc",
+          "token": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/token\")}"
+        },
+        "sumologic": {}
+      }
+    }
   sources.tf.json: |
     {
       "locals": {
@@ -751,37 +785,4 @@ data:
         "service",
         "statefulset"
       ]
-    }
-  variables.tf: |
-    variable "collector_name" {
-      type  = string
-    }
-
-    variable "namespace_name" {
-      type  = string
-    }
-
-    variable "secret_name" {
-      type = string
-    }
-
-    variable "create_fields" {
-      description = "If set, Terraform will attempt to create fields at Sumo Logic"
-      type        = bool
-      default     = true
-    }
-
-    variable "fields" {
-      description = "Log fields to create."
-      type = list(string)
-    }
-
-    variable "collector_fields" {
-      description = "Fields to set on the collector."
-      type = map(string)
-    }
-
-    variable "chart_version" {
-      description = "The Helm Chart version."
-      type = string
     }

--- a/tests/helm/testdata/goldenfile/terraform/traces.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/traces.output.yaml
@@ -250,23 +250,24 @@ data:
     INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
 
-    if [ "${SUMOLOGIC_MONITORS_STATUS}" = "enabled" ]; then
+    if [[ "${SUMOLOGIC_MONITORS_STATUS:?}" = "enabled" ]]; then
       MONITORS_DISABLED="false"
     else
       MONITORS_DISABLED="true"
     fi
 
-    MONITORS_ROOT_ID="$(curl -XGET -s \
+    MONITORS_CURL_RESPONSE=$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/root)
+    MONITORS_ROOT_ID="$(echo "${MONITORS_CURL_RESPONSE}" | jq -r '.id' )"
     readonly MONITORS_ROOT_ID
 
     # verify if the integrations folder already exists
-    INTEGRATIONS_RESPONSE="$(curl -XGET -s -G \
+    INTEGRATIONS_CURL_RESPONSE=$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
-            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}" | \
-            jq '.[]' )"
+            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}")
+    INTEGRATIONS_RESPONSE="$(echo "${INTEGRATIONS_CURL_RESPONSE}" | jq '.[]' )"
     readonly INTEGRATIONS_RESPONSE
 
     INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
@@ -274,20 +275,20 @@ data:
 
     # and create it if necessary
     if [[ -z "${INTEGRATIONS_FOLDER_ID}" ]]; then
-      INTEGRATIONS_FOLDER_ID="$(curl -XPOST -s \
+      INTEGRATIONS_FOLDER_CURL_RESPONSE=$(curl -XPOST -s \
                   -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
                   -H "Content-Type: application/json" \
                   -d "{\"name\":\"${INTEGRATIONS_FOLDER_NAME}\",\"type\":\"MonitorsLibraryFolder\",\"description\":\"Monitors provided by the Sumo Logic integrations.\"}" \
-                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}" | \
-                  jq -r " .id" )"
+                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}")
+      INTEGRATIONS_FOLDER_ID="$(echo "${INTEGRATIONS_FOLDER_CURL_RESPONSE}" | jq -r " .id" )"
     fi
 
     # verify if the k8s monitors folder already exists
-    MONITORS_RESPONSE="$(curl -XGET -s -G \
+    MONITORS_CURL_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
-            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}" | \
-            jq '.[]' )"
+            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}")"
+    MONITORS_RESPONSE="$(echo "${MONITORS_CURL_RESPONSE}" | jq '.[]' )"
     readonly MONITORS_RESPONSE
 
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \
@@ -319,7 +320,7 @@ data:
         -var="monitors_disabled=${MONITORS_DISABLED}"
       )
 
-      if [ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]; then
+      if [[ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]]; then
         NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{TriggerType}} on {{Name}}\",message_body=\"Triggered {{TriggerType}} alert on {{Name}}: {{QueryURL}}\""
         NOTIFICATIONS_SETTINGS="recipients=${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
         TERRAFORM_ARGS+=(
@@ -336,17 +337,6 @@ data:
       echo "You can (re)install them manually with:"
       echo "https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor/tree/main/monitor_packages/kubernetes"
     fi
-  providers.tf.json: |
-    {
-      "provider": {
-        "kubernetes": {
-          "cluster_ca_certificate": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt\")}",
-          "host": "https://kubernetes.default.svc",
-          "token": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/token\")}"
-        },
-        "sumologic": {}
-      }
-    }
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
@@ -465,7 +455,7 @@ data:
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
 
-    declare -ra FIELDS=($(jq -r '.fields[]' terraform.tfvars.json))
+    declare -ra FIELDS=("$(jq -r '.fields[]' terraform.tfvars.json)")
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file
@@ -489,7 +479,7 @@ data:
 
             terraform import \
                 -var="create_fields=1" \
-                sumologic_field.collection_field[\"${FIELD}\"] "${FIELD_ID}"
+                sumologic_field.collection_field[\""${FIELD}"\"] "${FIELD_ID}"
         done
     else
         readonly CREATE_FIELDS=0
@@ -503,7 +493,7 @@ data:
     if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
         jq -r '.resource[] | to_entries[] | "\(.key) \(.value.name)"' sources.tf.json | while read -r resource_name source_name; do
             terraform import "sumologic_http_source.${resource_name}" "${SUMOLOGIC_COLLECTOR_NAME}/${source_name}"
-        done
+        done || true
     fi
 
     # Kubernetes Secret
@@ -516,7 +506,7 @@ data:
         || { echo "Error during applying Terraform changes"; exit 1; }
 
     # Setup Sumo Logic monitors if enabled
-    if [ "${SUMOLOGIC_MONITORS_ENABLED}" = "true" ]; then
+    if [[ "${SUMOLOGIC_MONITORS_ENABLED:?}" = "true" ]]; then
         bash /etc/terraform/monitors.sh
     else
         echo "Installation of the Sumo Logic monitors is disabled."
@@ -525,7 +515,7 @@ data:
     fi
 
     # Setup Sumo Logic dashboards if enabled
-    if [ "${SUMOLOGIC_DASHBOARDS_ENABLED}" = "true" ]; then
+    if [[ "${SUMOLOGIC_DASHBOARDS_ENABLED:?}" = "true" ]]; then
         bash /etc/terraform/dashboards.sh
     else
         echo "Installation of the Sumo Logic dashboards is disabled."
@@ -539,6 +529,50 @@ data:
     export SUMOLOGIC_ACCESSID=
 
     bash /etc/terraform/custom.sh
+  variables.tf: |
+    variable "collector_name" {
+      type  = string
+    }
+
+    variable "namespace_name" {
+      type  = string
+    }
+
+    variable "secret_name" {
+      type = string
+    }
+
+    variable "create_fields" {
+      description = "If set, Terraform will attempt to create fields at Sumo Logic"
+      type        = bool
+      default     = true
+    }
+
+    variable "fields" {
+      description = "Log fields to create."
+      type = list(string)
+    }
+
+    variable "collector_fields" {
+      description = "Fields to set on the collector."
+      type = map(string)
+    }
+
+    variable "chart_version" {
+      description = "The Helm Chart version."
+      type = string
+    }
+  providers.tf.json: |
+    {
+      "provider": {
+        "kubernetes": {
+          "cluster_ca_certificate": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt\")}",
+          "host": "https://kubernetes.default.svc",
+          "token": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/token\")}"
+        },
+        "sumologic": {}
+      }
+    }
   sources.tf.json: |
     {
       "locals": {
@@ -602,37 +636,4 @@ data:
         "service",
         "statefulset"
       ]
-    }
-  variables.tf: |
-    variable "collector_name" {
-      type  = string
-    }
-
-    variable "namespace_name" {
-      type  = string
-    }
-
-    variable "secret_name" {
-      type = string
-    }
-
-    variable "create_fields" {
-      description = "If set, Terraform will attempt to create fields at Sumo Logic"
-      type        = bool
-      default     = true
-    }
-
-    variable "fields" {
-      description = "Log fields to create."
-      type = list(string)
-    }
-
-    variable "collector_fields" {
-      description = "Fields to set on the collector."
-      type = map(string)
-    }
-
-    variable "chart_version" {
-      description = "The Helm Chart version."
-      type = string
     }

--- a/tests/helm/testdata/goldenfile/terraform/tracing-metrics-disabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/tracing-metrics-disabled.output.yaml
@@ -250,23 +250,24 @@ data:
     INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
     MONITORS_FOLDER_NAME="Kubernetes"
 
-    if [ "${SUMOLOGIC_MONITORS_STATUS}" = "enabled" ]; then
+    if [[ "${SUMOLOGIC_MONITORS_STATUS:?}" = "enabled" ]]; then
       MONITORS_DISABLED="false"
     else
       MONITORS_DISABLED="true"
     fi
 
-    MONITORS_ROOT_ID="$(curl -XGET -s \
+    MONITORS_CURL_RESPONSE=$(curl -XGET -s \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
-            "${SUMOLOGIC_BASE_URL}"v1/monitors/root | jq -r '.id' )"
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/root)
+    MONITORS_ROOT_ID="$(echo "${MONITORS_CURL_RESPONSE}" | jq -r '.id' )"
     readonly MONITORS_ROOT_ID
 
     # verify if the integrations folder already exists
-    INTEGRATIONS_RESPONSE="$(curl -XGET -s -G \
+    INTEGRATIONS_CURL_RESPONSE=$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
-            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}" | \
-            jq '.[]' )"
+            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}")
+    INTEGRATIONS_RESPONSE="$(echo "${INTEGRATIONS_CURL_RESPONSE}" | jq '.[]' )"
     readonly INTEGRATIONS_RESPONSE
 
     INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
@@ -274,20 +275,20 @@ data:
 
     # and create it if necessary
     if [[ -z "${INTEGRATIONS_FOLDER_ID}" ]]; then
-      INTEGRATIONS_FOLDER_ID="$(curl -XPOST -s \
+      INTEGRATIONS_FOLDER_CURL_RESPONSE=$(curl -XPOST -s \
                   -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
                   -H "Content-Type: application/json" \
                   -d "{\"name\":\"${INTEGRATIONS_FOLDER_NAME}\",\"type\":\"MonitorsLibraryFolder\",\"description\":\"Monitors provided by the Sumo Logic integrations.\"}" \
-                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}" | \
-                  jq -r " .id" )"
+                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}")
+      INTEGRATIONS_FOLDER_ID="$(echo "${INTEGRATIONS_FOLDER_CURL_RESPONSE}" | jq -r " .id" )"
     fi
 
     # verify if the k8s monitors folder already exists
-    MONITORS_RESPONSE="$(curl -XGET -s -G \
+    MONITORS_CURL_RESPONSE="$(curl -XGET -s -G \
             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
             "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
-            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}" | \
-            jq '.[]' )"
+            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}")"
+    MONITORS_RESPONSE="$(echo "${MONITORS_CURL_RESPONSE}" | jq '.[]' )"
     readonly MONITORS_RESPONSE
 
     MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \
@@ -319,7 +320,7 @@ data:
         -var="monitors_disabled=${MONITORS_DISABLED}"
       )
 
-      if [ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]; then
+      if [[ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]]; then
         NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{TriggerType}} on {{Name}}\",message_body=\"Triggered {{TriggerType}} alert on {{Name}}: {{QueryURL}}\""
         NOTIFICATIONS_SETTINGS="recipients=${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
         TERRAFORM_ARGS+=(
@@ -336,17 +337,6 @@ data:
       echo "You can (re)install them manually with:"
       echo "https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor/tree/main/monitor_packages/kubernetes"
     fi
-  providers.tf.json: |
-    {
-      "provider": {
-        "kubernetes": {
-          "cluster_ca_certificate": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt\")}",
-          "host": "https://kubernetes.default.svc",
-          "token": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/token\")}"
-        },
-        "sumologic": {}
-      }
-    }
   resources.tf: |
     resource "sumologic_collector" "collector" {
         name  = var.collector_name
@@ -465,7 +455,7 @@ data:
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
 
-    declare -ra FIELDS=($(jq -r '.fields[]' terraform.tfvars.json))
+    declare -ra FIELDS=("$(jq -r '.fields[]' terraform.tfvars.json)")
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file
@@ -489,7 +479,7 @@ data:
 
             terraform import \
                 -var="create_fields=1" \
-                sumologic_field.collection_field[\"${FIELD}\"] "${FIELD_ID}"
+                sumologic_field.collection_field[\""${FIELD}"\"] "${FIELD_ID}"
         done
     else
         readonly CREATE_FIELDS=0
@@ -503,7 +493,7 @@ data:
     if terraform import sumologic_collector.collector "${SUMOLOGIC_COLLECTOR_NAME}"; then
         jq -r '.resource[] | to_entries[] | "\(.key) \(.value.name)"' sources.tf.json | while read -r resource_name source_name; do
             terraform import "sumologic_http_source.${resource_name}" "${SUMOLOGIC_COLLECTOR_NAME}/${source_name}"
-        done
+        done || true
     fi
 
     # Kubernetes Secret
@@ -516,7 +506,7 @@ data:
         || { echo "Error during applying Terraform changes"; exit 1; }
 
     # Setup Sumo Logic monitors if enabled
-    if [ "${SUMOLOGIC_MONITORS_ENABLED}" = "true" ]; then
+    if [[ "${SUMOLOGIC_MONITORS_ENABLED:?}" = "true" ]]; then
         bash /etc/terraform/monitors.sh
     else
         echo "Installation of the Sumo Logic monitors is disabled."
@@ -525,7 +515,7 @@ data:
     fi
 
     # Setup Sumo Logic dashboards if enabled
-    if [ "${SUMOLOGIC_DASHBOARDS_ENABLED}" = "true" ]; then
+    if [[ "${SUMOLOGIC_DASHBOARDS_ENABLED:?}" = "true" ]]; then
         bash /etc/terraform/dashboards.sh
     else
         echo "Installation of the Sumo Logic dashboards is disabled."
@@ -539,6 +529,50 @@ data:
     export SUMOLOGIC_ACCESSID=
 
     bash /etc/terraform/custom.sh
+  variables.tf: |
+    variable "collector_name" {
+      type  = string
+    }
+
+    variable "namespace_name" {
+      type  = string
+    }
+
+    variable "secret_name" {
+      type = string
+    }
+
+    variable "create_fields" {
+      description = "If set, Terraform will attempt to create fields at Sumo Logic"
+      type        = bool
+      default     = true
+    }
+
+    variable "fields" {
+      description = "Log fields to create."
+      type = list(string)
+    }
+
+    variable "collector_fields" {
+      description = "Fields to set on the collector."
+      type = map(string)
+    }
+
+    variable "chart_version" {
+      description = "The Helm Chart version."
+      type = string
+    }
+  providers.tf.json: |
+    {
+      "provider": {
+        "kubernetes": {
+          "cluster_ca_certificate": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt\")}",
+          "host": "https://kubernetes.default.svc",
+          "token": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/token\")}"
+        },
+        "sumologic": {}
+      }
+    }
   sources.tf.json: |
     {
       "locals": {
@@ -750,37 +784,4 @@ data:
         "service",
         "statefulset"
       ]
-    }
-  variables.tf: |
-    variable "collector_name" {
-      type  = string
-    }
-
-    variable "namespace_name" {
-      type  = string
-    }
-
-    variable "secret_name" {
-      type = string
-    }
-
-    variable "create_fields" {
-      description = "If set, Terraform will attempt to create fields at Sumo Logic"
-      type        = bool
-      default     = true
-    }
-
-    variable "fields" {
-      description = "Log fields to create."
-      type = list(string)
-    }
-
-    variable "collector_fields" {
-      description = "Fields to set on the collector."
-      type = map(string)
-    }
-
-    variable "chart_version" {
-      description = "The Helm Chart version."
-      type = string
     }


### PR DESCRIPTION
After removing Helm templating from setup and cleanup scripts in #3769, we can run shellcheck on them directly. This PR also fixes all the warnings.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
