### PR TITLE
chore: Update the K8s version support matrix

### DIFF
--- a/.changelog/3997.changed.txt
+++ b/.changelog/3997.changed.txt
@@ -1,0 +1,1 @@
+chore: Update the k8s version support matrix

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 !.vscode/extensions.json
 !.vscode/snippets.code-snippets
 
+# Intellij ignores
+.idea/*
+
 # Helm chart dependencies
 deploy/helm/sumologic/charts
 deploy/helm/sumologic/tmpcharts

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ Documentation links:
 - [Installation](https://help.sumologic.com/docs/send-data/kubernetes/install-helm-chart/)
 
 - Configuration
+
   - [Examples](/docs/configuration-examples.md)
   - Logs
     - [Collecting container logs](https://help.sumologic.com/docs/send-data/kubernetes/collecting-logs/)
@@ -45,6 +46,7 @@ Documentation links:
     - [OTLP source](/docs/otlp-source.md)
 
 - Upgrades
+
   - [Upgrade from v3 to v4][migration-doc-v4]
   - [Upgrade from v2 to v3][migration-doc-v3]
   - [Upgrade from v2.17 to v2.18][migration-doc-v2.18]

--- a/docs/README.md
+++ b/docs/README.md
@@ -84,7 +84,7 @@ The diagrams below illustrate the components of the Kubernetes collection soluti
 ## Minimum Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | K8s  | 1.21+   |
 | Helm | 3.5+    |
 
@@ -92,21 +92,21 @@ The diagrams below illustrate the components of the Kubernetes collection soluti
 
 The following table displays the tested Kubernetes and Helm versions.
 
-| Name                   | Version                                                    |
-| ---------------------- | ---------------------------------------------------------- |
-| K8s with EKS           | 1.26<br/>1.27<br/>1.28<br/>1.29<br/>1.30<br/>1.31<br/>1.32 |
-| K8s with EKS (fargate) | 1.26<br/>1.27<br/>1.28<br/>1.29<br/>1.30<br/>1.31          |
-| K8s with Kops          | 1.26<br/>1.27<br/>1.28<br/>1.29<br/>1.30                   |
-| K8s with GKE           | 1.26<br/>1.27<br/>1.28<br/>1.29<br/>1.30<br/>1.31<br/>1.32 |
-| K8s with AKS           | 1.26<br/>1.27<br/>1.28<br/>1.29<br/>1.30<br/>1.31<br/>     |
-| OpenShift              | 4.12<br/>4.13<br/>4.14<br/>4.15<br/>4.16                   |
-| Helm                   | 3.14.3 (Linux)                                             |
-| kubectl                | 1.29.3                                                     |
+| Name                   | Version                                           |
+|------------------------|---------------------------------------------------|
+| K8s with EKS           | 1.28<br/>1.29<br/>1.30<br/>1.31<br/>1.32<br/>1.33 |
+| K8s with EKS (fargate) | 1.28<br/>1.29<br/>1.30<br/>1.31<br/>1.32<br/>1.33 |
+| K8s with Kops          | 1.26<br/>1.27<br/>1.28<br/>1.29<br/>1.30          |
+| K8s with GKE           | 1.28<br/>1.29<br/>1.30<br/>1.31<br/>1.32<br/>1.33 |
+| K8s with AKS           | 1.29<br/>1.30<br/>1.31<br/>1.32<br/>1.33          |
+| OpenShift              | 4.12<br/>4.13<br/>4.14<br/>4.15<br/>4.16          |
+| Helm                   | 3.14.3 (Linux)                                    |
+| kubectl                | 1.29.3                                            |
 
 The following table displays the currently used software versions for our Helm chart.
 
 | Name                                      | Version |
-| ----------------------------------------- | ------- |
+|-------------------------------------------|---------|
 | OpenTelemetry Collector                   | 0.130.1 |
 | OpenTelemetry Operator                    | 0.86.4  |
 | kube-prometheus-stack/Prometheus Operator | 40.5.0  |

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,6 @@ Documentation links:
 - [Installation](https://help.sumologic.com/docs/send-data/kubernetes/install-helm-chart/)
 
 - Configuration
-
   - [Examples](/docs/configuration-examples.md)
   - Logs
     - [Collecting container logs](https://help.sumologic.com/docs/send-data/kubernetes/collecting-logs/)
@@ -46,7 +45,6 @@ Documentation links:
     - [OTLP source](/docs/otlp-source.md)
 
 - Upgrades
-
   - [Upgrade from v3 to v4][migration-doc-v4]
   - [Upgrade from v2 to v3][migration-doc-v3]
   - [Upgrade from v2.17 to v2.18][migration-doc-v2.18]
@@ -84,7 +82,7 @@ The diagrams below illustrate the components of the Kubernetes collection soluti
 ## Minimum Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | K8s  | 1.21+   |
 | Helm | 3.5+    |
 
@@ -93,7 +91,7 @@ The diagrams below illustrate the components of the Kubernetes collection soluti
 The following table displays the tested Kubernetes and Helm versions.
 
 | Name                   | Version                                                    |
-|------------------------|------------------------------------------------------------|
+| ---------------------- | ---------------------------------------------------------- |
 | K8s with EKS           | 1.28<br/>1.29<br/>1.30<br/>1.31<br/>1.32<br/>1.33          |
 | K8s with EKS (fargate) | 1.28<br/>1.29<br/>1.30<br/>1.31<br/>1.32<br/>1.33          |
 | K8s with Kops          | 1.26<br/>1.27<br/>1.28<br/>1.29<br/>1.30                   |
@@ -106,7 +104,7 @@ The following table displays the tested Kubernetes and Helm versions.
 The following table displays the currently used software versions for our Helm chart.
 
 | Name                                      | Version |
-|-------------------------------------------|---------|
+| ----------------------------------------- | ------- |
 | OpenTelemetry Collector                   | 0.130.1 |
 | OpenTelemetry Operator                    | 0.86.4  |
 | kube-prometheus-stack/Prometheus Operator | 40.5.0  |

--- a/docs/README.md
+++ b/docs/README.md
@@ -92,16 +92,16 @@ The diagrams below illustrate the components of the Kubernetes collection soluti
 
 The following table displays the tested Kubernetes and Helm versions.
 
-| Name                   | Version                                           |
-|------------------------|---------------------------------------------------|
-| K8s with EKS           | 1.28<br/>1.29<br/>1.30<br/>1.31<br/>1.32<br/>1.33 |
-| K8s with EKS (fargate) | 1.28<br/>1.29<br/>1.30<br/>1.31<br/>1.32<br/>1.33 |
-| K8s with Kops          | 1.26<br/>1.27<br/>1.28<br/>1.29<br/>1.30          |
-| K8s with GKE           | 1.28<br/>1.29<br/>1.30<br/>1.31<br/>1.32<br/>1.33 |
-| K8s with AKS           | 1.29<br/>1.30<br/>1.31<br/>1.32<br/>1.33          |
-| OpenShift              | 4.12<br/>4.13<br/>4.14<br/>4.15<br/>4.16          |
-| Helm                   | 3.14.3 (Linux)                                    |
-| kubectl                | 1.29.3                                            |
+| Name                   | Version                                                    |
+|------------------------|------------------------------------------------------------|
+| K8s with EKS           | 1.28<br/>1.29<br/>1.30<br/>1.31<br/>1.32<br/>1.33          |
+| K8s with EKS (fargate) | 1.28<br/>1.29<br/>1.30<br/>1.31<br/>1.32<br/>1.33          |
+| K8s with Kops          | 1.26<br/>1.27<br/>1.28<br/>1.29<br/>1.30                   |
+| K8s with GKE           | 1.28<br/>1.29<br/>1.30<br/>1.31<br/>1.32<br/>1.33          |
+| K8s with AKS           | 1.27<br/>1.28<br/>1.29<br/>1.30<br/>1.31<br/>1.32<br/>1.33 |
+| OpenShift              | 4.12<br/>4.13<br/>4.14<br/>4.15<br/>4.16                   |
+| Helm                   | 3.14.3 (Linux)                                             |
+| kubectl                | 1.29.3                                                     |
 
 The following table displays the currently used software versions for our Helm chart.
 


### PR DESCRIPTION
Update the k8s version support matrix.

**Jenkins tests**

EKS:1.33.0 - https://ct-jenkins.kumoroku.com/view/All%20Dev%20Jobs/job/dev-sumo-platform-test-k8s-collection/2533/
EKS Fargate:1.32.0 - https://ct-jenkins.kumoroku.com/view/All%20Dev%20Jobs/job/dev-sumo-platform-test-k8s-collection/2530/
EKS Fargate:1.33.0 - https://ct-jenkins.kumoroku.com/view/All%20Dev%20Jobs/job/dev-sumo-platform-test-k8s-collection/2531/
AKS:1.32.0 - https://ct-jenkins.kumoroku.com/view/All%20Dev%20Jobs/job/dev-sumo-platform-test-k8s-collection/2529/
AKS:1.33.0 - https://ct-jenkins.kumoroku.com/view/All%20Dev%20Jobs/job/dev-sumo-platform-test-k8s-collection/2527/
GKE: 1.33.0 - https://ct-jenkins.kumoroku.com/view/All%20Dev%20Jobs/job/dev-sumo-platform-test-k8s-collection/2526/

Updated older version based on environment supported versions.
* [AKS](https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli#lts-versions)
* [EKS](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar)
* [GKE](https://cloud.google.com/kubernetes-engine/docs/release-notes#current_versions)

### Checklist

- [x] Changelog updated or skip changelog label added
- [x] Documentation updated
