### PR TITLE
fix: Add the default release label for serviceMonitorSelectors and PodMonitorSelectors

### DIFF
--- a/.changelog/3927.fixed.txt
+++ b/.changelog/3927.fixed.txt
@@ -1,0 +1,1 @@
+fix: Add the default release label for serviceMonitorSelectors and PodMonitorSelectors

--- a/deploy/helm/sumologic/templates/metrics/collector/otelcol/opentelemetrycollector.yaml
+++ b/deploy/helm/sumologic/templates/metrics/collector/otelcol/opentelemetrycollector.yaml
@@ -44,8 +44,9 @@ spec:
         matchLabels:
 {{ include "metrics.collector.otelcol.serviceMonitorSelector" . | indent 10 }}
 {{ else }}
-      serviceMonitorSelector: 
-{{ toYaml .Values.sumologic.metrics.collector.otelcol.serviceMonitorSelector | nindent 8 }}
+      serviceMonitorSelector:
+        matchLabels:
+          release: {{ .Release.Name }}
 {{- end }}
 {{- if not (empty (include "metrics.collector.otelcol.podMonitorSelector" .)) }}
       podMonitorSelector:
@@ -53,7 +54,8 @@ spec:
 {{ include "metrics.collector.otelcol.podMonitorSelector" . | indent 10 }}
 {{ else }}
       podMonitorSelector:
-{{ toYaml .Values.sumologic.metrics.collector.otelcol.podMonitorSelector | nindent 8 }}
+        matchLabels:
+          release: {{ .Release.Name }}
 {{- end }}
     serviceAccount: {{ template "sumologic.metadata.name.metrics.targetallocator.serviceaccount" . }}
 {{- if not (empty (include "metrics.collector.otelcol.nodeSelector" .)) }}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -537,10 +537,16 @@ sumologic:
 
         ## Selector for ServiceMonitors used for target discovery. By default, this selects resources created by this Chart.
         ## See https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api/targetallocators.md#targetallocatorspecprometheuscr
+        ## Example
+        ## serviceMonitorSelector:
+        ##   release: sumologic
         serviceMonitorSelector: {}
 
         ## Selector for PodMonitors used for target discovery. By default, this selects resources created by this Chart.
         ## See https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api/targetallocators.md#targetallocatorspecprometheuscr
+        ## Example
+        ## podMonitorSelector:
+        ##   release: sumologic
         podMonitorSelector: {}
 
         securityContext:

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
@@ -25,8 +25,12 @@ spec:
     prometheusCR:
       enabled: true
       scrapeInterval: 30s
-      serviceMonitorSelector: {}
-      podMonitorSelector: {}
+      serviceMonitorSelector:
+        matchLabels:
+          release: RELEASE-NAME
+      podMonitorSelector:
+        matchLabels:
+          release: RELEASE-NAME
     serviceAccount: RELEASE-NAME-sumologic-metrics-targetallocator-sa
     nodeSelector:
       kubernetes.io/os: linux

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/debug.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/debug.output.yaml
@@ -25,8 +25,12 @@ spec:
     prometheusCR:
       enabled: true
       scrapeInterval: 30s
-      serviceMonitorSelector: {}
-      podMonitorSelector: {}
+      serviceMonitorSelector:
+        matchLabels:
+          release: RELEASE-NAME
+      podMonitorSelector:
+        matchLabels:
+          release: RELEASE-NAME
     serviceAccount: RELEASE-NAME-sumologic-metrics-targetallocator-sa
     nodeSelector:
       kubernetes.io/os: linux

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/kubelet.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/kubelet.output.yaml
@@ -25,8 +25,12 @@ spec:
     prometheusCR:
       enabled: true
       scrapeInterval: 30s
-      serviceMonitorSelector: {}
-      podMonitorSelector: {}
+      serviceMonitorSelector:
+        matchLabels:
+          release: RELEASE-NAME
+      podMonitorSelector:
+        matchLabels:
+          release: RELEASE-NAME
     serviceAccount: RELEASE-NAME-sumologic-metrics-targetallocator-sa
     nodeSelector:
       kubernetes.io/os: linux


### PR DESCRIPTION
Add the default release label for serviceMonitorSelectors and PodMonitorSelectors


- [x] Changelog updated or skip changelog label added
- [x] Documentation updated
- [x] Template tests added for new features
