### PR TITLE
fix: do not modify SUMOLOGIC_BASE_URL in cleanup.sh

### DIFF
--- a/.changelog/3930.fixed.txt
+++ b/.changelog/3930.fixed.txt
@@ -1,0 +1,1 @@
+fix: don't adjust SUMOLOGIC_BASE_URL in cleanup.sh

--- a/deploy/helm/sumologic/conf/cleanup/cleanup.sh
+++ b/deploy/helm/sumologic/conf/cleanup/cleanup.sh
@@ -2,8 +2,6 @@
 
 set -euo pipefail
 
-# Fix URL to remove "v1" or "v1/"
-export SUMOLOGIC_BASE_URL="${SUMOLOGIC_BASE_URL%v1*}"
 # Support proxy for Terraform
 export HTTP_PROXY="${HTTP_PROXY:=""}"
 export HTTPS_PROXY="${HTTPS_PROXY:=""}"
@@ -34,6 +32,5 @@ terraform import kubernetes_secret.sumologic_collection_secret "${NAMESPACE}/${S
 terraform destroy -auto-approve
 
 # Cleanup env variables
-export SUMOLOGIC_BASE_URL=
 export SUMOLOGIC_ACCESSKEY=
 export SUMOLOGIC_ACCESSID=


### PR DESCRIPTION
cleanup.sh can complain that `SUMOLOGIC_BASE_URL` is unbound. It attempts to modify the URL so that it does not contain a v1.

This seems like some sort of hack that should have been cleaned up. I don't think we should be doing this, so I am removing references to `SUMOLOGIC_BASE_URL` in this script.

Closes #3867 

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
