### PR TITLE
chore: upgrade tailing-sidecar to v0.16.0

### DIFF
--- a/.changelog/3856.changed.txt
+++ b/.changelog/3856.changed.txt
@@ -1,0 +1,1 @@
+chore: upgrade tailing-sidecar to v0.16.0

--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -29,7 +29,7 @@ dependencies:
     repository: https://helm.influxdata.com/
     condition: telegraf-operator.enabled
   - name: tailing-sidecar-operator
-    version: 0.15.0
+    version: 0.16.0
     repository: https://sumologic.github.io/tailing-sidecar
     condition: tailing-sidecar-operator.enabled
   - name: opentelemetry-operator

--- a/docs/README.md
+++ b/docs/README.md
@@ -113,7 +113,7 @@ The following table displays the currently used software versions for our Helm c
 | Falco                                     | 3.8.7   |
 | Metrics Server                            | 6.11.2  |
 | Telegraf Operator                         | 1.4.0   |
-| Tailing Sidecar Operator                  | 0.15.0  |
+| Tailing Sidecar Operator                  | 0.16.0  |
 
 ### ARM support
 


### PR DESCRIPTION
chore: upgrade tailing-sidecar to v0.16.0
