### PR TITLE
chore: fix link linter

### DIFF
--- a/.markdown_link_check.json
+++ b/.markdown_link_check.json
@@ -14,6 +14,9 @@
     },
     {
       "pattern": "^http://localhost"
+    },
+    {
+      "pattern": "^https://stackoverflow.com/"
     }
   ]
 }


### PR DESCRIPTION
Fix the link linter by not following Stack Overflow links. Stack Overflow is issuing 403 to crawlers and seems to consider Github Actions as one of them.