### PR TITLE
fix(TA): Allow the target allocator access to probes and scrapeconfigs in the coreos apiGroups

### DIFF
--- a/.changelog/3913.changed.txt
+++ b/.changelog/3913.changed.txt
@@ -1,0 +1,1 @@
+fix(TA): Allow the target allocator access to probes and scrapeconfigs in the coreos apiGroups

--- a/deploy/helm/sumologic/templates/metrics/collector/otelcol/targetallocator-clusterrole.yaml
+++ b/deploy/helm/sumologic/templates/metrics/collector/otelcol/targetallocator-clusterrole.yaml
@@ -47,6 +47,8 @@ rules:
   resources:
     - servicemonitors
     - podmonitors
+    - probes
+    - scrapeconfigs
   verbs:
     - get
     - watch


### PR DESCRIPTION
Allow the target allocator access to probes and scrapeconfigs in the coreos apiGroups


- [x] Changelog updated or skip changelog label added
- [x] Documentation updated
