### PR TITLE
ci: fix changelog for renovate branches

### DIFF
--- a/.changelog/4149.fixed.txt
+++ b/.changelog/4149.fixed.txt
@@ -1,0 +1,1 @@
+ci: fix changelog for renovate branches

--- a/.github/workflows/renovate-changelog.yaml
+++ b/.github/workflows/renovate-changelog.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   add-changelog:
-    if: startsWith(github.head_ref, 'renovate/sumologic-kubernetes-collection')
+    if: startsWith(github.head_ref, 'renovate/')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
<!---
Describe your PR here
-->
fixes changelog for renovate bot PRS
Changelog workflow is [failing](https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/4148) for renovate bot 
### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features
