### PR TITLE
fix: Better method to detect helm chart version in template tests

### DIFF
--- a/tests/helm/goldenfile_test.go
+++ b/tests/helm/goldenfile_test.go
@@ -133,8 +133,13 @@ func runGoldenFileTest(t *testing.T, valuesFileName string, outputFileName strin
 // expected templates
 func fixupRenderedYaml(yaml string, chartVersion string) string {
 	checksumRegex := regexp.MustCompile("checksum/config: [a-z0-9]{64}")
-	patternString := fmt.Sprintf(`(?m)^(\s*app\.kubernetes\.io\/version:\s*"%s"\s*)$|^(\s*chart:\s*"sumologic-%s"\s*)$|^(\s*chart:\s*sumologic-%s\s*)$|^(\s*client:\s*k8s_%s\s*)$|^(\s*value:\s*"%s"\s*)$`,
-	chartVersion, chartVersion, chartVersion, chartVersion, chartVersion)
+	patternString := fmt.Sprintf(
+		`(?m)^(\s*app\.kubernetes\.io\/version:\s*"%s"\s*)$`+
+			`|^(\s*chart:\s*"sumologic-%s"\s*)$`+
+			`|^(\s*chart:\s*sumologic-%s\s*)$`+
+			`|^(\s*client:\s*k8s_%s\s*)$`+
+			`|^(\s*value:\s*"%s"\s*)$`,
+		chartVersion, chartVersion, chartVersion, chartVersion, chartVersion)
 	pattern := regexp.MustCompile(patternString)
 	replacement := `%CURRENT_CHART_VERSION%`
 
@@ -145,7 +150,7 @@ func fixupRenderedYaml(yaml string, chartVersion string) string {
 		version := versionRegex.FindString(match)
 
 		return strings.Replace(match, version, replacement, 1)
-	})	
+	})
 	output = checksumRegex.ReplaceAllLiteralString(output, "checksum/config: '%CONFIG_CHECKSUM%'")
 	output = strings.TrimSuffix(output, "\n")
 	return output

--- a/tests/helm/goldenfile_test.go
+++ b/tests/helm/goldenfile_test.go
@@ -133,18 +133,24 @@ func runGoldenFileTest(t *testing.T, valuesFileName string, outputFileName strin
 // expected templates
 func fixupRenderedYaml(yaml string, chartVersion string) string {
 	checksumRegex := regexp.MustCompile("checksum/config: [a-z0-9]{64}")
-	replacements := map[string]string{
-		fmt.Sprintf("app.kubernetes.io/version: \"%s\"", chartVersion): "app.kubernetes.io/version: \"%CURRENT_CHART_VERSION%\"",
-		fmt.Sprintf("chart: \"sumologic-%s\"", chartVersion):           "chart: \"sumologic-%CURRENT_CHART_VERSION%\"",
-		fmt.Sprintf("chart: sumologic-%s", chartVersion):               "chart: sumologic-%CURRENT_CHART_VERSION%",
-		fmt.Sprintf("client: k8s_%s", chartVersion):                    "client: k8s_%CURRENT_CHART_VERSION%",
-		fmt.Sprintf("value: \"%s\"", chartVersion):                     "value: \"%CURRENT_CHART_VERSION%\"",
+	// replacements := map[string]string{
+	// 	fmt.Sprintf("app.kubernetes.io/version: \"%s\"", chartVersion): "app.kubernetes.io/version: \"%CURRENT_CHART_VERSION%\"",
+	// 	fmt.Sprintf("chart: \"sumologic-%s\"", chartVersion):           "chart: \"sumologic-%CURRENT_CHART_VERSION%\"",
+	// 	fmt.Sprintf("chart: sumologic-%s", chartVersion):               "chart: sumologic-%CURRENT_CHART_VERSION%",
+	// 	fmt.Sprintf("client: k8s_%s", chartVersion):                    "client: k8s_%CURRENT_CHART_VERSION%",
+	// 	fmt.Sprintf("value: \"%s\"", chartVersion):                     "value: \"%CURRENT_CHART_VERSION%\"",
+	// }
+	replacements := []string{
+		"app.kubernetes.io/version: \"%s\"",
+		"chart: \"sumologic-%s\"",
+		"chart: sumologic-%s",
+		"client: k8s_%s",
+		"value: \"%s\"",
 	}
-
 	output := yaml
 	output = strings.ReplaceAll(output, releaseName, "RELEASE-NAME")
-	for oldString, newString := range replacements {
-		output = strings.ReplaceAll(output, oldString, newString)
+	for _, r := range replacements {
+		output = strings.ReplaceAll(output, fmt.Sprintf(r, chartVersion), fmt.Sprintf(r, "%CURRENT_CHART_VERSION%"))
 	}
 	output = checksumRegex.ReplaceAllLiteralString(output, "checksum/config: '%CONFIG_CHECKSUM%'")
 	output = strings.TrimSuffix(output, "\n")

--- a/tests/helm/goldenfile_test.go
+++ b/tests/helm/goldenfile_test.go
@@ -1,6 +1,7 @@
 package helm
 
 import (
+	"fmt"
 	"os"
 	"regexp"
 	"strings"
@@ -132,10 +133,19 @@ func runGoldenFileTest(t *testing.T, valuesFileName string, outputFileName strin
 // expected templates
 func fixupRenderedYaml(yaml string, chartVersion string) string {
 	checksumRegex := regexp.MustCompile("checksum/config: [a-z0-9]{64}")
+	patternString := fmt.Sprintf(`(?m)^(\s*app\.kubernetes\.io\/version:\s*"%s"\s*)$|^(\s*chart:\s*"sumologic-%s"\s*)$|^(\s*chart:\s*sumologic-%s\s*)$|^(\s*client:\s*k8s_%s\s*)$|^(\s*value:\s*"%s"\s*)$`,
+	chartVersion, chartVersion, chartVersion, chartVersion, chartVersion)
+	pattern := regexp.MustCompile(patternString)
+	replacement := `%CURRENT_CHART_VERSION%`
 
 	output := yaml
 	output = strings.ReplaceAll(output, releaseName, "RELEASE-NAME")
-	output = strings.ReplaceAll(output, chartVersion, "%CURRENT_CHART_VERSION%")
+	output = pattern.ReplaceAllStringFunc(output, func(match string) string {
+		versionRegex := regexp.MustCompile(chartVersion)
+		version := versionRegex.FindString(match)
+
+		return strings.Replace(match, version, replacement, 1)
+	})	
 	output = checksumRegex.ReplaceAllLiteralString(output, "checksum/config: '%CONFIG_CHECKSUM%'")
 	output = strings.TrimSuffix(output, "\n")
 	return output

--- a/tests/helm/goldenfile_test.go
+++ b/tests/helm/goldenfile_test.go
@@ -133,19 +133,13 @@ func runGoldenFileTest(t *testing.T, valuesFileName string, outputFileName strin
 // expected templates
 func fixupRenderedYaml(yaml string, chartVersion string) string {
 	checksumRegex := regexp.MustCompile("checksum/config: [a-z0-9]{64}")
-	// replacements := map[string]string{
-	// 	fmt.Sprintf("app.kubernetes.io/version: \"%s\"", chartVersion): "app.kubernetes.io/version: \"%CURRENT_CHART_VERSION%\"",
-	// 	fmt.Sprintf("chart: \"sumologic-%s\"", chartVersion):           "chart: \"sumologic-%CURRENT_CHART_VERSION%\"",
-	// 	fmt.Sprintf("chart: sumologic-%s", chartVersion):               "chart: sumologic-%CURRENT_CHART_VERSION%",
-	// 	fmt.Sprintf("client: k8s_%s", chartVersion):                    "client: k8s_%CURRENT_CHART_VERSION%",
-	// 	fmt.Sprintf("value: \"%s\"", chartVersion):                     "value: \"%CURRENT_CHART_VERSION%\"",
-	// }
+
 	replacements := []string{
-		"app.kubernetes.io/version: \"%s\"",
+		"app.kubernetes.io/version: %q",
 		"chart: \"sumologic-%s\"",
 		"chart: sumologic-%s",
 		"client: k8s_%s",
-		"value: \"%s\"",
+		"value: %q",
 	}
 	output := yaml
 	output = strings.ReplaceAll(output, releaseName, "RELEASE-NAME")


### PR DESCRIPTION
This change finds a new method using regex for updating the helm chart version without affecting any other version that matches it
Find the [Ticket](https://sumologic.atlassian.net/browse/OSC-665)

### Checklist
- [X] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features
