### PR TITLE
fix: join multiparts on file beginning

### DIFF
--- a/.changelog/3784.fixed.txt
+++ b/.changelog/3784.fixed.txt
@@ -1,0 +1,1 @@
+fix: join multiparts on file beginning

--- a/deploy/helm/sumologic/conf/logs/collector/common/filelog_receiver.yaml
+++ b/deploy/helm/sumologic/conf/logs/collector/common/filelog_receiver.yaml
@@ -99,7 +99,8 @@ filelog/containers:
       output: strip-trailing-newline
       source_identifier: attributes["log.file.path"]
       type: recombine
-      max_unmatched_batch_size: 1
+      ## Ensure we are combine everything up to `is_last_entry` even on the file beginning
+      max_unmatched_batch_size: 0
 
     ## merge-cri-lines stitches back together log lines split by CRI logging drivers.
     ## Input Body (JSON): { "log": "2001-02-03 04:05:06 very long li", "logtag": "P" }
@@ -113,7 +114,8 @@ filelog/containers:
       overwrite_with: newest
       source_identifier: attributes["log.file.path"]
       type: recombine
-      max_unmatched_batch_size: 1
+      ## Ensure we are combine everything up to `is_last_entry` even on the file beginning
+      max_unmatched_batch_size: 0
 
     ## strip-trailing-newline removes the trailing "\n" from the `log` key. This is required for logs coming from Docker container runtime.
     ## Input Body (JSON): { "log": "2001-02-03 04:05:06 very long line that was split by the logging driver\n", "stream": "stdout" }

--- a/deploy/helm/sumologic/conf/logs/collector/common/filelog_receiver.yaml
+++ b/deploy/helm/sumologic/conf/logs/collector/common/filelog_receiver.yaml
@@ -99,7 +99,7 @@ filelog/containers:
       output: strip-trailing-newline
       source_identifier: attributes["log.file.path"]
       type: recombine
-      ## Ensure we are combine everything up to `is_last_entry` even on the file beginning
+      ## Ensure we combine everything up to `is_last_entry` even on the file beginning
       max_unmatched_batch_size: 0
 
     ## merge-cri-lines stitches back together log lines split by CRI logging drivers.
@@ -114,7 +114,7 @@ filelog/containers:
       overwrite_with: newest
       source_identifier: attributes["log.file.path"]
       type: recombine
-      ## Ensure we are combine everything up to `is_last_entry` even on the file beginning
+      ## Ensure we combine everything up to `is_last_entry` even on the file beginning
       max_unmatched_batch_size: 0
 
     ## strip-trailing-newline removes the trailing "\n" from the `log` key. This is required for logs coming from Docker container runtime.

--- a/deploy/helm/sumologic/conf/logs/collector/otelcloudwatch/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/collector/otelcloudwatch/config.yaml
@@ -61,7 +61,7 @@ processors:
         overwrite_with: newest
         source_identifier: resource["cloudwatch.log.stream"]
         type: recombine
-        ## Ensure we are combine everything up to `is_last_entry` even on the file beginning
+        ## Ensure we combine everything up to `is_last_entry` even on the file beginning
         max_unmatched_batch_size: 0
       - id: merge-multiline-logs
         combine_field: attributes.log

--- a/deploy/helm/sumologic/conf/logs/collector/otelcloudwatch/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/collector/otelcloudwatch/config.yaml
@@ -61,6 +61,7 @@ processors:
         overwrite_with: newest
         source_identifier: resource["cloudwatch.log.stream"]
         type: recombine
+        ## Ensure we are combine everything up to `is_last_entry` even on the file beginning
         max_unmatched_batch_size: 0
       - id: merge-multiline-logs
         combine_field: attributes.log

--- a/deploy/helm/sumologic/conf/logs/collector/otelcloudwatch/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/collector/otelcloudwatch/config.yaml
@@ -61,7 +61,7 @@ processors:
         overwrite_with: newest
         source_identifier: resource["cloudwatch.log.stream"]
         type: recombine
-        max_unmatched_batch_size: 1
+        max_unmatched_batch_size: 0
       - id: merge-multiline-logs
         combine_field: attributes.log
         combine_with: "\n"

--- a/tests/helm/testdata/goldenfile/logs_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc/basic.output.yaml
@@ -99,7 +99,7 @@ data:
           combine_with: ""
           id: merge-docker-lines
           is_last_entry: body.log matches "\n$"
-          max_unmatched_batch_size: 1
+          max_unmatched_batch_size: 0
           output: strip-trailing-newline
           source_identifier: attributes["log.file.path"]
           type: recombine
@@ -107,7 +107,7 @@ data:
           combine_with: ""
           id: merge-cri-lines
           is_last_entry: body.logtag == "F"
-          max_unmatched_batch_size: 1
+          max_unmatched_batch_size: 0
           output: extract-metadata-from-filepath
           overwrite_with: newest
           source_identifier: attributes["log.file.path"]

--- a/tests/helm/testdata/goldenfile/logs_otc/debug.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc/debug.output.yaml
@@ -109,7 +109,7 @@ data:
           combine_with: ""
           id: merge-docker-lines
           is_last_entry: body.log matches "\n$"
-          max_unmatched_batch_size: 1
+          max_unmatched_batch_size: 0
           output: strip-trailing-newline
           source_identifier: attributes["log.file.path"]
           type: recombine
@@ -117,7 +117,7 @@ data:
           combine_with: ""
           id: merge-cri-lines
           is_last_entry: body.logtag == "F"
-          max_unmatched_batch_size: 1
+          max_unmatched_batch_size: 0
           output: extract-metadata-from-filepath
           overwrite_with: newest
           source_identifier: attributes["log.file.path"]

--- a/tests/helm/testdata/goldenfile/logs_otc_daemonset/multiple_multiline.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_daemonset/multiple_multiline.output.yaml
@@ -99,7 +99,7 @@ data:
           combine_with: ""
           id: merge-docker-lines
           is_last_entry: body.log matches "\n$"
-          max_unmatched_batch_size: 1
+          max_unmatched_batch_size: 0
           output: strip-trailing-newline
           source_identifier: attributes["log.file.path"]
           type: recombine
@@ -107,7 +107,7 @@ data:
           combine_with: ""
           id: merge-cri-lines
           is_last_entry: body.logtag == "F"
-          max_unmatched_batch_size: 1
+          max_unmatched_batch_size: 0
           output: extract-metadata-from-filepath
           overwrite_with: newest
           source_identifier: attributes["log.file.path"]

--- a/tests/helm/testdata/goldenfile/logs_otc_windows/configmap/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_windows/configmap/basic.output.yaml
@@ -78,7 +78,7 @@ data:
           combine_with: ""
           id: merge-docker-lines
           is_last_entry: body.log matches "\n$"
-          max_unmatched_batch_size: 1
+          max_unmatched_batch_size: 0
           output: strip-trailing-newline
           source_identifier: attributes["log.file.path"]
           type: recombine
@@ -86,7 +86,7 @@ data:
           combine_with: ""
           id: merge-cri-lines
           is_last_entry: body.logtag == "F"
-          max_unmatched_batch_size: 1
+          max_unmatched_batch_size: 0
           output: extract-metadata-from-filepath
           overwrite_with: newest
           source_identifier: attributes["log.file.path"]

--- a/tests/helm/testdata/goldenfile/logs_otc_windows/configmap/debug.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_windows/configmap/debug.output.yaml
@@ -89,7 +89,7 @@ data:
           combine_with: ""
           id: merge-docker-lines
           is_last_entry: body.log matches "\n$"
-          max_unmatched_batch_size: 1
+          max_unmatched_batch_size: 0
           output: strip-trailing-newline
           source_identifier: attributes["log.file.path"]
           type: recombine
@@ -97,7 +97,7 @@ data:
           combine_with: ""
           id: merge-cri-lines
           is_last_entry: body.logtag == "F"
-          max_unmatched_batch_size: 1
+          max_unmatched_batch_size: 0
           output: extract-metadata-from-filepath
           overwrite_with: newest
           source_identifier: attributes["log.file.path"]

--- a/tests/helm/testdata/goldenfile/logs_otc_windows/daemonset/multiple_multiline.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_windows/daemonset/multiple_multiline.output.yaml
@@ -78,7 +78,7 @@ data:
           combine_with: ""
           id: merge-docker-lines
           is_last_entry: body.log matches "\n$"
-          max_unmatched_batch_size: 1
+          max_unmatched_batch_size: 0
           output: strip-trailing-newline
           source_identifier: attributes["log.file.path"]
           type: recombine
@@ -86,7 +86,7 @@ data:
           combine_with: ""
           id: merge-cri-lines
           is_last_entry: body.logtag == "F"
-          max_unmatched_batch_size: 1
+          max_unmatched_batch_size: 0
           output: extract-metadata-from-filepath
           overwrite_with: newest
           source_identifier: attributes["log.file.path"]


### PR DESCRIPTION
We are using `is_last_entry` and `max_unmatched_batch_size=1` which means we are sending all lines separately until `is_last_entry` matches. If we have multipart log on the beginning of file we will send every part separately.

Here is minimal reproduction:

log file:

```
2021-02-16T09:21:15.518430714Z stdout P a
2021-02-16T09:21:15.518430714Z stdout P b
2021-02-16T09:21:15.518430714Z stdout F c
```

config.yaml

```
exporters:
  debug:
    verbosity: detailed
receivers:
  filelog/containers:
    include:
      - logs/0.log
    start_at: beginning
    include_file_name: false
    include_file_path: true
    operators:
      - id: parser-containerd
        output: merge-cri-lines
        parse_to: body
        regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*)( |)(?P<log>.*)$
        timestamp:
          layout: "%Y-%m-%dT%H:%M:%S.%LZ"
          parse_from: body.time
        type: regex_parser
      - combine_field: body.log
        combine_with: ""
        id: merge-cri-lines
        is_last_entry: body.logtag == "F"
        max_unmatched_batch_size: 1
        overwrite_with: newest
        source_identifier: attributes["log.file.path"]
        type: recombine
service:
  pipelines:
    logs/containers:
      exporters:
        - debug
      receivers:
        - filelog/containers
```

output:

```
...
LogRecord #0
ObservedTimestamp: 2024-06-28 08:27:21.553009 +0000 UTC
Timestamp: 2021-02-16 09:21:15.518430714 +0000 UTC
SeverityText: 
SeverityNumber: Unspecified(0)
Body: Map({"log":"a","logtag":"P","stream":"stdout","time":"2021-02-16T09:21:15.518430714Z"})
Attributes:
     -> log.file.path: Str(logs/0.log)
Trace ID: 
Span ID: 
Flags: 0
LogRecord #1
ObservedTimestamp: 2024-06-28 08:27:21.553194 +0000 UTC
Timestamp: 2021-02-16 09:21:15.518430714 +0000 UTC
SeverityText: 
SeverityNumber: Unspecified(0)
Body: Map({"log":"b","logtag":"P","stream":"stdout","time":"2021-02-16T09:21:15.518430714Z"})
Attributes:
     -> log.file.path: Str(logs/0.log)
Trace ID: 
Span ID: 
Flags: 0
LogRecord #2
ObservedTimestamp: 2024-06-28 08:27:21.553214 +0000 UTC
Timestamp: 2021-02-16 09:21:15.518430714 +0000 UTC
SeverityText: 
SeverityNumber: Unspecified(0)
Body: Map({"log":"c","logtag":"F","stream":"stdout","time":"2021-02-16T09:21:15.518430714Z"})
Attributes:
     -> log.file.path: Str(logs/0.log)
Trace ID: 
Span ID: 
Flags: 0
        {"kind": "exporter", "data_type": "logs", "name": "debug"}
...
```

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [ ] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features
