### PR TITLE
feat: allow for hostNetwork in otellogs.daemonset

### DIFF
--- a/.changelog/3940.feat.txt
+++ b/.changelog/3940.feat.txt
@@ -1,0 +1,1 @@
+feat: allow for hostNetwork in otellogs.daemonset

--- a/deploy/helm/sumologic/templates/logs/collector/otelcol/daemonset.yaml
+++ b/deploy/helm/sumologic/templates/logs/collector/otelcol/daemonset.yaml
@@ -84,6 +84,9 @@ spec:
       {{- else }}
       priorityClassName: {{ include "sumologic.metadata.name.priorityclass" $ctx | quote }}
       {{- end }}
+      {{- if $daemonset.hostNetwork }}
+      hostNetwork: {{ $daemonset.hostNetwork }}
+      {{- end }}
       containers:
       - args:
         - --config=/etc/otelcol/config.yaml

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -2124,6 +2124,9 @@ otellogs:
     ## Add custom annotations to all otelcol daemonset pods
     podAnnotations: {}
 
+    ## Allow for hostNetwork to be used in the OTEL daemonsets
+    hostNetwork: false
+
     resources:
       limits:
         memory: 1Gi


### PR DESCRIPTION
This allows the consumer to set hostNetwork for the otellogs daemonset. This defaults to `false` to preserve the current behavior.

For some background on this we run a handful of large clusters where IP space is at a premium. In our larger clusters this would save ~2000 IPs, which would be great to claw back!

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [X] Changelog updated or skip changelog label added
- [X] Documentation updated
- [X] Template tests added for new features
- [X] Integration tests added or modified for major features
