### PR TITLE
fix: PVC cleaner support for single-layer metrics pipeline

### DIFF
--- a/.changelog/4262.fixed.txt
+++ b/.changelog/4262.fixed.txt
@@ -1,1 +1,1 @@
-fix: PVC cleaner now works correctly with single-layer metrics pipeline
+fix: PVC cleaner now works correctly with single-layer metrics pipeline. Note: on upgrade, existing PVCs will not have the new selector label until the metrics collector StatefulSet is recreated.

--- a/.changelog/4262.fixed.txt
+++ b/.changelog/4262.fixed.txt
@@ -1,0 +1,1 @@
+fix: PVC cleaner now works correctly with single-layer metrics pipeline

--- a/deploy/helm/sumologic/conf/pvc-cleaner/pvc-cleaner.sh
+++ b/deploy/helm/sumologic/conf/pvc-cleaner/pvc-cleaner.sh
@@ -142,8 +142,8 @@ if check_pvc_amount "${PVC_AMOUNT}"; then
   echo "Found ${PVC_AMOUNT} PVC instances in the '${NAMESPACE}' namespace with '${PVC_SELECTOR}' selector."
   echo
 else
-  echo "Did not found any PVC instances in the '${NAMESPACE}' namespace with '${PVC_SELECTOR}' selector. Exiting."
-  exit 1
+  echo "Did not find any PVC instances in the '${NAMESPACE}' namespace with '${PVC_SELECTOR}' selector. Nothing to clean."
+  exit 0
 fi
 
 # shellcheck disable=SC2310

--- a/deploy/helm/sumologic/templates/metrics/collector/otelcol/opentelemetrycollector.yaml
+++ b/deploy/helm/sumologic/templates/metrics/collector/otelcol/opentelemetrycollector.yaml
@@ -181,8 +181,9 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: file-storage
-{{- if .Values.metadata.persistence.pvcLabels }}
       labels:
+        sumologic.com/component: metrics-collector
+{{- if .Values.metadata.persistence.pvcLabels }}
 {{ toYaml .Values.metadata.persistence.pvcLabels | indent 8 }}
 {{- end }}
     spec:

--- a/deploy/helm/sumologic/templates/metrics/collector/otelcol/opentelemetrycollector.yaml
+++ b/deploy/helm/sumologic/templates/metrics/collector/otelcol/opentelemetrycollector.yaml
@@ -182,10 +182,11 @@ spec:
   - metadata:
       name: file-storage
       labels:
-        sumologic.com/component: metrics-collector
+{{- $pvcLabels := dict "sumologic.com/component" "metrics-collector" }}
 {{- if .Values.metadata.persistence.pvcLabels }}
-{{ toYaml .Values.metadata.persistence.pvcLabels | indent 8 }}
+{{- $pvcLabels = merge $pvcLabels .Values.metadata.persistence.pvcLabels }}
 {{- end }}
+{{ toYaml $pvcLabels | indent 8 }}
     spec:
       accessModes: [{{ .Values.metadata.persistence.accessMode }}]
 {{- if .Values.metadata.persistence.storageClass }}

--- a/deploy/helm/sumologic/templates/pvc-cleaner/cron-job-metrics.yaml
+++ b/deploy/helm/sumologic/templates/pvc-cleaner/cron-job-metrics.yaml
@@ -54,8 +54,12 @@ spec:
             - "bash"
             - "/pvc-cleaner/pvc-cleaner.sh"
             - "{{ template "sumologic.namespace" . }}"
+{{- if eq (include "metrics.collector.singleLayerPipeline.enabled" .) "true" }}
+            - "sumologic.com/component=metrics-collector"
+{{- else }}
             - "app={{ template "sumologic.labels.app.metrics.statefulset" . }}"
             - "{{ template "sumologic.metadata.name.metrics.hpa" . }}"
+{{- end }}
             imagePullPolicy: {{ .Values.pvcCleaner.job.image.pullPolicy }}
             resources:
               {{- toYaml .Values.pvcCleaner.job.resources | nindent 14 }}

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/single_layer_pipeline.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/single_layer_pipeline.output.yaml
@@ -88,6 +88,8 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: file-storage
+        labels:
+          sumologic.com/component: metrics-collector
       spec:
         accessModes: [ReadWriteOnce]
         resources:

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/single_layer_pipeline_extras.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/single_layer_pipeline_extras.output.yaml
@@ -98,6 +98,8 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: file-storage
+        labels:
+          sumologic.com/component: metrics-collector
       spec:
         accessModes: [ReadWriteOnce]
         resources:

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/single_layer_pipeline_remote_write.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/single_layer_pipeline_remote_write.output.yaml
@@ -88,6 +88,8 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: file-storage
+        labels:
+          sumologic.com/component: metrics-collector
       spec:
         accessModes: [ReadWriteOnce]
         resources:

--- a/tests/helm/testdata/goldenfile/pvc-cleaner/single_layer_pipeline_metrics.input.yaml
+++ b/tests/helm/testdata/goldenfile/pvc-cleaner/single_layer_pipeline_metrics.input.yaml
@@ -1,0 +1,12 @@
+sumologic:
+  metrics:
+    collector:
+      otelcol:
+        singleLayerPipeline:
+          enabled: true
+
+pvcCleaner:
+  metrics:
+    enabled: true
+  job:
+    schedule: "*/15 * * * *"

--- a/tests/helm/testdata/goldenfile/pvc-cleaner/single_layer_pipeline_metrics.output.yaml
+++ b/tests/helm/testdata/goldenfile/pvc-cleaner/single_layer_pipeline_metrics.output.yaml
@@ -29,28 +29,28 @@ spec:
           securityContext:
             runAsUser: 1000
           containers:
-          - name: pvc-cleaner
-            image: public.ecr.aws/sumologic/kubernetes-tools-kubectl:2.28.0
-            command:
-            - "bash"
-            - "/pvc-cleaner/pvc-cleaner.sh"
-            - "sumologic"
-            - "sumologic.com/component=metrics-collector"
-            imagePullPolicy: IfNotPresent
-            resources:
-              limits:
-                cpu: 2000m
-                memory: 256Mi
-              requests:
-                cpu: 100m
-                memory: 64Mi
-            volumeMounts:
             - name: pvc-cleaner
-              mountPath: /pvc-cleaner
+              image: public.ecr.aws/sumologic/kubernetes-tools-kubectl:2.28.0
+              command:
+                - "bash"
+                - "/pvc-cleaner/pvc-cleaner.sh"
+                - "sumologic"
+                - "sumologic.com/component=metrics-collector"
+              imagePullPolicy: IfNotPresent
+              resources:
+                limits:
+                  cpu: 2000m
+                  memory: 256Mi
+                requests:
+                  cpu: 100m
+                  memory: 64Mi
+              volumeMounts:
+                - name: pvc-cleaner
+                  mountPath: /pvc-cleaner
           volumes:
-          - configMap:
-              defaultMode: 420
-              name: RELEASE-NAME-sumologic-pvc-cleaner
-            name: pvc-cleaner
+            - configMap:
+                defaultMode: 420
+                name: RELEASE-NAME-sumologic-pvc-cleaner
+              name: pvc-cleaner
           restartPolicy: Never
           serviceAccountName: RELEASE-NAME-sumologic-pvc-cleaner

--- a/tests/helm/testdata/goldenfile/pvc-cleaner/single_layer_pipeline_metrics.output.yaml
+++ b/tests/helm/testdata/goldenfile/pvc-cleaner/single_layer_pipeline_metrics.output.yaml
@@ -1,0 +1,56 @@
+---
+# Source: sumologic/templates/pvc-cleaner/cron-job-metrics.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: RELEASE-NAME-sumologic-pvc-cleaner-metrics
+  namespace: sumologic
+  labels:
+    app: pvc-cleaner-metrics
+    chart: "sumologic-%CURRENT_CHART_VERSION%"
+    release: "RELEASE-NAME"
+    heritage: "Helm"
+spec:
+  schedule: "*/15 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          name: RELEASE-NAME-sumologic-pvc-cleaner-metrics
+          labels:
+            app: pvc-cleaner-metrics
+            chart: "sumologic-%CURRENT_CHART_VERSION%"
+            release: "RELEASE-NAME"
+            heritage: "Helm"
+          annotations:
+        spec:
+          nodeSelector:
+            kubernetes.io/os: linux
+          securityContext:
+            runAsUser: 1000
+          containers:
+          - name: pvc-cleaner
+            image: public.ecr.aws/sumologic/kubernetes-tools-kubectl:2.28.0
+            command:
+            - "bash"
+            - "/pvc-cleaner/pvc-cleaner.sh"
+            - "sumologic"
+            - "sumologic.com/component=metrics-collector"
+            imagePullPolicy: IfNotPresent
+            resources:
+              limits:
+                cpu: 2000m
+                memory: 256Mi
+              requests:
+                cpu: 100m
+                memory: 64Mi
+            volumeMounts:
+            - name: pvc-cleaner
+              mountPath: /pvc-cleaner
+          volumes:
+          - configMap:
+              defaultMode: 420
+              name: RELEASE-NAME-sumologic-pvc-cleaner
+            name: pvc-cleaner
+          restartPolicy: Never
+          serviceAccountName: RELEASE-NAME-sumologic-pvc-cleaner


### PR DESCRIPTION
When singleLayerPipeline is enabled, the metadata metrics StatefulSet and its HPA don't exist. The PVC cleaner was failing because it tried to look up the non-existent metadata HPA.

Changes:
- Add sumologic.com/component=metrics-collector label to the collector's volumeClaimTemplates so PVCs are identifiable by label
- In single-layer mode, PVC cleaner uses the new label selector (2-arg mode: deletes all unmounted PVCs matching the label)
- In 2-layer mode, behavior is unchanged (uses metadata label + HPA)

This avoids name truncation mismatches between the helm template and OTel Operator-managed resources, since the label is set directly on the volumeClaimTemplate and propagated to PVCs at creation time.

<!---
Describe your PR here
-->

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [ ] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features
