### PR TITLE
deps: upgrade opentelemetry-operator Chart to 0.56.1

### DIFF
--- a/.changelog/3777.changed.txt
+++ b/.changelog/3777.changed.txt
@@ -1,0 +1,1 @@
+deps: upgrade opentelemetry-operator Chart to 0.56.1

--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -33,7 +33,7 @@ dependencies:
     repository: https://sumologic.github.io/tailing-sidecar
     condition: tailing-sidecar-operator.enabled
   - name: opentelemetry-operator
-    version: 0.49.0
+    version: 0.56.1
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     condition: opentelemetry-operator.enabled,sumologic.metrics.collector.otelcol.enabled
   - name: prometheus-windows-exporter

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -2464,8 +2464,7 @@ opentelemetry-operator:
 
   ## Specific for OpenTelemetry Operator chart values
   admissionWebhooks:
-    failurePolicy: Fail
-    enabled: true
+    create: true
 
     ## skip admission webhook on our own OpenTelemetryCollector object to avoid having to wait for operator to start
     objectSelector:
@@ -2476,7 +2475,6 @@ opentelemetry-operator:
 
     certManager:
       enabled: false
-      issuerRef: {}
 
   manager:
     image:

--- a/docs/README.md
+++ b/docs/README.md
@@ -108,7 +108,7 @@ The following table displays the currently used software versions for our Helm c
 | Name                                      | Version |
 | ----------------------------------------- | ------- |
 | OpenTelemetry Collector                   | 0.102.1 |
-| OpenTelemetry Operator                    | 0.49.0  |
+| OpenTelemetry Operator                    | 0.56.1  |
 | kube-prometheus-stack/Prometheus Operator | 40.5.0  |
 | Falco                                     | 3.8.7   |
 | Metrics Server                            | 6.11.2  |


### PR DESCRIPTION
This is the last version before changes to CRD handling that will require changes on our end as well.

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
