### PR TITLE
ci: use dedicated Renovate GitHub App and fix Renovate configuration

### DIFF
--- a/.github/workflows/renovate-changelog.yaml
+++ b/.github/workflows/renovate-changelog.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Commit changelog
         run: |
           # Configure git
-          git config --local user.email "3519431+renovatebot-sumologic[bot]@users.noreply.github.com"
+          git config --local user.email "279692411+renovatebot-sumologic[bot]@users.noreply.github.com"
           git config --local user.name "renovatebot-sumologic[bot]"
 
           # Add and commit changelog if there are changes

--- a/.github/workflows/renovate-changelog.yaml
+++ b/.github/workflows/renovate-changelog.yaml
@@ -14,10 +14,17 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.BACKPORT_APP_ID }}
+          private-key: ${{ secrets.BACKPORT_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.generate_token.outputs.token }}
           ref: ${{ github.head_ref }}
 
       - name: Create changelog entry

--- a/.github/workflows/renovate-changelog.yaml
+++ b/.github/workflows/renovate-changelog.yaml
@@ -55,7 +55,11 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
 
-          # Add and commit changelog
+          # Add and commit changelog if there are changes
           git add .changelog/
-          git commit -m "chore: Add changelog entry for dependency update"
-          git push origin ${{ github.head_ref }}
+          if git diff --cached --quiet; then
+            echo "Changelog entry already exists, nothing to commit"
+          else
+            git commit -m "chore: Add changelog entry for dependency update"
+            git push origin ${{ github.head_ref }}
+          fi

--- a/.github/workflows/renovate-changelog.yaml
+++ b/.github/workflows/renovate-changelog.yaml
@@ -28,29 +28,8 @@ jobs:
           CHANGELOG_FILE=".changelog/${PR_NUMBER}.changed.txt"
           mkdir -p .changelog
 
-          CHANGELOG_TEXT="$PR_TITLE"
-          CHART_FILE="deploy/helm/sumologic/Chart.yaml"
-          VALUES_FILE="deploy/helm/sumologic/values.yaml"
-
-          # Enrich with old version from Chart.yaml (e.g. "Update falco to v7.2.1" -> "Update falco from 7.0.2 to v7.2.1")
-          if git diff HEAD~1 HEAD --name-only | grep -q "$CHART_FILE"; then
-            OLD_VER=$(git diff HEAD~1 HEAD -- "$CHART_FILE" | grep "^-.*version:" | head -1 | awk '{print $NF}')
-            if [[ -n "$OLD_VER" ]]; then
-              CHANGELOG_TEXT=$(echo "$PR_TITLE" | sed "s/ to / from $OLD_VER to /")
-            fi
-          fi
-
-          # Enrich with old/new tags from values.yaml (e.g. "Update otel-collector" -> "Update otel-collector (0.140.0-sumo-0 -> 0.143.0-sumo-0)")
-          if [[ "$CHANGELOG_TEXT" == "$PR_TITLE" ]] && git diff HEAD~1 HEAD --name-only | grep -q "$VALUES_FILE"; then
-            OLD_TAG=$(git diff HEAD~1 HEAD -- "$VALUES_FILE" | grep "^-.*tag:" | head -1 | awk '{print $NF}' | tr -d "\"'")
-            NEW_TAG=$(git diff HEAD~1 HEAD -- "$VALUES_FILE" | grep "^+.*tag:" | head -1 | awk '{print $NF}' | tr -d "\"'")
-            if [[ -n "$OLD_TAG" && -n "$NEW_TAG" ]]; then
-              CHANGELOG_TEXT="$PR_TITLE ($OLD_TAG -> $NEW_TAG)"
-            fi
-          fi
-
-          echo "$CHANGELOG_TEXT" > "$CHANGELOG_FILE"
-          echo "Created changelog file: $CHANGELOG_FILE with content: $CHANGELOG_TEXT"
+          echo "$PR_TITLE" > "$CHANGELOG_FILE"
+          echo "Created changelog file: $CHANGELOG_FILE with content: $PR_TITLE"
 
       - name: Commit changelog
         run: |

--- a/.github/workflows/renovate-changelog.yaml
+++ b/.github/workflows/renovate-changelog.yaml
@@ -21,29 +21,32 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Create changelog entry
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          # Create PR-based filename
           PR_NUMBER="${{ github.event.pull_request.number }}"
           CHANGELOG_FILE=".changelog/${PR_NUMBER}.changed.txt"
-
-          # Ensure .changelog directory exists
           mkdir -p .changelog
 
-          # Extract version information from git diff
-          OLD_VERSION=""
-          NEW_VERSION=""
+          CHANGELOG_TEXT="$PR_TITLE"
+          CHART_FILE="deploy/helm/sumologic/Chart.yaml"
+          VALUES_FILE="deploy/helm/sumologic/values.yaml"
 
-          # Check for version changes in values.yaml
-          if git diff HEAD~1 HEAD -- deploy/helm/sumologic/values.yaml | grep -E "tag.*sumo-"; then
-            OLD_VERSION=$(git diff HEAD~1 HEAD -- deploy/helm/sumologic/values.yaml | grep -E "^\-.*tag:" | head -1 | sed 's/.*tag: *["'"'"']*\([^"'"'"' ]*\)["'"'"']*.*/\1/' | grep "sumo-" || echo "")
-            NEW_VERSION=$(git diff HEAD~1 HEAD -- deploy/helm/sumologic/values.yaml | grep -E "^\+.*tag:" | head -1 | sed 's/.*tag: *["'"'"']*\([^"'"'"' ]*\)["'"'"']*.*/\1/' | grep "sumo-" || echo "")
+          # Enrich with old version from Chart.yaml (e.g. "Update falco to v7.2.1" -> "Update falco from 7.0.2 to v7.2.1")
+          if git diff HEAD~1 HEAD --name-only | grep -q "$CHART_FILE"; then
+            OLD_VER=$(git diff HEAD~1 HEAD -- "$CHART_FILE" | grep "^-.*version:" | head -1 | awk '{print $NF}')
+            if [[ -n "$OLD_VER" ]]; then
+              CHANGELOG_TEXT=$(echo "$PR_TITLE" | sed "s/ to / from $OLD_VER to /")
+            fi
           fi
 
-          # Create changelog message
-          if [[ -n "$OLD_VERSION" && -n "$NEW_VERSION" ]]; then
-            CHANGELOG_TEXT="Upgraded otel collector version from $OLD_VERSION to $NEW_VERSION"
-          else
-            CHANGELOG_TEXT="chore(deps): Update dependencies"
+          # Enrich with old/new tags from values.yaml (e.g. "Update otel-collector" -> "Update otel-collector (0.140.0-sumo-0 -> 0.143.0-sumo-0)")
+          if [[ "$CHANGELOG_TEXT" == "$PR_TITLE" ]] && git diff HEAD~1 HEAD --name-only | grep -q "$VALUES_FILE"; then
+            OLD_TAG=$(git diff HEAD~1 HEAD -- "$VALUES_FILE" | grep "^-.*tag:" | head -1 | awk '{print $NF}' | tr -d "\"'")
+            NEW_TAG=$(git diff HEAD~1 HEAD -- "$VALUES_FILE" | grep "^+.*tag:" | head -1 | awk '{print $NF}' | tr -d "\"'")
+            if [[ -n "$OLD_TAG" && -n "$NEW_TAG" ]]; then
+              CHANGELOG_TEXT="$PR_TITLE ($OLD_TAG -> $NEW_TAG)"
+            fi
           fi
 
           echo "$CHANGELOG_TEXT" > "$CHANGELOG_FILE"

--- a/.github/workflows/renovate-changelog.yaml
+++ b/.github/workflows/renovate-changelog.yaml
@@ -14,17 +14,17 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - name: Generate token
-        id: generate_token
+      - name: Generate GitHub App token
+        id: app-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.BACKPORT_APP_ID }}
-          private-key: ${{ secrets.BACKPORT_PRIVATE_KEY }}
+          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          private-key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
 
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          token: ${{ steps.generate_token.outputs.token }}
+          token: ${{ steps.app-token.outputs.token }}
           ref: ${{ github.head_ref }}
 
       - name: Create changelog entry
@@ -41,8 +41,8 @@ jobs:
       - name: Commit changelog
         run: |
           # Configure git
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          git config --local user.email "3519431+renovatebot-sumologic[bot]@users.noreply.github.com"
+          git config --local user.name "renovatebot-sumologic[bot]"
 
           # Add and commit changelog if there are changes
           git add .changelog/

--- a/.github/workflows/renovate-scheduler.yaml
+++ b/.github/workflows/renovate-scheduler.yaml
@@ -1,7 +1,7 @@
 name: Renovate-scheduler
 on:
   schedule:
-    - cron: "30 18 * * 2" # every Tuesday at 18:30 UTC (12:00 AM IST)
+    - cron: "30 18 * * *" # every day at 18:30 UTC (12:00 AM IST)
   workflow_dispatch: # allow manual runs
 
 jobs:

--- a/.github/workflows/renovate-scheduler.yaml
+++ b/.github/workflows/renovate-scheduler.yaml
@@ -2,7 +2,17 @@ name: Renovate-scheduler
 on:
   schedule:
     - cron: "30 18 * * *" # every day at 18:30 UTC (12:00 AM IST)
-  workflow_dispatch: # allow manual runs
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        description: "Run in dry-run mode (no changes made)"
+        type: choice
+        default: ""
+        options:
+          - ""
+          - "full"
+          - "lookup"
+          - "extract"
 
 jobs:
   renovate:
@@ -15,6 +25,7 @@ jobs:
         env:
           LOG_LEVEL: debug
           RENOVATE_REPOSITORIES: SumoLogic/sumologic-kubernetes-collection
+          RENOVATE_DRY_RUN: ${{ github.event.inputs.dryRun }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           configurationFile: renovate.json

--- a/.github/workflows/renovate-scheduler.yaml
+++ b/.github/workflows/renovate-scheduler.yaml
@@ -4,8 +4,16 @@ on:
     - cron: "30 18 * * *" # every day at 18:30 UTC (12:00 AM IST)
   workflow_dispatch:
     inputs:
+      logLevel:
+        description: "Log level"
+        type: choice
+        default: "info"
+        options:
+          - "info"
+          - "debug"
+          - "warn"
       dryRun:
-        description: "Run in dry-run mode (no changes made)"
+        description: "Dry-run: full (simulate PRs), lookup (check updates only), extract (parse deps only)"
         type: choice
         default: ""
         options:
@@ -16,16 +24,8 @@ on:
 
 jobs:
   renovate:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Renovate run
-        uses: renovatebot/github-action@v46.1.10
-        env:
-          LOG_LEVEL: debug
-          RENOVATE_REPOSITORIES: SumoLogic/sumologic-kubernetes-collection
-          RENOVATE_DRY_RUN: ${{ github.event.inputs.dryRun }}
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          configurationFile: renovate.json
+    uses: ./.github/workflows/workflow-renovate-run.yaml
+    with:
+      logLevel: ${{ github.event.inputs.logLevel || 'info' }}
+      dryRun: ${{ github.event.inputs.dryRun || '' }}
+    secrets: inherit

--- a/.github/workflows/workflow-renovate-run.yaml
+++ b/.github/workflows/workflow-renovate-run.yaml
@@ -1,0 +1,58 @@
+name: Renovate Run
+
+on:
+  workflow_call:
+    inputs:
+      logLevel:
+        description: "Override default log level"
+        required: false
+        default: "info"
+        type: string
+      dryRun:
+        description: "Dry-run mode (full, lookup, extract, or empty)"
+        required: false
+        default: ""
+        type: string
+      configurationFile:
+        description: "Path to renovate config file"
+        required: false
+        default: "renovate.json"
+        type: string
+    secrets:
+      RENOVATE_APP_ID:
+        required: true
+      RENOVATE_PRIVATE_KEY:
+        required: true
+
+concurrency: renovate
+
+jobs:
+  renovate:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Validate Renovate config
+        uses: rinchsan/renovate-config-validator@v0.2.0
+        with:
+          pattern: ${{ inputs.configurationFile }}
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          private-key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
+
+      - name: Renovate run
+        uses: renovatebot/github-action@v46.1.10
+        env:
+          LOG_LEVEL: ${{ inputs.logLevel }}
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_DRY_RUN: ${{ inputs.dryRun }}
+          RENOVATE_ONBOARDING: "false"
+          RENOVATE_USERNAME: "renovatebot-sumologic[bot]"
+          RENOVATE_GIT_AUTHOR: "RenovateBot-SumoLogic <3519431+renovatebot-sumologic[bot]@users.noreply.github.com>"
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          configurationFile: ${{ inputs.configurationFile }}

--- a/.github/workflows/workflow-renovate-run.yaml
+++ b/.github/workflows/workflow-renovate-run.yaml
@@ -52,7 +52,7 @@ jobs:
           RENOVATE_DRY_RUN: ${{ inputs.dryRun }}
           RENOVATE_ONBOARDING: "false"
           RENOVATE_USERNAME: "renovatebot-sumologic[bot]"
-          RENOVATE_GIT_AUTHOR: "RenovateBot-SumoLogic <3519431+renovatebot-sumologic[bot]@users.noreply.github.com>"
+          RENOVATE_GIT_AUTHOR: "renovatebot-sumologic[bot] <279692411+renovatebot-sumologic[bot]@users.noreply.github.com>"
         with:
           token: ${{ steps.app-token.outputs.token }}
           configurationFile: ${{ inputs.configurationFile }}

--- a/renovate.json
+++ b/renovate.json
@@ -311,10 +311,10 @@
     },
     {
       "customType": "regex",
-      "description": "Update telegraf sidecar image in values.yaml (inline format)",
-      "fileMatch": ["^deploy/helm/sumologic/values\\.yaml$"],
+      "description": "Update telegraf sidecar image in values.yaml and README.md",
+      "fileMatch": ["^deploy/helm/sumologic/values\\.yaml$", "^deploy/helm/sumologic/README\\.md$"],
       "matchStrings": [
-        "sidecarImage:\\s*\"?(?<depName>public\\.ecr\\.aws/sumologic/telegraf):(?<currentValue>[0-9][^\"\\s]+)\"?"
+        "(?<depName>public\\.ecr\\.aws/sumologic/telegraf):(?<currentValue>[0-9][^`\"\\s]+)"
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "semver"
@@ -465,6 +465,12 @@
       "description": "Group telegraf-operator Helm chart + docs/README updates",
       "matchPackageNames": ["telegraf-operator"],
       "groupName": "telegraf-operator"
+    },
+    {
+      "description": "Group telegraf sidecar image updates across values.yaml and README",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["public.ecr.aws/sumologic/telegraf"],
+      "groupName": "telegraf-sidecar"
     },
     {
       "description": "Add chore(deps) prefix to all dependency update commits",

--- a/renovate.json
+++ b/renovate.json
@@ -51,20 +51,20 @@
     },
     {
       "customType": "regex",
-      "description": "Update kubernetes-setup image in values.yaml",
+      "description": "Update Docker images in values.yaml (semver)",
       "fileMatch": ["^deploy/helm/sumologic/values\\.yaml$"],
       "matchStrings": [
-        "repository:\\s*(?<depName>public\\.ecr\\.aws/sumologic/kubernetes-setup)\\s*\\n\\s*tag:\\s*(?<currentValue>[0-9][^\\s]+)"
+        "repository:\\s*\"?(?<depName>public\\.ecr\\.aws/sumologic/(?:kubernetes-setup|metrics-server|kube-state-metrics|autoinstrumentation-(?:java|dotnet|nodejs)|kubernetes-tools-kubectl|sumologic-mock))\"?\\s*\\n\\s*tag:\\s*\"?(?<currentValue>[^\"\\s]+)\"?"
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "semver"
     },
     {
       "customType": "regex",
-      "description": "Update kubernetes-setup image in golden test files",
+      "description": "Update Docker images in golden test files (semver)",
       "fileMatch": ["^tests/helm/testdata/goldenfile/.*\\.yaml$"],
       "matchStrings": [
-        "image:\\s*(?<depName>public\\.ecr\\.aws/sumologic/kubernetes-setup):(?<currentValue>[0-9][a-zA-Z0-9._-]+)"
+        "image:\\s*(?<depName>public\\.ecr\\.aws/sumologic/(?:kubernetes-setup|metrics-server|kubernetes-tools-kubectl|sumologic-mock)):(?<currentValue>[a-zA-Z0-9._-]+)"
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "semver"
@@ -113,26 +113,6 @@
     },
     {
       "customType": "regex",
-      "description": "Update metrics-server image in values.yaml",
-      "fileMatch": ["^deploy/helm/sumologic/values\\.yaml$"],
-      "matchStrings": [
-        "repository:\\s*(?<depName>public\\.ecr\\.aws/sumologic/metrics-server)\\s*\\n\\s*tag:\\s*(?<currentValue>[^\\s]+)"
-      ],
-      "datasourceTemplate": "docker",
-      "versioningTemplate": "semver"
-    },
-    {
-      "customType": "regex",
-      "description": "Update metrics-server image in golden test files",
-      "fileMatch": ["^tests/helm/testdata/goldenfile/.*\\.yaml$"],
-      "matchStrings": [
-        "image:\\s*(?<depName>public\\.ecr\\.aws/sumologic/metrics-server):(?<currentValue>[a-zA-Z0-9._-]+)"
-      ],
-      "datasourceTemplate": "docker",
-      "versioningTemplate": "semver"
-    },
-    {
-      "customType": "regex",
       "description": "Update metrics-server image version in deploy/helm/sumologic/README.md",
       "fileMatch": ["^deploy/helm/sumologic/README\\.md$"],
       "matchStrings": [
@@ -144,16 +124,6 @@
     },
     {
       "customType": "regex",
-      "description": "Update kube-state-metrics image in values.yaml",
-      "fileMatch": ["^deploy/helm/sumologic/values\\.yaml$"],
-      "matchStrings": [
-        "repository:\\s*(?<depName>public\\.ecr\\.aws/sumologic/kube-state-metrics)\\s*\\n\\s*tag:\\s*\"?(?<currentValue>[^\"\\s]+)\"?"
-      ],
-      "datasourceTemplate": "docker",
-      "versioningTemplate": "semver"
-    },
-    {
-      "customType": "regex",
       "description": "Update kube-state-metrics image version in deploy/helm/sumologic/README.md",
       "fileMatch": ["^deploy/helm/sumologic/README\\.md$"],
       "matchStrings": [
@@ -161,16 +131,6 @@
       ],
       "datasourceTemplate": "docker",
       "depNameTemplate": "public.ecr.aws/sumologic/kube-state-metrics",
-      "versioningTemplate": "semver"
-    },
-    {
-      "customType": "regex",
-      "description": "Update autoinstrumentation images in values.yaml",
-      "fileMatch": ["^deploy/helm/sumologic/values\\.yaml$"],
-      "matchStrings": [
-        "repository:\\s*(?<depName>public\\.ecr\\.aws/sumologic/autoinstrumentation-(?:java|dotnet|nodejs))\\s*\\n\\s*tag:\\s*(?<currentValue>[^\\s]+)"
-      ],
-      "datasourceTemplate": "docker",
       "versioningTemplate": "semver"
     },
     {
@@ -249,26 +209,6 @@
     },
     {
       "customType": "regex",
-      "description": "Update kubernetes-tools-kubectl image in values.yaml",
-      "fileMatch": ["^deploy/helm/sumologic/values\\.yaml$"],
-      "matchStrings": [
-        "repository:\\s*(?<depName>public\\.ecr\\.aws/sumologic/kubernetes-tools-kubectl)\\s*\\n\\s*tag:\\s*(?<currentValue>[0-9][^\\s]+)"
-      ],
-      "datasourceTemplate": "docker",
-      "versioningTemplate": "semver"
-    },
-    {
-      "customType": "regex",
-      "description": "Update kubernetes-tools-kubectl image in golden test files",
-      "fileMatch": ["^tests/helm/testdata/goldenfile/.*\\.yaml$"],
-      "matchStrings": [
-        "image:\\s*(?<depName>public\\.ecr\\.aws/sumologic/kubernetes-tools-kubectl):(?<currentValue>[a-zA-Z0-9._-]+)"
-      ],
-      "datasourceTemplate": "docker",
-      "versioningTemplate": "semver"
-    },
-    {
-      "customType": "regex",
       "description": "Update kubernetes-tools-kubectl version in deploy/helm/sumologic/README.md",
       "fileMatch": ["^deploy/helm/sumologic/README\\.md$"],
       "matchStrings": [
@@ -276,26 +216,6 @@
       ],
       "datasourceTemplate": "docker",
       "depNameTemplate": "public.ecr.aws/sumologic/kubernetes-tools-kubectl",
-      "versioningTemplate": "semver"
-    },
-    {
-      "customType": "regex",
-      "description": "Update sumologic-mock image in values.yaml",
-      "fileMatch": ["^deploy/helm/sumologic/values\\.yaml$"],
-      "matchStrings": [
-        "repository:\\s*\"?(?<depName>public\\.ecr\\.aws/sumologic/sumologic-mock)\"?\\s*\\n\\s*tag:\\s*\"?(?<currentValue>[0-9][^\"\\s]+)\"?"
-      ],
-      "datasourceTemplate": "docker",
-      "versioningTemplate": "semver"
-    },
-    {
-      "customType": "regex",
-      "description": "Update sumologic-mock image in golden test files",
-      "fileMatch": ["^tests/helm/testdata/goldenfile/.*\\.yaml$"],
-      "matchStrings": [
-        "image:\\s*(?<depName>public\\.ecr\\.aws/sumologic/sumologic-mock):(?<currentValue>[a-zA-Z0-9._-]+)"
-      ],
-      "datasourceTemplate": "docker",
       "versioningTemplate": "semver"
     },
     {
@@ -465,12 +385,6 @@
       "description": "Group telegraf-operator Helm chart + docs/README updates",
       "matchPackageNames": ["telegraf-operator"],
       "groupName": "telegraf-operator"
-    },
-    {
-      "description": "Group telegraf sidecar image updates across values.yaml and README",
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["public.ecr.aws/sumologic/telegraf"],
-      "groupName": "telegraf-sidecar"
     },
     {
       "description": "Add chore(deps) prefix to all dependency update commits",

--- a/renovate.json
+++ b/renovate.json
@@ -61,10 +61,10 @@
     },
     {
       "customType": "regex",
-      "description": "Update kubernetes-setup image in golden test files",
+      "description": "Update Docker images in golden test files (semver)",
       "fileMatch": ["^tests/helm/testdata/goldenfile/.*\\.yaml$"],
       "matchStrings": [
-        "image:\\s*(?<depName>public\\.ecr\\.aws/sumologic/kubernetes-setup):(?<currentValue>[0-9][a-zA-Z0-9._-]+)"
+        "image:\\s*(?<depName>public\\.ecr\\.aws/sumologic/(?:kubernetes-setup|metrics-server|kubernetes-tools-kubectl|sumologic-mock)):(?<currentValue>[a-zA-Z0-9._-]+)"
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "semver"
@@ -117,16 +117,6 @@
       "fileMatch": ["^deploy/helm/sumologic/values\\.yaml$"],
       "matchStrings": [
         "repository:\\s*(?<depName>public\\.ecr\\.aws/sumologic/metrics-server)\\s*\\n\\s*tag:\\s*(?<currentValue>[^\\s]+)"
-      ],
-      "datasourceTemplate": "docker",
-      "versioningTemplate": "semver"
-    },
-    {
-      "customType": "regex",
-      "description": "Update metrics-server image in golden test files",
-      "fileMatch": ["^tests/helm/testdata/goldenfile/.*\\.yaml$"],
-      "matchStrings": [
-        "image:\\s*(?<depName>public\\.ecr\\.aws/sumologic/metrics-server):(?<currentValue>[a-zA-Z0-9._-]+)"
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "semver"
@@ -259,16 +249,6 @@
     },
     {
       "customType": "regex",
-      "description": "Update kubernetes-tools-kubectl image in golden test files",
-      "fileMatch": ["^tests/helm/testdata/goldenfile/.*\\.yaml$"],
-      "matchStrings": [
-        "image:\\s*(?<depName>public\\.ecr\\.aws/sumologic/kubernetes-tools-kubectl):(?<currentValue>[a-zA-Z0-9._-]+)"
-      ],
-      "datasourceTemplate": "docker",
-      "versioningTemplate": "semver"
-    },
-    {
-      "customType": "regex",
       "description": "Update kubernetes-tools-kubectl version in deploy/helm/sumologic/README.md",
       "fileMatch": ["^deploy/helm/sumologic/README\\.md$"],
       "matchStrings": [
@@ -284,16 +264,6 @@
       "fileMatch": ["^deploy/helm/sumologic/values\\.yaml$"],
       "matchStrings": [
         "repository:\\s*\"?(?<depName>public\\.ecr\\.aws/sumologic/sumologic-mock)\"?\\s*\\n\\s*tag:\\s*\"?(?<currentValue>[0-9][^\"\\s]+)\"?"
-      ],
-      "datasourceTemplate": "docker",
-      "versioningTemplate": "semver"
-    },
-    {
-      "customType": "regex",
-      "description": "Update sumologic-mock image in golden test files",
-      "fileMatch": ["^tests/helm/testdata/goldenfile/.*\\.yaml$"],
-      "matchStrings": [
-        "image:\\s*(?<depName>public\\.ecr\\.aws/sumologic/sumologic-mock):(?<currentValue>[a-zA-Z0-9._-]+)"
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "semver"
@@ -465,12 +435,6 @@
       "description": "Group telegraf-operator Helm chart + docs/README updates",
       "matchPackageNames": ["telegraf-operator"],
       "groupName": "telegraf-operator"
-    },
-    {
-      "description": "Group telegraf sidecar image updates across values.yaml and README",
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["public.ecr.aws/sumologic/telegraf"],
-      "groupName": "telegraf-sidecar"
     },
     {
       "description": "Add chore(deps) prefix to all dependency update commits",

--- a/renovate.json
+++ b/renovate.json
@@ -326,7 +326,7 @@
       "matchStrings": [
         "\\|\\s*OpenTelemetry Operator\\s*\\|\\s*(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\s*\\|"
       ],
-      "datasourceTemplate": "helm",
+      "datasourceTemplate": "helmv3",
       "depNameTemplate": "opentelemetry-operator",
       "registryUrlTemplate": "https://open-telemetry.github.io/opentelemetry-helm-charts"
     },
@@ -337,7 +337,7 @@
       "matchStrings": [
         "\\|\\s*Tailing Sidecar Operator\\s*\\|\\s*(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\s*\\|"
       ],
-      "datasourceTemplate": "helm",
+      "datasourceTemplate": "helmv3",
       "depNameTemplate": "tailing-sidecar-operator",
       "registryUrlTemplate": "https://sumologic.github.io/tailing-sidecar"
     },
@@ -348,7 +348,7 @@
       "matchStrings": [
         "\\|\\s*Falco\\s*\\|\\s*(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\s*\\|"
       ],
-      "datasourceTemplate": "helm",
+      "datasourceTemplate": "helmv3",
       "depNameTemplate": "falco",
       "registryUrlTemplate": "https://falcosecurity.github.io/charts"
     },
@@ -359,7 +359,7 @@
       "matchStrings": [
         "\\|\\s*Metrics Server\\s*\\|\\s*(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\s*\\|"
       ],
-      "datasourceTemplate": "helm",
+      "datasourceTemplate": "helmv3",
       "depNameTemplate": "metrics-server",
       "registryUrlTemplate": "https://kubernetes-sigs.github.io/metrics-server/"
     },
@@ -370,7 +370,7 @@
       "matchStrings": [
         "\\|\\s*Telegraf Operator\\s*\\|\\s*(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\s*\\|"
       ],
-      "datasourceTemplate": "helm",
+      "datasourceTemplate": "helmv3",
       "depNameTemplate": "telegraf-operator",
       "registryUrlTemplate": "https://helm.influxdata.com/"
     },
@@ -381,7 +381,7 @@
       "matchStrings": [
         "\\|\\s*kube-prometheus-stack/Prometheus Operator\\s*\\|\\s*(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\s*\\|"
       ],
-      "datasourceTemplate": "helm",
+      "datasourceTemplate": "helmv3",
       "depNameTemplate": "kube-prometheus-stack",
       "registryUrlTemplate": "https://prometheus-community.github.io/helm-charts"
     }
@@ -400,14 +400,12 @@
     },
     {
       "description": "Constrain falco Helm chart to minor upgrades only",
-      "matchManagers": ["helmv3"],
       "matchPackageNames": ["falco"],
       "matchUpdateTypes": ["major"],
       "enabled": false
     },
     {
       "description": "Constrain metrics-server Helm chart to minor upgrades only",
-      "matchManagers": ["helmv3"],
       "matchPackageNames": ["metrics-server"],
       "matchUpdateTypes": ["major"],
       "enabled": false

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "enabledManagers": ["custom.regex", "helmv3"],
+  "recreateWhen": "always",
   "prHourlyLimit": 10,
   "labels": ["dependencies"],
   "commitMessageAction": "bump",

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,8 @@
   "enabledManagers": ["custom.regex", "helmv3"],
   "prHourlyLimit": 10,
   "labels": ["dependencies"],
+  "commitMessageAction": "bump",
+  "commitMessageExtra": "{{#if isSingleVersion}}from {{{currentValue}}} to {{{newValue}}}{{/if}}",
   "customManagers": [
     {
       "customType": "regex",

--- a/renovate.json
+++ b/renovate.json
@@ -326,7 +326,7 @@
       "matchStrings": [
         "\\|\\s*OpenTelemetry Operator\\s*\\|\\s*(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\s*\\|"
       ],
-      "datasourceTemplate": "helmv3",
+      "datasourceTemplate": "helm",
       "depNameTemplate": "opentelemetry-operator",
       "registryUrlTemplate": "https://open-telemetry.github.io/opentelemetry-helm-charts"
     },
@@ -337,7 +337,7 @@
       "matchStrings": [
         "\\|\\s*Tailing Sidecar Operator\\s*\\|\\s*(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\s*\\|"
       ],
-      "datasourceTemplate": "helmv3",
+      "datasourceTemplate": "helm",
       "depNameTemplate": "tailing-sidecar-operator",
       "registryUrlTemplate": "https://sumologic.github.io/tailing-sidecar"
     },
@@ -348,7 +348,7 @@
       "matchStrings": [
         "\\|\\s*Falco\\s*\\|\\s*(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\s*\\|"
       ],
-      "datasourceTemplate": "helmv3",
+      "datasourceTemplate": "helm",
       "depNameTemplate": "falco",
       "registryUrlTemplate": "https://falcosecurity.github.io/charts"
     },
@@ -359,7 +359,7 @@
       "matchStrings": [
         "\\|\\s*Metrics Server\\s*\\|\\s*(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\s*\\|"
       ],
-      "datasourceTemplate": "helmv3",
+      "datasourceTemplate": "helm",
       "depNameTemplate": "metrics-server",
       "registryUrlTemplate": "https://kubernetes-sigs.github.io/metrics-server/"
     },
@@ -370,7 +370,7 @@
       "matchStrings": [
         "\\|\\s*Telegraf Operator\\s*\\|\\s*(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\s*\\|"
       ],
-      "datasourceTemplate": "helmv3",
+      "datasourceTemplate": "helm",
       "depNameTemplate": "telegraf-operator",
       "registryUrlTemplate": "https://helm.influxdata.com/"
     },
@@ -381,7 +381,7 @@
       "matchStrings": [
         "\\|\\s*kube-prometheus-stack/Prometheus Operator\\s*\\|\\s*(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\s*\\|"
       ],
-      "datasourceTemplate": "helmv3",
+      "datasourceTemplate": "helm",
       "depNameTemplate": "kube-prometheus-stack",
       "registryUrlTemplate": "https://prometheus-community.github.io/helm-charts"
     }

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "enabledManagers": ["custom.regex", "helmv3"],
+  "prHourlyLimit": 10,
+  "labels": ["dependencies"],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
## Summary

- Created a dedicated GitHub App (`RenovateBot-SumoLogic`, ID: `3519431`) to replace `GITHUB_TOKEN` in Renovate workflows. App token ensures commits can trigger downstream CI workflows.
- Added a reusable workflow (`workflow-renovate-run.yaml`) encapsulating: config validation, app token generation, concurrency control, bot identity, and configurable log level/dry-run inputs.
- Updated `renovate-scheduler.yaml` to call the reusable workflow.
- Updated `renovate-changelog.yaml` to use the Renovate app token with correct bot identity so Renovate recognizes changelog commits as its own and doesn't block auto-rebase.

## Renovate config fixes

- **Fixed `datasourceTemplate: "helmv3"` → `"helm"`** — `helmv3` is a valid manager but not a valid datasource, causing "Missing datasource" warnings.
- **Added `matchManagers: ["helmv3"]`** to falco and metrics-server major version constraints — without this, the custom.regex manager also detected these packages and bypassed the constraint.
- **Added telegraf sidecar README rule** — the telegraf image was only updated in `values.yaml`, not `README.md`, causing `check-configuration-keys` failures.
- **Consolidated regex rules** — merged 4 golden test file rules into 1, and 6 values.yaml semver rules into 1, using regex alternation.
- **Added `recreateWhen: "always"`** — ensures Renovate recreates PRs that were closed (e.g., due to config fixes).

## Files changed

| File | Change |
|------|--------|
| `.github/workflows/workflow-renovate-run.yaml` | New reusable workflow |
| `.github/workflows/renovate-scheduler.yaml` | Calls reusable workflow, adds configurable inputs |
| `.github/workflows/renovate-changelog.yaml` | Uses app token + correct bot identity |
| `renovate.json` | Datasource fix, consolidated rules, telegraf README rule, recreateWhen |

## New GitHub App

- **Name:** RenovateBot-SumoLogic
- **Bot user ID:** 279692411
- **Secrets added:** `RENOVATE_APP_ID`, `RENOVATE_PRIVATE_KEY`

## Expected flow

1. Renovate scheduler runs (daily 18:30 UTC) → opens/updates PRs via app identity
2. `renovate-changelog.yaml` triggers on PR → adds changelog commit using same bot identity
3. Renovate recognizes changelog commit as its own → auto-rebases freely
4. All checks pass → human approves and merges

## Test plan

- [x] Triggered `renovate-scheduler` manually — PRs created successfully
- [x] Verified Renovate detects correct packages and versions
- [x] Fixed "Missing datasource" warning (`helmv3` → `helm`)
- [x] Verified telegraf PR updates both `values.yaml` and `README.md`
- [ ] Verify changelog commit shows as `renovatebot-sumologic[bot]` (requires merge to main)
- [ ] Verify Renovate auto-rebases after changelog commit (requires merge to main)