### PR TITLE
fix(tests): add otelcol_exporter_in_flight_requests to FlakyMetrics

### DIFF
--- a/tests/integration/internal/constants.go
+++ b/tests/integration/internal/constants.go
@@ -338,6 +338,7 @@ var (
 		"otelcol_exporter_enqueue_failed_metric_points",
 		"otelcol_exporter_enqueue_failed_spans",
 		"otelcol_exporter_enqueue_failed_log_records",
+		"otelcol_exporter_in_flight_requests",
 		"otelcol_routing_processor_non_routed_metric_points",
 		"kube_pod_container_status_waiting_reason",
 		"kube_pod_container_status_terminated_reason",


### PR DESCRIPTION
## Summary

- Add `otelcol_exporter_in_flight_requests` to `FlakyMetrics` in `tests/integration/internal/constants.go`

## Reason

OpenTelemetry Collector v0.152.0 introduced a new `otelcol_exporter_in_flight_requests` UpDownCounter metric (via [open-telemetry/opentelemetry-collector#15009](https://github.com/open-telemetry/opentelemetry-collector/pull/15009)) that tracks the number of export requests currently in-flight per exporter.

When this metric appears but isn't in the expected/flaky list, the integration tests fail with:
> found the following unexpected metrics: [otelcol_exporter_in_flight_requests]

**CI failure:** https://github.com/SumoLogic/sumologic-kubernetes-collection/actions/runs/25914412575/job/76464109535?pr=4203

Adding it to `FlakyMetrics` (rather than `DefaultOtelcolMetrics`) because this metric may or may not appear depending on collector version and whether exports are actively in-flight during the test window.

## Test plan

- [ ] Integration tests pass with the collector v0.152.0 bump (PR #4203)
- [ ] Integration tests still pass on current main (metric absent is tolerated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)