### PR TITLE
fix(ci): fix Renovate PR checks and improve configuration

### DIFF
--- a/.github/workflows/renovate-changelog.yaml
+++ b/.github/workflows/renovate-changelog.yaml
@@ -14,10 +14,17 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.BACKPORT_APP_ID }}
+          private-key: ${{ secrets.BACKPORT_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.generate_token.outputs.token }}
           ref: ${{ github.head_ref }}
 
       - name: Create changelog entry

--- a/.github/workflows/renovate-changelog.yaml
+++ b/.github/workflows/renovate-changelog.yaml
@@ -55,7 +55,11 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
 
-          # Add and commit changelog
+          # Add and commit changelog if there are changes
           git add .changelog/
-          git commit -m "chore: Add changelog entry for dependency update"
-          git push origin ${{ github.head_ref }}
+          if git diff --cached --quiet; then
+            echo "Changelog entry already exists, nothing to commit"
+          else
+            git commit -m "chore: Add changelog entry for dependency update"
+            git push origin ${{ github.head_ref }}
+          fi

--- a/.github/workflows/renovate-changelog.yaml
+++ b/.github/workflows/renovate-changelog.yaml
@@ -28,29 +28,8 @@ jobs:
           CHANGELOG_FILE=".changelog/${PR_NUMBER}.changed.txt"
           mkdir -p .changelog
 
-          CHANGELOG_TEXT="$PR_TITLE"
-          CHART_FILE="deploy/helm/sumologic/Chart.yaml"
-          VALUES_FILE="deploy/helm/sumologic/values.yaml"
-
-          # Enrich with old version from Chart.yaml (e.g. "Update falco to v7.2.1" -> "Update falco from 7.0.2 to v7.2.1")
-          if git diff HEAD~1 HEAD --name-only | grep -q "$CHART_FILE"; then
-            OLD_VER=$(git diff HEAD~1 HEAD -- "$CHART_FILE" | grep "^-.*version:" | head -1 | awk '{print $NF}')
-            if [[ -n "$OLD_VER" ]]; then
-              CHANGELOG_TEXT=$(echo "$PR_TITLE" | sed "s/ to / from $OLD_VER to /")
-            fi
-          fi
-
-          # Enrich with old/new tags from values.yaml (e.g. "Update otel-collector" -> "Update otel-collector (0.140.0-sumo-0 -> 0.143.0-sumo-0)")
-          if [[ "$CHANGELOG_TEXT" == "$PR_TITLE" ]] && git diff HEAD~1 HEAD --name-only | grep -q "$VALUES_FILE"; then
-            OLD_TAG=$(git diff HEAD~1 HEAD -- "$VALUES_FILE" | grep "^-.*tag:" | head -1 | awk '{print $NF}' | tr -d "\"'")
-            NEW_TAG=$(git diff HEAD~1 HEAD -- "$VALUES_FILE" | grep "^+.*tag:" | head -1 | awk '{print $NF}' | tr -d "\"'")
-            if [[ -n "$OLD_TAG" && -n "$NEW_TAG" ]]; then
-              CHANGELOG_TEXT="$PR_TITLE ($OLD_TAG -> $NEW_TAG)"
-            fi
-          fi
-
-          echo "$CHANGELOG_TEXT" > "$CHANGELOG_FILE"
-          echo "Created changelog file: $CHANGELOG_FILE with content: $CHANGELOG_TEXT"
+          echo "$PR_TITLE" > "$CHANGELOG_FILE"
+          echo "Created changelog file: $CHANGELOG_FILE with content: $PR_TITLE"
 
       - name: Commit changelog
         run: |

--- a/.github/workflows/renovate-changelog.yaml
+++ b/.github/workflows/renovate-changelog.yaml
@@ -21,29 +21,32 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Create changelog entry
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          # Create PR-based filename
           PR_NUMBER="${{ github.event.pull_request.number }}"
           CHANGELOG_FILE=".changelog/${PR_NUMBER}.changed.txt"
-
-          # Ensure .changelog directory exists
           mkdir -p .changelog
 
-          # Extract version information from git diff
-          OLD_VERSION=""
-          NEW_VERSION=""
+          CHANGELOG_TEXT="$PR_TITLE"
+          CHART_FILE="deploy/helm/sumologic/Chart.yaml"
+          VALUES_FILE="deploy/helm/sumologic/values.yaml"
 
-          # Check for version changes in values.yaml
-          if git diff HEAD~1 HEAD -- deploy/helm/sumologic/values.yaml | grep -E "tag.*sumo-"; then
-            OLD_VERSION=$(git diff HEAD~1 HEAD -- deploy/helm/sumologic/values.yaml | grep -E "^\-.*tag:" | head -1 | sed 's/.*tag: *["'"'"']*\([^"'"'"' ]*\)["'"'"']*.*/\1/' | grep "sumo-" || echo "")
-            NEW_VERSION=$(git diff HEAD~1 HEAD -- deploy/helm/sumologic/values.yaml | grep -E "^\+.*tag:" | head -1 | sed 's/.*tag: *["'"'"']*\([^"'"'"' ]*\)["'"'"']*.*/\1/' | grep "sumo-" || echo "")
+          # Enrich with old version from Chart.yaml (e.g. "Update falco to v7.2.1" -> "Update falco from 7.0.2 to v7.2.1")
+          if git diff HEAD~1 HEAD --name-only | grep -q "$CHART_FILE"; then
+            OLD_VER=$(git diff HEAD~1 HEAD -- "$CHART_FILE" | grep "^-.*version:" | head -1 | awk '{print $NF}')
+            if [[ -n "$OLD_VER" ]]; then
+              CHANGELOG_TEXT=$(echo "$PR_TITLE" | sed "s/ to / from $OLD_VER to /")
+            fi
           fi
 
-          # Create changelog message
-          if [[ -n "$OLD_VERSION" && -n "$NEW_VERSION" ]]; then
-            CHANGELOG_TEXT="Upgraded otel collector version from $OLD_VERSION to $NEW_VERSION"
-          else
-            CHANGELOG_TEXT="chore(deps): Update dependencies"
+          # Enrich with old/new tags from values.yaml (e.g. "Update otel-collector" -> "Update otel-collector (0.140.0-sumo-0 -> 0.143.0-sumo-0)")
+          if [[ "$CHANGELOG_TEXT" == "$PR_TITLE" ]] && git diff HEAD~1 HEAD --name-only | grep -q "$VALUES_FILE"; then
+            OLD_TAG=$(git diff HEAD~1 HEAD -- "$VALUES_FILE" | grep "^-.*tag:" | head -1 | awk '{print $NF}' | tr -d "\"'")
+            NEW_TAG=$(git diff HEAD~1 HEAD -- "$VALUES_FILE" | grep "^+.*tag:" | head -1 | awk '{print $NF}' | tr -d "\"'")
+            if [[ -n "$OLD_TAG" && -n "$NEW_TAG" ]]; then
+              CHANGELOG_TEXT="$PR_TITLE ($OLD_TAG -> $NEW_TAG)"
+            fi
           fi
 
           echo "$CHANGELOG_TEXT" > "$CHANGELOG_FILE"

--- a/.github/workflows/renovate-scheduler.yaml
+++ b/.github/workflows/renovate-scheduler.yaml
@@ -1,7 +1,7 @@
 name: Renovate-scheduler
 on:
   schedule:
-    - cron: "30 18 * * 2" # every Tuesday at 18:30 UTC (12:00 AM IST)
+    - cron: "30 18 * * *" # every day at 18:30 UTC (12:00 AM IST)
   workflow_dispatch: # allow manual runs
 
 jobs:

--- a/.github/workflows/renovate-scheduler.yaml
+++ b/.github/workflows/renovate-scheduler.yaml
@@ -2,7 +2,17 @@ name: Renovate-scheduler
 on:
   schedule:
     - cron: "30 18 * * *" # every day at 18:30 UTC (12:00 AM IST)
-  workflow_dispatch: # allow manual runs
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        description: "Run in dry-run mode (no changes made)"
+        type: choice
+        default: ""
+        options:
+          - ""
+          - "full"
+          - "lookup"
+          - "extract"
 
 jobs:
   renovate:
@@ -15,6 +25,7 @@ jobs:
         env:
           LOG_LEVEL: debug
           RENOVATE_REPOSITORIES: SumoLogic/sumologic-kubernetes-collection
+          RENOVATE_DRY_RUN: ${{ github.event.inputs.dryRun }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           configurationFile: renovate.json

--- a/renovate.json
+++ b/renovate.json
@@ -326,7 +326,7 @@
       "matchStrings": [
         "\\|\\s*OpenTelemetry Operator\\s*\\|\\s*(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\s*\\|"
       ],
-      "datasourceTemplate": "helm",
+      "datasourceTemplate": "helmv3",
       "depNameTemplate": "opentelemetry-operator",
       "registryUrlTemplate": "https://open-telemetry.github.io/opentelemetry-helm-charts"
     },
@@ -337,7 +337,7 @@
       "matchStrings": [
         "\\|\\s*Tailing Sidecar Operator\\s*\\|\\s*(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\s*\\|"
       ],
-      "datasourceTemplate": "helm",
+      "datasourceTemplate": "helmv3",
       "depNameTemplate": "tailing-sidecar-operator",
       "registryUrlTemplate": "https://sumologic.github.io/tailing-sidecar"
     },
@@ -348,7 +348,7 @@
       "matchStrings": [
         "\\|\\s*Falco\\s*\\|\\s*(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\s*\\|"
       ],
-      "datasourceTemplate": "helm",
+      "datasourceTemplate": "helmv3",
       "depNameTemplate": "falco",
       "registryUrlTemplate": "https://falcosecurity.github.io/charts"
     },
@@ -359,7 +359,7 @@
       "matchStrings": [
         "\\|\\s*Metrics Server\\s*\\|\\s*(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\s*\\|"
       ],
-      "datasourceTemplate": "helm",
+      "datasourceTemplate": "helmv3",
       "depNameTemplate": "metrics-server",
       "registryUrlTemplate": "https://kubernetes-sigs.github.io/metrics-server/"
     },
@@ -370,7 +370,7 @@
       "matchStrings": [
         "\\|\\s*Telegraf Operator\\s*\\|\\s*(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\s*\\|"
       ],
-      "datasourceTemplate": "helm",
+      "datasourceTemplate": "helmv3",
       "depNameTemplate": "telegraf-operator",
       "registryUrlTemplate": "https://helm.influxdata.com/"
     },
@@ -381,7 +381,7 @@
       "matchStrings": [
         "\\|\\s*kube-prometheus-stack/Prometheus Operator\\s*\\|\\s*(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\s*\\|"
       ],
-      "datasourceTemplate": "helm",
+      "datasourceTemplate": "helmv3",
       "depNameTemplate": "kube-prometheus-stack",
       "registryUrlTemplate": "https://prometheus-community.github.io/helm-charts"
     }
@@ -400,14 +400,12 @@
     },
     {
       "description": "Constrain falco Helm chart to minor upgrades only",
-      "matchManagers": ["helmv3"],
       "matchPackageNames": ["falco"],
       "matchUpdateTypes": ["major"],
       "enabled": false
     },
     {
       "description": "Constrain metrics-server Helm chart to minor upgrades only",
-      "matchManagers": ["helmv3"],
       "matchPackageNames": ["metrics-server"],
       "matchUpdateTypes": ["major"],
       "enabled": false

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,8 @@
   "enabledManagers": ["custom.regex", "helmv3"],
   "prHourlyLimit": 10,
   "labels": ["dependencies"],
+  "commitMessageAction": "bump",
+  "commitMessageExtra": "{{#if isSingleVersion}}from {{{currentValue}}} to {{{newValue}}}{{/if}}",
   "customManagers": [
     {
       "customType": "regex",

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "enabledManagers": ["custom.regex", "helmv3"],
+  "prHourlyLimit": 10,
+  "labels": ["dependencies"],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
## Summary

Fixes Renovate bot PRs getting stuck on "waiting for status to be reported" in the GitHub PR checks tab, and improves Renovate configuration.

### Problem

When Renovate opens a PR, the `renovate-changelog.yaml` workflow pushes a changelog commit using `GITHUB_TOKEN`. Due to a [GitHub Actions security limitation](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow), commits pushed with `GITHUB_TOKEN` do not trigger further workflow runs. This means the new HEAD (with the changelog commit) has no CI checks, and the PR shows "waiting for status to be reported" indefinitely.

This is the same problem that was solved for the backport bot in PR #1471 and #1476.

### Fix

- **Use Backport GitHub App token in changelog workflow**: Replace `GITHUB_TOKEN` with a token generated from the existing Backport GitHub App (`BACKPORT_APP_ID` / `BACKPORT_PRIVATE_KEY`) in `renovate-changelog.yaml`. The app token push triggers `pull_request: synchronize` events, so PR checks run on the new HEAD.
- **Remove `matchManagers` from Renovate constraints**: The `matchManagers: ["helmv3"]` filter on falco and metrics-server package rules was too narrow — it only blocked major upgrades from the helmv3 manager but allowed them from custom.regex managers. Removing `matchManagers` ensures major upgrades are blocked regardless of which manager detects the update.
- **Fix `datasourceTemplate` values**: Changed `helm` to `helmv3` for custom regex managers in `docs/README.md` matchers to match the correct datasource.

## Changes

- `.github/workflows/renovate-changelog.yaml` — Generate app token and use it for checkout/push
- `renovate.json` — Fix datasource templates and broaden major upgrade constraints

## Test plan

- [ ] Trigger Renovate to open a new PR and verify:
  - Changelog commit is pushed
  - PR checks (`helmlint`, `test`, `changelog`, etc.) run on the new HEAD
  - PR does not get stuck on "waiting for status to be reported"
- [ ] Verify falco/metrics-server major upgrades are still blocked by running Renovate in dry-run mode