### PR TITLE
feat: Add the whenDeleted option to the PVC retention policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - feat: Allow custom pod annotations in the CRD configMap (setup) [#3901]
 - feat: Add a configuration knob to disable PersistentVolumeClaim retention policy [#3902]
+- feat: Add the whenDeleted option to the PersistentVolumeClaim retention policy [#3904]
 
 [#3901]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/3901
 [#3902]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/3902
+[#3904]: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/3904
 [v4.12.1]: https://github.com/SumoLogic/sumologic-kubernetes-collection/releases/v4.12.1
 
 ## [v4.12.0]

--- a/deploy/helm/sumologic/templates/logs/otelcol/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/logs/otelcol/statefulset.yaml
@@ -18,6 +18,7 @@ spec:
 {{- end }}
 {{- if .Values.sumologic.persistentVolumeClaimRetentionPolicyEnabled}}
   persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Retain
     whenScaled: {{ .Values.metadata.logs.statefulset.persistentVolumeClaimRetentionPolicywhenScaled }}
 {{- end}}
   template:

--- a/deploy/helm/sumologic/templates/metrics/otelcol/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/metrics/otelcol/statefulset.yaml
@@ -18,6 +18,7 @@ spec:
 {{- end }}
 {{- if .Values.sumologic.persistentVolumeClaimRetentionPolicyEnabled}}
   persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Retain
     whenScaled: {{ .Values.metadata.logs.statefulset.persistentVolumeClaimRetentionPolicywhenScaled }}
 {{- end }}
   template:

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc_statefulset/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc_statefulset/basic.output.yaml
@@ -17,6 +17,7 @@ spec:
   serviceName: RELEASE-NAME-sumologic-otelcol-logs-headless
   podManagementPolicy: "Parallel"
   persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Retain
     whenScaled: Retain
   template:
     metadata:

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc_statefulset/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc_statefulset/custom.output.yaml
@@ -18,6 +18,7 @@ spec:
   podManagementPolicy: "Parallel"
   replicas: 4
   persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Retain
     whenScaled: Retain
   template:
     metadata:

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc_statefulset/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc_statefulset/basic.output.yaml
@@ -17,6 +17,7 @@ spec:
   serviceName: RELEASE-NAME-sumologic-otelcol-metrics-headless
   podManagementPolicy: "Parallel"
   persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Retain
     whenScaled: Retain
   template:
     metadata:

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc_statefulset/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc_statefulset/custom.output.yaml
@@ -18,6 +18,7 @@ spec:
   podManagementPolicy: "Parallel"
   replicas: 4
   persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Retain
     whenScaled: Retain
   template:
     metadata:


### PR DESCRIPTION
Add the `whenDeleted` option to the PVC retention policy. This addition is to ensure consistency. When the policy is enabled both options must be configured or none. This change ensures that is the case and is not a breaking change.

https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention

- [x] Changelog updated or skip changelog label added
- [x] Documentation updated
- [x] Template tests added for new features
