### PR TITLE
chore: set GODEBUG=netdns=go in most environments

### DIFF
--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -4,6 +4,8 @@ version: 4.17.0
 appVersion: 4.17.0
 description: A Helm chart for collecting Kubernetes logs, metrics, traces and events into Sumo Logic.
 type: application
+env:
+  GODEBUG: netdns=go  # use the netgo DNS resolver for k8s
 keywords:
   - monitoring
   - logging

--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -4,8 +4,6 @@ version: 4.17.0
 appVersion: 4.17.0
 description: A Helm chart for collecting Kubernetes logs, metrics, traces and events into Sumo Logic.
 type: application
-env:
-  GODEBUG: netdns=go # use the netgo DNS resolver for k8s
 keywords:
   - monitoring
   - logging

--- a/deploy/helm/sumologic/Chart.yaml
+++ b/deploy/helm/sumologic/Chart.yaml
@@ -5,7 +5,7 @@ appVersion: 4.17.0
 description: A Helm chart for collecting Kubernetes logs, metrics, traces and events into Sumo Logic.
 type: application
 env:
-  GODEBUG: netdns=go  # use the netgo DNS resolver for k8s
+  GODEBUG: netdns=go # use the netgo DNS resolver for k8s
 keywords:
   - monitoring
   - logging

--- a/deploy/helm/sumologic/templates/_helpers/_common.tpl
+++ b/deploy/helm/sumologic/templates/_helpers/_common.tpl
@@ -480,6 +480,15 @@ Example:
 {{- end -}}
 
 {{/*
+GODEBUG environment variable, currently set to force netdns=go
+so that the cgo DNS resolver is not used.
+*/}}
+{{- define "godebug-env-variable" -}}
+- name: GODEBUG
+  value: "netdns=go"
+{{- end -}}
+
+{{/*
 Environment variables used to configure the HTTP proxy for programs using
 Go's net/http. See: https://pkg.go.dev/net/http#RoundTripper
 

--- a/deploy/helm/sumologic/templates/cleanup/job.yaml
+++ b/deploy/helm/sumologic/templates/cleanup/job.yaml
@@ -68,7 +68,7 @@ spec:
             value: "{{ .Chart.Version }}"
           - name: SUMOLOGIC_SECRET_NAME
             value: "{{ template "terraform.secret.name" }}"
-          {{- include "go-debug-variable" . | nindent 10 }}
+          {{- include "godebug-env-variable" . | nindent 10 }}
           {{- include "proxy-env-variables" . | nindent 10 }}
       securityContext:
         runAsUser: 1000

--- a/deploy/helm/sumologic/templates/cleanup/job.yaml
+++ b/deploy/helm/sumologic/templates/cleanup/job.yaml
@@ -68,6 +68,7 @@ spec:
             value: "{{ .Chart.Version }}"
           - name: SUMOLOGIC_SECRET_NAME
             value: "{{ template "terraform.secret.name" }}"
+          {{- include "go-debug-variable" . | nindent 10 }}
           {{- include "proxy-env-variables" . | nindent 10 }}
       securityContext:
         runAsUser: 1000

--- a/deploy/helm/sumologic/templates/events/otelcol/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/events/otelcol/statefulset.yaml
@@ -120,6 +120,7 @@ spec:
 {{- $ctx := .Values -}}
 {{- include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "events") | nindent 8 -}}
 {{- include "proxy-env-variables" . | nindent 8 -}}
+{{- include "go-debug-variable" . | nindent 8 -}}
 {{- include "pod-ip" . | nindent 8 -}}
         {{- if .Values.otelevents.statefulset.extraEnvVars }}
 {{ toYaml .Values.otelevents.statefulset.extraEnvVars | nindent 8 }}

--- a/deploy/helm/sumologic/templates/events/otelcol/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/events/otelcol/statefulset.yaml
@@ -120,7 +120,7 @@ spec:
 {{- $ctx := .Values -}}
 {{- include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "events") | nindent 8 -}}
 {{- include "proxy-env-variables" . | nindent 8 -}}
-{{- include "go-debug-variable" . | nindent 8 -}}
+{{- include "godebug-env-variable" . | nindent 8 -}}
 {{- include "pod-ip" . | nindent 8 -}}
         {{- if .Values.otelevents.statefulset.extraEnvVars }}
 {{ toYaml .Values.otelevents.statefulset.extraEnvVars | nindent 8 }}

--- a/deploy/helm/sumologic/templates/instrumentation/traces-gateway/deployment.yaml
+++ b/deploy/helm/sumologic/templates/instrumentation/traces-gateway/deployment.yaml
@@ -72,6 +72,7 @@ spec:
         - name: GOGC
           value: "80"
 {{- $ctx := .Values -}}
+{{- include "godebug-env-variable" . | nindent 8 -}}
 {{- include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "traces") | nindent 8 -}}
 {{- include "kubernetes.sources.env" (dict "Context" $ctx "Type" "metrics" "Name" "default" ) | nindent 8 }}
 {{- include "proxy-env-variables" . | nindent 8 -}}

--- a/deploy/helm/sumologic/templates/instrumentation/traces-sampler/deployment.yaml
+++ b/deploy/helm/sumologic/templates/instrumentation/traces-sampler/deployment.yaml
@@ -64,6 +64,7 @@ spec:
         - name: GOGC
           value: "80"
 {{- $ctx := .Values -}}
+{{- include "godebug-env-variable" . | nindent 8 -}}
 {{- include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "traces") | nindent 8 -}}
 {{- include "proxy-env-variables" . | nindent 8 -}}
 {{- include "pod-ip" . | nindent 8 -}}

--- a/deploy/helm/sumologic/templates/logs/otelcol/statefulset.yaml
+++ b/deploy/helm/sumologic/templates/logs/otelcol/statefulset.yaml
@@ -144,6 +144,7 @@ spec:
 {{- if or .Values.sumologic.collector.sources .Values.metadata.logs.statefulset.extraEnvVars }}
         env:
 {{- $ctx := .Values -}}
+{{- include "godebug-env-variable" . | nindent 8 -}}
 {{- include "kubernetes.sources.envs" (dict "Context" $ctx "Type" "logs") | nindent 8 -}}
 {{- include "proxy-env-variables" . | nindent 8 -}}
 {{- include "pod-ip" . | nindent 8 -}}

--- a/deploy/helm/sumologic/templates/setup/job.yaml
+++ b/deploy/helm/sumologic/templates/setup/job.yaml
@@ -108,6 +108,7 @@ spec:
 {{- end }}
         - name: SUMOLOGIC_DASHBOARDS_ENABLED
           value: "{{ .Values.sumologic.setup.dashboards.enabled }}"
+        {{- include "godebug-env-variable" . | nindent 8 -}}
         {{- include "proxy-env-variables" . | nindent 8 -}}
 {{- if .Values.sumologic.setup.debug }}
         - name: DEBUG_MODE

--- a/tests/helm/testdata/goldenfile/cleanup/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/cleanup/basic.output.yaml
@@ -64,6 +64,8 @@ spec:
             - name: SUMOLOGIC_SECRET_NAME
               value: "sumologic"
 
+            - name: GODEBUG
+              value: "netdns=go"
             - name: NO_PROXY
               value: kubernetes.default.svc
       securityContext:

--- a/tests/helm/testdata/goldenfile/cleanup/sumologic-mock-no-secret.output.yaml
+++ b/tests/helm/testdata/goldenfile/cleanup/sumologic-mock-no-secret.output.yaml
@@ -64,6 +64,8 @@ spec:
             - name: SUMOLOGIC_SECRET_NAME
               value: "sumologic"
 
+            - name: GODEBUG
+              value: "netdns=go"
             - name: NO_PROXY
               value: kubernetes.default.svc
       securityContext:

--- a/tests/helm/testdata/goldenfile/cleanup/sumologic-mock.output.yaml
+++ b/tests/helm/testdata/goldenfile/cleanup/sumologic-mock.output.yaml
@@ -64,6 +64,8 @@ spec:
             - name: SUMOLOGIC_SECRET_NAME
               value: "sumologic"
 
+            - name: GODEBUG
+              value: "netdns=go"
             - name: NO_PROXY
               value: kubernetes.default.svc
       securityContext:

--- a/tests/helm/testdata/goldenfile/events_otc_statefulset/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc_statefulset/basic.output.yaml
@@ -133,6 +133,8 @@ spec:
                   name: sumologic
                   key: endpoint-events-otlp
 
+            - name: GODEBUG
+              value: "netdns=go"
             - name: NO_PROXY
               value: kubernetes.default.svc
             - name: MY_POD_IP

--- a/tests/helm/testdata/goldenfile/events_otc_statefulset/common.output.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc_statefulset/common.output.yaml
@@ -131,6 +131,8 @@ spec:
                   name: sumologic
                   key: endpoint-events-otlp
 
+            - name: GODEBUG
+              value: "netdns=go"
             - name: NO_PROXY
               value: kubernetes.default.svc
             - name: MY_POD_IP

--- a/tests/helm/testdata/goldenfile/events_otc_statefulset/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc_statefulset/custom.output.yaml
@@ -117,6 +117,8 @@ spec:
                   name: sumologic
                   key: endpoint-events
 
+            - name: GODEBUG
+              value: "netdns=go"
             - name: NO_PROXY
               value: kubernetes.default.svc
             - name: MY_POD_IP

--- a/tests/helm/testdata/goldenfile/events_otc_statefulset/proxy.output.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc_statefulset/proxy.output.yaml
@@ -118,6 +118,8 @@ spec:
                   name: sumologic
                   key: endpoint-events-otlp
 
+            - name: GODEBUG
+              value: "netdns=go"
             - name: HTTP_PROXY
               value: http://proxy.internal
             - name: HTTPS_PROXY

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc_statefulset/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc_statefulset/basic.output.yaml
@@ -105,6 +105,8 @@ spec:
                   name: sumologic
                   key: endpoint-logs-otlp
 
+            - name: GODEBUG
+              value: "netdns=go"
             - name: NO_PROXY
               value: kubernetes.default.svc
             - name: MY_POD_IP

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc_statefulset/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc_statefulset/custom.output.yaml
@@ -124,6 +124,8 @@ spec:
                   name: sumologic
                   key: endpoint-logs
 
+            - name: GODEBUG
+              value: "netdns=go"
             - name: NO_PROXY
               value: kubernetes.default.svc
             - name: MY_POD_IP

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc_statefulset/pvcpolicyenabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc_statefulset/pvcpolicyenabled.output.yaml
@@ -121,6 +121,8 @@ spec:
                   name: sumologic
                   key: endpoint-logs
 
+            - name: GODEBUG
+              value: "netdns=go"
             - name: NO_PROXY
               value: kubernetes.default.svc
             - name: MY_POD_IP

--- a/tests/helm/testdata/goldenfile/setup/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/setup/basic.output.yaml
@@ -82,6 +82,8 @@ spec:
             - name: SUMOLOGIC_DASHBOARDS_ENABLED
               value: "true"
 
+            - name: GODEBUG
+              value: "netdns=go"
             - name: NO_PROXY
               value: kubernetes.default.svc
       securityContext:

--- a/tests/helm/testdata/goldenfile/setup/monitors_with_email_notifications.output.yaml
+++ b/tests/helm/testdata/goldenfile/setup/monitors_with_email_notifications.output.yaml
@@ -85,6 +85,8 @@ spec:
             - name: SUMOLOGIC_DASHBOARDS_ENABLED
               value: "true"
 
+            - name: GODEBUG
+              value: "netdns=go"
             - name: NO_PROXY
               value: kubernetes.default.svc
       securityContext:

--- a/tests/helm/testdata/goldenfile/setup/monitors_with_single_email.output.yaml
+++ b/tests/helm/testdata/goldenfile/setup/monitors_with_single_email.output.yaml
@@ -85,6 +85,8 @@ spec:
             - name: SUMOLOGIC_DASHBOARDS_ENABLED
               value: "true"
 
+            - name: GODEBUG
+              value: "netdns=go"
             - name: NO_PROXY
               value: kubernetes.default.svc
       securityContext:

--- a/tests/helm/testdata/goldenfile/setup/restart-policy.output.yaml
+++ b/tests/helm/testdata/goldenfile/setup/restart-policy.output.yaml
@@ -82,6 +82,8 @@ spec:
             - name: SUMOLOGIC_DASHBOARDS_ENABLED
               value: "true"
 
+            - name: GODEBUG
+              value: "netdns=go"
             - name: NO_PROXY
               value: kubernetes.default.svc
       securityContext:

--- a/tests/helm/testdata/goldenfile/setup/sumologic-mock-no-secret.output.yaml
+++ b/tests/helm/testdata/goldenfile/setup/sumologic-mock-no-secret.output.yaml
@@ -82,6 +82,8 @@ spec:
             - name: SUMOLOGIC_DASHBOARDS_ENABLED
               value: "true"
 
+            - name: GODEBUG
+              value: "netdns=go"
             - name: NO_PROXY
               value: kubernetes.default.svc
       securityContext:

--- a/tests/helm/testdata/goldenfile/setup/sumologic-mock.output.yaml
+++ b/tests/helm/testdata/goldenfile/setup/sumologic-mock.output.yaml
@@ -82,6 +82,8 @@ spec:
             - name: SUMOLOGIC_DASHBOARDS_ENABLED
               value: "true"
 
+            - name: GODEBUG
+              value: "netdns=go"
             - name: NO_PROXY
               value: kubernetes.default.svc
       securityContext:

--- a/tests/helm/testdata/goldenfile/traces-gateway-deployment/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-gateway-deployment/basic.output.yaml
@@ -61,6 +61,8 @@ spec:
                   name: sumologic
                   key: endpoint-metrics
 
+            - name: GODEBUG
+              value: "netdns=go"
             - name: NO_PROXY
               value: kubernetes.default.svc
             - name: MY_POD_IP

--- a/tests/helm/testdata/goldenfile/traces-gateway-deployment/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-gateway-deployment/custom.output.yaml
@@ -43,6 +43,8 @@ spec:
           args:
             - "--config=/conf/traces.gateway.conf.yaml"
           env:
+            - name: GODEBUG
+              value: "netdns=go"
             - name: GOGC
               value: "80"
             - name: SUMO_ENDPOINT_DEFAULT_TRACES_SOURCE

--- a/tests/helm/testdata/goldenfile/traces-sampler-deployment/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-sampler-deployment/basic.output.yaml
@@ -50,6 +50,8 @@ spec:
                   name: sumologic
                   key: endpoint-traces-otlp
 
+            - name: GODEBUG
+              value: "netdns=go"
             - name: NO_PROXY
               value: kubernetes.default.svc
             - name: MY_POD_IP

--- a/tests/helm/testdata/goldenfile/traces-sampler-deployment/persistence-enabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-sampler-deployment/persistence-enabled.output.yaml
@@ -50,6 +50,8 @@ spec:
                   name: sumologic
                   key: endpoint-traces-otlp
 
+            - name: GODEBUG
+              value: "netdns=go"
             - name: NO_PROXY
               value: kubernetes.default.svc
             - name: MY_POD_IP


### PR DESCRIPTION
This commit sets GODEBUG=netdns=go in deployments, jobs and statefulsets, selecting the netgo DNS resolver instead of the cgo resolver that is made available by the operating system. Previously, we relied on the collector to be built with only the netgo resolver. However, future releases of the collector will include both DNS resolvers, and a known issue in k8s collection requires the use of the netgo resolver.