### PR TITLE
fix(ci): remove --src-no-creds from skopeo sync to fix timeout

### DIFF
--- a/ci/sync-repository.sh
+++ b/ci/sync-repository.sh
@@ -15,7 +15,6 @@ docker run \
             --preserve-digests \
             --retry-times 5 \
             --src yaml \
-            --src-no-creds \
             --dest docker \
             "/workspace/${SRC_YAML_PATH}" \
             "${DESTINATION_NAMESPACE}"


### PR DESCRIPTION
## Summary

The `sync-repository.sh` script was failing with timeout errors during image syncing. The root cause is the `--src-no-creds` flag passed to `skopeo sync`, which forces unauthenticated access to source registries. Many public registries (e.g., Docker Hub, ECR Public) aggressively rate-limit anonymous pulls, causing repeated retries and eventual timeouts.

- Remove the `--src-no-creds` flag so skopeo can use available credentials from the Docker config mounted at `/tmp/auth.json`
- Authenticated pulls have significantly higher rate limits, avoiding the timeout failures

## Test plan

- [x] Verify the sync-repositories CI workflow completes successfully without timeout errors
- [x] Confirm images are synced correctly to the destination registry

Sample Run: https://github.com/SumoLogic/sumologic-kubernetes-collection/actions/runs/25100478181