### PR TITLE
chore: Removed KOPs 1.30, not supported yet

### DIFF
--- a/.changelog/3804.changed.2.txt
+++ b/.changelog/3804.changed.2.txt
@@ -1,1 +1,0 @@
-feat: add support for kubernetes 1.30 for KOPS

--- a/docs/README.md
+++ b/docs/README.md
@@ -96,7 +96,7 @@ The following table displays the tested Kubernetes and Helm versions.
 | ---------------------- | ------------------------------------------------- |
 | K8s with EKS           | 1.25<br/>1.26<br/>1.27<br/>1.28<br/>1.29<br/>1.30 |
 | K8s with EKS (fargate) | 1.25<br/>1.26<br/>1.27<br/>1.28<br/>1.29<br/>1.30 |
-| K8s with Kops          | 1.25<br/>1.26<br/>1.27<br/>1.28<br/>1.29<br/>1.30 |
+| K8s with Kops          | 1.25<br/>1.26<br/>1.27<br/>1.28<br/>1.29          |
 | K8s with GKE           | 1.26<br/>1.27<br/>1.28<br/>1.29<br/>1.30          |
 | K8s with AKS           | 1.26<br/>1.27<br/>1.28<br/>1.29<br/>1.30          |
 | OpenShift              | 4.12<br/>4.13<br/>4.14<br/>4.15<br/>4.16          |


### PR DESCRIPTION
- Removed KOPs 1.30, not supported yet
- not adding new changelog, just removed old one
- merging this once e2e pr merged

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features
