### PR TITLE
chore: disable auto-sync for repositories

### DIFF
--- a/.github/workflows/sync-repositories.yaml
+++ b/.github/workflows/sync-repositories.yaml
@@ -1,8 +1,6 @@
 name: Sync Repositories
 
 on:
-  schedule:
-    - cron: "0 0 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Disable auto sync, as we got some complains from docker team about it 

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [ ] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features
