### PR TITLE
feat(OSC-1274): Add export level batching

### DIFF
--- a/.changelog/4129.added.txt
+++ b/.changelog/4129.added.txt
@@ -1,0 +1,1 @@
+OSC-1274: Add export level batching

--- a/ci/check_configuration_keys.py
+++ b/ci/check_configuration_keys.py
@@ -53,8 +53,8 @@ SKIP_DEFAULTS = {
     'sumologic.setup.debug',
     'metrics-server.imagePullSecrets',
     'sumologic.events.sourceCategory',
-    'useExporterBatching',
-    'customBatchingConfigured',
+    'sumologic.useExporterBatching',
+    'sumologic.customBatchingConfigured',
 }
 
 def main(values_path: str, readme_path: str, full_diff=False) -> None:

--- a/ci/check_configuration_keys.py
+++ b/ci/check_configuration_keys.py
@@ -53,6 +53,8 @@ SKIP_DEFAULTS = {
     'sumologic.setup.debug',
     'metrics-server.imagePullSecrets',
     'sumologic.events.sourceCategory',
+    'useExporterBatching',
+    'customBatchingConfigured',
 }
 
 def main(values_path: str, readme_path: str, full_diff=False) -> None:

--- a/deploy/helm/sumologic/conf/events/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/events/otelcol/config.yaml
@@ -8,7 +8,7 @@ exporters:
 {{- if .Values.sumologic.events.persistence.enabled }}
       storage: file_storage
 {{- end }}
-{{- if eq .Values.useExporterBatching true }}
+{{- if eq .Values.sumologic.useExporterBatching true }}
       queue_size: 1024000
       batch:
         flush_timeout: 1s
@@ -19,7 +19,7 @@ exporters:
 {{- if eq .Values.debug.events.print true }}
   debug:
     verbosity: detailed
-{{- if eq .Values.useExporterBatching true }}
+{{- if eq .Values.sumologic.useExporterBatching true }}
     sending_queue:
       enabled: true
       queue_size: 1024000
@@ -37,7 +37,7 @@ exporters:
     log_format: {{ include "sumologic.events.exporter.format" . }}
     sending_queue:
       enabled: true
-{{- if eq .Values.useExporterBatching true }}
+{{- if eq .Values.sumologic.useExporterBatching true }}
       queue_size: 1024000
       batch:
         flush_timeout: 1s
@@ -182,7 +182,7 @@ service:
         - source
         - sumologic
         - transform/add_timestamp
-{{- if eq .Values.useExporterBatching false }}
+{{- if eq .Values.sumologic.useExporterBatching false }}
         - batch
 {{- end }}
       receivers:
@@ -207,7 +207,7 @@ service:
         - source
         - sumologic
         - transform/add_timestamp
-{{- if eq .Values.useExporterBatching false }}
+{{- if eq .Values.sumologic.useExporterBatching false }}
         - batch
 {{- end }}
       receivers:

--- a/deploy/helm/sumologic/conf/events/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/events/otelcol/config.yaml
@@ -8,10 +8,26 @@ exporters:
 {{- if .Values.sumologic.events.persistence.enabled }}
       storage: file_storage
 {{- end }}
+{{- if eq .Values.useExporterBatching true }}
+      queue_size: 1024000
+      batch:
+        flush_timeout: 1s
+        min_size: 1_024
+        max_size: 2_048
+{{- end }}
 
 {{- if eq .Values.debug.events.print true }}
   debug:
     verbosity: detailed
+{{- if eq .Values.useExporterBatching true }}
+    sending_queue:
+      enabled: true
+      queue_size: 1024000
+      batch:
+        flush_timeout: 1s
+        min_size: 1024
+        max_size: 2048
+{{- end }}
 {{- end }}
 
 {{- if eq (include "sumologic-mock.forward-events" .) "true" }}
@@ -21,6 +37,13 @@ exporters:
     log_format: {{ include "sumologic.events.exporter.format" . }}
     sending_queue:
       enabled: true
+{{- if eq .Values.useExporterBatching true }}
+      queue_size: 1024000
+      batch:
+        flush_timeout: 1s
+        min_size: 1_024
+        max_size: 2_048
+{{- end }}
 {{- end }}
 
 extensions:
@@ -159,7 +182,9 @@ service:
         - source
         - sumologic
         - transform/add_timestamp
+{{- if eq .Values.useExporterBatching false }}
         - batch
+{{- end }}
       receivers:
         - k8sobjects/configmaps
 {{- end }}
@@ -182,7 +207,9 @@ service:
         - source
         - sumologic
         - transform/add_timestamp
+{{- if eq .Values.useExporterBatching false }}
         - batch
+{{- end }}
       receivers:
 {{- if .Values.otelevents.useSumoK8sEventReceiver }}
         - raw_k8s_events

--- a/deploy/helm/sumologic/conf/instrumentation/otelcol.instrumentation.conf.yaml
+++ b/deploy/helm/sumologic/conf/instrumentation/otelcol.instrumentation.conf.yaml
@@ -5,6 +5,15 @@ exporters:
 {{- if eq .Values.debug.instrumentation.otelcolInstrumentation.print true }}
   debug:
     verbosity: detailed
+{{- if eq .Values.useExporterBatching true }}
+    sending_queue:
+      enabled: true
+      queue_size: 2560000
+      batch:
+        flush_timeout: 5s
+        min_size: 256
+        max_size: 512
+{{- end }}
 {{- end }}
 
   sumologic/metrics:
@@ -34,14 +43,31 @@ exporters:
       enabled: false
       ## Number of consumers that dequeue batches
       num_consumers: 10
+{{- if eq .Values.useExporterBatching true }}
+      queue_size: 1280000
+      batch:
+        flush_timeout: 5s
+        min_size: 256
+        max_size: 512
+{{ else }}
       ## Maximum number of batches kept in memory before data
       ## User should calculate this as num_seconds * requests_per_second where:
       ## num_seconds is the number of seconds to buffer in case of a backend outage
       ## requests_per_second is the average number of requests per seconds.
       queue_size: 5000
+{{- end }}
 {{- if eq .Values.tracesGateway.enabled true }}
   otlphttp/traces:
     endpoint: 'http://{{ include "otelcolinstrumentation.exporter.endpoint" . }}:4318'
+{{- if eq .Values.useExporterBatching true }}
+    sending_queue:
+      enabled: true
+      queue_size: 256000
+      batch:
+        flush_timeout: 5s
+        min_size: 256
+        max_size: 512
+{{- end }}
 {{- else }}
   loadbalancing:
     protocol:
@@ -52,7 +78,15 @@ exporters:
         sending_queue:
           enabled: true
           num_consumers: 10
+{{- if eq .Values.useExporterBatching true }}
+          queue_size: 2560000
+          batch:
+            flush_timeout: 5s
+            min_size: 256
+            max_size: 512
+{{ else }}
           queue_size: 10_000
+{{- end }}
     resolver:
       dns:
         hostname: '{{ include "tracesgateway.exporter.loadbalancing.endpoint" . }}'
@@ -231,7 +265,18 @@ service:
   pipelines:
     traces:
       receivers: [jaeger, otlp, otlp/deprecated, zipkin]
-      processors: [memory_limiter, {{ if .Values.otelcolInstrumentation.useSumoK8sProcessor }}k8s_tagger{{ else }}k8sattributes{{ end }}, source, resource, batch]
+      processors:
+        - memory_limiter
+{{ if .Values.otelcolInstrumentation.useSumoK8sProcessor }}
+        - k8s_tagger
+{{ else }}
+        - k8sattributes
+{{ end }}
+        - source
+        - resource
+{{- if eq .Values.useExporterBatching false }}
+        - batch
+{{- end }}
       exporters:
 {{- if eq .Values.tracesGateway.enabled true }}
         - otlphttp/traces
@@ -243,7 +288,18 @@ service:
 {{- end }}
     metrics:
       receivers: [otlp, otlp/deprecated]
-      processors: [memory_limiter, {{ if .Values.otelcolInstrumentation.useSumoK8sProcessor }}k8s_tagger{{ else }}k8sattributes{{ end }}, source, resource, batch]
+      processors:
+        - memory_limiter
+{{ if .Values.otelcolInstrumentation.useSumoK8sProcessor }}
+        - k8s_tagger
+{{ else }}
+        - k8sattributes
+{{ end }}
+        - source
+        - resource
+{{- if eq .Values.useExporterBatching false }}
+        - batch
+{{- end }}
       exporters:
         - sumologic/metrics
 {{- if eq .Values.debug.instrumentation.otelcolInstrumentation.print true }}

--- a/deploy/helm/sumologic/conf/instrumentation/otelcol.instrumentation.conf.yaml
+++ b/deploy/helm/sumologic/conf/instrumentation/otelcol.instrumentation.conf.yaml
@@ -5,7 +5,7 @@ exporters:
 {{- if eq .Values.debug.instrumentation.otelcolInstrumentation.print true }}
   debug:
     verbosity: detailed
-{{- if eq .Values.useExporterBatching true }}
+{{- if eq .Values.sumologic.useExporterBatching true }}
     sending_queue:
       enabled: true
       queue_size: 2560000
@@ -43,7 +43,7 @@ exporters:
       enabled: false
       ## Number of consumers that dequeue batches
       num_consumers: 10
-{{- if eq .Values.useExporterBatching true }}
+{{- if eq .Values.sumologic.useExporterBatching true }}
       queue_size: 1280000
       batch:
         flush_timeout: 5s
@@ -59,7 +59,7 @@ exporters:
 {{- if eq .Values.tracesGateway.enabled true }}
   otlphttp/traces:
     endpoint: 'http://{{ include "otelcolinstrumentation.exporter.endpoint" . }}:4318'
-{{- if eq .Values.useExporterBatching true }}
+{{- if eq .Values.sumologic.useExporterBatching true }}
     sending_queue:
       enabled: true
       queue_size: 256000
@@ -78,7 +78,7 @@ exporters:
         sending_queue:
           enabled: true
           num_consumers: 10
-{{- if eq .Values.useExporterBatching true }}
+{{- if eq .Values.sumologic.useExporterBatching true }}
           queue_size: 2560000
           batch:
             flush_timeout: 5s
@@ -274,7 +274,7 @@ service:
 {{ end }}
         - source
         - resource
-{{- if eq .Values.useExporterBatching false }}
+{{- if eq .Values.sumologic.useExporterBatching false }}
         - batch
 {{- end }}
       exporters:
@@ -297,7 +297,7 @@ service:
 {{ end }}
         - source
         - resource
-{{- if eq .Values.useExporterBatching false }}
+{{- if eq .Values.sumologic.useExporterBatching false }}
         - batch
 {{- end }}
       exporters:

--- a/deploy/helm/sumologic/conf/instrumentation/traces.gateway.conf.yaml
+++ b/deploy/helm/sumologic/conf/instrumentation/traces.gateway.conf.yaml
@@ -3,6 +3,15 @@ exporters:
 {{- if eq .Values.debug.instrumentation.tracesGateway.print true }}
   debug:
     verbosity: detailed
+{{- if eq .Values.useExporterBatching true }}
+    sending_queue:
+      enabled: true
+      queue_size: 2560000
+      batch:
+        flush_timeout: 5s
+        min_size: 256
+        max_size: 512
+{{- end }}
 {{- end }}
 
   loadbalancing:
@@ -14,7 +23,15 @@ exporters:
         sending_queue:
           enabled: true
           num_consumers: 10
+{{- if eq .Values.useExporterBatching true }}
+          queue_size: 2560000
+          batch:
+            flush_timeout: 5s
+            min_size: 256
+            max_size: 512
+{{ else }}
           queue_size: 10_000
+{{- end }}
     resolver:
       dns:
         hostname: '{{ include "tracesgateway.exporter.loadbalancing.endpoint" . }}'
@@ -64,7 +81,11 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [memory_limiter, batch]
+      processors: 
+        - memory_limiter
+{{- if eq .Values.useExporterBatching false }}
+        - batch
+{{- end }}
       exporters:
         - loadbalancing
 {{- if eq .Values.debug.instrumentation.tracesGateway.print true }}

--- a/deploy/helm/sumologic/conf/instrumentation/traces.gateway.conf.yaml
+++ b/deploy/helm/sumologic/conf/instrumentation/traces.gateway.conf.yaml
@@ -3,7 +3,7 @@ exporters:
 {{- if eq .Values.debug.instrumentation.tracesGateway.print true }}
   debug:
     verbosity: detailed
-{{- if eq .Values.useExporterBatching true }}
+{{- if eq .Values.sumologic.useExporterBatching true }}
     sending_queue:
       enabled: true
       queue_size: 2560000
@@ -23,7 +23,7 @@ exporters:
         sending_queue:
           enabled: true
           num_consumers: 10
-{{- if eq .Values.useExporterBatching true }}
+{{- if eq .Values.sumologic.useExporterBatching true }}
           queue_size: 2560000
           batch:
             flush_timeout: 5s
@@ -81,9 +81,9 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: 
+      processors:
         - memory_limiter
-{{- if eq .Values.useExporterBatching false }}
+{{- if eq .Values.sumologic.useExporterBatching false }}
         - batch
 {{- end }}
       exporters:

--- a/deploy/helm/sumologic/conf/instrumentation/traces.sampler.conf.yaml
+++ b/deploy/helm/sumologic/conf/instrumentation/traces.sampler.conf.yaml
@@ -3,7 +3,7 @@ exporters:
 {{- if eq .Values.debug.instrumentation.tracesSampler.print true }}
   debug:
     verbosity: detailed
-{{- if eq .Values.useExporterBatching true }}
+{{- if eq .Values.sumologic.useExporterBatching true }}
     sending_queue:
       enabled: true
       queue_size: 2560000
@@ -22,7 +22,7 @@ exporters:
     endpoint: {{ include "sumologic-mock.receiver-endpoint" . }}
 {{- end }}
     compression: gzip
-{{- if eq .Values.useExporterBatching true }}
+{{- if eq .Values.sumologic.useExporterBatching true }}
     sending_queue:
       enabled: true
       queue_size: 2560000
@@ -43,7 +43,7 @@ exporters:
     sending_queue:
       enabled: true
       num_consumers: 10
-{{- if eq .Values.useExporterBatching true }}
+{{- if eq .Values.sumologic.useExporterBatching true }}
       queue_size: 2560000
       batch:
         flush_timeout: 5s
@@ -121,7 +121,7 @@ service:
       processors:
         - memory_limiter
         - cascading_filter
-{{- if eq .Values.useExporterBatching false }}
+{{- if eq .Values.sumologic.useExporterBatching false }}
         - batch
 {{- end }}
       exporters:

--- a/deploy/helm/sumologic/conf/instrumentation/traces.sampler.conf.yaml
+++ b/deploy/helm/sumologic/conf/instrumentation/traces.sampler.conf.yaml
@@ -3,6 +3,15 @@ exporters:
 {{- if eq .Values.debug.instrumentation.tracesSampler.print true }}
   debug:
     verbosity: detailed
+{{- if eq .Values.useExporterBatching true }}
+    sending_queue:
+      enabled: true
+      queue_size: 2560000
+      batch:
+        flush_timeout: 5s
+        min_size: 256
+        max_size: 512
+{{- end }}
 {{- end }}
 
 {{- if eq (include "sumologic-mock.forward-instrumentation" .) "true" }}
@@ -13,6 +22,15 @@ exporters:
     endpoint: {{ include "sumologic-mock.receiver-endpoint" . }}
 {{- end }}
     compression: gzip
+{{- if eq .Values.useExporterBatching true }}
+    sending_queue:
+      enabled: true
+      queue_size: 2560000
+      batch:
+        flush_timeout: 5s
+        min_size: 256
+        max_size: 512
+{{- end }}
 {{- end }}
 
   otlphttp:
@@ -25,7 +43,15 @@ exporters:
     sending_queue:
       enabled: true
       num_consumers: 10
+{{- if eq .Values.useExporterBatching true }}
+      queue_size: 2560000
+      batch:
+        flush_timeout: 5s
+        min_size: 256
+        max_size: 512
+{{ else }}
       queue_size: 10_000
+{{- end }}
 {{- if .Values.tracesSampler.persistence.enabled }}
       storage: file_storage
 {{- end }}
@@ -92,7 +118,12 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [memory_limiter, cascading_filter, batch]
+      processors:
+        - memory_limiter
+        - cascading_filter
+{{- if eq .Values.useExporterBatching false }}
+        - batch
+{{- end }}
       exporters:
         - otlphttp
 {{- if eq (include "sumologic-mock.forward-instrumentation" .) "true" }}

--- a/deploy/helm/sumologic/conf/logs/collector/otelcloudwatch/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/collector/otelcloudwatch/config.yaml
@@ -2,7 +2,7 @@ exporters:
   otlphttp:
     endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.{{ .Values.sumologic.clusterDNSDomain }}.:4318
     sending_queue:
-{{- if eq .Values.useExporterBatching true }}
+{{- if eq .Values.sumologic.useExporterBatching true }}
       queue_size: 10000
       batch:
         flush_timeout: 1s
@@ -105,7 +105,7 @@ service:
         - transform/parsejson
         - logstransform/cloudwatch
         - transform/metadata
-{{- if eq .Values.useExporterBatching false }}
+{{- if eq .Values.sumologic.useExporterBatching false }}
         - batch
 {{- end }}
       exporters:

--- a/deploy/helm/sumologic/conf/logs/collector/otelcloudwatch/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/collector/otelcloudwatch/config.yaml
@@ -2,7 +2,15 @@ exporters:
   otlphttp:
     endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.{{ .Values.sumologic.clusterDNSDomain }}.:4318
     sending_queue:
+{{- if eq .Values.useExporterBatching true }}
+      queue_size: 10000
+      batch:
+        flush_timeout: 1s
+        min_size: 1000
+        max_size: 2000
+{{ else }}
       queue_size: 10
+{{- end }}
     # this improves load balancing at the cost of more network traffic
     disable_keep_alives: true
 
@@ -97,7 +105,9 @@ service:
         - transform/parsejson
         - logstransform/cloudwatch
         - transform/metadata
+{{- if eq .Values.useExporterBatching false }}
         - batch
+{{- end }}
       exporters:
         - otlphttp
   telemetry:

--- a/deploy/helm/sumologic/conf/logs/collector/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/collector/otelcol/config.yaml
@@ -2,7 +2,7 @@ exporters:
   otlphttp:
     endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.{{ .Values.sumologic.clusterDNSDomain }}.:4318
     sending_queue:
-{{- if eq .Values.useExporterBatching true }}
+{{- if eq .Values.sumologic.useExporterBatching true }}
       queue_size: 10000
       batch:
         flush_timeout: 1s
@@ -141,7 +141,7 @@ service:
         - debug
 {{- end }}
       processors:
-{{- if eq .Values.useExporterBatching false }}
+{{- if eq .Values.sumologic.useExporterBatching false }}
         - batch
 {{- end }}
       receivers:
@@ -156,7 +156,7 @@ service:
 {{- end }}
       processors:
         - logstransform/systemd
-{{- if eq .Values.useExporterBatching false }}
+{{- if eq .Values.sumologic.useExporterBatching false }}
         - batch
 {{- end }}
       receivers:

--- a/deploy/helm/sumologic/conf/logs/collector/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/collector/otelcol/config.yaml
@@ -2,7 +2,15 @@ exporters:
   otlphttp:
     endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.{{ .Values.sumologic.clusterDNSDomain }}.:4318
     sending_queue:
+{{- if eq .Values.useExporterBatching true }}
+      queue_size: 10000
+      batch:
+        flush_timeout: 1s
+        min_size: 1000
+        max_size: 2000
+{{ else }}
       queue_size: 10
+{{- end }}
     # this improves load balancing at the cost of more network traffic
     disable_keep_alives: true
 {{- if eq .Values.debug.logs.collector.print true }}
@@ -133,7 +141,9 @@ service:
         - debug
 {{- end }}
       processors:
+{{- if eq .Values.useExporterBatching false }}
         - batch
+{{- end }}
       receivers:
         - filelog/containers
 {{- end }}
@@ -146,7 +156,9 @@ service:
 {{- end }}
       processors:
         - logstransform/systemd
+{{- if eq .Values.useExporterBatching false }}
         - batch
+{{- end }}
       receivers:
         - journald
 {{- end }}

--- a/deploy/helm/sumologic/conf/logs/collector/otellogswindows/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/collector/otellogswindows/config.yaml
@@ -2,7 +2,7 @@ exporters:
   otlphttp:
     endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.{{ .Values.sumologic.clusterDNSDomain }}.:4318
     sending_queue:
-{{- if eq .Values.useExporterBatching true }}
+{{- if eq .Values.sumologic.useExporterBatching true }}
       queue_size: 10000
       batch:
         flush_timeout: 1s
@@ -54,7 +54,7 @@ service:
         - debug
 {{- end }}
       processors:
-{{- if eq .Values.useExporterBatching false }}
+{{- if eq .Values.sumologic.useExporterBatching false }}
         - batch
 {{- end }}
       receivers:

--- a/deploy/helm/sumologic/conf/logs/collector/otellogswindows/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/collector/otellogswindows/config.yaml
@@ -2,7 +2,15 @@ exporters:
   otlphttp:
     endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.{{ .Values.sumologic.clusterDNSDomain }}.:4318
     sending_queue:
+{{- if eq .Values.useExporterBatching true }}
+      queue_size: 10000
+      batch:
+        flush_timeout: 1s
+        min_size: 1000
+        max_size: 2000
+{{ else }}
       queue_size: 10
+{{- end }}
     # this improves load balancing at the cost of more network traffic
     disable_keep_alives: true
 {{- if eq .Values.debug.logs.otellogswindows.print true }}
@@ -46,7 +54,9 @@ service:
         - debug
 {{- end }}
       processors:
+{{- if eq .Values.useExporterBatching false }}
         - batch
+{{- end }}
       receivers:
         - filelog/containers
 {{- end }}

--- a/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
@@ -12,7 +12,15 @@ exporters:
     sending_queue:
       enabled: true
       num_consumers: 10
+{{- if eq .Values.useExporterBatching true }}
+      queue_size: 10240000
+      batch:
+        flush_timeout: 1s
+        min_size: 1_024
+        max_size: 2_048
+{{ else }}
       queue_size: 10_000
+{{- end }}
 {{- if .Values.metadata.persistence.enabled }}
       storage: file_storage
 {{- end }}
@@ -24,7 +32,15 @@ exporters:
     sending_queue:
       enabled: true
       num_consumers: 10
+{{- if eq .Values.useExporterBatching true }}
+      queue_size: 10240000
+      batch:
+        flush_timeout: 1s
+        min_size: 1_024
+        max_size: 2_048
+{{ else }}
       queue_size: 10_000
+{{- end }}
 {{- if .Values.metadata.persistence.enabled }}
       storage: file_storage
 {{- end }}
@@ -39,7 +55,15 @@ exporters:
     sending_queue:
       enabled: true
       num_consumers: 10
+{{- if eq .Values.useExporterBatching true }}
+      queue_size: 10240000
+      batch:
+        flush_timeout: 1s
+        min_size: 1_024
+        max_size: 2_048
+{{ else }}
       queue_size: 10_000
+{{- end }}
 {{- if .Values.metadata.persistence.enabled }}
       storage: file_storage
 {{- end }}
@@ -51,7 +75,15 @@ exporters:
     sending_queue:
       enabled: true
       num_consumers: 10
+{{- if eq .Values.useExporterBatching true }}
+      queue_size: 10240000
+      batch:
+        flush_timeout: 1s
+        min_size: 1_024
+        max_size: 2_048
+{{ else }}
       queue_size: 10_000
+{{- end }}
 {{- if .Values.metadata.persistence.enabled }}
       storage: file_storage
 {{- end }}
@@ -67,7 +99,15 @@ exporters:
     sending_queue:
       enabled: true
       num_consumers: 10
+{{- if eq .Values.useExporterBatching true }}
+      queue_size: 10240000
+      batch:
+        flush_timeout: 1s
+        min_size: 1_024
+        max_size: 2_048
+{{ else }}
       queue_size: 10_000
+{{- end }}
 {{- if .Values.metadata.persistence.enabled }}
       storage: file_storage
 {{- end }}
@@ -80,7 +120,15 @@ exporters:
     sending_queue:
       enabled: true
       num_consumers: 10
+{{- if eq .Values.useExporterBatching true }}
+      queue_size: 10240000
+      batch:
+        flush_timeout: 1s
+        min_size: 1_024
+        max_size: 2_048
+{{ else }}
       queue_size: 10_000
+{{- end }}
 {{- if .Values.metadata.persistence.enabled }}
       storage: file_storage
 {{- end }}
@@ -638,7 +686,9 @@ service:
 {{- if and .Values.sumologic.logs.otelcol.routing.table (not .Values.sumologic.logs.otelcol.useDefaultExporters) }}
         - transform/add_default_pipeline_tag
 {{- end }}
+{{- if eq .Values.useExporterBatching false }}
         - batch
+{{- end }}
       receivers:
         - otlp
 {{ end }}
@@ -675,7 +725,9 @@ service:
 {{- if and .Values.sumologic.logs.otelcol.routing.table (not .Values.sumologic.logs.otelcol.useDefaultExporters) }}
         - transform/add_default_pipeline_tag
 {{- end }}
+{{- if eq .Values.useExporterBatching false }}
         - batch
+{{- end }}
       receivers:
         - otlp
 
@@ -711,7 +763,9 @@ service:
 {{- if and .Values.sumologic.logs.otelcol.routing.table (not .Values.sumologic.logs.otelcol.useDefaultExporters) }}
         - transform/add_default_pipeline_tag
 {{- end }}
+{{- if eq .Values.useExporterBatching false }}
         - batch
+{{- end }}
       receivers:
         - otlp
 {{ end }}

--- a/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
@@ -12,7 +12,7 @@ exporters:
     sending_queue:
       enabled: true
       num_consumers: 10
-{{- if eq .Values.useExporterBatching true }}
+{{- if eq .Values.sumologic.useExporterBatching true }}
       queue_size: 10240000
       batch:
         flush_timeout: 1s
@@ -32,7 +32,7 @@ exporters:
     sending_queue:
       enabled: true
       num_consumers: 10
-{{- if eq .Values.useExporterBatching true }}
+{{- if eq .Values.sumologic.useExporterBatching true }}
       queue_size: 10240000
       batch:
         flush_timeout: 1s
@@ -55,7 +55,7 @@ exporters:
     sending_queue:
       enabled: true
       num_consumers: 10
-{{- if eq .Values.useExporterBatching true }}
+{{- if eq .Values.sumologic.useExporterBatching true }}
       queue_size: 10240000
       batch:
         flush_timeout: 1s
@@ -75,7 +75,7 @@ exporters:
     sending_queue:
       enabled: true
       num_consumers: 10
-{{- if eq .Values.useExporterBatching true }}
+{{- if eq .Values.sumologic.useExporterBatching true }}
       queue_size: 10240000
       batch:
         flush_timeout: 1s
@@ -99,7 +99,7 @@ exporters:
     sending_queue:
       enabled: true
       num_consumers: 10
-{{- if eq .Values.useExporterBatching true }}
+{{- if eq .Values.sumologic.useExporterBatching true }}
       queue_size: 10240000
       batch:
         flush_timeout: 1s
@@ -120,7 +120,7 @@ exporters:
     sending_queue:
       enabled: true
       num_consumers: 10
-{{- if eq .Values.useExporterBatching true }}
+{{- if eq .Values.sumologic.useExporterBatching true }}
       queue_size: 10240000
       batch:
         flush_timeout: 1s
@@ -686,7 +686,7 @@ service:
 {{- if and .Values.sumologic.logs.otelcol.routing.table (not .Values.sumologic.logs.otelcol.useDefaultExporters) }}
         - transform/add_default_pipeline_tag
 {{- end }}
-{{- if eq .Values.useExporterBatching false }}
+{{- if eq .Values.sumologic.useExporterBatching false }}
         - batch
 {{- end }}
       receivers:
@@ -725,7 +725,7 @@ service:
 {{- if and .Values.sumologic.logs.otelcol.routing.table (not .Values.sumologic.logs.otelcol.useDefaultExporters) }}
         - transform/add_default_pipeline_tag
 {{- end }}
-{{- if eq .Values.useExporterBatching false }}
+{{- if eq .Values.sumologic.useExporterBatching false }}
         - batch
 {{- end }}
       receivers:
@@ -763,7 +763,7 @@ service:
 {{- if and .Values.sumologic.logs.otelcol.routing.table (not .Values.sumologic.logs.otelcol.useDefaultExporters) }}
         - transform/add_default_pipeline_tag
 {{- end }}
-{{- if eq .Values.useExporterBatching false }}
+{{- if eq .Values.sumologic.useExporterBatching false }}
         - batch
 {{- end }}
       receivers:

--- a/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
@@ -8,9 +8,17 @@ exporters:
   otlphttp:
     endpoint: http://${METADATA_METRICS_SVC}.${NAMESPACE}.svc.{{ .Values.sumologic.clusterDNSDomain }}.:4318
     sending_queue:
-      queue_size: 10000
       num_consumers: 10
       storage: file_storage
+{{- if eq .Values.useExporterBatching true }}
+      queue_size: 10000000
+      batch:
+        flush_timeout: 1s
+        min_size: 1000
+        max_size: 2000
+{{ else }}
+      queue_size: 10000
+{{- end }}
     # this improves load balancing at the cost of more network traffic
     disable_keep_alives: true
 
@@ -89,7 +97,9 @@ service:
 {{- end }}
         - otlphttp
       processors:
+{{- if eq .Values.useExporterBatching false }}
         - batch
+{{- end }}
         - filter/drop_stale_datapoints
 {{- if .Values.sumologic.metrics.dropHistogramBuckets }}
         - transform/extract_sum_count_from_histograms

--- a/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
@@ -10,7 +10,7 @@ exporters:
     sending_queue:
       num_consumers: 10
       storage: file_storage
-{{- if eq .Values.useExporterBatching true }}
+{{- if eq .Values.sumologic.useExporterBatching true }}
       queue_size: 10000000
       batch:
         flush_timeout: 1s
@@ -97,7 +97,7 @@ service:
 {{- end }}
         - otlphttp
       processors:
-{{- if eq .Values.useExporterBatching false }}
+{{- if eq .Values.sumologic.useExporterBatching false }}
         - batch
 {{- end }}
         - filter/drop_stale_datapoints

--- a/deploy/helm/sumologic/conf/metrics/otelcol/exporters.yaml
+++ b/deploy/helm/sumologic/conf/metrics/otelcol/exporters.yaml
@@ -1,7 +1,7 @@
 {{- if eq .Values.debug.metrics.metadata.print true }}
 debug:
   verbosity: detailed
-{{- if eq .Values.useExporterBatching true }}
+{{- if eq .Values.sumologic.useExporterBatching true }}
   sending_queue:
     enabled: true
     queue_size: 1024000
@@ -30,7 +30,7 @@ sumologic/sumologic-mock-default:
     num_consumers: 10
     ## setting queue_size a high number, so we always use maximum space of the storage
     ## minimal alert non-triggering queue size (if only one exporter is being used): 10GB/16MB = 640
-{{- if eq .Values.useExporterBatching true }}
+{{- if eq .Values.sumologic.useExporterBatching true }}
     queue_size: 10240000
     batch:
       flush_timeout: 1s
@@ -53,7 +53,7 @@ sumologic/sumologic-mock-http:
     storage: file_storage
 {{- end }}
     num_consumers: 10
-{{- if eq .Values.useExporterBatching true }}
+{{- if eq .Values.sumologic.useExporterBatching true }}
     queue_size: 10240000
     batch:
       flush_timeout: 1s
@@ -86,7 +86,7 @@ sumologic/default:
     num_consumers: 10
     ## setting queue_size a high number, so we always use maximum space of the storage
     ## minimal alert non-triggering queue size (if only one exporter is being used): 10GB/16MB = 640
-{{- if eq .Values.useExporterBatching true }}
+{{- if eq .Values.sumologic.useExporterBatching true }}
     queue_size: 10240000
     batch:
       flush_timeout: 1s
@@ -109,7 +109,7 @@ sumologic/apiserver:
     storage: file_storage
 {{- end }}
     num_consumers: 10
-{{- if eq .Values.useExporterBatching true }}
+{{- if eq .Values.sumologic.useExporterBatching true }}
     queue_size: 10240000
     batch:
       flush_timeout: 1s
@@ -131,7 +131,7 @@ sumologic/control_plane:
     storage: file_storage
 {{- end }}
     num_consumers: 10
-{{- if eq .Values.useExporterBatching true }}
+{{- if eq .Values.sumologic.useExporterBatching true }}
     queue_size: 10240000
     batch:
       flush_timeout: 1s
@@ -153,7 +153,7 @@ sumologic/controller:
     storage: file_storage
 {{- end }}
     num_consumers: 10
-{{- if eq .Values.useExporterBatching true }}
+{{- if eq .Values.sumologic.useExporterBatching true }}
     queue_size: 10240000
     batch:
       flush_timeout: 1s
@@ -175,7 +175,7 @@ sumologic/kubelet:
     storage: file_storage
 {{- end }}
     num_consumers: 10
-{{- if eq .Values.useExporterBatching true }}
+{{- if eq .Values.sumologic.useExporterBatching true }}
     queue_size: 10240000
     batch:
       flush_timeout: 1s
@@ -197,7 +197,7 @@ sumologic/node:
     storage: file_storage
 {{- end }}
     num_consumers: 10
-{{- if eq .Values.useExporterBatching true }}
+{{- if eq .Values.sumologic.useExporterBatching true }}
     queue_size: 10240000
     batch:
       flush_timeout: 1s
@@ -219,7 +219,7 @@ sumologic/scheduler:
     storage: file_storage
 {{- end }}
     num_consumers: 10
-{{- if eq .Values.useExporterBatching true }}
+{{- if eq .Values.sumologic.useExporterBatching true }}
     queue_size: 10240000
     batch:
       flush_timeout: 1s
@@ -241,7 +241,7 @@ sumologic/state:
     storage: file_storage
 {{- end }}
     num_consumers: 10
-{{- if eq .Values.useExporterBatching true }}
+{{- if eq .Values.sumologic.useExporterBatching true }}
     queue_size: 10240000
     batch:
       flush_timeout: 1s

--- a/deploy/helm/sumologic/conf/metrics/otelcol/exporters.yaml
+++ b/deploy/helm/sumologic/conf/metrics/otelcol/exporters.yaml
@@ -1,6 +1,15 @@
 {{- if eq .Values.debug.metrics.metadata.print true }}
 debug:
   verbosity: detailed
+{{- if eq .Values.useExporterBatching true }}
+  sending_queue:
+    enabled: true
+    queue_size: 1024000
+    batch:
+      flush_timeout: 1s
+      min_size: 1_024
+      max_size: 2_048
+{{- end }}
 {{- end }}
 
 {{- if eq (include "sumologic-mock.forward-metrics-metadata" .) "true" }}
@@ -21,7 +30,15 @@ sumologic/sumologic-mock-default:
     num_consumers: 10
     ## setting queue_size a high number, so we always use maximum space of the storage
     ## minimal alert non-triggering queue size (if only one exporter is being used): 10GB/16MB = 640
+{{- if eq .Values.useExporterBatching true }}
+    queue_size: 10240000
+    batch:
+      flush_timeout: 1s
+      min_size: 1_024
+      max_size: 2_048
+{{ else }}
     queue_size: 10_000
+{{- end }}
   max_request_body_size: 16_777_216  # 16 MB before compression
   ## set timeout to 30s due to big requests
   timeout: 30s
@@ -36,7 +53,15 @@ sumologic/sumologic-mock-http:
     storage: file_storage
 {{- end }}
     num_consumers: 10
+{{- if eq .Values.useExporterBatching true }}
+    queue_size: 10240000
+    batch:
+      flush_timeout: 1s
+      min_size: 1_024
+      max_size: 2_048
+{{ else }}
     queue_size: 10_000
+{{- end }}
   max_request_body_size: 16_777_216  # 16 MB before compression
   ## set timeout to 30s due to big requests
   timeout: 30s
@@ -61,7 +86,15 @@ sumologic/default:
     num_consumers: 10
     ## setting queue_size a high number, so we always use maximum space of the storage
     ## minimal alert non-triggering queue size (if only one exporter is being used): 10GB/16MB = 640
+{{- if eq .Values.useExporterBatching true }}
+    queue_size: 10240000
+    batch:
+      flush_timeout: 1s
+      min_size: 1_024
+      max_size: 2_048
+{{ else }}
     queue_size: 10_000
+{{- end }}
   max_request_body_size: 16_777_216  # 16 MB before compression
   ## set timeout to 30s due to big requests
   timeout: 30s
@@ -76,7 +109,15 @@ sumologic/apiserver:
     storage: file_storage
 {{- end }}
     num_consumers: 10
+{{- if eq .Values.useExporterBatching true }}
+    queue_size: 10240000
+    batch:
+      flush_timeout: 1s
+      min_size: 1_024
+      max_size: 2_048
+{{ else }}
     queue_size: 10_000
+{{- end }}
   max_request_body_size: 16_777_216  # 16 MB before compression
   ## set timeout to 30s due to big requests
   timeout: 30s
@@ -90,7 +131,15 @@ sumologic/control_plane:
     storage: file_storage
 {{- end }}
     num_consumers: 10
+{{- if eq .Values.useExporterBatching true }}
+    queue_size: 10240000
+    batch:
+      flush_timeout: 1s
+      min_size: 1_024
+      max_size: 2_048
+{{ else }}
     queue_size: 10_000
+{{- end }}
   max_request_body_size: 16_777_216  # 16 MB before compression
   ## set timeout to 30s due to big requests
   timeout: 30s
@@ -104,7 +153,15 @@ sumologic/controller:
     storage: file_storage
 {{- end }}
     num_consumers: 10
+{{- if eq .Values.useExporterBatching true }}
+    queue_size: 10240000
+    batch:
+      flush_timeout: 1s
+      min_size: 1_024
+      max_size: 2_048
+{{ else }}
     queue_size: 10_000
+{{- end }}
   max_request_body_size: 16_777_216  # 16 MB before compression
   ## set timeout to 30s due to big requests
   timeout: 30s
@@ -118,7 +175,15 @@ sumologic/kubelet:
     storage: file_storage
 {{- end }}
     num_consumers: 10
+{{- if eq .Values.useExporterBatching true }}
+    queue_size: 10240000
+    batch:
+      flush_timeout: 1s
+      min_size: 1_024
+      max_size: 2_048
+{{ else }}
     queue_size: 10_000
+{{- end }}
   max_request_body_size: 16_777_216  # 16 MB before compression
   ## set timeout to 30s due to big requests
   timeout: 30s
@@ -132,7 +197,15 @@ sumologic/node:
     storage: file_storage
 {{- end }}
     num_consumers: 10
+{{- if eq .Values.useExporterBatching true }}
+    queue_size: 10240000
+    batch:
+      flush_timeout: 1s
+      min_size: 1_024
+      max_size: 2_048
+{{ else }}
     queue_size: 10_000
+{{- end }}
   max_request_body_size: 16_777_216  # 16 MB before compression
   ## set timeout to 30s due to big requests
   timeout: 30s
@@ -146,7 +219,15 @@ sumologic/scheduler:
     storage: file_storage
 {{- end }}
     num_consumers: 10
+{{- if eq .Values.useExporterBatching true }}
+    queue_size: 10240000
+    batch:
+      flush_timeout: 1s
+      min_size: 1_024
+      max_size: 2_048
+{{ else }}
     queue_size: 10_000
+{{- end }}
   max_request_body_size: 16_777_216  # 16 MB before compression
   ## set timeout to 30s due to big requests
   timeout: 30s
@@ -160,7 +241,15 @@ sumologic/state:
     storage: file_storage
 {{- end }}
     num_consumers: 10
+{{- if eq .Values.useExporterBatching true }}
+    queue_size: 10240000
+    batch:
+      flush_timeout: 1s
+      min_size: 1_024
+      max_size: 2_048
+{{ else }}
     queue_size: 10_000
+{{- end }}
   max_request_body_size: 16_777_216  # 16 MB before compression
   ## set timeout to 30s due to big requests
   timeout: 30s

--- a/deploy/helm/sumologic/conf/metrics/otelcol/pipeline.yaml
+++ b/deploy/helm/sumologic/conf/metrics/otelcol/pipeline.yaml
@@ -49,7 +49,7 @@ processors:
 {{- if .Values.sumologic.metrics.enableDefaultFilters }}
   - filter/app_metrics
 {{- end }}
-{{- if eq .Values.useExporterBatching false }}
+{{- if eq .Values.sumologic.useExporterBatching false }}
   - batch
 {{- end }}
 receivers:

--- a/deploy/helm/sumologic/conf/metrics/otelcol/pipeline.yaml
+++ b/deploy/helm/sumologic/conf/metrics/otelcol/pipeline.yaml
@@ -49,7 +49,9 @@ processors:
 {{- if .Values.sumologic.metrics.enableDefaultFilters }}
   - filter/app_metrics
 {{- end }}
+{{- if eq .Values.useExporterBatching false }}
   - batch
+{{- end }}
 receivers:
 {{- if .Values.metadata.metrics.enableSumoPrometheusRemotewriteReceiver }}
   - telegraf

--- a/deploy/helm/sumologic/templates/checks.txt
+++ b/deploy/helm/sumologic/templates/checks.txt
@@ -106,7 +106,16 @@
 {{- end -}}
 {{- end -}}
 
-{{/* Check if queue_size is configured in sending_queue for any exporter (only when useExporterBatching is enabled and customBatchingConfigured is not set) */}}
+{{/* Helper: fail if the batch processor is configured in the given processors map.
+     Call with: (dict "processors" <map> "path" <string>) */}}
+{{- define "check.processors.batch" -}}
+{{- if hasKey .processors "batch" -}}
+{{- fail (printf "\nCustom configuration of batch processor is found in %s.batch. Please refer https://www.sumologic.com/help/docs/send-data/kubernetes/best-practices/#opentelemetry-collector-queueing-and-batching" .path) -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Check if queue_size is configured in sending_queue for any exporter, or if batch processor is configured
+     in processors (only when useExporterBatching is enabled and customBatchingConfigured is not set) */}}
 {{- if and .Values.sumologic.useExporterBatching (not .Values.sumologic.customBatchingConfigured) -}}
 {{/* Instrumentation */}}
 {{- include "check.exporters.queueSize" (dict "exporters" (dig "otelcolInstrumentation" "config" "merge" "exporters" dict .Values.AsMap) "path" "otelcolInstrumentation.config.merge.exporters") -}}
@@ -125,4 +134,20 @@
 {{- include "check.exporters.queueSize" (dict "exporters" (dig "sumologic" "metrics" "collector" "otelcol" "config" "override" "exporters" dict .Values.AsMap) "path" "sumologic.metrics.collector.otelcol.config.override.exporters") -}}
 {{- include "check.exporters.queueSize" (dict "exporters" (dig "metadata" "metrics" "config" "merge" "exporters" dict .Values.AsMap) "path" "metadata.metrics.config.merge.exporters") -}}
 {{- include "check.exporters.queueSize" (dict "exporters" (dig "metadata" "metrics" "config" "override" "exporters" dict .Values.AsMap) "path" "metadata.metrics.config.override.exporters") -}}
+{{/* Instrumentation */}}
+{{- include "check.processors.batch" (dict "processors" (dig "otelcolInstrumentation" "config" "merge" "processors" dict .Values.AsMap) "path" "otelcolInstrumentation.config.merge.processors") -}}
+{{- include "check.processors.batch" (dict "processors" (dig "otelcolInstrumentation" "config" "override" "processors" dict .Values.AsMap) "path" "otelcolInstrumentation.config.override.processors") -}}
+{{/* Events */}}
+{{- include "check.processors.batch" (dict "processors" (dig "otelevents" "config" "merge" "processors" dict .Values.AsMap) "path" "otelevents.config.merge.processors") -}}
+{{- include "check.processors.batch" (dict "processors" (dig "otelevents" "config" "override" "processors" dict .Values.AsMap) "path" "otelevents.config.override.processors") -}}
+{{/* Logs */}}
+{{- include "check.processors.batch" (dict "processors" (dig "otellogs" "config" "merge" "processors" dict .Values.AsMap) "path" "otellogs.config.merge.processors") -}}
+{{- include "check.processors.batch" (dict "processors" (dig "otellogs" "config" "override" "processors" dict .Values.AsMap) "path" "otellogs.config.override.processors") -}}
+{{- include "check.processors.batch" (dict "processors" (dig "metadata" "logs" "config" "merge" "processors" dict .Values.AsMap) "path" "metadata.logs.config.merge.processors") -}}
+{{- include "check.processors.batch" (dict "processors" (dig "metadata" "logs" "config" "override" "processors" dict .Values.AsMap) "path" "metadata.logs.config.override.processors") -}}
+{{/* Metrics */}}
+{{- include "check.processors.batch" (dict "processors" (dig "sumologic" "metrics" "collector" "otelcol" "config" "merge" "processors" dict .Values.AsMap) "path" "sumologic.metrics.collector.otelcol.config.merge.processors") -}}
+{{- include "check.processors.batch" (dict "processors" (dig "sumologic" "metrics" "collector" "otelcol" "config" "override" "processors" dict .Values.AsMap) "path" "sumologic.metrics.collector.otelcol.config.override.processors") -}}
+{{- include "check.processors.batch" (dict "processors" (dig "metadata" "metrics" "config" "merge" "processors" dict .Values.AsMap) "path" "metadata.metrics.config.merge.processors") -}}
+{{- include "check.processors.batch" (dict "processors" (dig "metadata" "metrics" "config" "override" "processors" dict .Values.AsMap) "path" "metadata.metrics.config.override.processors") -}}
 {{- end -}}

--- a/deploy/helm/sumologic/templates/checks.txt
+++ b/deploy/helm/sumologic/templates/checks.txt
@@ -98,7 +98,8 @@
 {{- define "check.exporters.queueSize" -}}
 {{- range $_, $exporterConfig := .exporters -}}
 {{- if kindIs "map" $exporterConfig -}}
-{{- if dig "sending_queue" "queue_size" nil $exporterConfig -}}
+{{- $sendingQueue := dig "sending_queue" nil $exporterConfig -}}
+{{- if and (kindIs "map" $sendingQueue) (hasKey $sendingQueue "queue_size") -}}
 {{- fail (printf "\nCustom configuration of queue_size is found in %s.[exporter].sending_queue.queue_size. Please refer https://www.sumologic.com/help/docs/send-data/kubernetes/best-practices/#opentelemetry-collector-queueing-and-batching" $.path) -}}
 {{- end -}}
 {{- end -}}
@@ -106,7 +107,7 @@
 {{- end -}}
 
 {{/* Check if queue_size is configured in sending_queue for any exporter (only when useExporterBatching is enabled and customBatchingConfigured is not set) */}}
-{{- if and .Values.useExporterBatching (not .Values.customBatchingConfigured) -}}
+{{- if and .Values.sumologic.useExporterBatching (not .Values.sumologic.customBatchingConfigured) -}}
 {{/* Instrumentation */}}
 {{- include "check.exporters.queueSize" (dict "exporters" (dig "otelcolInstrumentation" "config" "merge" "exporters" dict .Values.AsMap) "path" "otelcolInstrumentation.config.merge.exporters") -}}
 {{- include "check.exporters.queueSize" (dict "exporters" (dig "otelcolInstrumentation" "config" "override" "exporters" dict .Values.AsMap) "path" "otelcolInstrumentation.config.override.exporters") -}}

--- a/deploy/helm/sumologic/templates/checks.txt
+++ b/deploy/helm/sumologic/templates/checks.txt
@@ -92,3 +92,36 @@
 {{- if (index .Values "metrics-server").extraArgs -}}
 {{- fail "\nCannot use `metrics-server.extraArgs`. Please refer https://www.sumologic.com/help/docs/send-data/kubernetes/v4/important-changes/#metrics-server-source-chart-changed" }}
 {{- end -}}
+
+{{/* Helper: fail if any exporter in the given map has sending_queue.queue_size set.
+     Call with: (dict "exporters" <map> "path" <string>) */}}
+{{- define "check.exporters.queueSize" -}}
+{{- range $_, $exporterConfig := .exporters -}}
+{{- if kindIs "map" $exporterConfig -}}
+{{- if dig "sending_queue" "queue_size" nil $exporterConfig -}}
+{{- fail (printf "\nCustom configuration of queue_size is found in %s.[exporter].sending_queue.queue_size. Please refer https://www.sumologic.com/help/docs/send-data/kubernetes/best-practices/#opentelemetry-collector-queueing-and-batching" $.path) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Check if queue_size is configured in sending_queue for any exporter (only when useExporterBatching is enabled and customBatchingConfigured is not set) */}}
+{{- if and .Values.useExporterBatching (not .Values.customBatchingConfigured) -}}
+{{/* Instrumentation */}}
+{{- include "check.exporters.queueSize" (dict "exporters" (dig "otelcolInstrumentation" "config" "merge" "exporters" dict .Values.AsMap) "path" "otelcolInstrumentation.config.merge.exporters") -}}
+{{- include "check.exporters.queueSize" (dict "exporters" (dig "otelcolInstrumentation" "config" "override" "exporters" dict .Values.AsMap) "path" "otelcolInstrumentation.config.override.exporters") -}}
+{{/* Events */}}
+{{- include "check.exporters.queueSize" (dict "exporters" (dig "otelevents" "config" "merge" "exporters" dict .Values.AsMap) "path" "otelevents.config.merge.exporters") -}}
+{{- include "check.exporters.queueSize" (dict "exporters" (dig "otelevents" "config" "override" "exporters" dict .Values.AsMap) "path" "otelevents.config.override.exporters") -}}
+{{/* Logs */}}
+{{- include "check.exporters.queueSize" (dict "exporters" (dig "sumologic" "logs" "otelcol" "extraExporters" dict .Values.AsMap) "path" "sumologic.logs.otelcol.extraExporters") -}}
+{{- include "check.exporters.queueSize" (dict "exporters" (dig "otellogs" "config" "merge" "exporters" dict .Values.AsMap) "path" "otellogs.config.merge.exporters") -}}
+{{- include "check.exporters.queueSize" (dict "exporters" (dig "otellogs" "config" "override" "exporters" dict .Values.AsMap) "path" "otellogs.config.override.exporters") -}}
+{{- include "check.exporters.queueSize" (dict "exporters" (dig "metadata" "logs" "config" "merge" "exporters" dict .Values.AsMap) "path" "metadata.logs.config.merge.exporters") -}}
+{{- include "check.exporters.queueSize" (dict "exporters" (dig "metadata" "logs" "config" "override" "exporters" dict .Values.AsMap) "path" "metadata.logs.config.override.exporters") -}}
+{{/* Metrics */}}
+{{- include "check.exporters.queueSize" (dict "exporters" (dig "sumologic" "metrics" "collector" "otelcol" "config" "merge" "exporters" dict .Values.AsMap) "path" "sumologic.metrics.collector.otelcol.config.merge.exporters") -}}
+{{- include "check.exporters.queueSize" (dict "exporters" (dig "sumologic" "metrics" "collector" "otelcol" "config" "override" "exporters" dict .Values.AsMap) "path" "sumologic.metrics.collector.otelcol.config.override.exporters") -}}
+{{- include "check.exporters.queueSize" (dict "exporters" (dig "metadata" "metrics" "config" "merge" "exporters" dict .Values.AsMap) "path" "metadata.metrics.config.merge.exporters") -}}
+{{- include "check.exporters.queueSize" (dict "exporters" (dig "metadata" "metrics" "config" "override" "exporters" dict .Values.AsMap) "path" "metadata.metrics.config.override.exporters") -}}
+{{- end -}}

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -6,6 +6,12 @@ fullnameOverride: ""
 ## Use the same namespace as namespaceOverride in 'kube-prometheus-stack.namespaceOverride' if Prometheus setup is also enabled
 namespaceOverride: ""
 
+## flag to switch the implementation between batch processor and export level batching
+useExporterBatching: false
+
+## used for helm checks to verify that customer has cautiously read the docs and enabled the export level batching
+customBatchingConfigured: false
+
 sumologic:
   ### Setup
 
@@ -624,10 +630,11 @@ sumologic:
           ## be directly merged with the generated configuration, overriding existing values.
           ## For example:
           # override:
-          #   processors:
-          #     batch:
-          #       send_batch_size: 512
-          ## will change the batch size of the pipeline.
+          #   exporters:
+          #     otlphttp:
+          #       sending_queue:
+          #         queue_size: 8
+          ## will change the queue size of the otlphttp exporter.
           ##
           ## WARNING: This field is not subject to backwards-compatibility guarantees offered by the rest
           ## of this chart. It involves implementation details that may change even in minor versions.
@@ -1444,10 +1451,11 @@ otelcolInstrumentation:
     ## be directly merged with the generated configuration, overriding existing values.
     ## For example:
     # override:
-    #   processors:
-    #     batch:
-    #       send_batch_size: 512
-    ## will change the batch size of the pipeline.
+    #   exporters:
+    #     otlphttp:
+    #       sending_queue:
+    #         queue_size: 8
+    ## will change the queue size of the otlphttp exporter
     ##
     ## WARNING: This field is not subject to backwards-compatibility guarantees offered by the rest
     ## of this chart. It involves implementation details that may change even in minor versions.
@@ -1515,10 +1523,11 @@ tracesSampler:
     ## be directly merged with the generated configuration, overriding existing values.
     ## For example:
     # override:
-    #   processors:
-    #     batch:
-    #       send_batch_size: 512
-    ## will change the batch size of the pipeline.
+    #   exporters:
+    #     otlphttp:
+    #       sending_queue:
+    #         queue_size: 8
+    ## will change the queue size of the otlphttp exporter
     ##
     ## WARNING: This field is not subject to backwards-compatibility guarantees offered by the rest
     ## of this chart. It involves implementation details that may change even in minor versions.
@@ -1622,10 +1631,11 @@ metadata:
       ## be directly merged with the generated configuration, overriding existing values.
       ## For example:
       # override:
-      #   processors:
-      #     batch:
-      #       send_batch_size: 512
-      ## will change the batch size of the pipeline.
+      #   exporters:
+      #     otlphttp:
+      #       sending_queue:
+      #         queue_size: 8
+      ## will change the queue size of the otlphttp exporter
       ##
       ## WARNING: This field is not subject to backwards-compatibility guarantees offered by the rest
       ## of this chart. It involves implementation details that may change even in minor versions.
@@ -1740,10 +1750,11 @@ metadata:
       ## be directly merged with the generated configuration, overriding existing values.
       ## For example:
       # override:
-      #   processors:
-      #     batch:
-      #       send_batch_size: 512
-      ## will change the batch size of the pipeline.
+      #   exporters:
+      #     otlphttp:
+      #       sending_queue:
+      #         queue_size: 8
+      ## will change the queue size of the otlphttp exporter
       ##
       ## WARNING: This field is not subject to backwards-compatibility guarantees offered by the rest
       ## of this chart. It involves implementation details that may change even in minor versions.
@@ -1921,10 +1932,11 @@ tracesGateway:
     ## be directly merged with the generated configuration, overriding existing values.
     ## For example:
     # override:
-    #   processors:
-    #     batch:
-    #       send_batch_size: 512
-    ## will change the batch size of the pipeline.
+    #   exporters:
+    #     otlphttp:
+    #       sending_queue:
+    #         queue_size: 8
+    ## will change the queue size of the otlphttp exporter
     ##
     ## WARNING: This field is not subject to backwards-compatibility guarantees offered by the rest
     ## of this chart. It involves implementation details that may change even in minor versions.
@@ -1962,10 +1974,11 @@ otelevents:
     ## be directly merged with the generated configuration, overriding existing values.
     ## For example:
     # override:
-    #   processors:
-    #     batch:
-    #       send_batch_size: 512
-    ## will change the batch size of the pipeline.
+    #   exporters:
+    #     otlphttp:
+    #       sending_queue:
+    #         queue_size: 8
+    ## will change the queue size of the otlphttp exporter
     ##
     ## WARNING: This field is not subject to backwards-compatibility guarantees offered by the rest
     ## of this chart. It involves implementation details that may change even in minor versions.
@@ -2117,10 +2130,11 @@ otellogs:
     ## be directly merged with the generated configuration, overriding existing values.
     ## For example:
     # override:
-    #   processors:
-    #     batch:
-    #       send_batch_size: 512
-    ## will change the batch size of the pipeline.
+    #   exporters:
+    #     otlphttp:
+    #       sending_queue:
+    #         queue_size: 8
+    ## will change the queue size of the otlphttp exporter
     ##
     ## WARNING: This field is not subject to backwards-compatibility guarantees offered by the rest
     ## of this chart. It involves implementation details that may change even in minor versions.
@@ -2269,10 +2283,11 @@ otellogswindows:
     ## be directly merged with the generated configuration, overriding existing values.
     ## For example:
     # override:
-    #   processors:
-    #     batch:
-    #       send_batch_size: 512
-    ## will change the batch size of the pipeline.
+    #   exporters:
+    #     otlphttp:
+    #       sending_queue:
+    #         queue_size: 8
+    ## will change the queue size of the otlphttp exporter
     ##
     ## WARNING: This field is not subject to backwards-compatibility guarantees offered by the rest
     ## of this chart. It involves implementation details that may change even in minor versions.

--- a/deploy/helm/sumologic/values.yaml
+++ b/deploy/helm/sumologic/values.yaml
@@ -6,13 +6,13 @@ fullnameOverride: ""
 ## Use the same namespace as namespaceOverride in 'kube-prometheus-stack.namespaceOverride' if Prometheus setup is also enabled
 namespaceOverride: ""
 
-## flag to switch the implementation between batch processor and export level batching
-useExporterBatching: false
-
-## used for helm checks to verify that customer has cautiously read the docs and enabled the export level batching
-customBatchingConfigured: false
-
 sumologic:
+  ## flag to switch the implementation between batch processor and export level batching
+  useExporterBatching: false
+
+  ## used for helm checks to verify that customer has cautiously read the docs and enabled the export level batching
+  customBatchingConfigured: false
+
   ### Setup
 
   ## If enabled, a pre-install hook will create Collector and Sources in Sumo Logic
@@ -633,7 +633,7 @@ sumologic:
           #   exporters:
           #     otlphttp:
           #       sending_queue:
-          #         queue_size: 8
+          #         queue_size: 10000
           ## will change the queue size of the otlphttp exporter.
           ##
           ## WARNING: This field is not subject to backwards-compatibility guarantees offered by the rest
@@ -1454,7 +1454,7 @@ otelcolInstrumentation:
     #   exporters:
     #     otlphttp:
     #       sending_queue:
-    #         queue_size: 8
+    #         queue_size: 10000
     ## will change the queue size of the otlphttp exporter
     ##
     ## WARNING: This field is not subject to backwards-compatibility guarantees offered by the rest
@@ -1526,7 +1526,7 @@ tracesSampler:
     #   exporters:
     #     otlphttp:
     #       sending_queue:
-    #         queue_size: 8
+    #         queue_size: 10000
     ## will change the queue size of the otlphttp exporter
     ##
     ## WARNING: This field is not subject to backwards-compatibility guarantees offered by the rest
@@ -1634,7 +1634,7 @@ metadata:
       #   exporters:
       #     otlphttp:
       #       sending_queue:
-      #         queue_size: 8
+      #         queue_size: 10000
       ## will change the queue size of the otlphttp exporter
       ##
       ## WARNING: This field is not subject to backwards-compatibility guarantees offered by the rest
@@ -1753,7 +1753,7 @@ metadata:
       #   exporters:
       #     otlphttp:
       #       sending_queue:
-      #         queue_size: 8
+      #         queue_size: 10000
       ## will change the queue size of the otlphttp exporter
       ##
       ## WARNING: This field is not subject to backwards-compatibility guarantees offered by the rest
@@ -1935,7 +1935,7 @@ tracesGateway:
     #   exporters:
     #     otlphttp:
     #       sending_queue:
-    #         queue_size: 8
+    #         queue_size: 10000
     ## will change the queue size of the otlphttp exporter
     ##
     ## WARNING: This field is not subject to backwards-compatibility guarantees offered by the rest
@@ -1977,7 +1977,7 @@ otelevents:
     #   exporters:
     #     otlphttp:
     #       sending_queue:
-    #         queue_size: 8
+    #         queue_size: 10000
     ## will change the queue size of the otlphttp exporter
     ##
     ## WARNING: This field is not subject to backwards-compatibility guarantees offered by the rest
@@ -2133,7 +2133,7 @@ otellogs:
     #   exporters:
     #     otlphttp:
     #       sending_queue:
-    #         queue_size: 8
+    #         queue_size: 10000
     ## will change the queue size of the otlphttp exporter
     ##
     ## WARNING: This field is not subject to backwards-compatibility guarantees offered by the rest
@@ -2286,7 +2286,7 @@ otellogswindows:
     #   exporters:
     #     otlphttp:
     #       sending_queue:
-    #         queue_size: 8
+    #         queue_size: 10000
     ## will change the queue size of the otlphttp exporter
     ##
     ## WARNING: This field is not subject to backwards-compatibility guarantees offered by the rest

--- a/tests/helm/metrics_test.go
+++ b/tests/helm/metrics_test.go
@@ -136,7 +136,6 @@ func TestMetadataMetricsOtelConfigExtraProcessors(t *testing.T) {
 		"groupbyattrs/group_by_name",
 		"transform/remove_name",
 		"filter/drop_unnecessary_metrics",
-		"batch",
 	}
 
 	require.Equal(t, expectedPipelineValue, otelConfig.Service.Pipelines.Metrics.Processors)

--- a/tests/helm/testdata/custom-global-config-attributes.yaml
+++ b/tests/helm/testdata/custom-global-config-attributes.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   pullSecrets:
     - name: customImagePullSecrets
     - name: customImagePullSecrets2

--- a/tests/helm/testdata/everything-enabled.yaml
+++ b/tests/helm/testdata/everything-enabled.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   pullSecrets:
     - name: pullSecret
   setup:

--- a/tests/helm/testdata/fipsmode.yaml
+++ b/tests/helm/testdata/fipsmode.yaml
@@ -1,3 +1,4 @@
 sumologic:
+  useExporterBatching: true
   otelcolImage:
     addFipsSuffix: true

--- a/tests/helm/testdata/goldenfile/cleanup/basic.input.yaml
+++ b/tests/helm/testdata/goldenfile/cleanup/basic.input.yaml
@@ -1,2 +1,3 @@
 sumologic:
+  useExporterBatching: true
   cleanupEnabled: true

--- a/tests/helm/testdata/goldenfile/cleanup/sumologic-mock-no-secret.input.yaml
+++ b/tests/helm/testdata/goldenfile/cleanup/sumologic-mock-no-secret.input.yaml
@@ -5,5 +5,6 @@ debug:
   enableLocalMode: true
 
 sumologic:
+  useExporterBatching: true
   envFromSecret: false
   cleanupEnabled: true

--- a/tests/helm/testdata/goldenfile/cleanup/sumologic-mock-secret.input.yaml
+++ b/tests/helm/testdata/goldenfile/cleanup/sumologic-mock-secret.input.yaml
@@ -5,4 +5,5 @@ debug:
   enableLocalMode: true
 
 sumologic:
+  useExporterBatching: true
   cleanupEnabled: true

--- a/tests/helm/testdata/goldenfile/cleanup/sumologic-mock.input.yaml
+++ b/tests/helm/testdata/goldenfile/cleanup/sumologic-mock.input.yaml
@@ -5,6 +5,7 @@ debug:
   enableLocalMode: true
 
 sumologic:
+  useExporterBatching: true
   cleanupEnabled: true
   setup:
     job:

--- a/tests/helm/testdata/goldenfile/common/clusterrole.input.yaml
+++ b/tests/helm/testdata/goldenfile/common/clusterrole.input.yaml
@@ -1,0 +1,2 @@
+sumologic:
+  useExporterBatching: true

--- a/tests/helm/testdata/goldenfile/events_otc/basic.input.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc/basic.input.yaml
@@ -1,0 +1,2 @@
+sumologic:
+  useExporterBatching: true

--- a/tests/helm/testdata/goldenfile/events_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc/basic.output.yaml
@@ -18,7 +18,12 @@ data:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_OTLP_EVENTS_SOURCE}
         log_format: otlp
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
+          queue_size: 1024000
           storage: file_storage
     extensions:
       file_storage:
@@ -92,7 +97,6 @@ data:
           - source
           - sumologic
           - transform/add_timestamp
-          - batch
           receivers:
           - k8sobjects/configmaps
         logs/events:
@@ -103,7 +107,6 @@ data:
           - source
           - sumologic
           - transform/add_timestamp
-          - batch
           receivers:
           - raw_k8s_events
       telemetry:

--- a/tests/helm/testdata/goldenfile/events_otc/k8sobjects-events.input.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc/k8sobjects-events.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 otelevents:
   useSumoK8sEventReceiver: false
   reportConfigMaps: false

--- a/tests/helm/testdata/goldenfile/events_otc/k8sobjects-events.output.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc/k8sobjects-events.output.yaml
@@ -18,7 +18,12 @@ data:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_OTLP_EVENTS_SOURCE}
         log_format: otlp
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
+          queue_size: 1024000
           storage: file_storage
     extensions:
       file_storage:
@@ -93,7 +98,6 @@ data:
           - source
           - sumologic
           - transform/add_timestamp
-          - batch
           receivers:
           - k8sobjects/events
       telemetry:

--- a/tests/helm/testdata/goldenfile/events_otc/options.input.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc/options.input.yaml
@@ -4,6 +4,7 @@ otelevents:
   reportConfigMaps: false
 
 sumologic:
+  useExporterBatching: true
   ipv6mode: true
   clusterName: testCluster
   collectorName: testCollector

--- a/tests/helm/testdata/goldenfile/events_otc/options.output.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc/options.output.yaml
@@ -18,7 +18,12 @@ data:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_OTLP_EVENTS_SOURCE}
         log_format: otlp
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
+          queue_size: 1024000
     extensions:
       health_check:
         endpoint: '[${env:MY_POD_IP}]:13133'
@@ -62,7 +67,6 @@ data:
           - source
           - sumologic
           - transform/add_timestamp
-          - batch
           receivers:
           - raw_k8s_events
       telemetry:

--- a/tests/helm/testdata/goldenfile/events_otc/sumologic-mock.input.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc/sumologic-mock.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 debug:
   sumologicMock:
     enabled: true

--- a/tests/helm/testdata/goldenfile/events_otc/sumologic-mock.output.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc/sumologic-mock.output.yaml
@@ -14,20 +14,37 @@ data:
   config.yaml: |
     exporters:
       debug:
+        sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
+          enabled: true
+          queue_size: 1024000
         verbosity: detailed
       sumologic:
         client: k8s_%CURRENT_CHART_VERSION%
         endpoint: ${SUMO_ENDPOINT_DEFAULT_OTLP_EVENTS_SOURCE}
         log_format: otlp
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
+          queue_size: 1024000
           storage: file_storage
       sumologic/sumologic-mock:
         client: k8s_%CURRENT_CHART_VERSION%
         endpoint: http://RELEASE-NAME-sumologic-mock.sumologic.svc.cluster.local.:3000/receiver
         log_format: otlp
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
+          queue_size: 1024000
     extensions:
       file_storage:
         directory: /var/lib/storage/events
@@ -102,7 +119,6 @@ data:
           - source
           - sumologic
           - transform/add_timestamp
-          - batch
           receivers:
           - k8sobjects/configmaps
         logs/events:
@@ -115,7 +131,6 @@ data:
           - source
           - sumologic
           - transform/add_timestamp
-          - batch
           receivers:
           - raw_k8s_events
       telemetry:

--- a/tests/helm/testdata/goldenfile/events_otc_statefulset/basic.input.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc_statefulset/basic.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 otelevents:
   statefulset:
     nodeSelector:

--- a/tests/helm/testdata/goldenfile/events_otc_statefulset/common.input.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc_statefulset/common.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   nodeSelector:
     kubernetes.io/os: linux
   affinity:

--- a/tests/helm/testdata/goldenfile/events_otc_statefulset/custom.input.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc_statefulset/custom.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   events:
     sourceType: http
   podAnnotations:

--- a/tests/helm/testdata/goldenfile/events_otc_statefulset/proxy.input.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc_statefulset/proxy.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   httpProxy: http://proxy.internal
   httpsProxy: https://proxy.internal
   noProxy: http://non-proxy.internal

--- a/tests/helm/testdata/goldenfile/logs_otc/basic.input.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc/basic.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   logs:
     collector:
       otelcol:

--- a/tests/helm/testdata/goldenfile/logs_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc/basic.output.yaml
@@ -17,7 +17,11 @@ data:
         disable_keep_alives: true
         endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local.:4318
         sending_queue:
-          queue_size: 10
+          batch:
+            flush_timeout: 1s
+            max_size: 2000
+            min_size: 1000
+          queue_size: 10000
     extensions:
       file_storage:
         compaction:
@@ -223,8 +227,7 @@ data:
         logs/containers:
           exporters:
           - otlphttp
-          processors:
-          - batch
+          processors: null
           receivers:
           - filelog/containers
         logs/systemd:
@@ -232,7 +235,6 @@ data:
           - otlphttp
           processors:
           - logstransform/systemd
-          - batch
           receivers:
           - journald
       telemetry:

--- a/tests/helm/testdata/goldenfile/logs_otc/debug.input.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc/debug.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   logs:
     collector:
       otelcol:

--- a/tests/helm/testdata/goldenfile/logs_otc/debug.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc/debug.output.yaml
@@ -19,7 +19,11 @@ data:
         disable_keep_alives: true
         endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local.:4318
         sending_queue:
-          queue_size: 10
+          batch:
+            flush_timeout: 1s
+            max_size: 2000
+            min_size: 1000
+          queue_size: 10000
     extensions:
       file_storage:
         compaction:
@@ -234,8 +238,7 @@ data:
           exporters:
           - otlphttp
           - debug
-          processors:
-          - batch
+          processors: null
           receivers:
           - filelog/containers
         logs/systemd:
@@ -244,7 +247,6 @@ data:
           - debug
           processors:
           - logstransform/systemd
-          - batch
           receivers:
           - journald
       telemetry:

--- a/tests/helm/testdata/goldenfile/logs_otc/options.input.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc/options.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   ipv6mode: true
   logs:
     collector:

--- a/tests/helm/testdata/goldenfile/logs_otc/options.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc/options.output.yaml
@@ -17,7 +17,11 @@ data:
         disable_keep_alives: true
         endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local.:4318
         sending_queue:
-          queue_size: 10
+          batch:
+            flush_timeout: 1s
+            max_size: 2000
+            min_size: 1000
+          queue_size: 10000
     extensions:
       file_storage:
         compaction:
@@ -117,7 +121,6 @@ data:
           - otlphttp
           processors:
           - logstransform/systemd
-          - batch
           receivers:
           - journald
       telemetry:

--- a/tests/helm/testdata/goldenfile/logs_otc_cloudwatch/basic.input.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_cloudwatch/basic.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   logs:
     collector:
       otelcloudwatch:

--- a/tests/helm/testdata/goldenfile/logs_otc_cloudwatch/custom.input.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_cloudwatch/custom.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   logs:
     collector:
       otelcloudwatch:

--- a/tests/helm/testdata/goldenfile/logs_otc_daemonset/additional-complex.input.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_daemonset/additional-complex.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 otellogs:
   additionalDaemonSets:
     linux:

--- a/tests/helm/testdata/goldenfile/logs_otc_daemonset/additional.input.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_daemonset/additional.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 otellogs:
   additionalDaemonSets:
     linux:

--- a/tests/helm/testdata/goldenfile/logs_otc_daemonset/basic.input.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_daemonset/basic.input.yaml
@@ -1,5 +1,6 @@
 namespaceOverride: "sumologic"
 sumologic:
+  useExporterBatching: true
   logs:
     collector:
       otelcol:

--- a/tests/helm/testdata/goldenfile/logs_otc_daemonset/complex.input.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_daemonset/complex.input.yaml
@@ -1,5 +1,6 @@
 namespaceOverride: "sumologic"
 sumologic:
+  useExporterBatching: true
   nodeSelector:
     sumologic.com/kind: worker
   tolerations:

--- a/tests/helm/testdata/goldenfile/logs_otc_daemonset/multiple_multiline.input.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_daemonset/multiple_multiline.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   logs:
     multiline:
       enabled: true

--- a/tests/helm/testdata/goldenfile/logs_otc_daemonset/multiple_multiline.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_daemonset/multiple_multiline.output.yaml
@@ -17,7 +17,11 @@ data:
         disable_keep_alives: true
         endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local.:4318
         sending_queue:
-          queue_size: 10
+          batch:
+            flush_timeout: 1s
+            max_size: 2000
+            min_size: 1000
+          queue_size: 10000
     extensions:
       file_storage:
         compaction:
@@ -256,8 +260,7 @@ data:
         logs/containers:
           exporters:
           - otlphttp
-          processors:
-          - batch
+          processors: null
           receivers:
           - filelog/containers
         logs/systemd:
@@ -265,7 +268,6 @@ data:
           - otlphttp
           processors:
           - logstransform/systemd
-          - batch
           receivers:
           - journald
       telemetry:

--- a/tests/helm/testdata/goldenfile/logs_otc_serviceaccount/basic.input.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_serviceaccount/basic.input.yaml
@@ -1,0 +1,2 @@
+sumologic:
+  useExporterBatching: true

--- a/tests/helm/testdata/goldenfile/logs_otc_serviceaccount/image_pull_secrets.input.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_serviceaccount/image_pull_secrets.input.yaml
@@ -1,3 +1,4 @@
 sumologic:
+  useExporterBatching: true
   pullSecrets:
     - name: myRegistryKeySecretName

--- a/tests/helm/testdata/goldenfile/logs_otc_windows/configmap/basic.input.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_windows/configmap/basic.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   logs:
     collector:
       otellogswindows:

--- a/tests/helm/testdata/goldenfile/logs_otc_windows/configmap/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_windows/configmap/basic.output.yaml
@@ -17,7 +17,11 @@ data:
         disable_keep_alives: true
         endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local.:4318
         sending_queue:
-          queue_size: 10
+          batch:
+            flush_timeout: 1s
+            max_size: 2000
+            min_size: 1000
+          queue_size: 10000
     extensions:
       file_storage:
         compaction:
@@ -151,8 +155,7 @@ data:
         logs/containers:
           exporters:
           - otlphttp
-          processors:
-          - batch
+          processors: null
           receivers:
           - filelog/containers
       telemetry:

--- a/tests/helm/testdata/goldenfile/logs_otc_windows/configmap/debug.input.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_windows/configmap/debug.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   logs:
     collector:
       otellogswindows:

--- a/tests/helm/testdata/goldenfile/logs_otc_windows/configmap/debug.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_windows/configmap/debug.output.yaml
@@ -19,7 +19,11 @@ data:
         disable_keep_alives: true
         endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local.:4318
         sending_queue:
-          queue_size: 10
+          batch:
+            flush_timeout: 1s
+            max_size: 2000
+            min_size: 1000
+          queue_size: 10000
     extensions:
       file_storage:
         compaction:
@@ -162,8 +166,7 @@ data:
         logs/containers:
           exporters:
           - otlphttp
-          processors:
-          - batch
+          processors: null
           receivers:
           - filelog/containers
       telemetry:

--- a/tests/helm/testdata/goldenfile/logs_otc_windows/configmap/options.input.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_windows/configmap/options.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   ipv6mode: true
   logs:
     collector:

--- a/tests/helm/testdata/goldenfile/logs_otc_windows/configmap/options.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_windows/configmap/options.output.yaml
@@ -17,7 +17,11 @@ data:
         disable_keep_alives: true
         endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local.:4318
         sending_queue:
-          queue_size: 10
+          batch:
+            flush_timeout: 1s
+            max_size: 2000
+            min_size: 1000
+          queue_size: 10000
     extensions:
       file_storage:
         compaction:

--- a/tests/helm/testdata/goldenfile/logs_otc_windows/daemonset/additional-complex.input.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_windows/daemonset/additional-complex.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   logs:
     collector:
       otellogswindows:

--- a/tests/helm/testdata/goldenfile/logs_otc_windows/daemonset/additional.input.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_windows/daemonset/additional.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   logs:
     collector:
       otellogswindows:

--- a/tests/helm/testdata/goldenfile/logs_otc_windows/daemonset/basic.input.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_windows/daemonset/basic.input.yaml
@@ -1,5 +1,6 @@
 namespaceOverride: "sumologic"
 sumologic:
+  useExporterBatching: true
   logs:
     collector:
       otellogswindows:

--- a/tests/helm/testdata/goldenfile/logs_otc_windows/daemonset/complex.input.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_windows/daemonset/complex.input.yaml
@@ -1,5 +1,6 @@
 namespaceOverride: "sumologic"
 sumologic:
+  useExporterBatching: true
   nodeSelector:
     sumologic.com/kind: worker
   tolerations:

--- a/tests/helm/testdata/goldenfile/logs_otc_windows/daemonset/multiple_multiline.input.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_windows/daemonset/multiple_multiline.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   logs:
     multiline:
       enabled: true

--- a/tests/helm/testdata/goldenfile/logs_otc_windows/daemonset/multiple_multiline.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_windows/daemonset/multiple_multiline.output.yaml
@@ -17,7 +17,11 @@ data:
         disable_keep_alives: true
         endpoint: http://${LOGS_METADATA_SVC}.${NAMESPACE}.svc.cluster.local.:4318
         sending_queue:
-          queue_size: 10
+          batch:
+            flush_timeout: 1s
+            max_size: 2000
+            min_size: 1000
+          queue_size: 10000
     extensions:
       file_storage:
         compaction:
@@ -184,8 +188,7 @@ data:
         logs/containers:
           exporters:
           - otlphttp
-          processors:
-          - batch
+          processors: null
           receivers:
           - filelog/containers
       telemetry:

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/debug.input.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/debug.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 debug:
   logs:
     metadata:

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/debug.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/debug.output.yaml
@@ -20,9 +20,13 @@ data:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_OTLP_LOGS_SOURCE}
         log_format: otlp
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
     extensions:
       file_storage:
@@ -327,7 +331,6 @@ data:
           - resource/remove_pod_name
           - resource/drop_annotations
           - transform/add_timestamp
-          - batch
           receivers:
           - otlp
         logs/otlp/kubelet:
@@ -350,7 +353,6 @@ data:
           - transform/remove_attributes
           - transform/flatten
           - transform/add_timestamp
-          - batch
           receivers:
           - otlp
         logs/otlp/systemd:
@@ -374,7 +376,6 @@ data:
           - transform/remove_attributes
           - transform/flatten
           - transform/add_timestamp
-          - batch
           receivers:
           - otlp
       telemetry:

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/debug_with_sumologic_mock.input.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/debug_with_sumologic_mock.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 debug:
   sumologicMock:
     enabled: true

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/debug_with_sumologic_mock.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/debug_with_sumologic_mock.output.yaml
@@ -20,18 +20,26 @@ data:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_OTLP_LOGS_SOURCE}
         log_format: otlp
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
       sumologic/sumologic-mock:
         client: k8s_%CURRENT_CHART_VERSION%
         endpoint: http://RELEASE-NAME-sumologic-mock.sumologic.svc.cluster.local.:3000/receiver
         log_format: otlp
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
     extensions:
       file_storage:
@@ -337,7 +345,6 @@ data:
           - resource/remove_pod_name
           - resource/drop_annotations
           - transform/add_timestamp
-          - batch
           receivers:
           - otlp
         logs/otlp/kubelet:
@@ -361,7 +368,6 @@ data:
           - transform/remove_attributes
           - transform/flatten
           - transform/add_timestamp
-          - batch
           receivers:
           - otlp
         logs/otlp/systemd:
@@ -386,7 +392,6 @@ data:
           - transform/remove_attributes
           - transform/flatten
           - transform/add_timestamp
-          - batch
           receivers:
           - otlp
       telemetry:

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/debug_with_sumologic_mock_http.input.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/debug_with_sumologic_mock_http.input.yaml
@@ -7,5 +7,6 @@ debug:
       forwardToSumologicMock: true
       stopLogsIngestion: true
 sumologic:
+  useExporterBatching: true
   logs:
     sourceType: http

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/debug_with_sumologic_mock_http.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/debug_with_sumologic_mock_http.output.yaml
@@ -19,33 +19,49 @@ data:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE}
         log_format: json
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
       sumologic/sumologic-mock-containers:
         endpoint: http://RELEASE-NAME-sumologic-mock.sumologic.svc.cluster.local.:3000/receiver
         log_format: json
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
       sumologic/sumologic-mock-systemd:
         endpoint: http://RELEASE-NAME-sumologic-mock.sumologic.svc.cluster.local.:3000/receiver
         log_format: json
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
       sumologic/systemd:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE}
         log_format: json
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
     extensions:
       file_storage:
@@ -351,7 +367,6 @@ data:
           - resource/remove_pod_name
           - resource/drop_annotations
           - transform/add_timestamp
-          - batch
           receivers:
           - otlp
         logs/otlp/kubelet:
@@ -375,7 +390,6 @@ data:
           - transform/remove_attributes
           - transform/flatten
           - transform/add_timestamp
-          - batch
           receivers:
           - otlp
         logs/otlp/systemd:
@@ -400,7 +414,6 @@ data:
           - transform/remove_attributes
           - transform/flatten
           - transform/add_timestamp
-          - batch
           receivers:
           - otlp
       telemetry:

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/extra_exporter.input.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/extra_exporter.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   logs:
     collector:
       otelcol:

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/extra_exporter.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/extra_exporter.output.yaml
@@ -20,9 +20,13 @@ data:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_OTLP_LOGS_SOURCE}
         log_format: otlp
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
       sumologic/test:
         endpoint: https://test-endpoint
@@ -330,7 +334,6 @@ data:
           - resource/remove_pod_name
           - resource/drop_annotations
           - transform/add_timestamp
-          - batch
           receivers:
           - otlp
         logs/otlp/kubelet:
@@ -354,7 +357,6 @@ data:
           - transform/remove_attributes
           - transform/flatten
           - transform/add_timestamp
-          - batch
           receivers:
           - otlp
         logs/otlp/systemd:
@@ -379,7 +381,6 @@ data:
           - transform/remove_attributes
           - transform/flatten
           - transform/add_timestamp
-          - batch
           receivers:
           - otlp
       telemetry:

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/k8sattributes.input.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/k8sattributes.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   collector:
     otelcol:
       enabled: true

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/k8sattributes.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/k8sattributes.output.yaml
@@ -18,9 +18,13 @@ data:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_OTLP_LOGS_SOURCE}
         log_format: otlp
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
     extensions:
       file_storage:
@@ -324,7 +328,6 @@ data:
           - resource/remove_pod_name
           - resource/drop_annotations
           - transform/add_timestamp
-          - batch
           receivers:
           - otlp
         logs/otlp/kubelet:
@@ -346,7 +349,6 @@ data:
           - transform/remove_attributes
           - transform/flatten
           - transform/add_timestamp
-          - batch
           receivers:
           - otlp
         logs/otlp/systemd:
@@ -369,7 +371,6 @@ data:
           - transform/remove_attributes
           - transform/flatten
           - transform/add_timestamp
-          - batch
           receivers:
           - otlp
       telemetry:

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/otel.input.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/otel.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   ipv6mode: true
   logs:
     collector:

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/otel.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/otel.output.yaml
@@ -18,9 +18,13 @@ data:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_OTLP_LOGS_SOURCE}
         log_format: otlp
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
     extensions:
       file_storage:
@@ -324,7 +328,6 @@ data:
           - resource/remove_pod_name
           - resource/drop_annotations
           - transform/add_timestamp
-          - batch
           receivers:
           - otlp
         logs/otlp/kubelet:
@@ -346,7 +349,6 @@ data:
           - transform/remove_attributes
           - transform/flatten
           - transform/add_timestamp
-          - batch
           receivers:
           - otlp
         logs/otlp/systemd:
@@ -369,7 +371,6 @@ data:
           - transform/remove_attributes
           - transform/flatten
           - transform/add_timestamp
-          - batch
           receivers:
           - otlp
       telemetry:

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/routing_connector.input.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/routing_connector.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   logs:
     collector:
       otelcol:

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/routing_connector.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/routing_connector.output.yaml
@@ -45,9 +45,13 @@ data:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_OTLP_LOGS_SOURCE}
         log_format: otlp
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
       sumologic/test:
         endpoint: https://test-endpoint
@@ -357,7 +361,6 @@ data:
           - resource/drop_annotations
           - transform/add_timestamp
           - transform/add_default_pipeline_tag
-          - batch
           receivers:
           - otlp
         logs/otlp/containers/routing/debug:
@@ -396,7 +399,6 @@ data:
           - transform/flatten
           - transform/add_timestamp
           - transform/add_default_pipeline_tag
-          - batch
           receivers:
           - otlp
         logs/otlp/systemd:
@@ -420,7 +422,6 @@ data:
           - transform/flatten
           - transform/add_timestamp
           - transform/add_default_pipeline_tag
-          - batch
           receivers:
           - otlp
         logs/otlp/systemd/routing/debug:

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/routing_connector_with_defaults.input.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/routing_connector_with_defaults.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   logs:
     collector:
       otelcol:

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/routing_connector_with_defaults.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/routing_connector_with_defaults.output.yaml
@@ -39,9 +39,13 @@ data:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_OTLP_LOGS_SOURCE}
         log_format: otlp
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
       sumologic/test:
         endpoint: https://test-endpoint
@@ -347,7 +351,6 @@ data:
           - resource/remove_pod_name
           - resource/drop_annotations
           - transform/add_timestamp
-          - batch
           receivers:
           - otlp
         logs/otlp/containers/routing/default:
@@ -379,7 +382,6 @@ data:
           - transform/remove_attributes
           - transform/flatten
           - transform/add_timestamp
-          - batch
           receivers:
           - otlp
         logs/otlp/systemd:
@@ -402,7 +404,6 @@ data:
           - transform/remove_attributes
           - transform/flatten
           - transform/add_timestamp
-          - batch
           receivers:
           - otlp
         logs/otlp/systemd/routing/default:

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/routing_connector_with_defaults_http.input.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/routing_connector_with_defaults_http.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   logs:
     sourceType: http
     collector:

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/routing_connector_with_defaults_http.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/routing_connector_with_defaults_http.output.yaml
@@ -38,17 +38,25 @@ data:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE}
         log_format: json
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
       sumologic/systemd:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE}
         log_format: json
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
       sumologic/test:
         endpoint: https://test-endpoint
@@ -354,7 +362,6 @@ data:
           - resource/remove_pod_name
           - resource/drop_annotations
           - transform/add_timestamp
-          - batch
           receivers:
           - otlp
         logs/otlp/containers/routing/default:
@@ -386,7 +393,6 @@ data:
           - transform/remove_attributes
           - transform/flatten
           - transform/add_timestamp
-          - batch
           receivers:
           - otlp
         logs/otlp/systemd:
@@ -409,7 +415,6 @@ data:
           - transform/remove_attributes
           - transform/flatten
           - transform/add_timestamp
-          - batch
           receivers:
           - otlp
         logs/otlp/systemd/routing/default:

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/templates.input.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/templates.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   collectorName: my_collectorName
   logs:
     collector:

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc/templates.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc/templates.output.yaml
@@ -18,9 +18,13 @@ data:
         endpoint: ${SUMO_ENDPOINT_DEFAULT_OTLP_LOGS_SOURCE}
         log_format: otlp
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
     extensions:
       file_storage:
@@ -353,7 +357,6 @@ data:
           - resource/remove_pod_name
           - resource/drop_annotations
           - transform/add_timestamp
-          - batch
           receivers:
           - otlp
         logs/otlp/kubelet:
@@ -377,7 +380,6 @@ data:
           - transform/add_timestamp
           - resource/add-resource-attribute-kubelet
           - resource/remove-kubelet
-          - batch
           receivers:
           - otlp
         logs/otlp/systemd:
@@ -402,7 +404,6 @@ data:
           - transform/add_timestamp
           - resource/add-resource-attribute-systemd
           - resource/remove-systemd
-          - batch
           receivers:
           - otlp
       telemetry:

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc_statefulset/basic.input.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc_statefulset/basic.input.yaml
@@ -1,0 +1,2 @@
+sumologic:
+  useExporterBatching: true

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc_statefulset/custom.input.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc_statefulset/custom.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   logs:
     sourceType: http
   nodeSelector:

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc_statefulset/pvcpolicyenabled.input.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc_statefulset/pvcpolicyenabled.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   persistentVolumeClaimRetentionPolicyEnabled: false
   logs:
     sourceType: http

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/additional_endpoints.input.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/additional_endpoints.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 metadata:
   metrics:
     enableSumoPrometheusRemotewriteReceiver: true

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/additional_endpoints.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/additional_endpoints.output.yaml
@@ -21,9 +21,13 @@ data:
         max_request_body_size: 16777216
         metric_format: otlp
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
     extensions:
@@ -209,7 +213,6 @@ data:
           - groupbyattrs/group_by_name
           - transform/remove_name
           - filter/drop_unnecessary_metrics
-          - batch
           receivers:
           - telegraf
           - otlp

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/allow_histograms.input.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/allow_histograms.input.yaml
@@ -1,3 +1,4 @@
 sumologic:
+  useExporterBatching: true
   metrics:
     allowHistogramRegex: "^(apiserver_request_duration_seconds)$"

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/allow_histograms.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/allow_histograms.output.yaml
@@ -21,9 +21,13 @@ data:
         max_request_body_size: 16777216
         metric_format: otlp
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
     extensions:
@@ -197,7 +201,6 @@ data:
           - groupbyattrs/group_by_name
           - transform/remove_name
           - filter/drop_unnecessary_metrics
-          - batch
           receivers:
           - prometheusremotewrite
           - otlp

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/basic.input.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/basic.input.yaml
@@ -1,0 +1,2 @@
+sumologic:
+  useExporterBatching: true

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/basic.output.yaml
@@ -21,9 +21,13 @@ data:
         max_request_body_size: 16777216
         metric_format: otlp
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
     extensions:
@@ -197,7 +201,6 @@ data:
           - groupbyattrs/group_by_name
           - transform/remove_name
           - filter/drop_unnecessary_metrics
-          - batch
           receivers:
           - prometheusremotewrite
           - otlp

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/custom_routing_connector.input.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/custom_routing_connector.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   ipv6mode: true
   metrics:
     sourceType: http

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/custom_routing_connector.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/custom_routing_connector.output.yaml
@@ -52,6 +52,13 @@ data:
           statement: route() where resource.attributes["job"] == "kube-state-metrics"
     exporters:
       debug:
+        sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
+          enabled: true
+          queue_size: 1024000
         verbosity: detailed
       sumologic/apiserver:
         client: k8s_%CURRENT_CHART_VERSION%
@@ -59,9 +66,13 @@ data:
         max_request_body_size: 16777216
         metric_format: prometheus
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
       sumologic/control_plane:
@@ -70,9 +81,13 @@ data:
         max_request_body_size: 16777216
         metric_format: prometheus
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
       sumologic/controller:
@@ -81,9 +96,13 @@ data:
         max_request_body_size: 16777216
         metric_format: prometheus
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
       sumologic/default:
@@ -94,9 +113,13 @@ data:
         max_request_body_size: 16777216
         metric_format: prometheus
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
       sumologic/kubelet:
@@ -105,9 +128,13 @@ data:
         max_request_body_size: 16777216
         metric_format: prometheus
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
       sumologic/node:
@@ -116,9 +143,13 @@ data:
         max_request_body_size: 16777216
         metric_format: prometheus
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
       sumologic/scheduler:
@@ -127,9 +158,13 @@ data:
         max_request_body_size: 16777216
         metric_format: prometheus
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
       sumologic/state:
@@ -138,9 +173,13 @@ data:
         max_request_body_size: 16777216
         metric_format: prometheus
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
     extensions:
@@ -314,7 +353,6 @@ data:
           - groupbyattrs/group_by_name
           - transform/remove_name
           - filter/drop_unnecessary_metrics
-          - batch
           receivers:
           - prometheusremotewrite
           - otlp

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/debug.input.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/debug.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 debug:
   metrics:
     metadata:

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/debug.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/debug.output.yaml
@@ -14,6 +14,13 @@ data:
   config.yaml: |
     exporters:
       debug:
+        sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
+          enabled: true
+          queue_size: 1024000
         verbosity: detailed
       sumologic/default:
         client: k8s_%CURRENT_CHART_VERSION%
@@ -23,9 +30,13 @@ data:
         max_request_body_size: 16777216
         metric_format: otlp
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
     extensions:
@@ -200,7 +211,6 @@ data:
           - groupbyattrs/group_by_name
           - transform/remove_name
           - filter/drop_unnecessary_metrics
-          - batch
           receivers:
           - prometheusremotewrite
           - otlp

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/debug_with_sumologic_mock.input.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/debug_with_sumologic_mock.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 debug:
   sumologicMock:
     enabled: true

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/debug_with_sumologic_mock.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/debug_with_sumologic_mock.output.yaml
@@ -14,6 +14,13 @@ data:
   config.yaml: |
     exporters:
       debug:
+        sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
+          enabled: true
+          queue_size: 1024000
         verbosity: detailed
       sumologic/default:
         client: k8s_%CURRENT_CHART_VERSION%
@@ -23,9 +30,13 @@ data:
         max_request_body_size: 16777216
         metric_format: otlp
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
       sumologic/sumologic-mock-default:
@@ -36,9 +47,13 @@ data:
         max_request_body_size: 16777216
         metric_format: otlp
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
       sumologic/sumologic-mock-http:
@@ -47,9 +62,13 @@ data:
         max_request_body_size: 16777216
         metric_format: prometheus
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
     extensions:
@@ -225,7 +244,6 @@ data:
           - groupbyattrs/group_by_name
           - transform/remove_name
           - filter/drop_unnecessary_metrics
-          - batch
           receivers:
           - prometheusremotewrite
           - otlp

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/debug_with_sumologic_mock_http.input.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/debug_with_sumologic_mock_http.input.yaml
@@ -7,5 +7,6 @@ debug:
       forwardToSumologicMock: true
       stopLogsIngestion: true
 sumologic:
+  useExporterBatching: true
   metrics:
     sourceType: http

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/debug_with_sumologic_mock_http.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/debug_with_sumologic_mock_http.output.yaml
@@ -61,6 +61,13 @@ data:
           statement: route() where resource.attributes["job"] == "kube-state-metrics"
     exporters:
       debug:
+        sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
+          enabled: true
+          queue_size: 1024000
         verbosity: detailed
       sumologic/apiserver:
         client: k8s_%CURRENT_CHART_VERSION%
@@ -68,9 +75,13 @@ data:
         max_request_body_size: 16777216
         metric_format: prometheus
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
       sumologic/control_plane:
@@ -79,9 +90,13 @@ data:
         max_request_body_size: 16777216
         metric_format: prometheus
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
       sumologic/controller:
@@ -90,9 +105,13 @@ data:
         max_request_body_size: 16777216
         metric_format: prometheus
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
       sumologic/default:
@@ -103,9 +122,13 @@ data:
         max_request_body_size: 16777216
         metric_format: prometheus
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
       sumologic/kubelet:
@@ -114,9 +137,13 @@ data:
         max_request_body_size: 16777216
         metric_format: prometheus
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
       sumologic/node:
@@ -125,9 +152,13 @@ data:
         max_request_body_size: 16777216
         metric_format: prometheus
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
       sumologic/scheduler:
@@ -136,9 +167,13 @@ data:
         max_request_body_size: 16777216
         metric_format: prometheus
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
       sumologic/state:
@@ -147,9 +182,13 @@ data:
         max_request_body_size: 16777216
         metric_format: prometheus
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
       sumologic/sumologic-mock-default:
@@ -160,9 +199,13 @@ data:
         max_request_body_size: 16777216
         metric_format: prometheus
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
       sumologic/sumologic-mock-http:
@@ -171,9 +214,13 @@ data:
         max_request_body_size: 16777216
         metric_format: prometheus
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
     extensions:
@@ -347,7 +394,6 @@ data:
           - groupbyattrs/group_by_name
           - transform/remove_name
           - filter/drop_unnecessary_metrics
-          - batch
           receivers:
           - prometheusremotewrite
           - otlp

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/debug_with_sumologic_mock_http_routing_connector.input.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/debug_with_sumologic_mock_http_routing_connector.input.yaml
@@ -7,5 +7,6 @@ debug:
       forwardToSumologicMock: true
       stopLogsIngestion: true
 sumologic:
+  useExporterBatching: true
   metrics:
     sourceType: http

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/debug_with_sumologic_mock_http_routing_connector.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/debug_with_sumologic_mock_http_routing_connector.output.yaml
@@ -61,6 +61,13 @@ data:
           statement: route() where resource.attributes["job"] == "kube-state-metrics"
     exporters:
       debug:
+        sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
+          enabled: true
+          queue_size: 1024000
         verbosity: detailed
       sumologic/apiserver:
         client: k8s_%CURRENT_CHART_VERSION%
@@ -68,9 +75,13 @@ data:
         max_request_body_size: 16777216
         metric_format: prometheus
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
       sumologic/control_plane:
@@ -79,9 +90,13 @@ data:
         max_request_body_size: 16777216
         metric_format: prometheus
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
       sumologic/controller:
@@ -90,9 +105,13 @@ data:
         max_request_body_size: 16777216
         metric_format: prometheus
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
       sumologic/default:
@@ -103,9 +122,13 @@ data:
         max_request_body_size: 16777216
         metric_format: prometheus
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
       sumologic/kubelet:
@@ -114,9 +137,13 @@ data:
         max_request_body_size: 16777216
         metric_format: prometheus
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
       sumologic/node:
@@ -125,9 +152,13 @@ data:
         max_request_body_size: 16777216
         metric_format: prometheus
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
       sumologic/scheduler:
@@ -136,9 +167,13 @@ data:
         max_request_body_size: 16777216
         metric_format: prometheus
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
       sumologic/state:
@@ -147,9 +182,13 @@ data:
         max_request_body_size: 16777216
         metric_format: prometheus
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
       sumologic/sumologic-mock-default:
@@ -160,9 +199,13 @@ data:
         max_request_body_size: 16777216
         metric_format: prometheus
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
       sumologic/sumologic-mock-http:
@@ -171,9 +214,13 @@ data:
         max_request_body_size: 16777216
         metric_format: prometheus
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
     extensions:
@@ -347,7 +394,6 @@ data:
           - groupbyattrs/group_by_name
           - transform/remove_name
           - filter/drop_unnecessary_metrics
-          - batch
           receivers:
           - prometheusremotewrite
           - otlp

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/filtered_app_metrics.input.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/filtered_app_metrics.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   metrics:
     metadata:
       provider: otelcol

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc/filtered_app_metrics.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc/filtered_app_metrics.output.yaml
@@ -21,9 +21,13 @@ data:
         max_request_body_size: 16777216
         metric_format: otlp
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2048
+            min_size: 1024
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10240000
           storage: file_storage
         timeout: 30s
     extensions:
@@ -222,7 +226,6 @@ data:
           - transform/remove_name
           - filter/drop_unnecessary_metrics
           - filter/app_metrics
-          - batch
           receivers:
           - prometheusremotewrite
           - otlp

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc_statefulset/basic.input.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc_statefulset/basic.input.yaml
@@ -1,0 +1,2 @@
+sumologic:
+  useExporterBatching: true

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc_statefulset/custom.input.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc_statefulset/custom.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   metrics:
     sourceType: http
   nodeSelector:

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc_statefulset/pvcpolicyenabled.input.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc_statefulset/pvcpolicyenabled.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   persistentVolumeClaimRetentionPolicyEnabled: false
   logs:
     sourceType: http

--- a/tests/helm/testdata/goldenfile/metrics-server/basic.input.yaml
+++ b/tests/helm/testdata/goldenfile/metrics-server/basic.input.yaml
@@ -1,2 +1,4 @@
+sumologic:
+  useExporterBatching: true
 metrics-server:
   enabled: true

--- a/tests/helm/testdata/goldenfile/metrics_additional_service_monitors/basic.input.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_additional_service_monitors/basic.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   metrics:
     additionalServiceMonitors:
       - name: basic-service-monitor

--- a/tests/helm/testdata/goldenfile/metrics_additional_service_monitors/custom.input.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_additional_service_monitors/custom.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   metrics:
     additionalServiceMonitors:
       - name: custom-service-monitor

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.input.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.input.yaml
@@ -1,0 +1,2 @@
+sumologic:
+  useExporterBatching: true

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
@@ -88,8 +88,12 @@ spec:
         disable_keep_alives: true
         endpoint: http://${METADATA_METRICS_SVC}.${NAMESPACE}.svc.cluster.local.:4318
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2000
+            min_size: 1000
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10000000
           storage: file_storage
     extensions:
       file_storage:
@@ -263,7 +267,6 @@ spec:
           exporters:
             - otlphttp
           processors:
-            - batch
             - filter/drop_stale_datapoints
             - transform/extract_sum_count_from_histograms
             - transform/drop_unnecessary_attributes

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.input.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.input.yaml
@@ -1,4 +1,5 @@
-sumologic:
+sumologic:sumologic:
+  useExporterBatching: true
   ipv6mode: true
   nodeSelector:
     workingGroup: testing

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
@@ -12,73 +12,36 @@ metadata:
     release: "RELEASE-NAME"
     heritage: "Helm"
     sumologic.com/scrape: "true"
-
-    podLabelKey: podLabelValue
-
-    podKey: podValue
 spec:
-  image: "my_repository:my_tag"
+  image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.151.0-sumo-0"
   mode: statefulset
   replicas: 1
   serviceAccount: RELEASE-NAME-sumologic-metrics
   managementState: managed
   upgradeStrategy: automatic
   targetAllocator:
-    allocationStrategy: consistent-hashing
     enabled: true
     filterStrategy: relabel-config
     prometheusCR:
       enabled: true
-      scrapeInterval: 60s
+      scrapeInterval: 30s
       serviceMonitorSelector:
         matchLabels:
-          smkey: smvalue
-
+          release: RELEASE-NAME
       podMonitorSelector:
         matchLabels:
-          pmkey: pmvalue
-
+          release: RELEASE-NAME
     serviceAccount: RELEASE-NAME-sumologic-metrics-targetallocator-sa
     nodeSelector:
       kubernetes.io/os: linux
-      workingGroup: production
-    resources:
-      limits:
-        cpu: 2000m
-        memory: 3Gi
-      requests:
-        cpu: 500m
-        memory: 2Gi
-    tolerations:
-      - effect: NoSchedule
-        key: null
-        operator: Exists
-    affinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: topology.kubernetes.io/zone
-                operator: In
-                values:
-                  - sumo-east1
-                  - sumo-west1
+    resources: {}
   nodeSelector:
     kubernetes.io/os: linux
-    workingGroup: production
-  tolerations:
-    - effect: NoSchedule
-      key: null
-      operator: Exists
-  affinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      nodeSelectorTerms:
-        - matchExpressions:
-            - key: topology.kubernetes.io/zone
-              operator: In
-              values:
-                - sumo-east1
-                - sumo-west1
-  priorityClassName: "customPriority"
+  autoscaler:
+    maxReplicas: 10
+    minReplicas: 1
+    targetCPUUtilization: 70
+    targetMemoryUtilization: 70
   env:
     - name: METADATA_METRICS_SVC
       valueFrom:
@@ -97,8 +60,6 @@ spec:
   podAnnotations:
     ## The operator adds this annotation by default, but we use our own ServiceMonitor
     prometheus.io/scrape: "false"
-    podAnnotationKey: podAnnotationValue
-    annotationKey: annotationValue
   podSecurityContext:
     fsGroup: 999
   ports:
@@ -106,11 +67,11 @@ spec:
       port: 1777
   resources:
     limits:
-      cpu: 3000m
+      cpu: 1000m
       memory: 2Gi
     requests:
-      cpu: 1000m
-      memory: 1Gi
+      cpu: 100m
+      memory: 768Mi
   volumes:
     - name: tmp
       emptyDir: {}
@@ -138,12 +99,12 @@ spec:
         directory: /var/lib/storage/otc
         timeout: 10s
       health_check:
-        endpoint: "[${env:MY_POD_IP}]:13133"
+        endpoint: ${env:MY_POD_IP}:13133
       pprof: {}
     processors:
       batch:
         send_batch_max_size: 2000
-        send_batch_size: 5000
+        send_batch_size: 1000
         timeout: 1s
       filter/drop_stale_datapoints:
         metrics:
@@ -159,12 +120,139 @@ spec:
               - delete_key(attributes, "net.host.port")
               - delete_key(attributes, "service.instance.id")
               - delete_matching_keys(attributes, "k8s.*")
+      transform/extract_sum_count_from_histograms:
+        error_mode: ignore
+        metric_statements:
+          - context: metric
+            statements:
+              - extract_sum_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM or type ==
+                METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
+              - extract_count_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM or type ==
+                METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
     receivers:
       prometheus:
         config:
           global:
-            scrape_interval: 60s
-          scrape_configs: []
+            scrape_interval: 30s
+          scrape_configs:
+            - job_name: pod-annotations
+              kubernetes_sd_configs:
+                - role: pod
+              relabel_configs:
+                - action: keep
+                  regex: true
+                  source_labels:
+                    - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+                - action: replace
+                  regex: (.+)
+                  source_labels:
+                    - __meta_kubernetes_pod_annotation_prometheus_io_path
+                  target_label: __metrics_path__
+                - action: replace
+                  regex: ([^:]+)(?::\d+)?;(\d+)
+                  replacement: $1:$2
+                  source_labels:
+                    - __address__
+                    - __meta_kubernetes_pod_annotation_prometheus_io_port
+                  target_label: __address__
+                - action: replace
+                  regex: (.*)
+                  replacement: $1
+                  separator: ;
+                  source_labels:
+                    - __metrics_path__
+                  target_label: endpoint
+                - action: replace
+                  source_labels:
+                    - __meta_kubernetes_namespace
+                  target_label: namespace
+                - action: labelmap
+                  regex: __meta_kubernetes_pod_label_(.+)
+                - action: replace
+                  regex: (.*)
+                  replacement: $1
+                  separator: ;
+                  source_labels:
+                    - __meta_kubernetes_pod_name
+                  target_label: pod
+            - authorization:
+                credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              honor_labels: true
+              job_name: kubelet
+              kubernetes_sd_configs:
+                - role: node
+              metric_relabel_configs:
+                - action: keep
+                  regex: (?:kubelet_docker_operations_errors(?:|_total)|kubelet_(?:docker|runtime)_operations_duration_seconds_(?:count|sum)|kubelet_running_(?:container|pod)(?:_count|s)|kubelet_(:?docker|runtime)_operations_latency_microseconds(?:|_count|_sum))
+                  source_labels:
+                    - __name__
+                - action: labeldrop
+                  regex: id
+              relabel_configs:
+                - source_labels:
+                    - __meta_kubernetes_node_name
+                  target_label: node
+                - replacement: https-metrics
+                  target_label: endpoint
+                - action: replace
+                  source_labels:
+                    - __metrics_path__
+                  target_label: metrics_path
+                - action: replace
+                  source_labels:
+                    - __address__
+                  target_label: instance
+              scheme: https
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: true
+            - authorization:
+                credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              honor_labels: true
+              job_name: cadvisor
+              kubernetes_sd_configs:
+                - role: node
+              metric_relabel_configs:
+                - action: replace
+                  regex: .*
+                  replacement: kubelet
+                  source_labels:
+                    - __name__
+                  target_label: job
+                - action: keep
+                  regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes|container_cpu_cfs_throttled_seconds_total|container_network_receive_bytes_total|container_network_transmit_bytes_total)
+                  source_labels:
+                    - __name__
+                - action: drop
+                  regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes);$
+                  source_labels:
+                    - __name__
+                    - container
+                - action: labelmap
+                  regex: container_name
+                  replacement: container
+                - action: drop
+                  regex: POD
+                  source_labels:
+                    - container
+                - action: labeldrop
+                  regex: (id|name)
+              metrics_path: /metrics/cadvisor
+              relabel_configs:
+                - replacement: https-metrics
+                  target_label: endpoint
+                - action: replace
+                  source_labels:
+                    - __metrics_path__
+                  target_label: metrics_path
+                - action: replace
+                  source_labels:
+                    - __address__
+                  target_label: instance
+              scheme: https
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: true
     service:
       extensions:
         - health_check
@@ -177,6 +265,7 @@ spec:
           processors:
             - batch
             - filter/drop_stale_datapoints
+            - transform/extract_sum_count_from_histograms
             - transform/drop_unnecessary_attributes
           receivers:
             - prometheus

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/debug.input.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/debug.input.yaml
@@ -5,6 +5,7 @@ debug:
       stopLogsIngestion: true
 
 sumologic:
+  useExporterBatching: true
   metrics:
     collector:
       otelcol:

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/debug.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/debug.output.yaml
@@ -43,19 +43,18 @@ spec:
     targetCPUUtilization: 70
     targetMemoryUtilization: 70
     behavior:
-      scaleUp:
-        stabilizationWindowSeconds: 60
-        policies:
-          - type: Percent
-            value: 100
-            periodSeconds: 60
       scaleDown:
-        stabilizationWindowSeconds: 60
         policies:
-          - type: Percent
+          - periodSeconds: 60
+            type: Percent
             value: 100
-            periodSeconds: 60
-
+        stabilizationWindowSeconds: 60
+      scaleUp:
+        policies:
+          - periodSeconds: 60
+            type: Percent
+            value: 100
+        stabilizationWindowSeconds: 60
   env:
     - name: METADATA_METRICS_SVC
       valueFrom:
@@ -104,8 +103,12 @@ spec:
         disable_keep_alives: true
         endpoint: http://${METADATA_METRICS_SVC}.${NAMESPACE}.svc.cluster.local.:4318
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2000
+            min_size: 1000
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10000000
           storage: file_storage
     extensions:
       file_storage:
@@ -280,7 +283,6 @@ spec:
             - debug
             - otlphttp
           processors:
-            - batch
             - filter/drop_stale_datapoints
             - transform/extract_sum_count_from_histograms
             - transform/drop_unnecessary_attributes

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/kubelet.input.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/kubelet.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   metrics:
     collector:
       otelcol:

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/kubelet.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/kubelet.output.yaml
@@ -88,8 +88,12 @@ spec:
         disable_keep_alives: true
         endpoint: http://${METADATA_METRICS_SVC}.${NAMESPACE}.svc.cluster.local.:4318
         sending_queue:
+          batch:
+            flush_timeout: 1s
+            max_size: 2000
+            min_size: 1000
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 10000000
           storage: file_storage
     extensions:
       file_storage:
@@ -263,7 +267,6 @@ spec:
           exporters:
             - otlphttp
           processors:
-            - batch
             - filter/drop_stale_datapoints
             - transform/extract_sum_count_from_histograms
             - transform/drop_unnecessary_attributes

--- a/tests/helm/testdata/goldenfile/opentelemetry_operator_instrumentation_cr_configmap/instrumentation.additionalenvs.input.yaml
+++ b/tests/helm/testdata/goldenfile/opentelemetry_operator_instrumentation_cr_configmap/instrumentation.additionalenvs.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 opentelemetry-operator:
   enabled: true
   manager:

--- a/tests/helm/testdata/goldenfile/opentelemetry_operator_instrumentation_cr_configmap/instrumentation.input.yaml
+++ b/tests/helm/testdata/goldenfile/opentelemetry_operator_instrumentation_cr_configmap/instrumentation.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 opentelemetry-operator:
   enabled: true
 instrumentation:

--- a/tests/helm/testdata/goldenfile/opentelemetry_operator_instrumentation_cr_configmap/instrumentation.repository.input.yaml
+++ b/tests/helm/testdata/goldenfile/opentelemetry_operator_instrumentation_cr_configmap/instrumentation.repository.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 opentelemetry-operator:
   enabled: true
   manager:

--- a/tests/helm/testdata/goldenfile/opentelemetry_operator_instrumentation_cr_job/job.input.yaml
+++ b/tests/helm/testdata/goldenfile/opentelemetry_operator_instrumentation_cr_job/job.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 opentelemetry-operator:
   enabled: true
 instrumentation:

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/config-from-merge.input.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/config-from-merge.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 otelcolInstrumentation:
   config:
     merge:

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/config-from-merge.input.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/config-from-merge.input.yaml
@@ -4,5 +4,5 @@ otelcolInstrumentation:
   config:
     merge:
       processors:
-        batch:
-          timeout: 10s
+        memory_limiter:
+          check_interval: 10s

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/config-from-merge.output.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/config-from-merge.output.yaml
@@ -15,6 +15,13 @@ data:
     exporters:
       otlphttp/traces:
         endpoint: http://RELEASE-NAME-sumologic-traces-gateway.sumologic:4318
+        sending_queue:
+          batch:
+            flush_timeout: 5s
+            max_size: 512
+            min_size: 256
+          enabled: true
+          queue_size: 256000
       sumologic/metrics:
         client: k8s_%CURRENT_CHART_VERSION%
         compression: gzip
@@ -28,9 +35,13 @@ data:
           max_elapsed_time: 120s
           max_interval: 30s
         sending_queue:
+          batch:
+            flush_timeout: 5s
+            max_size: 512
+            min_size: 256
           enabled: false
           num_consumers: 10
-          queue_size: 5000
+          queue_size: 1280000
         timeout: 5s
     extensions:
       health_check:
@@ -148,7 +159,6 @@ data:
           - k8sattributes
           - source
           - resource
-          - batch
           receivers:
           - otlp
           - otlp/deprecated
@@ -160,7 +170,6 @@ data:
           - k8sattributes
           - source
           - resource
-          - batch
           receivers:
           - jaeger
           - otlp

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/config-from-merge.output.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/config-from-merge.output.yaml
@@ -51,7 +51,7 @@ data:
       batch:
         send_batch_max_size: 512
         send_batch_size: 256
-        timeout: 10s
+        timeout: 5s
       k8sattributes:
         auth_type: serviceAccount
         extract:
@@ -94,7 +94,7 @@ data:
         wait_for_metadata: true
         wait_for_metadata_timeout: 10s
       memory_limiter:
-        check_interval: 5s
+        check_interval: 10s
         limit_percentage: 90
         spike_limit_percentage: 20
       resource:

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/config-from-override.input.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/config-from-override.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 otelcolInstrumentation:
   config:
     override:

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/config-from-values-backward-compatibility.input.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/config-from-values-backward-compatibility.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 otelcolInstrumentation:
   config:
     merge:

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/config-from-values-backward-compatibility.output.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/config-from-values-backward-compatibility.output.yaml
@@ -15,6 +15,13 @@ data:
     exporters:
       otlphttp/traces:
         endpoint: http://RELEASE-NAME-sumologic-traces-gateway.sumologic:4318
+        sending_queue:
+          batch:
+            flush_timeout: 5s
+            max_size: 512
+            min_size: 256
+          enabled: true
+          queue_size: 256000
       sumologic/metrics:
         client: k8s_%CURRENT_CHART_VERSION%
         compression: gzip
@@ -28,9 +35,13 @@ data:
           max_elapsed_time: 120s
           max_interval: 30s
         sending_queue:
+          batch:
+            flush_timeout: 5s
+            max_size: 512
+            min_size: 256
           enabled: false
           num_consumers: 10
-          queue_size: 5000
+          queue_size: 1280000
         timeout: 5s
     extensions:
       health_check:
@@ -148,7 +159,6 @@ data:
           - k8sattributes
           - source
           - resource
-          - batch
           receivers:
           - otlp
           - otlp/deprecated
@@ -160,7 +170,6 @@ data:
           - k8sattributes
           - source
           - resource
-          - batch
           receivers:
           - jaeger
           - otlp

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/config-ipv6.input.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/config-ipv6.input.yaml
@@ -1,2 +1,3 @@
 sumologic:
+  useExporterBatching: true
   ipv6mode: true

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/config-ipv6.output.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/config-ipv6.output.yaml
@@ -15,6 +15,13 @@ data:
     exporters:
       otlphttp/traces:
         endpoint: http://RELEASE-NAME-sumologic-traces-gateway.sumologic:4318
+        sending_queue:
+          batch:
+            flush_timeout: 5s
+            max_size: 512
+            min_size: 256
+          enabled: true
+          queue_size: 256000
       sumologic/metrics:
         client: k8s_%CURRENT_CHART_VERSION%
         compression: gzip
@@ -28,9 +35,13 @@ data:
           max_elapsed_time: 120s
           max_interval: 30s
         sending_queue:
+          batch:
+            flush_timeout: 5s
+            max_size: 512
+            min_size: 256
           enabled: false
           num_consumers: 10
-          queue_size: 5000
+          queue_size: 1280000
         timeout: 5s
     extensions:
       health_check:
@@ -148,7 +159,6 @@ data:
           - k8sattributes
           - source
           - resource
-          - batch
           receivers:
           - otlp
           - otlp/deprecated
@@ -160,7 +170,6 @@ data:
           - k8sattributes
           - source
           - resource
-          - batch
           receivers:
           - jaeger
           - otlp

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/traces-gateway-disabled.input.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/traces-gateway-disabled.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 otelcolInstrumentation:
   sourceMetadata:
     excludeNamespaceRegex: "kube\\s+"

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/traces-gateway-disabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/traces-gateway-disabled.output.yaml
@@ -17,9 +17,13 @@ data:
         protocol:
           otlp:
             sending_queue:
+              batch:
+                flush_timeout: 5s
+                max_size: 512
+                min_size: 256
               enabled: true
               num_consumers: 10
-              queue_size: 10000
+              queue_size: 2560000
             timeout: 10s
             tls:
               insecure: true
@@ -40,9 +44,13 @@ data:
           max_elapsed_time: 120s
           max_interval: 30s
         sending_queue:
+          batch:
+            flush_timeout: 5s
+            max_size: 512
+            min_size: 256
           enabled: false
           num_consumers: 10
-          queue_size: 5000
+          queue_size: 1280000
         timeout: 5s
     extensions:
       health_check:
@@ -160,7 +168,6 @@ data:
           - k8sattributes
           - source
           - resource
-          - batch
           receivers:
           - otlp
           - otlp/deprecated
@@ -172,7 +179,6 @@ data:
           - k8sattributes
           - source
           - resource
-          - batch
           receivers:
           - jaeger
           - otlp

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/traces-gateway-disabled.sumologic-mock.input.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/traces-gateway-disabled.sumologic-mock.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 otelcolInstrumentation:
   sourceMetadata:
     excludeNamespaceRegex: "kube\\s+"

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/traces-gateway-disabled.sumologic-mock.output.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/traces-gateway-disabled.sumologic-mock.output.yaml
@@ -14,14 +14,25 @@ data:
   otelcol.instrumentation.conf.yaml: |
     exporters:
       debug:
+        sending_queue:
+          batch:
+            flush_timeout: 5s
+            max_size: 512
+            min_size: 256
+          enabled: true
+          queue_size: 2560000
         verbosity: detailed
       loadbalancing:
         protocol:
           otlp:
             sending_queue:
+              batch:
+                flush_timeout: 5s
+                max_size: 512
+                min_size: 256
               enabled: true
               num_consumers: 10
-              queue_size: 10000
+              queue_size: 2560000
             timeout: 10s
             tls:
               insecure: true
@@ -42,9 +53,13 @@ data:
           max_elapsed_time: 120s
           max_interval: 30s
         sending_queue:
+          batch:
+            flush_timeout: 5s
+            max_size: 512
+            min_size: 256
           enabled: false
           num_consumers: 10
-          queue_size: 5000
+          queue_size: 1280000
         timeout: 5s
     extensions:
       health_check:
@@ -163,7 +178,6 @@ data:
           - k8sattributes
           - source
           - resource
-          - batch
           receivers:
           - otlp
           - otlp/deprecated
@@ -176,7 +190,6 @@ data:
           - k8sattributes
           - source
           - resource
-          - batch
           receivers:
           - jaeger
           - otlp

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/traces-gateway-enabled.input.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/traces-gateway-enabled.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 otelcolInstrumentation:
   sourceMetadata:
     excludeNamespaceRegex: "kube\\s+"

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/traces-gateway-enabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/traces-gateway-enabled.output.yaml
@@ -15,6 +15,13 @@ data:
     exporters:
       otlphttp/traces:
         endpoint: http://RELEASE-NAME-sumologic-traces-gateway.sumologic:4318
+        sending_queue:
+          batch:
+            flush_timeout: 5s
+            max_size: 512
+            min_size: 256
+          enabled: true
+          queue_size: 256000
       sumologic/metrics:
         client: k8s_%CURRENT_CHART_VERSION%
         compression: gzip
@@ -28,9 +35,13 @@ data:
           max_elapsed_time: 120s
           max_interval: 30s
         sending_queue:
+          batch:
+            flush_timeout: 5s
+            max_size: 512
+            min_size: 256
           enabled: false
           num_consumers: 10
-          queue_size: 5000
+          queue_size: 1280000
         timeout: 5s
     extensions:
       health_check:
@@ -148,7 +159,6 @@ data:
           - k8sattributes
           - source
           - resource
-          - batch
           receivers:
           - otlp
           - otlp/deprecated
@@ -160,7 +170,6 @@ data:
           - k8sattributes
           - source
           - resource
-          - batch
           receivers:
           - jaeger
           - otlp

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/traces-gateway-enabled.sumologic-mock.input.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/traces-gateway-enabled.sumologic-mock.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 otelcolInstrumentation:
   sourceMetadata:
     excludeNamespaceRegex: "kube\\s+"

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/traces-gateway-enabled.sumologic-mock.output.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-config/traces-gateway-enabled.sumologic-mock.output.yaml
@@ -14,14 +14,25 @@ data:
   otelcol.instrumentation.conf.yaml: |
     exporters:
       debug:
+        sending_queue:
+          batch:
+            flush_timeout: 5s
+            max_size: 512
+            min_size: 256
+          enabled: true
+          queue_size: 2560000
         verbosity: detailed
       loadbalancing:
         protocol:
           otlp:
             sending_queue:
+              batch:
+                flush_timeout: 5s
+                max_size: 512
+                min_size: 256
               enabled: true
               num_consumers: 10
-              queue_size: 10000
+              queue_size: 2560000
             timeout: 10s
             tls:
               insecure: true
@@ -42,9 +53,13 @@ data:
           max_elapsed_time: 120s
           max_interval: 30s
         sending_queue:
+          batch:
+            flush_timeout: 5s
+            max_size: 512
+            min_size: 256
           enabled: false
           num_consumers: 10
-          queue_size: 5000
+          queue_size: 1280000
         timeout: 5s
     extensions:
       health_check:
@@ -163,7 +178,6 @@ data:
           - k8sattributes
           - source
           - resource
-          - batch
           receivers:
           - otlp
           - otlp/deprecated
@@ -176,7 +190,6 @@ data:
           - k8sattributes
           - source
           - resource
-          - batch
           receivers:
           - jaeger
           - otlp

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-hpa/basic.input.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-hpa/basic.input.yaml
@@ -2,5 +2,6 @@ otelcolInstrumentation:
   enabled: true
 
 sumologic:
+  useExporterBatching: true
   traces:
     enabled: true

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-statefulset/basic.input.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-statefulset/basic.input.yaml
@@ -1,0 +1,2 @@
+sumologic:
+  useExporterBatching: true

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-statefulset/custom.input.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-statefulset/custom.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 otelcolInstrumentation:
   statefulset:
     image:

--- a/tests/helm/testdata/goldenfile/otellogs_metrics/enabled.input.yaml
+++ b/tests/helm/testdata/goldenfile/otellogs_metrics/enabled.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 otellogs:
   metrics:
     enabled: true

--- a/tests/helm/testdata/goldenfile/pvc-cleaner/full_config_logs.input.yaml
+++ b/tests/helm/testdata/goldenfile/pvc-cleaner/full_config_logs.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   podLabels:
     someSumo: label
   podAnnotations:

--- a/tests/helm/testdata/goldenfile/pvc-cleaner/full_config_metrics.input.yaml
+++ b/tests/helm/testdata/goldenfile/pvc-cleaner/full_config_metrics.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   podLabels:
     someSumo: label
   podAnnotations:

--- a/tests/helm/testdata/goldenfile/remote_write_proxy/basic.input.yaml
+++ b/tests/helm/testdata/goldenfile/remote_write_proxy/basic.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   metrics:
     remoteWriteProxy:
       enabled: true

--- a/tests/helm/testdata/goldenfile/remote_write_proxy/full_config.input.yaml
+++ b/tests/helm/testdata/goldenfile/remote_write_proxy/full_config.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   nodeSelector:
     disktype: hdd
   tolerations:

--- a/tests/helm/testdata/goldenfile/remote_write_proxy/full_configmap.input.yaml
+++ b/tests/helm/testdata/goldenfile/remote_write_proxy/full_configmap.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   nodeSelector:
     disktype: hdd
   metrics:

--- a/tests/helm/testdata/goldenfile/services_with_service_monitor_labels/services_with_service_monitor_labels/default.input.yaml
+++ b/tests/helm/testdata/goldenfile/services_with_service_monitor_labels/services_with_service_monitor_labels/default.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 metadata:
   logs:
     statefulset:

--- a/tests/helm/testdata/goldenfile/setup/basic.input.yaml
+++ b/tests/helm/testdata/goldenfile/setup/basic.input.yaml
@@ -1,0 +1,2 @@
+sumologic:
+  useExporterBatching: true

--- a/tests/helm/testdata/goldenfile/setup/monitors_with_email_notifications.input.yaml
+++ b/tests/helm/testdata/goldenfile/setup/monitors_with_email_notifications.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   setup:
     monitors:
       enabled: "true"

--- a/tests/helm/testdata/goldenfile/setup/monitors_with_single_email.input.yaml
+++ b/tests/helm/testdata/goldenfile/setup/monitors_with_single_email.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   setup:
     monitors:
       enabled: "true"

--- a/tests/helm/testdata/goldenfile/setup/restart-policy.input.yaml
+++ b/tests/helm/testdata/goldenfile/setup/restart-policy.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   setup:
     job:
       restartPolicy: Never # or OnFailure (default)

--- a/tests/helm/testdata/goldenfile/setup/sumologic-mock-no-secret.input.yaml
+++ b/tests/helm/testdata/goldenfile/setup/sumologic-mock-no-secret.input.yaml
@@ -5,4 +5,5 @@ debug:
   enableLocalMode: true
 
 sumologic:
+  useExporterBatching: true
   envFromSecret: false

--- a/tests/helm/testdata/goldenfile/setup/sumologic-mock-secret.input.yaml
+++ b/tests/helm/testdata/goldenfile/setup/sumologic-mock-secret.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 debug:
   sumologicMock:
     enabled: true

--- a/tests/helm/testdata/goldenfile/setup/sumologic-mock.input.yaml
+++ b/tests/helm/testdata/goldenfile/setup/sumologic-mock.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 debug:
   sumologicMock:
     enabled: true

--- a/tests/helm/testdata/goldenfile/sumologic-mock/basic.input.yaml
+++ b/tests/helm/testdata/goldenfile/sumologic-mock/basic.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 debug:
   sumologicMock:
     enabled: true

--- a/tests/helm/testdata/goldenfile/sumologic-mock/complex.input.yaml
+++ b/tests/helm/testdata/goldenfile/sumologic-mock/complex.input.yaml
@@ -1,4 +1,6 @@
 namespaceOverride: "collection"
+sumologic:
+  useExporterBatching: true
 debug:
   sumologicMock:
     enabled: true

--- a/tests/helm/testdata/goldenfile/terraform/all_fields.input.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/all_fields.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   collector:
     sources:
       metrics:

--- a/tests/helm/testdata/goldenfile/terraform/collector_fields.input.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/collector_fields.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   collector:
     fields:
       test_fields: test_value

--- a/tests/helm/testdata/goldenfile/terraform/conditional_sources.input.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/conditional_sources.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   metrics:
     enabled: false
   logs:

--- a/tests/helm/testdata/goldenfile/terraform/custom.input.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/custom.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   metrics:
     enabled: false
   logs:

--- a/tests/helm/testdata/goldenfile/terraform/default.input.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/default.input.yaml
@@ -1,0 +1,2 @@
+sumologic:
+  useExporterBatching: true

--- a/tests/helm/testdata/goldenfile/terraform/disable_default_metrics.input.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disable_default_metrics.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   collector:
     sources:
       metrics:

--- a/tests/helm/testdata/goldenfile/terraform/disabled_dashboards.input.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disabled_dashboards.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   setup:
     dashboards:
       enabled: false

--- a/tests/helm/testdata/goldenfile/terraform/disabled_monitors.input.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/disabled_monitors.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   setup:
     monitors:
       enabled: false

--- a/tests/helm/testdata/goldenfile/terraform/logs_fields.input.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/logs_fields.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   logs:
     additionalFields:
       - addfield1

--- a/tests/helm/testdata/goldenfile/terraform/monitors_with_email_notifications.input.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/monitors_with_email_notifications.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   setup:
     monitors:
       notificationEmails: ["test@test.lh", "email@locahost.lh"]

--- a/tests/helm/testdata/goldenfile/terraform/monitors_with_single_email.input.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/monitors_with_single_email.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   setup:
     monitors:
       notificationEmails: "email@locahost.lh"

--- a/tests/helm/testdata/goldenfile/terraform/strip_extrapolation.input.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/strip_extrapolation.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   cluster:
     host: "https://kubernetes.default.svc"
     cluster_ca_certificate: '${file("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")}'

--- a/tests/helm/testdata/goldenfile/terraform/traces.input.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/traces.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   metrics:
     enabled: false
   logs:

--- a/tests/helm/testdata/goldenfile/terraform/tracing-metrics-disabled.input.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/tracing-metrics-disabled.input.yaml
@@ -1,4 +1,6 @@
-metrics:
-  enabled: false
-traces:
-  enabled: true
+sumologic:
+  useExporterBatching: true
+  metrics:
+    enabled: false
+  traces:
+    enabled: true

--- a/tests/helm/testdata/goldenfile/terraform/tracing-metrics-disabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/tracing-metrics-disabled.output.yaml
@@ -616,18 +616,6 @@ data:
     {
       "locals": {
         "source_configs": {
-          "apiserver_metrics_source": {
-            "config-name": "endpoint-metrics-apiserver",
-            "name": "apiserver-metrics"
-          },
-          "control_plane_metrics_source": {
-            "config-name": "endpoint-control_plane_metrics_source",
-            "name": "control-plane-metrics"
-          },
-          "controller_metrics_source": {
-            "config-name": "endpoint-metrics-kube-controller-manager",
-            "name": "kube-controller-manager-metrics"
-          },
           "default_events_source": {
             "config-name": "endpoint-events",
             "name": "events",
@@ -670,13 +658,6 @@ data:
               "content_type": "Otlp"
             }
           },
-          "default_otlp_metrics_source": {
-            "config-name": "endpoint-metrics-otlp",
-            "name": "metrics-otlp",
-            "properties": {
-              "content_type": "Otlp"
-            }
-          },
           "default_otlp_traces_source": {
             "config-name": "endpoint-traces-otlp",
             "name": "traces-otlp",
@@ -690,56 +671,20 @@ data:
             "properties": {
               "content_type": "Zipkin"
             }
-          },
-          "kubelet_metrics_source": {
-            "config-name": "endpoint-metrics-kubelet",
-            "name": "kubelet-metrics"
-          },
-          "node_metrics_source": {
-            "config-name": "endpoint-metrics-node-exporter",
-            "name": "node-exporter-metrics"
-          },
-          "scheduler_metrics_source": {
-            "config-name": "endpoint-metrics-kube-scheduler",
-            "name": "kube-scheduler-metrics"
-          },
-          "state_metrics_source": {
-            "config-name": "endpoint-metrics-kube-state",
-            "name": "kube-state-metrics"
           }
         },
         "sources": {
-          "apiserver_metrics_source": "${ sumologic_http_source.apiserver_metrics_source }",
-          "control_plane_metrics_source": "${ sumologic_http_source.control_plane_metrics_source }",
-          "controller_metrics_source": "${ sumologic_http_source.controller_metrics_source }",
           "default_events_source": "${ sumologic_http_source.default_events_source }",
           "default_logs_source": "${ sumologic_http_source.default_logs_source }",
           "default_metrics_source": "${ sumologic_http_source.default_metrics_source }",
           "default_otlp_events_source": "${ sumologic_http_source.default_otlp_events_source }",
           "default_otlp_logs_source": "${ sumologic_http_source.default_otlp_logs_source }",
-          "default_otlp_metrics_source": "${ sumologic_http_source.default_otlp_metrics_source }",
           "default_otlp_traces_source": "${ sumologic_http_source.default_otlp_traces_source }",
-          "default_traces_source": "${ sumologic_http_source.default_traces_source }",
-          "kubelet_metrics_source": "${ sumologic_http_source.kubelet_metrics_source }",
-          "node_metrics_source": "${ sumologic_http_source.node_metrics_source }",
-          "scheduler_metrics_source": "${ sumologic_http_source.scheduler_metrics_source }",
-          "state_metrics_source": "${ sumologic_http_source.state_metrics_source }"
+          "default_traces_source": "${ sumologic_http_source.default_traces_source }"
         }
       },
       "resource": {
         "sumologic_http_source": {
-          "apiserver_metrics_source": {
-            "collector_id": "${ sumologic_collector.collector.id }",
-            "name": "apiserver-metrics"
-          },
-          "control_plane_metrics_source": {
-            "collector_id": "${ sumologic_collector.collector.id }",
-            "name": "control-plane-metrics"
-          },
-          "controller_metrics_source": {
-            "collector_id": "${ sumologic_collector.collector.id }",
-            "name": "kube-controller-manager-metrics"
-          },
           "default_events_source": {
             "collector_id": "${ sumologic_collector.collector.id }",
             "default_date_formats": [
@@ -774,11 +719,6 @@ data:
             "content_type": "Otlp",
             "name": "logs-otlp"
           },
-          "default_otlp_metrics_source": {
-            "collector_id": "${ sumologic_collector.collector.id }",
-            "content_type": "Otlp",
-            "name": "metrics-otlp"
-          },
           "default_otlp_traces_source": {
             "collector_id": "${ sumologic_collector.collector.id }",
             "content_type": "Otlp",
@@ -788,22 +728,6 @@ data:
             "collector_id": "${ sumologic_collector.collector.id }",
             "content_type": "Zipkin",
             "name": "traces"
-          },
-          "kubelet_metrics_source": {
-            "collector_id": "${ sumologic_collector.collector.id }",
-            "name": "kubelet-metrics"
-          },
-          "node_metrics_source": {
-            "collector_id": "${ sumologic_collector.collector.id }",
-            "name": "node-exporter-metrics"
-          },
-          "scheduler_metrics_source": {
-            "collector_id": "${ sumologic_collector.collector.id }",
-            "name": "kube-scheduler-metrics"
-          },
-          "state_metrics_source": {
-            "collector_id": "${ sumologic_collector.collector.id }",
-            "name": "kube-state-metrics"
           }
         }
       }

--- a/tests/helm/testdata/goldenfile/terraform_custom/custom.input.yaml
+++ b/tests/helm/testdata/goldenfile/terraform_custom/custom.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   metrics:
     enabled: false
   logs:

--- a/tests/helm/testdata/goldenfile/terraform_custom/empty.input.yaml
+++ b/tests/helm/testdata/goldenfile/terraform_custom/empty.input.yaml
@@ -1,0 +1,2 @@
+sumologic:
+  useExporterBatching: true

--- a/tests/helm/testdata/goldenfile/traces-gateway-deployment/basic.input.yaml
+++ b/tests/helm/testdata/goldenfile/traces-gateway-deployment/basic.input.yaml
@@ -1,0 +1,2 @@
+sumologic:
+  useExporterBatching: true

--- a/tests/helm/testdata/goldenfile/traces-gateway-deployment/custom.input.yaml
+++ b/tests/helm/testdata/goldenfile/traces-gateway-deployment/custom.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   traces:
     sourceType: http
 

--- a/tests/helm/testdata/goldenfile/traces-gateway-hpa/basic.input.yaml
+++ b/tests/helm/testdata/goldenfile/traces-gateway-hpa/basic.input.yaml
@@ -2,5 +2,6 @@ tracesGateway:
   enabled: true
 
 sumologic:
+  useExporterBatching: true
   traces:
     enabled: true

--- a/tests/helm/testdata/goldenfile/traces-gateway-loadbalancing/config-from-merge.input.yaml
+++ b/tests/helm/testdata/goldenfile/traces-gateway-loadbalancing/config-from-merge.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 tracesGateway:
   config:
     merge:

--- a/tests/helm/testdata/goldenfile/traces-gateway-loadbalancing/config-from-merge.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-gateway-loadbalancing/config-from-merge.output.yaml
@@ -17,9 +17,13 @@ data:
         protocol:
           otlp:
             sending_queue:
+              batch:
+                flush_timeout: 5s
+                max_size: 512
+                min_size: 256
               enabled: true
               num_consumers: 10
-              queue_size: 10000
+              queue_size: 2560000
             timeout: 10s
             tls:
               insecure: true
@@ -59,7 +63,6 @@ data:
           - loadbalancing
           processors:
           - memory_limiter
-          - batch
           receivers:
           - otlp
       telemetry:

--- a/tests/helm/testdata/goldenfile/traces-gateway-loadbalancing/config-from-override.input.yaml
+++ b/tests/helm/testdata/goldenfile/traces-gateway-loadbalancing/config-from-override.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 tracesGateway:
   config:
     override:

--- a/tests/helm/testdata/goldenfile/traces-gateway-loadbalancing/config-from-values-backward-compatibility.input.yaml
+++ b/tests/helm/testdata/goldenfile/traces-gateway-loadbalancing/config-from-values-backward-compatibility.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 tracesGateway:
   config:
     merge:

--- a/tests/helm/testdata/goldenfile/traces-gateway-loadbalancing/config-from-values-backward-compatibility.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-gateway-loadbalancing/config-from-values-backward-compatibility.output.yaml
@@ -17,6 +17,10 @@ data:
         protocol:
           otlp:
             sending_queue:
+              batch:
+                flush_timeout: 5s
+                max_size: 512
+                min_size: 256
               enabled: true
               num_consumers: 10
               queue_size: 100000
@@ -57,7 +61,6 @@ data:
           - loadbalancing
           processors:
           - memory_limiter
-          - batch
           receivers:
           - otlp
       telemetry:

--- a/tests/helm/testdata/goldenfile/traces-gateway-loadbalancing/config-ipv6.input.yaml
+++ b/tests/helm/testdata/goldenfile/traces-gateway-loadbalancing/config-ipv6.input.yaml
@@ -1,2 +1,3 @@
 sumologic:
+  useExporterBatching: true
   ipv6mode: true

--- a/tests/helm/testdata/goldenfile/traces-gateway-loadbalancing/config-ipv6.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-gateway-loadbalancing/config-ipv6.output.yaml
@@ -17,9 +17,13 @@ data:
         protocol:
           otlp:
             sending_queue:
+              batch:
+                flush_timeout: 5s
+                max_size: 512
+                min_size: 256
               enabled: true
               num_consumers: 10
-              queue_size: 10000
+              queue_size: 2560000
             timeout: 10s
             tls:
               insecure: true
@@ -57,7 +61,6 @@ data:
           - loadbalancing
           processors:
           - memory_limiter
-          - batch
           receivers:
           - otlp
       telemetry:

--- a/tests/helm/testdata/goldenfile/traces-gateway-loadbalancing/sumologic-mock.input.yaml
+++ b/tests/helm/testdata/goldenfile/traces-gateway-loadbalancing/sumologic-mock.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 debug:
   instrumentation:
     tracesGateway:

--- a/tests/helm/testdata/goldenfile/traces-gateway-loadbalancing/sumologic-mock.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-gateway-loadbalancing/sumologic-mock.output.yaml
@@ -14,14 +14,25 @@ data:
   traces.gateway.conf.yaml: |
     exporters:
       debug:
+        sending_queue:
+          batch:
+            flush_timeout: 5s
+            max_size: 512
+            min_size: 256
+          enabled: true
+          queue_size: 2560000
         verbosity: detailed
       loadbalancing:
         protocol:
           otlp:
             sending_queue:
+              batch:
+                flush_timeout: 5s
+                max_size: 512
+                min_size: 256
               enabled: true
               num_consumers: 10
-              queue_size: 10000
+              queue_size: 2560000
             timeout: 10s
             tls:
               insecure: true
@@ -60,7 +71,6 @@ data:
           - debug
           processors:
           - memory_limiter
-          - batch
           receivers:
           - otlp
       telemetry:

--- a/tests/helm/testdata/goldenfile/traces-gateway-loadbalancing/traces-gateway-true.input.yaml
+++ b/tests/helm/testdata/goldenfile/traces-gateway-loadbalancing/traces-gateway-true.input.yaml
@@ -1,0 +1,2 @@
+sumologic:
+  useExporterBatching: true

--- a/tests/helm/testdata/goldenfile/traces-gateway-loadbalancing/traces-gateway-true.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-gateway-loadbalancing/traces-gateway-true.output.yaml
@@ -17,9 +17,13 @@ data:
         protocol:
           otlp:
             sending_queue:
+              batch:
+                flush_timeout: 5s
+                max_size: 512
+                min_size: 256
               enabled: true
               num_consumers: 10
-              queue_size: 10000
+              queue_size: 2560000
             timeout: 10s
             tls:
               insecure: true
@@ -57,7 +61,6 @@ data:
           - loadbalancing
           processors:
           - memory_limiter
-          - batch
           receivers:
           - otlp
       telemetry:

--- a/tests/helm/testdata/goldenfile/traces-sampler-deployment/basic.input.yaml
+++ b/tests/helm/testdata/goldenfile/traces-sampler-deployment/basic.input.yaml
@@ -1,0 +1,2 @@
+sumologic:
+  useExporterBatching: true

--- a/tests/helm/testdata/goldenfile/traces-sampler-deployment/custom.input.yaml
+++ b/tests/helm/testdata/goldenfile/traces-sampler-deployment/custom.input.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   traces:
     sourceType: http
 

--- a/tests/helm/testdata/goldenfile/traces-sampler-deployment/persistence-enabled.input.yaml
+++ b/tests/helm/testdata/goldenfile/traces-sampler-deployment/persistence-enabled.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 tracesSampler:
   persistence:
     enabled: true

--- a/tests/helm/testdata/goldenfile/traces-sampler/config-from-merge.input.yaml
+++ b/tests/helm/testdata/goldenfile/traces-sampler/config-from-merge.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 tracesSampler:
   config:
     merge:

--- a/tests/helm/testdata/goldenfile/traces-sampler/config-from-merge.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-sampler/config-from-merge.output.yaml
@@ -17,9 +17,13 @@ data:
         compression: gzip
         endpoint: ${SUMO_ENDPOINT_DEFAULT_OTLP_TRACES_SOURCE}
         sending_queue:
+          batch:
+            flush_timeout: 5s
+            max_size: 512
+            min_size: 256
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 2560000
     extensions:
       health_check:
         endpoint: ${env:MY_POD_IP}:13133
@@ -55,7 +59,6 @@ data:
           processors:
           - memory_limiter
           - cascading_filter
-          - batch
           receivers:
           - otlp
       telemetry:

--- a/tests/helm/testdata/goldenfile/traces-sampler/config-from-override.input.yaml
+++ b/tests/helm/testdata/goldenfile/traces-sampler/config-from-override.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 tracesSampler:
   config:
     override:

--- a/tests/helm/testdata/goldenfile/traces-sampler/config-from-values-backward-compatibility.input.yaml
+++ b/tests/helm/testdata/goldenfile/traces-sampler/config-from-values-backward-compatibility.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 tracesSampler:
   config:
     merge:

--- a/tests/helm/testdata/goldenfile/traces-sampler/config-from-values-backward-compatibility.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-sampler/config-from-values-backward-compatibility.output.yaml
@@ -17,9 +17,13 @@ data:
         compression: gzip
         endpoint: ${SUMO_ENDPOINT_DEFAULT_OTLP_TRACES_SOURCE}
         sending_queue:
+          batch:
+            flush_timeout: 5s
+            max_size: 512
+            min_size: 256
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 2560000
     extensions:
       health_check:
         endpoint: ${env:MY_POD_IP}:13133
@@ -53,7 +57,6 @@ data:
           processors:
           - memory_limiter
           - cascading_filter
-          - batch
           receivers:
           - otlp
       telemetry:

--- a/tests/helm/testdata/goldenfile/traces-sampler/config-ipv6.input.yaml
+++ b/tests/helm/testdata/goldenfile/traces-sampler/config-ipv6.input.yaml
@@ -1,2 +1,3 @@
 sumologic:
+  useExporterBatching: true
   ipv6mode: true

--- a/tests/helm/testdata/goldenfile/traces-sampler/config-ipv6.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-sampler/config-ipv6.output.yaml
@@ -17,9 +17,13 @@ data:
         compression: gzip
         endpoint: ${SUMO_ENDPOINT_DEFAULT_OTLP_TRACES_SOURCE}
         sending_queue:
+          batch:
+            flush_timeout: 5s
+            max_size: 512
+            min_size: 256
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 2560000
     extensions:
       health_check:
         endpoint: '[${env:MY_POD_IP}]:13133'
@@ -53,7 +57,6 @@ data:
           processors:
           - memory_limiter
           - cascading_filter
-          - batch
           receivers:
           - otlp
       telemetry:

--- a/tests/helm/testdata/goldenfile/traces-sampler/httpendpoint.input.yaml
+++ b/tests/helm/testdata/goldenfile/traces-sampler/httpendpoint.input.yaml
@@ -1,3 +1,4 @@
 sumologic:
+  useExporterBatching: true
   traces:
     sourceType: http

--- a/tests/helm/testdata/goldenfile/traces-sampler/httpendpoint.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-sampler/httpendpoint.output.yaml
@@ -16,9 +16,13 @@ data:
       otlphttp:
         compression: gzip
         sending_queue:
+          batch:
+            flush_timeout: 5s
+            max_size: 512
+            min_size: 256
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 2560000
         traces_endpoint: ${SUMO_ENDPOINT_DEFAULT_TRACES_SOURCE}
     extensions:
       health_check:
@@ -53,7 +57,6 @@ data:
           processors:
           - memory_limiter
           - cascading_filter
-          - batch
           receivers:
           - otlp
       telemetry:

--- a/tests/helm/testdata/goldenfile/traces-sampler/persistence-enabled.input.yaml
+++ b/tests/helm/testdata/goldenfile/traces-sampler/persistence-enabled.input.yaml
@@ -1,3 +1,4 @@
-tracesSampler:
+sumologic:
+  useExporterBatching: true
   persistence:
     enabled: true

--- a/tests/helm/testdata/goldenfile/traces-sampler/persistence-enabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-sampler/persistence-enabled.output.yaml
@@ -17,17 +17,14 @@ data:
         compression: gzip
         endpoint: ${SUMO_ENDPOINT_DEFAULT_OTLP_TRACES_SOURCE}
         sending_queue:
+          batch:
+            flush_timeout: 5s
+            max_size: 512
+            min_size: 256
           enabled: true
           num_consumers: 10
-          queue_size: 10000
-          storage: file_storage
+          queue_size: 2560000
     extensions:
-      file_storage:
-        compaction:
-          directory: /tmp
-          on_rebound: true
-        directory: /var/lib/storage/tracessampler
-        timeout: 10s
       health_check:
         endpoint: ${env:MY_POD_IP}:13133
       pprof: {}
@@ -52,7 +49,6 @@ data:
     service:
       extensions:
       - health_check
-      - file_storage
       - pprof
       pipelines:
         traces:
@@ -61,7 +57,6 @@ data:
           processors:
           - memory_limiter
           - cascading_filter
-          - batch
           receivers:
           - otlp
       telemetry:

--- a/tests/helm/testdata/goldenfile/traces-sampler/simple.input.yaml
+++ b/tests/helm/testdata/goldenfile/traces-sampler/simple.input.yaml
@@ -1,0 +1,2 @@
+sumologic:
+  useExporterBatching: true

--- a/tests/helm/testdata/goldenfile/traces-sampler/simple.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-sampler/simple.output.yaml
@@ -17,9 +17,13 @@ data:
         compression: gzip
         endpoint: ${SUMO_ENDPOINT_DEFAULT_OTLP_TRACES_SOURCE}
         sending_queue:
+          batch:
+            flush_timeout: 5s
+            max_size: 512
+            min_size: 256
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 2560000
     extensions:
       health_check:
         endpoint: ${env:MY_POD_IP}:13133
@@ -53,7 +57,6 @@ data:
           processors:
           - memory_limiter
           - cascading_filter
-          - batch
           receivers:
           - otlp
       telemetry:

--- a/tests/helm/testdata/goldenfile/traces-sampler/sumologic-mock.input.yaml
+++ b/tests/helm/testdata/goldenfile/traces-sampler/sumologic-mock.input.yaml
@@ -1,3 +1,5 @@
+sumologic:
+  useExporterBatching: true
 debug:
   sumologicMock:
     enabled: true

--- a/tests/helm/testdata/goldenfile/traces-sampler/sumologic-mock.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-sampler/sumologic-mock.output.yaml
@@ -14,17 +14,35 @@ data:
   traces.sampler.conf.yaml: |
     exporters:
       debug:
+        sending_queue:
+          batch:
+            flush_timeout: 5s
+            max_size: 512
+            min_size: 256
+          enabled: true
+          queue_size: 2560000
         verbosity: detailed
       otlphttp:
         compression: gzip
         endpoint: ${SUMO_ENDPOINT_DEFAULT_OTLP_TRACES_SOURCE}
         sending_queue:
+          batch:
+            flush_timeout: 5s
+            max_size: 512
+            min_size: 256
           enabled: true
           num_consumers: 10
-          queue_size: 10000
+          queue_size: 2560000
       otlphttp/sumologic-mock:
         compression: gzip
         endpoint: http://RELEASE-NAME-sumologic-mock.sumologic.svc.cluster.local.:3000/receiver
+        sending_queue:
+          batch:
+            flush_timeout: 5s
+            max_size: 512
+            min_size: 256
+          enabled: true
+          queue_size: 2560000
     extensions:
       health_check:
         endpoint: ${env:MY_POD_IP}:13133
@@ -60,7 +78,6 @@ data:
           processors:
           - memory_limiter
           - cascading_filter
-          - batch
           receivers:
           - otlp
       telemetry:

--- a/tests/helm/testdata/node-selector.yaml
+++ b/tests/helm/testdata/node-selector.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   nodeSelector:
     disktype: hdd
   tolerations:

--- a/tests/helm/testdata/opentelemetry-metrics-extra-processors.yaml
+++ b/tests/helm/testdata/opentelemetry-metrics-extra-processors.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   metrics:
     otelcol:
       extraProcessors:

--- a/tests/helm/testdata/operator-crds-disabled.yaml
+++ b/tests/helm/testdata/operator-crds-disabled.yaml
@@ -1,4 +1,5 @@
 sumologic:
+  useExporterBatching: true
   pullSecrets:
     - name: pullSecret
   setup:

--- a/tests/integration/internal/constants.go
+++ b/tests/integration/internal/constants.go
@@ -239,15 +239,15 @@ var (
 		"otelcol_exporter_requests_sent",
 		"otelcol_exporter_sent_metric_points",
 		"otelcol_processor_accepted_metric_points",
-		"otelcol_processor_batch_batch_send_size_count",
-		"otelcol_processor_batch_batch_send_size_sum",
-		"otelcol_processor_batch_timeout_trigger_send",
+		// "otelcol_processor_batch_batch_send_size_count", // Deprecated
+		// "otelcol_processor_batch_batch_send_size_sum", // Deprecated
+		// "otelcol_processor_batch_timeout_trigger_send", // Deprecated
 		"otelcol_processor_groupbyattrs_metric_groups_count",
 		"otelcol_processor_groupbyattrs_metric_groups_sum",
 		"otelcol_processor_groupbyattrs_num_non_grouped_metrics",
 		"otelcol_processor_outgoing_items",
 		"otelcol_processor_incoming_items",
-		"otelcol_processor_batch_metadata_cardinality",
+		// "otelcol_processor_batch_metadata_cardinality", // Deprecated
 	}
 	LogsOtelcolMetrics = []string{
 		"otelcol_exporter_sent_log_records",

--- a/tests/integration/values/values_common.yaml
+++ b/tests/integration/values/values_common.yaml
@@ -6,6 +6,7 @@
 ##   on CI runners' machines
 
 sumologic:
+  useExporterBatching: true
   setupEnabled: true
   # This is set in yamls/cluster.yaml to check if we work correctly with a custom domain
   clusterDNSDomain: "my.cluster"

--- a/vagrant/opentelemetry-collector.yaml
+++ b/vagrant/opentelemetry-collector.yaml
@@ -31,12 +31,15 @@ spec:
         check_interval: 1s
         limit_percentage: 75
         spike_limit_percentage: 15
-      batch:
-        send_batch_size: 10000
-        timeout: 10s
 
     exporters:
       debug:
+        sending_queue:
+        enabled: true
+        queue_size: 10000000
+        batch:
+          flush_timeout: 10s
+          min_size: 10000
 
     service:
       pipelines:

--- a/vagrant/opentelemetry-collector.yaml
+++ b/vagrant/opentelemetry-collector.yaml
@@ -35,11 +35,11 @@ spec:
     exporters:
       debug:
         sending_queue:
-        enabled: true
-        queue_size: 10000000
-        batch:
-          flush_timeout: 10s
-          min_size: 10000
+          enabled: true
+          queue_size: 10000000
+          batch:
+            flush_timeout: 10s
+            min_size: 10000
 
     service:
       pipelines:


### PR DESCRIPTION
<!---
Describe your PR here
-->

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [x] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features



We have introduced two internal flags
1. Before rolling this out externally we wanted to test this in sumologic clusters and that can done only after release hence we wanted to have the additional check `useExporterBatching` to switch the behaviour.
2. The queue_size is a critical change for the customer who has configured their own exporters we wanted to use `customBatchingConfigured` flag as a acknowledgement from the user which can be removed in the next major release of the helm.


In an ideal default scenario the current PR is expected to retain the existing behaviors of all observability signals. When the flags are enabled the new implementation should take effect. 

Related Docs PR: https://github.com/SumoLogic/sumologic-documentation/pull/6683