### PR TITLE
chore(SUMO-286654): Update k8s min cluster version to 1.24 and remove docker-shim parser path

### DIFF
--- a/.changelog/4234.breaking.txt
+++ b/.changelog/4234.breaking.txt
@@ -1,0 +1,1 @@
+chore(SUMO-286654): Update k8s min cluster version to 1.24 and remove docker-shim parser path

--- a/deploy/helm/sumologic/conf/logs/collector/common/filelog_receiver.yaml
+++ b/deploy/helm/sumologic/conf/logs/collector/common/filelog_receiver.yaml
@@ -28,24 +28,15 @@ filelog/containers:
     {{- if eq .Values.debug.events.stopLogsIngestion true }}
     {{ include "events.collector.files.list" . }}
     {{- end }}
-
-{{ if lt (int (include "kubernetes.minor" .)) 24 }}
-  ## sets fingerprint_size to 17kb in order to match the longest possible docker line (which by default is 16kb)
-  ## we want to include timestamp, which is at the end of the line
-  ## Not necessary in 1.24 and later, as docker-shim is not present anymore
-  fingerprint_size: 17408
-{{ end }}
   include:
     - /var/log/pods/*/*/*.log
   include_file_name: false
   include_file_path: true
   operators:
     ## Detect the container runtime log format
-    ## Can be: docker-shim, CRI-O and containerd
+    ## Can be: CRI-O and containerd
     - id: get-format
       routes:
-        - expr: 'body matches "^\\{"'
-          output: parser-docker
         - expr: 'body matches "^[^ Z]+ "'
           output: parser-crio
         - expr: 'body matches "^[^ Z]+Z"'
@@ -73,35 +64,6 @@ filelog/containers:
         parse_from: body.time
       type: regex_parser
 
-    ## Parse docker-shim format
-    ## parser-docker interprets the input string as JSON and moves the `time` field from the JSON to Timestamp field in the OTLP log
-    ## record.
-    ## Input Body (string): '{"log":"2001-02-03 04:05:06 first line\n","stream":"stdout","time":"2021-11-25T09:59:13.23887954Z"}'
-    ## Output Body (JSON): { "log": "2001-02-03 04:05:06 first line\n", "stream": "stdout" }
-    ## Input Timestamp: _empty_
-    ## Output Timestamp: 2021-11-25 09:59:13.23887954 +0000 UTC
-    - id: parser-docker
-      output: merge-docker-lines
-      parse_to: body
-      timestamp:
-        layout: '%Y-%m-%dT%H:%M:%S.%LZ'
-        parse_from: body.time
-      type: json_parser
-
-    ## merge-docker-lines stitches back together log lines split by Docker logging driver.
-    ## Input Body (JSON): { "log": "2001-02-03 04:05:06 very long li", "stream": "stdout" }
-    ## Input Body (JSON): { "log": "ne that was split by the logging driver\n", "stream": "stdout" }
-    ## Output Body (JSON): { "log": "2001-02-03 04:05:06 very long line that was split by the logging driver\n","stream":"stdout"}
-    - id: merge-docker-lines
-      combine_field: body.log
-      combine_with: ""
-      is_last_entry: body.log matches "\n$"
-      output: strip-trailing-newline
-      source_identifier: attributes["log.file.path"]
-      type: recombine
-      ## Ensure we combine everything up to `is_last_entry` even on the file beginning
-      max_unmatched_batch_size: 0
-
     ## merge-cri-lines stitches back together log lines split by CRI logging drivers.
     ## Input Body (JSON): { "log": "2001-02-03 04:05:06 very long li", "logtag": "P" }
     ## Input Body (JSON): { "log": "ne that was split by the logging driver", "logtag": "F" }
@@ -116,16 +78,6 @@ filelog/containers:
       type: recombine
       ## Ensure we combine everything up to `is_last_entry` even on the file beginning
       max_unmatched_batch_size: 0
-
-    ## strip-trailing-newline removes the trailing "\n" from the `log` key. This is required for logs coming from Docker container runtime.
-    ## Input Body (JSON): { "log": "2001-02-03 04:05:06 very long line that was split by the logging driver\n", "stream": "stdout" }
-    ## Output Body (JSON): { "log": "2001-02-03 04:05:06 very long line that was split by the logging driver", "stream": "stdout" }
-    - id: strip-trailing-newline
-      output: extract-metadata-from-filepath
-      parse_from: body.log
-      parse_to: body
-      regex: "^(?P<log>.*)\n$"
-      type: regex_parser
 
     ## extract-metadata-from-filepath extracts data from the `log.file.path` Attribute into the Attributes
     ## Input Attributes:

--- a/deploy/helm/sumologic/templates/checks.txt
+++ b/deploy/helm/sumologic/templates/checks.txt
@@ -1,7 +1,7 @@
-{{/* Check if kubernetes version is less than 1.16 */}}
+{{/* Check if kubernetes version is less than 1.24 */}}
 {{- if not .Values.sumologic.setup.force -}}
-{{- if and (eq .Capabilities.KubeVersion.Major "1") (lt (int (include "kubernetes.minor" .)) 16) -}}
-{{- fail "\nAt least k8s 1.16 is required. Please update your k8s version or set sumologic.setup.force to true" -}}
+{{- if and (eq .Capabilities.KubeVersion.Major "1") (lt (int (include "kubernetes.minor" .)) 24) -}}
+{{- fail "\nAt least k8s 1.24 is required. Please update your k8s version or set sumologic.setup.force to true" -}}
 {{- end -}}
 {{- end -}}
 

--- a/docs/fluentbit-otc-comparison.md
+++ b/docs/fluentbit-otc-comparison.md
@@ -10,9 +10,8 @@ include:
 - Different container runtimes
 
   OpenTelemetry Collector will automatically detect the format of and parse logs from different container runtimes. In particular, it will
-  gracefully handle clusters running docker-shim and containerd in parallel on different Nodes, which is useful for migrations. If your
-  modifications to the Fluent Bit config were only needed to deal with container runtime log formatting, you can use the default otel
-  configuration.
+  gracefully handle clusters running containerd in parallel on different Nodes, which is useful for migrations. If your modifications to the
+  Fluent Bit config were only needed to deal with container runtime log formatting, you can use the default otel configuration.
 
 - Multiline log parsing
 

--- a/tests/helm/testdata/goldenfile/logs_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc/basic.output.yaml
@@ -69,8 +69,6 @@ data:
         operators:
         - id: get-format
           routes:
-          - expr: body matches "^\\{"
-            output: parser-docker
           - expr: body matches "^[^ Z]+ "
             output: parser-crio
           - expr: body matches "^[^ Z]+Z"
@@ -93,21 +91,6 @@ data:
             layout: '%Y-%m-%dT%H:%M:%S.%LZ'
             parse_from: body.time
           type: regex_parser
-        - id: parser-docker
-          output: merge-docker-lines
-          parse_to: body
-          timestamp:
-            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
-            parse_from: body.time
-          type: json_parser
-        - combine_field: body.log
-          combine_with: ""
-          id: merge-docker-lines
-          is_last_entry: body.log matches "\n$"
-          max_unmatched_batch_size: 0
-          output: strip-trailing-newline
-          source_identifier: attributes["log.file.path"]
-          type: recombine
         - combine_field: body.log
           combine_with: ""
           id: merge-cri-lines
@@ -117,14 +100,6 @@ data:
           overwrite_with: newest
           source_identifier: attributes["log.file.path"]
           type: recombine
-        - id: strip-trailing-newline
-          output: extract-metadata-from-filepath
-          parse_from: body.log
-          parse_to: body
-          regex: |-
-            ^(?P<log>.*)
-            $
-          type: regex_parser
         - id: extract-metadata-from-filepath
           parse_from: attributes["log.file.path"]
           regex: ^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]+)\/(?P<container_name>[^\._]+)\/(?P<run_id>\d+)\.log$

--- a/tests/helm/testdata/goldenfile/logs_otc/debug.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc/debug.output.yaml
@@ -79,8 +79,6 @@ data:
         operators:
         - id: get-format
           routes:
-          - expr: body matches "^\\{"
-            output: parser-docker
           - expr: body matches "^[^ Z]+ "
             output: parser-crio
           - expr: body matches "^[^ Z]+Z"
@@ -103,21 +101,6 @@ data:
             layout: '%Y-%m-%dT%H:%M:%S.%LZ'
             parse_from: body.time
           type: regex_parser
-        - id: parser-docker
-          output: merge-docker-lines
-          parse_to: body
-          timestamp:
-            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
-            parse_from: body.time
-          type: json_parser
-        - combine_field: body.log
-          combine_with: ""
-          id: merge-docker-lines
-          is_last_entry: body.log matches "\n$"
-          max_unmatched_batch_size: 0
-          output: strip-trailing-newline
-          source_identifier: attributes["log.file.path"]
-          type: recombine
         - combine_field: body.log
           combine_with: ""
           id: merge-cri-lines
@@ -127,14 +110,6 @@ data:
           overwrite_with: newest
           source_identifier: attributes["log.file.path"]
           type: recombine
-        - id: strip-trailing-newline
-          output: extract-metadata-from-filepath
-          parse_from: body.log
-          parse_to: body
-          regex: |-
-            ^(?P<log>.*)
-            $
-          type: regex_parser
         - id: extract-metadata-from-filepath
           parse_from: attributes["log.file.path"]
           regex: ^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]+)\/(?P<container_name>[^\._]+)\/(?P<run_id>\d+)\.log$

--- a/tests/helm/testdata/goldenfile/logs_otc_daemonset/multiple_multiline.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_daemonset/multiple_multiline.output.yaml
@@ -69,8 +69,6 @@ data:
         operators:
         - id: get-format
           routes:
-          - expr: body matches "^\\{"
-            output: parser-docker
           - expr: body matches "^[^ Z]+ "
             output: parser-crio
           - expr: body matches "^[^ Z]+Z"
@@ -93,21 +91,6 @@ data:
             layout: '%Y-%m-%dT%H:%M:%S.%LZ'
             parse_from: body.time
           type: regex_parser
-        - id: parser-docker
-          output: merge-docker-lines
-          parse_to: body
-          timestamp:
-            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
-            parse_from: body.time
-          type: json_parser
-        - combine_field: body.log
-          combine_with: ""
-          id: merge-docker-lines
-          is_last_entry: body.log matches "\n$"
-          max_unmatched_batch_size: 0
-          output: strip-trailing-newline
-          source_identifier: attributes["log.file.path"]
-          type: recombine
         - combine_field: body.log
           combine_with: ""
           id: merge-cri-lines
@@ -117,14 +100,6 @@ data:
           overwrite_with: newest
           source_identifier: attributes["log.file.path"]
           type: recombine
-        - id: strip-trailing-newline
-          output: extract-metadata-from-filepath
-          parse_from: body.log
-          parse_to: body
-          regex: |-
-            ^(?P<log>.*)
-            $
-          type: regex_parser
         - id: extract-metadata-from-filepath
           parse_from: attributes["log.file.path"]
           regex: ^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]+)\/(?P<container_name>[^\._]+)\/(?P<run_id>\d+)\.log$

--- a/tests/helm/testdata/goldenfile/logs_otc_windows/configmap/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_windows/configmap/basic.output.yaml
@@ -48,8 +48,6 @@ data:
         operators:
         - id: get-format
           routes:
-          - expr: body matches "^\\{"
-            output: parser-docker
           - expr: body matches "^[^ Z]+ "
             output: parser-crio
           - expr: body matches "^[^ Z]+Z"
@@ -72,21 +70,6 @@ data:
             layout: '%Y-%m-%dT%H:%M:%S.%LZ'
             parse_from: body.time
           type: regex_parser
-        - id: parser-docker
-          output: merge-docker-lines
-          parse_to: body
-          timestamp:
-            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
-            parse_from: body.time
-          type: json_parser
-        - combine_field: body.log
-          combine_with: ""
-          id: merge-docker-lines
-          is_last_entry: body.log matches "\n$"
-          max_unmatched_batch_size: 0
-          output: strip-trailing-newline
-          source_identifier: attributes["log.file.path"]
-          type: recombine
         - combine_field: body.log
           combine_with: ""
           id: merge-cri-lines
@@ -96,14 +79,6 @@ data:
           overwrite_with: newest
           source_identifier: attributes["log.file.path"]
           type: recombine
-        - id: strip-trailing-newline
-          output: extract-metadata-from-filepath
-          parse_from: body.log
-          parse_to: body
-          regex: |-
-            ^(?P<log>.*)
-            $
-          type: regex_parser
         - id: extract-metadata-from-filepath
           parse_from: attributes["log.file.path"]
           regex: ^.*\\(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]+)\\(?P<container_name>[^\._]+)\\(?P<run_id>\d+)\.log$

--- a/tests/helm/testdata/goldenfile/logs_otc_windows/configmap/debug.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_windows/configmap/debug.output.yaml
@@ -59,8 +59,6 @@ data:
         operators:
         - id: get-format
           routes:
-          - expr: body matches "^\\{"
-            output: parser-docker
           - expr: body matches "^[^ Z]+ "
             output: parser-crio
           - expr: body matches "^[^ Z]+Z"
@@ -83,21 +81,6 @@ data:
             layout: '%Y-%m-%dT%H:%M:%S.%LZ'
             parse_from: body.time
           type: regex_parser
-        - id: parser-docker
-          output: merge-docker-lines
-          parse_to: body
-          timestamp:
-            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
-            parse_from: body.time
-          type: json_parser
-        - combine_field: body.log
-          combine_with: ""
-          id: merge-docker-lines
-          is_last_entry: body.log matches "\n$"
-          max_unmatched_batch_size: 0
-          output: strip-trailing-newline
-          source_identifier: attributes["log.file.path"]
-          type: recombine
         - combine_field: body.log
           combine_with: ""
           id: merge-cri-lines
@@ -107,14 +90,6 @@ data:
           overwrite_with: newest
           source_identifier: attributes["log.file.path"]
           type: recombine
-        - id: strip-trailing-newline
-          output: extract-metadata-from-filepath
-          parse_from: body.log
-          parse_to: body
-          regex: |-
-            ^(?P<log>.*)
-            $
-          type: regex_parser
         - id: extract-metadata-from-filepath
           parse_from: attributes["log.file.path"]
           regex: ^.*\\(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]+)\\(?P<container_name>[^\._]+)\\(?P<run_id>\d+)\.log$

--- a/tests/helm/testdata/goldenfile/logs_otc_windows/daemonset/multiple_multiline.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_windows/daemonset/multiple_multiline.output.yaml
@@ -48,8 +48,6 @@ data:
         operators:
         - id: get-format
           routes:
-          - expr: body matches "^\\{"
-            output: parser-docker
           - expr: body matches "^[^ Z]+ "
             output: parser-crio
           - expr: body matches "^[^ Z]+Z"
@@ -72,21 +70,6 @@ data:
             layout: '%Y-%m-%dT%H:%M:%S.%LZ'
             parse_from: body.time
           type: regex_parser
-        - id: parser-docker
-          output: merge-docker-lines
-          parse_to: body
-          timestamp:
-            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
-            parse_from: body.time
-          type: json_parser
-        - combine_field: body.log
-          combine_with: ""
-          id: merge-docker-lines
-          is_last_entry: body.log matches "\n$"
-          max_unmatched_batch_size: 0
-          output: strip-trailing-newline
-          source_identifier: attributes["log.file.path"]
-          type: recombine
         - combine_field: body.log
           combine_with: ""
           id: merge-cri-lines
@@ -96,14 +79,6 @@ data:
           overwrite_with: newest
           source_identifier: attributes["log.file.path"]
           type: recombine
-        - id: strip-trailing-newline
-          output: extract-metadata-from-filepath
-          parse_from: body.log
-          parse_to: body
-          regex: |-
-            ^(?P<log>.*)
-            $
-          type: regex_parser
         - id: extract-metadata-from-filepath
           parse_from: attributes["log.file.path"]
           regex: ^.*\\(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]+)\\(?P<container_name>[^\._]+)\\(?P<run_id>\d+)\.log$


### PR DESCRIPTION
Kubernetes 1.23 reached EOL Feb 2024 hence updating the cluster requirement to 1.24 and removing the docker shim flow which was removed in 1.24

https://sumologic.atlassian.net/browse/SUMO-286654
### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [ ] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features
