### PR TITLE
fix(ci): prevent changelog workflow from overwriting manual edits

### DIFF
--- a/.github/workflows/renovate-changelog.yaml
+++ b/.github/workflows/renovate-changelog.yaml
@@ -35,8 +35,13 @@ jobs:
           CHANGELOG_FILE=".changelog/${PR_NUMBER}.changed.txt"
           mkdir -p .changelog
 
-          echo "$PR_TITLE" > "$CHANGELOG_FILE"
-          echo "Created changelog file: $CHANGELOG_FILE with content: $PR_TITLE"
+          # Skip if any changelog fragment already exists for this PR (changed, fixed, breaking, added)
+          if ls .changelog/${PR_NUMBER}.*.txt 1>/dev/null 2>&1; then
+            echo "Changelog entry already exists for PR #${PR_NUMBER}, skipping"
+          else
+            echo "$PR_TITLE" > "$CHANGELOG_FILE"
+            echo "Created changelog file: $CHANGELOG_FILE with content: $PR_TITLE"
+          fi
 
       - name: Commit changelog
         run: |


### PR DESCRIPTION
## Summary

- Adds an existence check before creating changelog entries in the Renovate changelog workflow
- Checks for any towncrier fragment (`${PR_NUMBER}.*.txt`) — covers `.changed`, `.fixed`, `.breaking`, `.added`
- If a fragment already exists, the workflow skips and does not overwrite

## Problem

The workflow triggers on `pull_request: [opened, synchronize]`. On every push (synchronize), it unconditionally wrote the PR title to `.changelog/${PR_NUMBER}.changed.txt`, overwriting any manual edits made by the user (e.g., custom changelog messages or different fragment types like `.breaking.txt`).

Observed on PR #4170: a commit of a custom changelog entry triggered `synchronize`, and the workflow overwrote it.

## Behavior after fix

| Scenario | Result |
|----------|--------|
| PR opened (no fragment exists) | Creates `.changed.txt` |
| User edits/replaces fragment + pushes | Skips (fragment exists) |
| Renovate rebases (fragment lost) | Recreates `.changed.txt` |
| User changes to `.breaking.txt` + pushes | Skips (fragment exists) |

## Test plan

- [ ] Open a Renovate PR → verify `.changed.txt` is created
- [ ] Push a manual changelog edit → verify workflow skips
- [ ] Delete fragment + push → verify workflow recreates it