### PR TITLE
test(integration): Added custom service account annotations test

### DIFF
--- a/.changelog/3803.changed.txt
+++ b/.changelog/3803.changed.txt
@@ -1,0 +1,1 @@
+test: Added custom service account annotation tests for global configuration attributes

--- a/deploy/helm/sumologic/templates/logs/collector/common/serviceaccount.yaml
+++ b/deploy/helm/sumologic/templates/logs/collector/common/serviceaccount.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     app: {{ template "sumologic.labels.app.logs.collector.serviceaccount" . }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
+  {{- if .Values.sumologic.serviceAccount.annotations }}
+  annotations:
+  {{ toYaml .Values.sumologic.serviceAccount.annotations | indent 2 }}
+  {{- end }}
 {{- if .Values.sumologic.pullSecrets }}
 imagePullSecrets:
 {{ toYaml .Values.sumologic.pullSecrets | indent 2 }}

--- a/deploy/helm/sumologic/templates/metrics/collector/otelcol/serviceaccount-targetallocator.yaml
+++ b/deploy/helm/sumologic/templates/metrics/collector/otelcol/serviceaccount-targetallocator.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     {{- include "sumologic.labels.metrics.serviceaccount" . | nindent 4 }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
+  {{- if .Values.sumologic.serviceAccount.annotations }}
+  annotations:
+  {{ toYaml .Values.sumologic.serviceAccount.annotations | indent 2 }}
+  {{- end }}    
 {{- if .Values.sumologic.pullSecrets }}
 imagePullSecrets:
 {{ toYaml .Values.sumologic.pullSecrets | indent 2 }}

--- a/deploy/helm/sumologic/templates/metrics/collector/otelcol/serviceaccount.yaml
+++ b/deploy/helm/sumologic/templates/metrics/collector/otelcol/serviceaccount.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     {{- include "sumologic.labels.metrics.serviceaccount" . | nindent 4 }}
     {{- include "sumologic.labels.common" . | nindent 4 }}
+  {{- if .Values.sumologic.serviceAccount.annotations }}
+  annotations:
+  {{ toYaml .Values.sumologic.serviceAccount.annotations | indent 2 }}
+  {{- end }}    
 {{- if .Values.sumologic.pullSecrets }}
 imagePullSecrets:
 {{ toYaml .Values.sumologic.pullSecrets | indent 2 }}

--- a/tests/helm/const.go
+++ b/tests/helm/const.go
@@ -36,6 +36,10 @@ var subChartNames []string = []string{
 	"opentelemetry-operator",
 }
 
+var expectedAnnotations = map[string]string{
+	"customServiceAccountAnnotationKey": "customServiceAccountAnnotationValue",
+}
+
 var toleration = corev1.Toleration{
 	Key:      "key",
 	Value:    "value",

--- a/tests/helm/testdata/custom-global-config-attributes.yaml
+++ b/tests/helm/testdata/custom-global-config-attributes.yaml
@@ -7,6 +7,9 @@ sumologic:
     customLabelKey: customLabelValue
   podAnnotations:
     customAnnotationsKey: customAnnotationsValue
+  serviceAccount:
+    annotations:
+      customServiceAccountAnnotationKey: customServiceAccountAnnotationValue
 
 kube-prometheus-stack:
   kube-state-metrics:


### PR DESCRIPTION
### Overview
- github issue: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2699
- added annotations test SPECIFICALLY for service account in global configs

1 more to go:
```
 sumologic.pullSecrets
```

### Checklist
- [x] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [x] Integration tests added or modified for major features
