### PR TITLE
fix(setup): importing log fields

### DIFF
--- a/deploy/helm/sumologic/conf/setup/setup.sh
+++ b/deploy/helm/sumologic/conf/setup/setup.sh
@@ -95,7 +95,8 @@ function should_create_fields() {
 cp /etc/terraform/* /terraform/
 cd /terraform || exit 1
 
-declare -ra FIELDS=("$(jq -r '.fields[]' terraform.tfvars.json)")
+FIELDS_STRING=$(jq -r '.fields[]' terraform.tfvars.json)
+mapfile -t FIELDS < <(echo "${FIELDS_STRING}")
 
 # Fall back to init -upgrade to prevent:
 # Error: Inconsistent dependency lock file

--- a/tests/helm/testdata/goldenfile/terraform/all_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/all_fields.output.yaml
@@ -455,7 +455,8 @@ data:
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
 
-    declare -ra FIELDS=("$(jq -r '.fields[]' terraform.tfvars.json)")
+    FIELDS_STRING=$(jq -r '.fields[]' terraform.tfvars.json)
+    mapfile -t FIELDS < <(echo "${FIELDS_STRING}")
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file

--- a/tests/helm/testdata/goldenfile/terraform/collector_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/collector_fields.output.yaml
@@ -455,7 +455,8 @@ data:
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
 
-    declare -ra FIELDS=("$(jq -r '.fields[]' terraform.tfvars.json)")
+    FIELDS_STRING=$(jq -r '.fields[]' terraform.tfvars.json)
+    mapfile -t FIELDS < <(echo "${FIELDS_STRING}")
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file

--- a/tests/helm/testdata/goldenfile/terraform/conditional_sources.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/conditional_sources.output.yaml
@@ -455,7 +455,8 @@ data:
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
 
-    declare -ra FIELDS=("$(jq -r '.fields[]' terraform.tfvars.json)")
+    FIELDS_STRING=$(jq -r '.fields[]' terraform.tfvars.json)
+    mapfile -t FIELDS < <(echo "${FIELDS_STRING}")
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file

--- a/tests/helm/testdata/goldenfile/terraform/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/custom.output.yaml
@@ -455,7 +455,8 @@ data:
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
 
-    declare -ra FIELDS=("$(jq -r '.fields[]' terraform.tfvars.json)")
+    FIELDS_STRING=$(jq -r '.fields[]' terraform.tfvars.json)
+    mapfile -t FIELDS < <(echo "${FIELDS_STRING}")
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file

--- a/tests/helm/testdata/goldenfile/terraform/default.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/default.output.yaml
@@ -455,7 +455,8 @@ data:
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
 
-    declare -ra FIELDS=("$(jq -r '.fields[]' terraform.tfvars.json)")
+    FIELDS_STRING=$(jq -r '.fields[]' terraform.tfvars.json)
+    mapfile -t FIELDS < <(echo "${FIELDS_STRING}")
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file

--- a/tests/helm/testdata/goldenfile/terraform/disable_default_metrics.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disable_default_metrics.output.yaml
@@ -455,7 +455,8 @@ data:
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
 
-    declare -ra FIELDS=("$(jq -r '.fields[]' terraform.tfvars.json)")
+    FIELDS_STRING=$(jq -r '.fields[]' terraform.tfvars.json)
+    mapfile -t FIELDS < <(echo "${FIELDS_STRING}")
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file

--- a/tests/helm/testdata/goldenfile/terraform/disabled_dashboards.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disabled_dashboards.output.yaml
@@ -455,7 +455,8 @@ data:
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
 
-    declare -ra FIELDS=("$(jq -r '.fields[]' terraform.tfvars.json)")
+    FIELDS_STRING=$(jq -r '.fields[]' terraform.tfvars.json)
+    mapfile -t FIELDS < <(echo "${FIELDS_STRING}")
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file

--- a/tests/helm/testdata/goldenfile/terraform/disabled_monitors.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disabled_monitors.output.yaml
@@ -455,7 +455,8 @@ data:
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
 
-    declare -ra FIELDS=("$(jq -r '.fields[]' terraform.tfvars.json)")
+    FIELDS_STRING=$(jq -r '.fields[]' terraform.tfvars.json)
+    mapfile -t FIELDS < <(echo "${FIELDS_STRING}")
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file

--- a/tests/helm/testdata/goldenfile/terraform/logs_fields.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/logs_fields.output.yaml
@@ -455,7 +455,8 @@ data:
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
 
-    declare -ra FIELDS=("$(jq -r '.fields[]' terraform.tfvars.json)")
+    FIELDS_STRING=$(jq -r '.fields[]' terraform.tfvars.json)
+    mapfile -t FIELDS < <(echo "${FIELDS_STRING}")
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file

--- a/tests/helm/testdata/goldenfile/terraform/monitors_with_email_notifications.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/monitors_with_email_notifications.output.yaml
@@ -455,7 +455,8 @@ data:
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
 
-    declare -ra FIELDS=("$(jq -r '.fields[]' terraform.tfvars.json)")
+    FIELDS_STRING=$(jq -r '.fields[]' terraform.tfvars.json)
+    mapfile -t FIELDS < <(echo "${FIELDS_STRING}")
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file

--- a/tests/helm/testdata/goldenfile/terraform/monitors_with_single_email.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/monitors_with_single_email.output.yaml
@@ -455,7 +455,8 @@ data:
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
 
-    declare -ra FIELDS=("$(jq -r '.fields[]' terraform.tfvars.json)")
+    FIELDS_STRING=$(jq -r '.fields[]' terraform.tfvars.json)
+    mapfile -t FIELDS < <(echo "${FIELDS_STRING}")
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file

--- a/tests/helm/testdata/goldenfile/terraform/strip_extrapolation.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/strip_extrapolation.output.yaml
@@ -455,7 +455,8 @@ data:
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
 
-    declare -ra FIELDS=("$(jq -r '.fields[]' terraform.tfvars.json)")
+    FIELDS_STRING=$(jq -r '.fields[]' terraform.tfvars.json)
+    mapfile -t FIELDS < <(echo "${FIELDS_STRING}")
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file

--- a/tests/helm/testdata/goldenfile/terraform/traces.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/traces.output.yaml
@@ -455,7 +455,8 @@ data:
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
 
-    declare -ra FIELDS=("$(jq -r '.fields[]' terraform.tfvars.json)")
+    FIELDS_STRING=$(jq -r '.fields[]' terraform.tfvars.json)
+    mapfile -t FIELDS < <(echo "${FIELDS_STRING}")
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file

--- a/tests/helm/testdata/goldenfile/terraform/tracing-metrics-disabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/tracing-metrics-disabled.output.yaml
@@ -455,7 +455,8 @@ data:
     cp /etc/terraform/* /terraform/
     cd /terraform || exit 1
 
-    declare -ra FIELDS=("$(jq -r '.fields[]' terraform.tfvars.json)")
+    FIELDS_STRING=$(jq -r '.fields[]' terraform.tfvars.json)
+    mapfile -t FIELDS < <(echo "${FIELDS_STRING}")
 
     # Fall back to init -upgrade to prevent:
     # Error: Inconsistent dependency lock file


### PR DESCRIPTION
Bash arrays are hard. #3770 introduced a bug where an array wasn't parsed correctly.

<!---
Describe your PR here
-->

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
