### PR TITLE
feat(otellogs): add hostNetwork and dnsPolicy configuration

### DIFF
--- a/.changelog/3993.added.txt
+++ b/.changelog/3993.added.txt
@@ -1,0 +1,1 @@
+Making hostNetwork and dnsPolicy configurable in otellogs.daemonset

--- a/deploy/helm/sumologic/templates/logs/collector/otelcol/daemonset.yaml
+++ b/deploy/helm/sumologic/templates/logs/collector/otelcol/daemonset.yaml
@@ -77,6 +77,12 @@ spec:
       tolerations:
 {{ $tolerations | indent 8 }}
 {{- end }}
+{{- if $daemonset.hostNetwork }}
+      hostNetwork: {{ $daemonset.hostNetwork }}
+{{- end }}
+{{- if $daemonset.dnsPolicy }}
+      dnsPolicy: {{ $daemonset.dnsPolicy }}
+{{- end }}
       securityContext:
         {{- toYaml $daemonset.securityContext | nindent 8 }}
       {{- if $daemonset.priorityClassName }}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -2108,6 +2108,11 @@ otellogs:
     override: {}
 
   daemonset:
+    ## Enable host network for the daemonset pods
+    hostNetwork: false
+    ## DNS policy for the daemonset pods
+    dnsPolicy: ClusterFirst
+
     ## Set securityContext for containers running in pods in log collector daemonset
     securityContext:
       ## In order to reliably read logs from mounted node logging paths, we need to run as root


### PR DESCRIPTION
Allows for configurable `hostNetwork` and `dnsPolicy`. Related with https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/3940 

### Checklist

- [x] Changelog updated or skip changelog label added
- [x] Template tests added for new features
