### PR TITLE
feat: enable scheduled renovate runs 

### DIFF
--- a/.changelog/4145.fixed.txt
+++ b/.changelog/4145.fixed.txt
@@ -1,0 +1,1 @@
+ci: enable renovate bot and add more dependencies in it

--- a/.github/workflows/renovate-scheduler.yaml
+++ b/.github/workflows/renovate-scheduler.yaml
@@ -1,7 +1,7 @@
 name: Renovate-scheduler
 on:
   schedule:
-    - cron: '30 9 * * *'   # every day at 3 PM IST (9:30 AM UTC)
+    - cron: '30 18 * * 2'  # every Tuesday at 18:30 UTC (12:00 AM IST)
   workflow_dispatch: # allow manual runs
 
 jobs:

--- a/.github/workflows/renovate-scheduler.yaml
+++ b/.github/workflows/renovate-scheduler.yaml
@@ -1,7 +1,7 @@
 name: Renovate-scheduler
 on:
-  #   schedule:
-  #     - cron: '30 9 * * *'   # every day at 3 PM IST (9:30 AM UTC)
+  schedule:
+    - cron: '30 9 * * *'   # every day at 3 PM IST (9:30 AM UTC)
   workflow_dispatch: # allow manual runs
 
 jobs:

--- a/.github/workflows/renovate-scheduler.yaml
+++ b/.github/workflows/renovate-scheduler.yaml
@@ -1,7 +1,7 @@
 name: Renovate-scheduler
 on:
   schedule:
-    - cron: '30 18 * * 2'  # every Tuesday at 18:30 UTC (12:00 AM IST)
+    - cron: "30 18 * * 2" # every Tuesday at 18:30 UTC (12:00 AM IST)
   workflow_dispatch: # allow manual runs
 
 jobs:

--- a/renovate.json
+++ b/renovate.json
@@ -466,7 +466,7 @@
     },
     {
       "description": "Add chore(deps) prefix to all dependency update commits",
-      "matchPackagePatterns": ["*"],
+      "matchPackagePatterns": [".*"],
       "commitMessagePrefix": "chore(deps):"
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,10 @@
 {
-  "enabledManagers": ["custom.regex"],
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "enabledManagers": ["custom.regex", "helmv3"],
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Update Sumo Logic container images in values.yaml (repository/tag pattern)",
+      "description": "Update sumologic-otel-collector image in values.yaml (repository/tag pattern)",
       "fileMatch": ["^deploy/helm/sumologic/values\\.yaml$"],
       "matchStrings": [
         "repository:\\s*\"?(?<depName>public\\.ecr\\.aws/sumologic/sumologic-otel-collector)\"?\\s*\\n\\s*tag:\\s*\"?(?<currentValue>[^\"\\s]+)\"?"
@@ -13,7 +14,7 @@
     },
     {
       "customType": "regex",
-      "description": "Update Sumo Logic container images in test files",
+      "description": "Update sumologic-otel-collector image in golden test files",
       "fileMatch": ["^tests/helm/testdata/goldenfile/.*\\.yaml$"],
       "matchStrings": [
         "image:\\s*\"?(?<depName>public\\.ecr\\.aws/sumologic/sumologic-otel-collector):(?<currentValue>[a-zA-Z0-9._-]+)\"?"
@@ -23,7 +24,7 @@
     },
     {
       "customType": "regex",
-      "description": "Update version references in documentation tables",
+      "description": "Update sumologic-otel-collector version in deploy/helm/sumologic/README.md",
       "fileMatch": ["^deploy/helm/sumologic/README\\.md$"],
       "matchStrings": [
         "\\|\\s*`(sumologic\\.otelcolImage\\.tag|opentelemetry-operator\\.manager\\.collectorImage\\.tag)`\\s*\\|.*?\\|\\s*`(?<currentValue>[0-9.]+(?:-[a-z0-9-]+)?)`\\s*\\|"
@@ -34,7 +35,7 @@
     },
     {
       "customType": "regex",
-      "description": "Update OpenTelemetry Collector version in docs README table",
+      "description": "Update OpenTelemetry Collector version in docs/README.md table",
       "fileMatch": ["^docs/README\\.md$"],
       "matchStrings": [
         "\\|\\s*OpenTelemetry Collector\\s*\\|\\s*(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\s*\\|"
@@ -43,17 +44,429 @@
       "depNameTemplate": "public.ecr.aws/sumologic/sumologic-otel-collector",
       "versioningTemplate": "loose",
       "extractVersionTemplate": "^(?<version>[0-9]+\\.[0-9]+\\.[0-9]+)"
+    },
+    {
+      "customType": "regex",
+      "description": "Update kubernetes-setup image in values.yaml",
+      "fileMatch": ["^deploy/helm/sumologic/values\\.yaml$"],
+      "matchStrings": [
+        "repository:\\s*(?<depName>public\\.ecr\\.aws/sumologic/kubernetes-setup)\\s*\\n\\s*tag:\\s*(?<currentValue>[0-9][^\\s]+)"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Update kubernetes-setup image in golden test files",
+      "fileMatch": ["^tests/helm/testdata/goldenfile/.*\\.yaml$"],
+      "matchStrings": [
+        "image:\\s*(?<depName>public\\.ecr\\.aws/sumologic/kubernetes-setup):(?<currentValue>[0-9][a-zA-Z0-9._-]+)"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Update kubernetes-setup version in deploy/helm/sumologic/README.md",
+      "fileMatch": ["^deploy/helm/sumologic/README\\.md$"],
+      "matchStrings": [
+        "\\|\\s*`sumologic\\.setup\\.job\\.image\\.tag`\\s*\\|.*?\\|\\s*`(?<currentValue>[0-9][^`]+)`\\s*\\|"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "public.ecr.aws/sumologic/kubernetes-setup",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Update nginx-unprivileged image in values.yaml",
+      "fileMatch": ["^deploy/helm/sumologic/values\\.yaml$"],
+      "matchStrings": [
+        "repository:\\s*(?<depName>public\\.ecr\\.aws/sumologic/nginx-unprivileged)[^\\n]*\\n(?:[^\\n]*\\n){0,3}\\s*tag:\\s*(?<currentValue>[^\\s\"]+)"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "regex:^(?<major>[0-9]+)\\.(?<minor>[0-9]+)\\.(?<patch>[0-9]+)-alpine-sumo-(?<build>[0-9]+)$"
+    },
+    {
+      "customType": "regex",
+      "description": "Update nginx-unprivileged image in golden test files",
+      "fileMatch": ["^tests/helm/testdata/goldenfile/.*\\.yaml$"],
+      "matchStrings": [
+        "image:\\s*(?<depName>public\\.ecr\\.aws/sumologic/nginx-unprivileged):(?<currentValue>[a-zA-Z0-9._-]+)"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "regex:^(?<major>[0-9]+)\\.(?<minor>[0-9]+)\\.(?<patch>[0-9]+)-alpine-sumo-(?<build>[0-9]+)$"
+    },
+    {
+      "customType": "regex",
+      "description": "Update nginx-unprivileged version in deploy/helm/sumologic/README.md",
+      "fileMatch": ["^deploy/helm/sumologic/README\\.md$"],
+      "matchStrings": [
+        "\\|\\s*`sumologic\\.metrics\\.remoteWriteProxy\\.image`\\s*\\|.*?\"tag\":\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+-alpine-sumo-[0-9]+)\""
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "public.ecr.aws/sumologic/nginx-unprivileged",
+      "versioningTemplate": "regex:^(?<major>[0-9]+)\\.(?<minor>[0-9]+)\\.(?<patch>[0-9]+)-alpine-sumo-(?<build>[0-9]+)$"
+    },
+    {
+      "customType": "regex",
+      "description": "Update metrics-server image in values.yaml",
+      "fileMatch": ["^deploy/helm/sumologic/values\\.yaml$"],
+      "matchStrings": [
+        "repository:\\s*(?<depName>public\\.ecr\\.aws/sumologic/metrics-server)\\s*\\n\\s*tag:\\s*(?<currentValue>[^\\s]+)"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Update metrics-server image in golden test files",
+      "fileMatch": ["^tests/helm/testdata/goldenfile/.*\\.yaml$"],
+      "matchStrings": [
+        "image:\\s*(?<depName>public\\.ecr\\.aws/sumologic/metrics-server):(?<currentValue>[a-zA-Z0-9._-]+)"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Update metrics-server image version in deploy/helm/sumologic/README.md",
+      "fileMatch": ["^deploy/helm/sumologic/README\\.md$"],
+      "matchStrings": [
+        "\\|\\s*`metrics-server\\.image\\.tag`\\s*\\|.*?\\|\\s*`(?<currentValue>[^`]+)`\\s*\\|"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "public.ecr.aws/sumologic/metrics-server",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Update kube-state-metrics image in values.yaml",
+      "fileMatch": ["^deploy/helm/sumologic/values\\.yaml$"],
+      "matchStrings": [
+        "repository:\\s*(?<depName>public\\.ecr\\.aws/sumologic/kube-state-metrics)\\s*\\n\\s*tag:\\s*\"?(?<currentValue>[^\"\\s]+)\"?"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Update kube-state-metrics image version in deploy/helm/sumologic/README.md",
+      "fileMatch": ["^deploy/helm/sumologic/README\\.md$"],
+      "matchStrings": [
+        "\\|\\s*`kube-prometheus-stack\\.kube-state-metrics\\.image\\.tag`\\s*\\|.*?\\|\\s*`(?<currentValue>[^`]+)`\\s*\\|"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "public.ecr.aws/sumologic/kube-state-metrics",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Update autoinstrumentation images in values.yaml",
+      "fileMatch": ["^deploy/helm/sumologic/values\\.yaml$"],
+      "matchStrings": [
+        "repository:\\s*(?<depName>public\\.ecr\\.aws/sumologic/autoinstrumentation-(?:java|dotnet|nodejs))\\s*\\n\\s*tag:\\s*(?<currentValue>[^\\s]+)"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Update autoinstrumentation-python image in values.yaml (PEP 440 versioning)",
+      "fileMatch": ["^deploy/helm/sumologic/values\\.yaml$"],
+      "matchStrings": [
+        "repository:\\s*(?<depName>public\\.ecr\\.aws/sumologic/autoinstrumentation-python)\\s*\\n\\s*tag:\\s*(?<currentValue>[^\\s]+)"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "pep440"
+    },
+    {
+      "customType": "regex",
+      "description": "Update autoinstrumentation images in golden test files",
+      "fileMatch": ["^tests/helm/testdata/goldenfile/.*\\.yaml$"],
+      "matchStrings": [
+        "image:\\s*(?<depName>public\\.ecr\\.aws/sumologic/autoinstrumentation-(?:java|dotnet|nodejs)):(?<currentValue>[a-zA-Z0-9._-]+)"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Update autoinstrumentation-python image in golden test files (PEP 440 versioning)",
+      "fileMatch": ["^tests/helm/testdata/goldenfile/.*\\.yaml$"],
+      "matchStrings": [
+        "image:\\s*(?<depName>public\\.ecr\\.aws/sumologic/autoinstrumentation-python):(?<currentValue>[a-zA-Z0-9._-]+)"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "pep440"
+    },
+    {
+      "customType": "regex",
+      "description": "Update autoinstrumentation-java version in deploy/helm/sumologic/README.md",
+      "fileMatch": ["^deploy/helm/sumologic/README\\.md$"],
+      "matchStrings": [
+        "\\|\\s*`opentelemetry-operator\\.manager\\.autoInstrumentationImage\\.java\\.tag`\\s*\\|.*?\\|\\s*`(?<currentValue>[^`]+)`\\s*\\|"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "public.ecr.aws/sumologic/autoinstrumentation-java",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Update autoinstrumentation-dotnet version in deploy/helm/sumologic/README.md",
+      "fileMatch": ["^deploy/helm/sumologic/README\\.md$"],
+      "matchStrings": [
+        "\\|\\s*`opentelemetry-operator\\.manager\\.autoInstrumentationImage\\.dotnet\\.tag`\\s*\\|.*?\\|\\s*`(?<currentValue>[^`]+)`\\s*\\|"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "public.ecr.aws/sumologic/autoinstrumentation-dotnet",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Update autoinstrumentation-nodejs version in deploy/helm/sumologic/README.md",
+      "fileMatch": ["^deploy/helm/sumologic/README\\.md$"],
+      "matchStrings": [
+        "\\|\\s*`opentelemetry-operator\\.manager\\.autoInstrumentationImage\\.nodejs\\.tag`\\s*\\|.*?\\|\\s*`(?<currentValue>[^`]+)`\\s*\\|"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "public.ecr.aws/sumologic/autoinstrumentation-nodejs",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Update autoinstrumentation-python version in deploy/helm/sumologic/README.md",
+      "fileMatch": ["^deploy/helm/sumologic/README\\.md$"],
+      "matchStrings": [
+        "\\|\\s*`opentelemetry-operator\\.manager\\.autoInstrumentationImage\\.python\\.tag`\\s*\\|.*?\\|\\s*`(?<currentValue>[^`]+)`\\s*\\|"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "public.ecr.aws/sumologic/autoinstrumentation-python",
+      "versioningTemplate": "pep440"
+    },
+    {
+      "customType": "regex",
+      "description": "Update kubernetes-tools-kubectl image in values.yaml",
+      "fileMatch": ["^deploy/helm/sumologic/values\\.yaml$"],
+      "matchStrings": [
+        "repository:\\s*(?<depName>public\\.ecr\\.aws/sumologic/kubernetes-tools-kubectl)\\s*\\n\\s*tag:\\s*(?<currentValue>[0-9][^\\s]+)"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Update kubernetes-tools-kubectl image in golden test files",
+      "fileMatch": ["^tests/helm/testdata/goldenfile/.*\\.yaml$"],
+      "matchStrings": [
+        "image:\\s*(?<depName>public\\.ecr\\.aws/sumologic/kubernetes-tools-kubectl):(?<currentValue>[a-zA-Z0-9._-]+)"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Update kubernetes-tools-kubectl version in deploy/helm/sumologic/README.md",
+      "fileMatch": ["^deploy/helm/sumologic/README\\.md$"],
+      "matchStrings": [
+        "\\|\\s*`(?:pvcCleaner\\.job\\.image\\.tag|instrumentation\\.instrumentationJobImage\\.image\\.tag)`\\s*\\|.*?\\|\\s*`(?<currentValue>[^`]+)`\\s*\\|"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "public.ecr.aws/sumologic/kubernetes-tools-kubectl",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Update sumologic-mock image in values.yaml",
+      "fileMatch": ["^deploy/helm/sumologic/values\\.yaml$"],
+      "matchStrings": [
+        "repository:\\s*\"?(?<depName>public\\.ecr\\.aws/sumologic/sumologic-mock)\"?\\s*\\n\\s*tag:\\s*\"?(?<currentValue>[0-9][^\"\\s]+)\"?"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Update sumologic-mock image in golden test files",
+      "fileMatch": ["^tests/helm/testdata/goldenfile/.*\\.yaml$"],
+      "matchStrings": [
+        "image:\\s*(?<depName>public\\.ecr\\.aws/sumologic/sumologic-mock):(?<currentValue>[a-zA-Z0-9._-]+)"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Update sumologic-mock version in deploy/helm/sumologic/README.md",
+      "fileMatch": ["^deploy/helm/sumologic/README\\.md$"],
+      "matchStrings": [
+        "\\|\\s*`debug\\.sumologicMock\\.image`\\s*\\|.*?\"tag\":\\s*\"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "public.ecr.aws/sumologic/sumologic-mock",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Update telegraf sidecar image in values.yaml (inline format)",
+      "fileMatch": ["^deploy/helm/sumologic/values\\.yaml$"],
+      "matchStrings": [
+        "sidecarImage:\\s*\"?(?<depName>public\\.ecr\\.aws/sumologic/telegraf):(?<currentValue>[0-9][^\"\\s]+)\"?"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Update OpenTelemetry Operator chart version in docs/README.md",
+      "fileMatch": ["^docs/README\\.md$"],
+      "matchStrings": [
+        "\\|\\s*OpenTelemetry Operator\\s*\\|\\s*(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\s*\\|"
+      ],
+      "datasourceTemplate": "helm",
+      "depNameTemplate": "opentelemetry-operator",
+      "registryUrlTemplate": "https://open-telemetry.github.io/opentelemetry-helm-charts"
+    },
+    {
+      "customType": "regex",
+      "description": "Update Tailing Sidecar Operator chart version in docs/README.md",
+      "fileMatch": ["^docs/README\\.md$"],
+      "matchStrings": [
+        "\\|\\s*Tailing Sidecar Operator\\s*\\|\\s*(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\s*\\|"
+      ],
+      "datasourceTemplate": "helm",
+      "depNameTemplate": "tailing-sidecar-operator",
+      "registryUrlTemplate": "https://sumologic.github.io/tailing-sidecar"
+    },
+    {
+      "customType": "regex",
+      "description": "Update Falco chart version in docs/README.md",
+      "fileMatch": ["^docs/README\\.md$"],
+      "matchStrings": [
+        "\\|\\s*Falco\\s*\\|\\s*(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\s*\\|"
+      ],
+      "datasourceTemplate": "helm",
+      "depNameTemplate": "falco",
+      "registryUrlTemplate": "https://falcosecurity.github.io/charts"
+    },
+    {
+      "customType": "regex",
+      "description": "Update Metrics Server chart version in docs/README.md",
+      "fileMatch": ["^docs/README\\.md$"],
+      "matchStrings": [
+        "\\|\\s*Metrics Server\\s*\\|\\s*(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\s*\\|"
+      ],
+      "datasourceTemplate": "helm",
+      "depNameTemplate": "metrics-server",
+      "registryUrlTemplate": "https://kubernetes-sigs.github.io/metrics-server/"
+    },
+    {
+      "customType": "regex",
+      "description": "Update Telegraf Operator chart version in docs/README.md",
+      "fileMatch": ["^docs/README\\.md$"],
+      "matchStrings": [
+        "\\|\\s*Telegraf Operator\\s*\\|\\s*(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\s*\\|"
+      ],
+      "datasourceTemplate": "helm",
+      "depNameTemplate": "telegraf-operator",
+      "registryUrlTemplate": "https://helm.influxdata.com/"
+    },
+    {
+      "customType": "regex",
+      "description": "Update kube-prometheus-stack chart version in docs/README.md",
+      "fileMatch": ["^docs/README\\.md$"],
+      "matchStrings": [
+        "\\|\\s*kube-prometheus-stack/Prometheus Operator\\s*\\|\\s*(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\s*\\|"
+      ],
+      "datasourceTemplate": "helm",
+      "depNameTemplate": "kube-prometheus-stack",
+      "registryUrlTemplate": "https://prometheus-community.github.io/helm-charts"
     }
   ],
   "packageRules": [
     {
-      "description": "Group OpenTelemetry Collector updates together",
+      "description": "Disable kube-prometheus-stack — intentionally pinned for OpenShift CRD compatibility",
+      "matchPackageNames": ["kube-prometheus-stack"],
+      "enabled": false
+    },
+    {
+      "description": "Disable busybox — floating/utility init container",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["public.ecr.aws/sumologic/busybox"],
+      "enabled": false
+    },
+    {
+      "description": "Constrain falco Helm chart to minor upgrades only",
+      "matchManagers": ["helmv3"],
+      "matchPackageNames": ["falco"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "description": "Constrain metrics-server Helm chart to minor upgrades only",
+      "matchManagers": ["helmv3"],
+      "matchPackageNames": ["metrics-server"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "description": "Group sumologic-otel-collector updates across all files",
       "matchDatasources": ["docker"],
       "matchPackageNames": ["public.ecr.aws/sumologic/sumologic-otel-collector"],
-      "groupName": "sumologic-kubernetes-collection",
-      "commitMessage": "chore(deps): update sumologic-otel-collector version",
+      "groupName": "sumologic-otel-collector",
+      "commitMessageTopic": "sumologic-otel-collector version",
       "separateMinorPatch": false,
-      "allowedVersions": "/^0\\.[0-9]+\\.[0-9]+(\\-sumo\\-[0-9]+)?$/"
+      "allowedVersions": "/^[0-9]+\\.[0-9]+\\.[0-9]+-sumo-[0-9]+$/"
+    },
+    {
+      "description": "Group opentelemetry-operator Helm chart + docs/README updates",
+      "matchPackageNames": ["opentelemetry-operator"],
+      "groupName": "opentelemetry-operator"
+    },
+    {
+      "description": "Group tailing-sidecar-operator Helm chart + docs/README updates",
+      "matchPackageNames": ["tailing-sidecar-operator"],
+      "groupName": "tailing-sidecar-operator"
+    },
+    {
+      "description": "Group kubernetes-tools-kubectl and sumologic-mock updates",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "public.ecr.aws/sumologic/kubernetes-tools-kubectl",
+        "public.ecr.aws/sumologic/sumologic-mock"
+      ],
+      "groupName": "kubernetes-tools"
+    },
+    {
+      "description": "Group autoinstrumentation image updates (java, dotnet, nodejs)",
+      "matchDatasources": ["docker"],
+      "matchPackagePatterns": ["^public\\.ecr\\.aws/sumologic/autoinstrumentation-(?:java|dotnet|nodejs)$"],
+      "groupName": "autoinstrumentation"
+    },
+    {
+      "description": "Group autoinstrumentation-python separately (PEP 440 versioning)",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["public.ecr.aws/sumologic/autoinstrumentation-python"],
+      "groupName": "autoinstrumentation-python"
+    },
+    {
+      "description": "Group falco Helm chart + docs/README updates",
+      "matchPackageNames": ["falco"],
+      "groupName": "falco"
+    },
+    {
+      "description": "Group metrics-server Helm chart + docs/README + image updates",
+      "matchPackageNames": ["metrics-server", "public.ecr.aws/sumologic/metrics-server"],
+      "groupName": "metrics-server"
+    },
+    {
+      "description": "Group telegraf-operator Helm chart + docs/README updates",
+      "matchPackageNames": ["telegraf-operator"],
+      "groupName": "telegraf-operator"
+    },
+    {
+      "description": "Add chore(deps) prefix to all dependency update commits",
+      "matchPackagePatterns": ["*"],
+      "commitMessagePrefix": "chore(deps):"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "dryRun": "full",
   "enabledManagers": ["custom.regex", "helmv3"],
   "customManagers": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -426,7 +426,8 @@
     {
       "description": "Group tailing-sidecar-operator Helm chart + docs/README updates",
       "matchPackageNames": ["tailing-sidecar-operator"],
-      "groupName": "tailing-sidecar-operator"
+      "groupName": "tailing-sidecar-operator",
+      "allowedVersions": "<= 0.99.0"
     },
     {
       "description": "Group kubernetes-tools-kubectl and sumologic-mock updates",

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "dryRun": "full",
   "enabledManagers": ["custom.regex", "helmv3"],
   "customManagers": [
     {


### PR DESCRIPTION
## Summary

Expands Renovate bot configuration to automatically track and update **all** container images and Helm subchart dependencies, replacing the previous config that only covered `sumologic-otel-collector`.

### What's new

**Helm subcharts** (via `helmv3` manager — auto-updates `Chart.yaml`):
- `opentelemetry-operator`, `tailing-sidecar-operator`, `falco`, `metrics-server`, `telegraf-operator`, `prometheus-windows-exporter`

**Container images** (via `custom.regex` managers — updates `values.yaml`, golden test files, and READMEs):
- `kubernetes-setup`, `nginx-unprivileged`, `metrics-server`, `kube-state-metrics`
- `autoinstrumentation-java`, `autoinstrumentation-dotnet`, `autoinstrumentation-python`, `autoinstrumentation-nodejs`
- `kubernetes-tools-kubectl`, `sumologic-mock`, `telegraf` (sidecar)

**Docs version tables** (via `custom.regex` with `helm` datasource):
- `docs/README.md` version table kept in sync with Chart.yaml subchart versions

### Grouping

Updates are grouped into logical PRs to reduce noise:

| PR group | Packages |
|---|---|
| `sumologic-otel-collector` | OTC image across all files |
| `opentelemetry-operator` | Helm chart + docs/README |
| `tailing-sidecar-operator` | Helm chart + docs/README |
| `autoinstrumentation` | java, dotnet, nodejs images |
| `autoinstrumentation-python` | Separate due to PEP 440 versioning |
| `kubernetes-tools` | kubectl + sumologic-mock |
| Individual PRs | falco, metrics-server, telegraf-operator, nginx, kubernetes-setup, kube-state-metrics, telegraf sidecar |

### Exclusions & constraints

- **`kube-prometheus-stack`** — disabled (intentionally pinned for OpenShift CRD compatibility)
- **`busybox`** — disabled (floating `latest` tag / utility init container)
- **`falco`, `metrics-server`** (Helm) — major upgrades blocked
- **`tailing-sidecar-operator`** — versions capped at `<= 0.99.0` (the Helm repo contains a stale `0.111.0` chart that is not a real release; latest actual release is [v0.20.3](https://github.com/SumoLogic/tailing-sidecar/releases/tag/v0.20.3))

### Pending upgrades Renovate will create PRs for

| Dependency | Current | Latest |
|---|---|---|
| `opentelemetry-operator` (chart) | `0.109.0` | `0.110.0` |
| `falco` (chart) | `7.0.2` | `7.2.1` |
| `prometheus-windows-exporter` (chart) | `0.3.1` | `0.12.6` |
| `kubernetes-setup` (image) | `3.16.0` | `3.17.0` |
| `autoinstrumentation-dotnet` | `1.9.0` | `1.11.0` |
| `autoinstrumentation-nodejs` | `0.54.0` | `0.58.0` |
| `autoinstrumentation-python` | `0.48b0` | `0.53b1` |
| `telegraf` (sidecar) | `1.21.2` | `1.31.0` |

**Already up to date:** `tailing-sidecar-operator` (0.20.3), `metrics-server` (3.13.0), `telegraf-operator` (1.4.0), `sumologic-otel-collector` (0.149.0-sumo-0), `kubernetes-tools-kubectl` (2.27.0), `sumologic-mock` (2.27.0), `kube-state-metrics` (v2.18.0), `nginx-unprivileged` (1.26.0-alpine-sumo-0)

### Test plan

- [x] Trigger dry-run workflow: `gh workflow run renovate-scheduler.yaml --ref enable-renovate`
- [x] Verify discovered packages in workflow logs: `grep "DRY-RUN: Would create PR" <logs>`
- [ ] Remove `"dryRun": "full"` before merging
- [ ] After merge, trigger workflow and verify PRs are created