### PR TITLE
ci: improve renovate changelog workflow and PR titles

### DIFF
--- a/.github/workflows/renovate-changelog.yaml
+++ b/.github/workflows/renovate-changelog.yaml
@@ -55,7 +55,11 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
 
-          # Add and commit changelog
+          # Add and commit changelog if there are changes
           git add .changelog/
-          git commit -m "chore: Add changelog entry for dependency update"
-          git push origin ${{ github.head_ref }}
+          if git diff --cached --quiet; then
+            echo "Changelog entry already exists, nothing to commit"
+          else
+            git commit -m "chore: Add changelog entry for dependency update"
+            git push origin ${{ github.head_ref }}
+          fi

--- a/.github/workflows/renovate-changelog.yaml
+++ b/.github/workflows/renovate-changelog.yaml
@@ -28,29 +28,8 @@ jobs:
           CHANGELOG_FILE=".changelog/${PR_NUMBER}.changed.txt"
           mkdir -p .changelog
 
-          CHANGELOG_TEXT="$PR_TITLE"
-          CHART_FILE="deploy/helm/sumologic/Chart.yaml"
-          VALUES_FILE="deploy/helm/sumologic/values.yaml"
-
-          # Enrich with old version from Chart.yaml (e.g. "Update falco to v7.2.1" -> "Update falco from 7.0.2 to v7.2.1")
-          if git diff HEAD~1 HEAD --name-only | grep -q "$CHART_FILE"; then
-            OLD_VER=$(git diff HEAD~1 HEAD -- "$CHART_FILE" | grep "^-.*version:" | head -1 | awk '{print $NF}')
-            if [[ -n "$OLD_VER" ]]; then
-              CHANGELOG_TEXT=$(echo "$PR_TITLE" | sed "s/ to / from $OLD_VER to /")
-            fi
-          fi
-
-          # Enrich with old/new tags from values.yaml (e.g. "Update otel-collector" -> "Update otel-collector (0.140.0-sumo-0 -> 0.143.0-sumo-0)")
-          if [[ "$CHANGELOG_TEXT" == "$PR_TITLE" ]] && git diff HEAD~1 HEAD --name-only | grep -q "$VALUES_FILE"; then
-            OLD_TAG=$(git diff HEAD~1 HEAD -- "$VALUES_FILE" | grep "^-.*tag:" | head -1 | awk '{print $NF}' | tr -d "\"'")
-            NEW_TAG=$(git diff HEAD~1 HEAD -- "$VALUES_FILE" | grep "^+.*tag:" | head -1 | awk '{print $NF}' | tr -d "\"'")
-            if [[ -n "$OLD_TAG" && -n "$NEW_TAG" ]]; then
-              CHANGELOG_TEXT="$PR_TITLE ($OLD_TAG -> $NEW_TAG)"
-            fi
-          fi
-
-          echo "$CHANGELOG_TEXT" > "$CHANGELOG_FILE"
-          echo "Created changelog file: $CHANGELOG_FILE with content: $CHANGELOG_TEXT"
+          echo "$PR_TITLE" > "$CHANGELOG_FILE"
+          echo "Created changelog file: $CHANGELOG_FILE with content: $PR_TITLE"
 
       - name: Commit changelog
         run: |

--- a/.github/workflows/renovate-changelog.yaml
+++ b/.github/workflows/renovate-changelog.yaml
@@ -21,29 +21,32 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Create changelog entry
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          # Create PR-based filename
           PR_NUMBER="${{ github.event.pull_request.number }}"
           CHANGELOG_FILE=".changelog/${PR_NUMBER}.changed.txt"
-
-          # Ensure .changelog directory exists
           mkdir -p .changelog
 
-          # Extract version information from git diff
-          OLD_VERSION=""
-          NEW_VERSION=""
+          CHANGELOG_TEXT="$PR_TITLE"
+          CHART_FILE="deploy/helm/sumologic/Chart.yaml"
+          VALUES_FILE="deploy/helm/sumologic/values.yaml"
 
-          # Check for version changes in values.yaml
-          if git diff HEAD~1 HEAD -- deploy/helm/sumologic/values.yaml | grep -E "tag.*sumo-"; then
-            OLD_VERSION=$(git diff HEAD~1 HEAD -- deploy/helm/sumologic/values.yaml | grep -E "^\-.*tag:" | head -1 | sed 's/.*tag: *["'"'"']*\([^"'"'"' ]*\)["'"'"']*.*/\1/' | grep "sumo-" || echo "")
-            NEW_VERSION=$(git diff HEAD~1 HEAD -- deploy/helm/sumologic/values.yaml | grep -E "^\+.*tag:" | head -1 | sed 's/.*tag: *["'"'"']*\([^"'"'"' ]*\)["'"'"']*.*/\1/' | grep "sumo-" || echo "")
+          # Enrich with old version from Chart.yaml (e.g. "Update falco to v7.2.1" -> "Update falco from 7.0.2 to v7.2.1")
+          if git diff HEAD~1 HEAD --name-only | grep -q "$CHART_FILE"; then
+            OLD_VER=$(git diff HEAD~1 HEAD -- "$CHART_FILE" | grep "^-.*version:" | head -1 | awk '{print $NF}')
+            if [[ -n "$OLD_VER" ]]; then
+              CHANGELOG_TEXT=$(echo "$PR_TITLE" | sed "s/ to / from $OLD_VER to /")
+            fi
           fi
 
-          # Create changelog message
-          if [[ -n "$OLD_VERSION" && -n "$NEW_VERSION" ]]; then
-            CHANGELOG_TEXT="Upgraded otel collector version from $OLD_VERSION to $NEW_VERSION"
-          else
-            CHANGELOG_TEXT="chore(deps): Update dependencies"
+          # Enrich with old/new tags from values.yaml (e.g. "Update otel-collector" -> "Update otel-collector (0.140.0-sumo-0 -> 0.143.0-sumo-0)")
+          if [[ "$CHANGELOG_TEXT" == "$PR_TITLE" ]] && git diff HEAD~1 HEAD --name-only | grep -q "$VALUES_FILE"; then
+            OLD_TAG=$(git diff HEAD~1 HEAD -- "$VALUES_FILE" | grep "^-.*tag:" | head -1 | awk '{print $NF}' | tr -d "\"'")
+            NEW_TAG=$(git diff HEAD~1 HEAD -- "$VALUES_FILE" | grep "^+.*tag:" | head -1 | awk '{print $NF}' | tr -d "\"'")
+            if [[ -n "$OLD_TAG" && -n "$NEW_TAG" ]]; then
+              CHANGELOG_TEXT="$PR_TITLE ($OLD_TAG -> $NEW_TAG)"
+            fi
           fi
 
           echo "$CHANGELOG_TEXT" > "$CHANGELOG_FILE"

--- a/.github/workflows/renovate-scheduler.yaml
+++ b/.github/workflows/renovate-scheduler.yaml
@@ -1,7 +1,7 @@
 name: Renovate-scheduler
 on:
   schedule:
-    - cron: "30 18 * * 2" # every Tuesday at 18:30 UTC (12:00 AM IST)
+    - cron: "30 18 * * *" # every day at 18:30 UTC (12:00 AM IST)
   workflow_dispatch: # allow manual runs
 
 jobs:

--- a/.github/workflows/renovate-scheduler.yaml
+++ b/.github/workflows/renovate-scheduler.yaml
@@ -2,7 +2,17 @@ name: Renovate-scheduler
 on:
   schedule:
     - cron: "30 18 * * *" # every day at 18:30 UTC (12:00 AM IST)
-  workflow_dispatch: # allow manual runs
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        description: "Run in dry-run mode (no changes made)"
+        type: choice
+        default: ""
+        options:
+          - ""
+          - "full"
+          - "lookup"
+          - "extract"
 
 jobs:
   renovate:
@@ -15,6 +25,7 @@ jobs:
         env:
           LOG_LEVEL: debug
           RENOVATE_REPOSITORIES: SumoLogic/sumologic-kubernetes-collection
+          RENOVATE_DRY_RUN: ${{ github.event.inputs.dryRun }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           configurationFile: renovate.json

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,8 @@
   "enabledManagers": ["custom.regex", "helmv3"],
   "prHourlyLimit": 10,
   "labels": ["dependencies"],
+  "commitMessageAction": "bump",
+  "commitMessageExtra": "{{#if isSingleVersion}}from {{{currentValue}}} to {{{newValue}}}{{/if}}",
   "customManagers": [
     {
       "customType": "regex",

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "enabledManagers": ["custom.regex", "helmv3"],
+  "prHourlyLimit": 10,
+  "labels": ["dependencies"],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
## Summary

### renovate-changelog.yaml
- Fix "nothing to commit" failure on re-runs by checking `git diff --cached --quiet` before committing
- Use Renovate PR title as the changelog entry text (instead of generic "chore(deps): Update dependencies")

### renovate.json
- Set `commitMessageAction` to `"bump"` for dependabot-style PR titles
- Set `commitMessageExtra` to include `from {currentValue} to {newValue}` for single-version updates
- Add `prHourlyLimit: 10` and `labels: ["dependencies"]`

### renovate-scheduler.yaml
- Change schedule from weekly (Tuesday) to daily
- Add `dryRun` input for manual workflow dispatch (optional, defaults to no dry-run)

## Example PR titles (after this change)
| Package | PR title |
|---------|----------|
| falco | `chore(deps): bump falco from 7.0.2 to 7.2.1` |
| otel-collector | `chore(deps): bump sumologic-otel-collector version from 0.149.0-sumo-0 to 0.150.0-sumo-0` |
| autoinstrumentation (multi-version) | `chore(deps): bump autoinstrumentation` |
| kubernetes-tools (multi-version) | `chore(deps): bump kubernetes-tools` |

## Test plan
- [x] Verified changelog text generation against 7 real commits
- [x] Verified `git diff --cached --quiet` prevents "nothing to commit" failure
- [x] Verified `GITHUB_TOKEN` push does trigger `synchronize` (confirmed from PR #4148 run history)
- [x] Ran Renovate in `lookup` dry-run mode — config loaded correctly, updates detected
- [ ] Verify PR titles on next Renovate run

🤖 Generated with [Claude Code](https://claude.com/claude-code)