### PR TITLE
Fix: k8s sumologic extension - collector name format change to podName+clusterName

### DIFF
--- a/.changelog/4280.fixed.txt
+++ b/.changelog/4280.fixed.txt
@@ -1,0 +1,1 @@
+Fix: k8s sumologic extension - collector name format changed to podName+clusterName

--- a/deploy/helm/sumologic/conf/events/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/events/otelcol/config.yaml
@@ -60,6 +60,7 @@ extensions:
 {{- if .Values.sumologic.sourcelessMode }}
   sumologic:
     installation_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
+    collector_name: ${MY_POD_NAME}
     collector_fields:
       cluster: {{ .Values.sumologic.clusterName | quote }}
 {{- if .Values.sumologic.events.persistence.enabled }}

--- a/deploy/helm/sumologic/conf/events/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/events/otelcol/config.yaml
@@ -60,7 +60,7 @@ extensions:
 {{- if .Values.sumologic.sourcelessMode }}
   sumologic:
     installation_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
-    collector_name: ${MY_POD_NAME}
+    collector_name: ${MY_POD_NAME}-{{ .Values.sumologic.clusterName }}
     collector_fields:
       cluster: {{ .Values.sumologic.clusterName | quote }}
 {{- if .Values.sumologic.events.persistence.enabled }}

--- a/deploy/helm/sumologic/conf/instrumentation/otelcol.instrumentation.conf.yaml
+++ b/deploy/helm/sumologic/conf/instrumentation/otelcol.instrumentation.conf.yaml
@@ -237,7 +237,7 @@ extensions:
 {{- if .Values.sumologic.sourcelessMode }}
   sumologic:
     installation_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
-    collector_name: ${MY_POD_NAME}
+    collector_name: ${MY_POD_NAME}-{{ .Values.sumologic.clusterName }}
     collector_fields:
       cluster: {{ .Values.sumologic.clusterName | quote }}
     ephemeral: true

--- a/deploy/helm/sumologic/conf/instrumentation/otelcol.instrumentation.conf.yaml
+++ b/deploy/helm/sumologic/conf/instrumentation/otelcol.instrumentation.conf.yaml
@@ -237,6 +237,7 @@ extensions:
 {{- if .Values.sumologic.sourcelessMode }}
   sumologic:
     installation_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
+    collector_name: ${MY_POD_NAME}
     collector_fields:
       cluster: {{ .Values.sumologic.clusterName | quote }}
     ephemeral: true

--- a/deploy/helm/sumologic/conf/instrumentation/traces.sampler.conf.yaml
+++ b/deploy/helm/sumologic/conf/instrumentation/traces.sampler.conf.yaml
@@ -131,7 +131,7 @@ extensions:
 {{- if .Values.sumologic.sourcelessMode }}
   sumologic:
     installation_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
-    collector_name: ${MY_POD_NAME}
+    collector_name: ${MY_POD_NAME}-{{ .Values.sumologic.clusterName }}
     collector_fields:
       cluster: {{ .Values.sumologic.clusterName | quote }}
 {{- if .Values.tracesSampler.persistence.enabled }}

--- a/deploy/helm/sumologic/conf/instrumentation/traces.sampler.conf.yaml
+++ b/deploy/helm/sumologic/conf/instrumentation/traces.sampler.conf.yaml
@@ -131,6 +131,7 @@ extensions:
 {{- if .Values.sumologic.sourcelessMode }}
   sumologic:
     installation_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
+    collector_name: ${MY_POD_NAME}
     collector_fields:
       cluster: {{ .Values.sumologic.clusterName | quote }}
 {{- if .Values.tracesSampler.persistence.enabled }}

--- a/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
@@ -160,7 +160,7 @@ extensions:
 {{- if .Values.sumologic.sourcelessMode }}
   sumologic:
     installation_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
-    collector_name: ${MY_POD_NAME}
+    collector_name: ${MY_POD_NAME}-{{ .Values.sumologic.clusterName }}
     collector_fields:
       cluster: {{ .Values.sumologic.clusterName | quote }}
 {{- if .Values.metadata.persistence.enabled }}

--- a/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/logs/otelcol/config.yaml
@@ -160,6 +160,7 @@ extensions:
 {{- if .Values.sumologic.sourcelessMode }}
   sumologic:
     installation_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
+    collector_name: ${MY_POD_NAME}
     collector_fields:
       cluster: {{ .Values.sumologic.clusterName | quote }}
 {{- if .Values.metadata.persistence.enabled }}

--- a/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
@@ -140,7 +140,7 @@ extensions:
 {{- if .Values.sumologic.sourcelessMode }}
   sumologic:
     installation_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
-    collector_name: ${MY_POD_NAME}
+    collector_name: ${MY_POD_NAME}-{{ .Values.sumologic.clusterName }}
     collector_fields:
       cluster: {{ .Values.sumologic.clusterName | quote }}
 {{- if .Values.metadata.persistence.enabled }}

--- a/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/metrics/collector/otelcol/config.yaml
@@ -140,6 +140,7 @@ extensions:
 {{- if .Values.sumologic.sourcelessMode }}
   sumologic:
     installation_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
+    collector_name: ${MY_POD_NAME}
     collector_fields:
       cluster: {{ .Values.sumologic.clusterName | quote }}
 {{- if .Values.metadata.persistence.enabled }}

--- a/deploy/helm/sumologic/conf/metrics/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/metrics/otelcol/config.yaml
@@ -22,6 +22,7 @@ extensions:
 {{- if .Values.sumologic.sourcelessMode }}
   sumologic:
     installation_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
+    collector_name: ${MY_POD_NAME}
     collector_fields:
       cluster: {{ .Values.sumologic.clusterName | quote }}
 {{- if .Values.metadata.persistence.enabled }}

--- a/deploy/helm/sumologic/conf/metrics/otelcol/config.yaml
+++ b/deploy/helm/sumologic/conf/metrics/otelcol/config.yaml
@@ -22,7 +22,7 @@ extensions:
 {{- if .Values.sumologic.sourcelessMode }}
   sumologic:
     installation_token: ${SUMOLOGIC_INSTALLATION_TOKEN}
-    collector_name: ${MY_POD_NAME}
+    collector_name: ${MY_POD_NAME}-{{ .Values.sumologic.clusterName }}
     collector_fields:
       cluster: {{ .Values.sumologic.clusterName | quote }}
 {{- if .Values.metadata.persistence.enabled }}

--- a/deploy/helm/sumologic/templates/_helpers/_common.tpl
+++ b/deploy/helm/sumologic/templates/_helpers/_common.tpl
@@ -525,6 +525,11 @@ Example Usage:
     fieldRef:
       apiVersion: v1
       fieldPath: status.podIP
+- name: MY_POD_NAME
+  valueFrom:
+    fieldRef:
+      apiVersion: v1
+      fieldPath: metadata.name
 {{- end -}}
 
 {{/*

--- a/deploy/helm/sumologic/templates/metrics/collector/otelcol/opentelemetrycollector.yaml
+++ b/deploy/helm/sumologic/templates/metrics/collector/otelcol/opentelemetrycollector.yaml
@@ -148,6 +148,11 @@ spec:
       fieldRef:
         apiVersion: v1
         fieldPath: status.podIP
+  - name: MY_POD_NAME
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: metadata.name
   podAnnotations:
     ## The operator adds this annotation by default, but we use our own ServiceMonitor
     prometheus.io/scrape: "false"

--- a/tests/helm/testdata/goldenfile/events_otc_statefulset/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc_statefulset/basic.output.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: '%CONFIG_CHECKSUM%'
+        checksum/config: "%CONFIG_CHECKSUM%"
         someAnnotation: someValue
       labels:
         app: RELEASE-NAME-sumologic-otelcol-events
@@ -44,116 +44,114 @@ spec:
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - RELEASE-NAME-sumologic-otelcol-logs
-                - RELEASE-NAME-sumologic-otelcol-metrics
-                - RELEASE-NAME-sumologic-otelcol-events
-                - RELEASE-NAME-sumologic-otelcol-instrumentation
-              - key: app
-                operator: In
-                values:
-                - prometheus-operator-prometheus
-            topologyKey: "kubernetes.io/hostname"
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - RELEASE-NAME-sumologic-otelcol-logs
+                      - RELEASE-NAME-sumologic-otelcol-metrics
+                      - RELEASE-NAME-sumologic-otelcol-events
+                      - RELEASE-NAME-sumologic-otelcol-instrumentation
+                  - key: app
+                    operator: In
+                    values:
+                      - prometheus-operator-prometheus
+              topologyKey: "kubernetes.io/hostname"
 
       volumes:
-      - name: config-volume
-        configMap:
-          name: RELEASE-NAME-sumologic-otelcol-events
-      - name: es-certs
-        secret:
-          defaultMode: 420
-          secretName: es-certs
+        - name: config-volume
+          configMap:
+            name: RELEASE-NAME-sumologic-otelcol-events
+        - name: es-certs
+          secret:
+            defaultMode: 420
+            secretName: es-certs
       securityContext:
         fsGroup: 999
       priorityClassName: "prio"
       containers:
-      - name: otelcol
-        image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
-        imagePullPolicy: IfNotPresent
-        args:
-          - --config=/etc/otel/config.yaml
-        resources:
-          limits:
-            cpu: 2000m
-            memory: 2Gi
-          requests:
-            cpu: 100m
-            memory: 777Mi
-        ports:
-        - name: metrics
-          containerPort: 8888
-          protocol: TCP
-        - name: pprof
-          containerPort: 1777
-          protocol: TCP
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 3
-          initialDelaySeconds: 15
-          periodSeconds: 15
-          timeoutSeconds: 10
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 3
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          timeoutSeconds: 3
-        startupProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 60
-          periodSeconds: 3
-        volumeMounts:
-        - name: config-volume
-          mountPath: /etc/otel/config.yaml
-          subPath: config.yaml
-        - name: file-storage
-          mountPath: /var/lib/storage/events
-        - mountPath: /certs
-          name: es-certs
-          readOnly: true
-        env:
-        - name: SUMO_ENDPOINT_DEFAULT_OTLP_EVENTS_SOURCE
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-events-otlp
-        
-        
-        - name: NO_PROXY
-          value: kubernetes.default.svc
-        - name: MY_POD_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: MY_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
+        - name: otelcol
+          image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config=/etc/otel/config.yaml
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 100m
+              memory: 777Mi
+          ports:
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+            - name: pprof
+              containerPort: 1777
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 3
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 60
+            periodSeconds: 3
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/otel/config.yaml
+              subPath: config.yaml
+            - name: file-storage
+              mountPath: /var/lib/storage/events
+            - mountPath: /certs
+              name: es-certs
+              readOnly: true
+          env:
+            - name: SUMO_ENDPOINT_DEFAULT_OTLP_EVENTS_SOURCE
+              valueFrom:
+                secretKeyRef:
+                  name: sumologic
+                  key: endpoint-events-otlp
 
-        - name: VALUE_FROM_SECRET
-          valueFrom:
-            secretKeyRef:
-              key: secret_key
-              name: secret_name
+            - name: NO_PROXY
+              value: kubernetes.default.svc
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+
+            - name: VALUE_FROM_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: secret_key
+                  name: secret_name
   volumeClaimTemplates:
-  - metadata:
-      name: file-storage
-    spec:
-      accessModes: [ReadWriteOnce]
-      storageClassName: 
-      resources:
-        requests:
-          storage: 10Gi
-
+    - metadata:
+        name: file-storage
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName:
+        resources:
+          requests:
+            storage: 10Gi

--- a/tests/helm/testdata/goldenfile/events_otc_statefulset/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc_statefulset/basic.output.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: "%CONFIG_CHECKSUM%"
+        checksum/config: '%CONFIG_CHECKSUM%'
         someAnnotation: someValue
       labels:
         app: RELEASE-NAME-sumologic-otelcol-events
@@ -44,109 +44,116 @@ spec:
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                  - key: app
-                    operator: In
-                    values:
-                      - RELEASE-NAME-sumologic-otelcol-logs
-                      - RELEASE-NAME-sumologic-otelcol-metrics
-                      - RELEASE-NAME-sumologic-otelcol-events
-                      - RELEASE-NAME-sumologic-otelcol-instrumentation
-                  - key: app
-                    operator: In
-                    values:
-                      - prometheus-operator-prometheus
-              topologyKey: "kubernetes.io/hostname"
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - RELEASE-NAME-sumologic-otelcol-logs
+                - RELEASE-NAME-sumologic-otelcol-metrics
+                - RELEASE-NAME-sumologic-otelcol-events
+                - RELEASE-NAME-sumologic-otelcol-instrumentation
+              - key: app
+                operator: In
+                values:
+                - prometheus-operator-prometheus
+            topologyKey: "kubernetes.io/hostname"
 
       volumes:
-        - name: config-volume
-          configMap:
-            name: RELEASE-NAME-sumologic-otelcol-events
-        - name: es-certs
-          secret:
-            defaultMode: 420
-            secretName: es-certs
+      - name: config-volume
+        configMap:
+          name: RELEASE-NAME-sumologic-otelcol-events
+      - name: es-certs
+        secret:
+          defaultMode: 420
+          secretName: es-certs
       securityContext:
         fsGroup: 999
       priorityClassName: "prio"
       containers:
-        - name: otelcol
-          image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
-          imagePullPolicy: IfNotPresent
-          args:
-            - --config=/etc/otel/config.yaml
-          resources:
-            limits:
-              cpu: 2000m
-              memory: 2Gi
-            requests:
-              cpu: 100m
-              memory: 777Mi
-          ports:
-            - name: metrics
-              containerPort: 8888
-              protocol: TCP
-            - name: pprof
-              containerPort: 1777
-              protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 3
-            initialDelaySeconds: 15
-            periodSeconds: 15
-            timeoutSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 3
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 3
-          startupProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 60
-            periodSeconds: 3
-          volumeMounts:
-            - name: config-volume
-              mountPath: /etc/otel/config.yaml
-              subPath: config.yaml
-            - name: file-storage
-              mountPath: /var/lib/storage/events
-            - mountPath: /certs
-              name: es-certs
-              readOnly: true
-          env:
-            - name: SUMO_ENDPOINT_DEFAULT_OTLP_EVENTS_SOURCE
-              valueFrom:
-                secretKeyRef:
-                  name: sumologic
-                  key: endpoint-events-otlp
-
-            - name: NO_PROXY
-              value: kubernetes.default.svc
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP
-
-            - name: VALUE_FROM_SECRET
-              valueFrom:
-                secretKeyRef:
-                  key: secret_key
-                  name: secret_name
-  volumeClaimTemplates:
-    - metadata:
-        name: file-storage
-      spec:
-        accessModes: [ReadWriteOnce]
-        storageClassName:
+      - name: otelcol
+        image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
+        imagePullPolicy: IfNotPresent
+        args:
+          - --config=/etc/otel/config.yaml
         resources:
+          limits:
+            cpu: 2000m
+            memory: 2Gi
           requests:
-            storage: 10Gi
+            cpu: 100m
+            memory: 777Mi
+        ports:
+        - name: metrics
+          containerPort: 8888
+          protocol: TCP
+        - name: pprof
+          containerPort: 1777
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 3
+        startupProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 60
+          periodSeconds: 3
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/otel/config.yaml
+          subPath: config.yaml
+        - name: file-storage
+          mountPath: /var/lib/storage/events
+        - mountPath: /certs
+          name: es-certs
+          readOnly: true
+        env:
+        - name: SUMO_ENDPOINT_DEFAULT_OTLP_EVENTS_SOURCE
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-events-otlp
+        
+        
+        - name: NO_PROXY
+          value: kubernetes.default.svc
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+
+        - name: VALUE_FROM_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: secret_key
+              name: secret_name
+  volumeClaimTemplates:
+  - metadata:
+      name: file-storage
+    spec:
+      accessModes: [ReadWriteOnce]
+      storageClassName: 
+      resources:
+        requests:
+          storage: 10Gi
+

--- a/tests/helm/testdata/goldenfile/events_otc_statefulset/common.output.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc_statefulset/common.output.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: '%CONFIG_CHECKSUM%'
+        checksum/config: "%CONFIG_CHECKSUM%"
       labels:
         app: RELEASE-NAME-sumologic-otelcol-events
         sumologic.com/scrape: "true"
@@ -42,110 +42,108 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/os
-                operator: NotIn
-                values:
-                - windows
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: NotIn
+                    values:
+                      - windows
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - RELEASE-NAME-sumologic-otelcol-logs
-                  - RELEASE-NAME-sumologic-otelcol-metrics
-                  - RELEASE-NAME-sumologic-otelcol-events
-                  - RELEASE-NAME-sumologic-otelcol-instrumentation
-                - key: app
-                  operator: In
-                  values:
-                  - prometheus-operator-prometheus
-              topologyKey: "kubernetes.io/hostname"
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - RELEASE-NAME-sumologic-otelcol-logs
+                        - RELEASE-NAME-sumologic-otelcol-metrics
+                        - RELEASE-NAME-sumologic-otelcol-events
+                        - RELEASE-NAME-sumologic-otelcol-instrumentation
+                    - key: app
+                      operator: In
+                      values:
+                        - prometheus-operator-prometheus
+                topologyKey: "kubernetes.io/hostname"
       volumes:
-      - name: config-volume
-        configMap:
-          name: RELEASE-NAME-sumologic-otelcol-events
+        - name: config-volume
+          configMap:
+            name: RELEASE-NAME-sumologic-otelcol-events
       securityContext:
         fsGroup: 999
       containers:
-      - name: otelcol
-        image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
-        imagePullPolicy: IfNotPresent
-        args:
-          - --config=/etc/otel/config.yaml
-        resources:
-          limits:
-            cpu: 2000m
-            memory: 2Gi
-          requests:
-            cpu: 200m
-            memory: 500Mi
-        ports:
-        - name: metrics
-          containerPort: 8888
-          protocol: TCP
-        - name: pprof
-          containerPort: 1777
-          protocol: TCP
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 3
-          initialDelaySeconds: 15
-          periodSeconds: 15
-          timeoutSeconds: 10
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 3
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          timeoutSeconds: 3
-        startupProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 60
-          periodSeconds: 3
-        volumeMounts:
-        - name: config-volume
-          mountPath: /etc/otel/config.yaml
-          subPath: config.yaml
-        - name: file-storage
-          mountPath: /var/lib/storage/events
-        env:
-        - name: SUMO_ENDPOINT_DEFAULT_OTLP_EVENTS_SOURCE
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-events-otlp
-        
-        
-        - name: NO_PROXY
-          value: kubernetes.default.svc
-        - name: MY_POD_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: MY_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-  volumeClaimTemplates:
-  - metadata:
-      name: file-storage
-    spec:
-      accessModes: [ReadWriteOnce]
-      storageClassName: 
-      resources:
-        requests:
-          storage: 10Gi
+        - name: otelcol
+          image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config=/etc/otel/config.yaml
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 200m
+              memory: 500Mi
+          ports:
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+            - name: pprof
+              containerPort: 1777
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 3
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 60
+            periodSeconds: 3
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/otel/config.yaml
+              subPath: config.yaml
+            - name: file-storage
+              mountPath: /var/lib/storage/events
+          env:
+            - name: SUMO_ENDPOINT_DEFAULT_OTLP_EVENTS_SOURCE
+              valueFrom:
+                secretKeyRef:
+                  name: sumologic
+                  key: endpoint-events-otlp
 
+            - name: NO_PROXY
+              value: kubernetes.default.svc
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+  volumeClaimTemplates:
+    - metadata:
+        name: file-storage
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName:
+        resources:
+          requests:
+            storage: 10Gi

--- a/tests/helm/testdata/goldenfile/events_otc_statefulset/common.output.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc_statefulset/common.output.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: "%CONFIG_CHECKSUM%"
+        checksum/config: '%CONFIG_CHECKSUM%'
       labels:
         app: RELEASE-NAME-sumologic-otelcol-events
         sumologic.com/scrape: "true"
@@ -42,103 +42,110 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-              - matchExpressions:
-                  - key: kubernetes.io/os
-                    operator: NotIn
-                    values:
-                      - windows
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: NotIn
+                values:
+                - windows
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: app
-                      operator: In
-                      values:
-                        - RELEASE-NAME-sumologic-otelcol-logs
-                        - RELEASE-NAME-sumologic-otelcol-metrics
-                        - RELEASE-NAME-sumologic-otelcol-events
-                        - RELEASE-NAME-sumologic-otelcol-instrumentation
-                    - key: app
-                      operator: In
-                      values:
-                        - prometheus-operator-prometheus
-                topologyKey: "kubernetes.io/hostname"
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - RELEASE-NAME-sumologic-otelcol-logs
+                  - RELEASE-NAME-sumologic-otelcol-metrics
+                  - RELEASE-NAME-sumologic-otelcol-events
+                  - RELEASE-NAME-sumologic-otelcol-instrumentation
+                - key: app
+                  operator: In
+                  values:
+                  - prometheus-operator-prometheus
+              topologyKey: "kubernetes.io/hostname"
       volumes:
-        - name: config-volume
-          configMap:
-            name: RELEASE-NAME-sumologic-otelcol-events
+      - name: config-volume
+        configMap:
+          name: RELEASE-NAME-sumologic-otelcol-events
       securityContext:
         fsGroup: 999
       containers:
-        - name: otelcol
-          image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
-          imagePullPolicy: IfNotPresent
-          args:
-            - --config=/etc/otel/config.yaml
-          resources:
-            limits:
-              cpu: 2000m
-              memory: 2Gi
-            requests:
-              cpu: 200m
-              memory: 500Mi
-          ports:
-            - name: metrics
-              containerPort: 8888
-              protocol: TCP
-            - name: pprof
-              containerPort: 1777
-              protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 3
-            initialDelaySeconds: 15
-            periodSeconds: 15
-            timeoutSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 3
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 3
-          startupProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 60
-            periodSeconds: 3
-          volumeMounts:
-            - name: config-volume
-              mountPath: /etc/otel/config.yaml
-              subPath: config.yaml
-            - name: file-storage
-              mountPath: /var/lib/storage/events
-          env:
-            - name: SUMO_ENDPOINT_DEFAULT_OTLP_EVENTS_SOURCE
-              valueFrom:
-                secretKeyRef:
-                  name: sumologic
-                  key: endpoint-events-otlp
-
-            - name: NO_PROXY
-              value: kubernetes.default.svc
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP
-  volumeClaimTemplates:
-    - metadata:
-        name: file-storage
-      spec:
-        accessModes: [ReadWriteOnce]
-        storageClassName:
+      - name: otelcol
+        image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
+        imagePullPolicy: IfNotPresent
+        args:
+          - --config=/etc/otel/config.yaml
         resources:
+          limits:
+            cpu: 2000m
+            memory: 2Gi
           requests:
-            storage: 10Gi
+            cpu: 200m
+            memory: 500Mi
+        ports:
+        - name: metrics
+          containerPort: 8888
+          protocol: TCP
+        - name: pprof
+          containerPort: 1777
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 3
+        startupProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 60
+          periodSeconds: 3
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/otel/config.yaml
+          subPath: config.yaml
+        - name: file-storage
+          mountPath: /var/lib/storage/events
+        env:
+        - name: SUMO_ENDPOINT_DEFAULT_OTLP_EVENTS_SOURCE
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-events-otlp
+        
+        
+        - name: NO_PROXY
+          value: kubernetes.default.svc
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+  volumeClaimTemplates:
+  - metadata:
+      name: file-storage
+    spec:
+      accessModes: [ReadWriteOnce]
+      storageClassName: 
+      resources:
+        requests:
+          storage: 10Gi
+

--- a/tests/helm/testdata/goldenfile/events_otc_statefulset/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc_statefulset/custom.output.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: '%CONFIG_CHECKSUM%'
+        checksum/config: "%CONFIG_CHECKSUM%"
         sumoAnnotation: sumoValue
         statefulsetAnnotation: statefulsetValue
       labels:
@@ -40,103 +40,101 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - RELEASE-NAME-sumologic-otelcol-logs
-                  - RELEASE-NAME-sumologic-otelcol-metrics
-                  - RELEASE-NAME-sumologic-otelcol-events
-                  - RELEASE-NAME-sumologic-otelcol-instrumentation
-                - key: app
-                  operator: In
-                  values:
-                  - prometheus-operator-prometheus
-              topologyKey: "kubernetes.io/hostname"
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - RELEASE-NAME-sumologic-otelcol-logs
+                        - RELEASE-NAME-sumologic-otelcol-metrics
+                        - RELEASE-NAME-sumologic-otelcol-events
+                        - RELEASE-NAME-sumologic-otelcol-instrumentation
+                    - key: app
+                      operator: In
+                      values:
+                        - prometheus-operator-prometheus
+                topologyKey: "kubernetes.io/hostname"
       volumes:
-      - name: config-volume
-        configMap:
-          name: RELEASE-NAME-sumologic-otelcol-events
+        - name: config-volume
+          configMap:
+            name: RELEASE-NAME-sumologic-otelcol-events
       securityContext:
         fsGroup: 999
       containers:
-      - name: otelcol
-        image: "my_repository:my_tag"
-        imagePullPolicy: IfNotPresent
-        args:
-          - --config=/etc/otel/config.yaml
-        resources:
-          limits:
-            cpu: 2000m
-            memory: 2Gi
-          requests:
-            cpu: 200m
-            memory: 500Mi
-        ports:
-        - name: metrics
-          containerPort: 8888
-          protocol: TCP
-        - name: pprof
-          containerPort: 1777
-          protocol: TCP
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 3
-          initialDelaySeconds: 15
-          periodSeconds: 15
-          timeoutSeconds: 10
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 3
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          timeoutSeconds: 3
-        startupProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 60
-          periodSeconds: 3
-        volumeMounts:
-        - name: config-volume
-          mountPath: /etc/otel/config.yaml
-          subPath: config.yaml
-        - name: file-storage
-          mountPath: /var/lib/storage/events
-        env:
-        - name: SUMO_ENDPOINT_DEFAULT_EVENTS_SOURCE
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-events
-        
-        
-        - name: NO_PROXY
-          value: kubernetes.default.svc
-        - name: MY_POD_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: MY_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-  volumeClaimTemplates:
-  - metadata:
-      name: file-storage
-    spec:
-      accessModes: [ReadWriteOnce]
-      storageClassName: 
-      resources:
-        requests:
-          storage: 10Gi
+        - name: otelcol
+          image: "my_repository:my_tag"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config=/etc/otel/config.yaml
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 200m
+              memory: 500Mi
+          ports:
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+            - name: pprof
+              containerPort: 1777
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 3
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 60
+            periodSeconds: 3
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/otel/config.yaml
+              subPath: config.yaml
+            - name: file-storage
+              mountPath: /var/lib/storage/events
+          env:
+            - name: SUMO_ENDPOINT_DEFAULT_EVENTS_SOURCE
+              valueFrom:
+                secretKeyRef:
+                  name: sumologic
+                  key: endpoint-events
 
+            - name: NO_PROXY
+              value: kubernetes.default.svc
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+  volumeClaimTemplates:
+    - metadata:
+        name: file-storage
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName:
+        resources:
+          requests:
+            storage: 10Gi

--- a/tests/helm/testdata/goldenfile/events_otc_statefulset/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc_statefulset/custom.output.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: "%CONFIG_CHECKSUM%"
+        checksum/config: '%CONFIG_CHECKSUM%'
         sumoAnnotation: sumoValue
         statefulsetAnnotation: statefulsetValue
       labels:
@@ -40,96 +40,103 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: app
-                      operator: In
-                      values:
-                        - RELEASE-NAME-sumologic-otelcol-logs
-                        - RELEASE-NAME-sumologic-otelcol-metrics
-                        - RELEASE-NAME-sumologic-otelcol-events
-                        - RELEASE-NAME-sumologic-otelcol-instrumentation
-                    - key: app
-                      operator: In
-                      values:
-                        - prometheus-operator-prometheus
-                topologyKey: "kubernetes.io/hostname"
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - RELEASE-NAME-sumologic-otelcol-logs
+                  - RELEASE-NAME-sumologic-otelcol-metrics
+                  - RELEASE-NAME-sumologic-otelcol-events
+                  - RELEASE-NAME-sumologic-otelcol-instrumentation
+                - key: app
+                  operator: In
+                  values:
+                  - prometheus-operator-prometheus
+              topologyKey: "kubernetes.io/hostname"
       volumes:
-        - name: config-volume
-          configMap:
-            name: RELEASE-NAME-sumologic-otelcol-events
+      - name: config-volume
+        configMap:
+          name: RELEASE-NAME-sumologic-otelcol-events
       securityContext:
         fsGroup: 999
       containers:
-        - name: otelcol
-          image: "my_repository:my_tag"
-          imagePullPolicy: IfNotPresent
-          args:
-            - --config=/etc/otel/config.yaml
-          resources:
-            limits:
-              cpu: 2000m
-              memory: 2Gi
-            requests:
-              cpu: 200m
-              memory: 500Mi
-          ports:
-            - name: metrics
-              containerPort: 8888
-              protocol: TCP
-            - name: pprof
-              containerPort: 1777
-              protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 3
-            initialDelaySeconds: 15
-            periodSeconds: 15
-            timeoutSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 3
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 3
-          startupProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 60
-            periodSeconds: 3
-          volumeMounts:
-            - name: config-volume
-              mountPath: /etc/otel/config.yaml
-              subPath: config.yaml
-            - name: file-storage
-              mountPath: /var/lib/storage/events
-          env:
-            - name: SUMO_ENDPOINT_DEFAULT_EVENTS_SOURCE
-              valueFrom:
-                secretKeyRef:
-                  name: sumologic
-                  key: endpoint-events
-
-            - name: NO_PROXY
-              value: kubernetes.default.svc
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP
-  volumeClaimTemplates:
-    - metadata:
-        name: file-storage
-      spec:
-        accessModes: [ReadWriteOnce]
-        storageClassName:
+      - name: otelcol
+        image: "my_repository:my_tag"
+        imagePullPolicy: IfNotPresent
+        args:
+          - --config=/etc/otel/config.yaml
         resources:
+          limits:
+            cpu: 2000m
+            memory: 2Gi
           requests:
-            storage: 10Gi
+            cpu: 200m
+            memory: 500Mi
+        ports:
+        - name: metrics
+          containerPort: 8888
+          protocol: TCP
+        - name: pprof
+          containerPort: 1777
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 3
+        startupProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 60
+          periodSeconds: 3
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/otel/config.yaml
+          subPath: config.yaml
+        - name: file-storage
+          mountPath: /var/lib/storage/events
+        env:
+        - name: SUMO_ENDPOINT_DEFAULT_EVENTS_SOURCE
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-events
+        
+        
+        - name: NO_PROXY
+          value: kubernetes.default.svc
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+  volumeClaimTemplates:
+  - metadata:
+      name: file-storage
+    spec:
+      accessModes: [ReadWriteOnce]
+      storageClassName: 
+      resources:
+        requests:
+          storage: 10Gi
+

--- a/tests/helm/testdata/goldenfile/events_otc_statefulset/proxy.output.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc_statefulset/proxy.output.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: "%CONFIG_CHECKSUM%"
+        checksum/config: '%CONFIG_CHECKSUM%'
       labels:
         app: RELEASE-NAME-sumologic-otelcol-events
         sumologic.com/scrape: "true"
@@ -36,100 +36,107 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: app
-                      operator: In
-                      values:
-                        - RELEASE-NAME-sumologic-otelcol-logs
-                        - RELEASE-NAME-sumologic-otelcol-metrics
-                        - RELEASE-NAME-sumologic-otelcol-events
-                        - RELEASE-NAME-sumologic-otelcol-instrumentation
-                    - key: app
-                      operator: In
-                      values:
-                        - prometheus-operator-prometheus
-                topologyKey: "kubernetes.io/hostname"
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - RELEASE-NAME-sumologic-otelcol-logs
+                  - RELEASE-NAME-sumologic-otelcol-metrics
+                  - RELEASE-NAME-sumologic-otelcol-events
+                  - RELEASE-NAME-sumologic-otelcol-instrumentation
+                - key: app
+                  operator: In
+                  values:
+                  - prometheus-operator-prometheus
+              topologyKey: "kubernetes.io/hostname"
       volumes:
-        - name: config-volume
-          configMap:
-            name: RELEASE-NAME-sumologic-otelcol-events
+      - name: config-volume
+        configMap:
+          name: RELEASE-NAME-sumologic-otelcol-events
       securityContext:
         fsGroup: 999
       containers:
-        - name: otelcol
-          image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
-          imagePullPolicy: IfNotPresent
-          args:
-            - --config=/etc/otel/config.yaml
-          resources:
-            limits:
-              cpu: 2000m
-              memory: 2Gi
-            requests:
-              cpu: 200m
-              memory: 500Mi
-          ports:
-            - name: metrics
-              containerPort: 8888
-              protocol: TCP
-            - name: pprof
-              containerPort: 1777
-              protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 3
-            initialDelaySeconds: 15
-            periodSeconds: 15
-            timeoutSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 3
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 3
-          startupProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 60
-            periodSeconds: 3
-          volumeMounts:
-            - name: config-volume
-              mountPath: /etc/otel/config.yaml
-              subPath: config.yaml
-            - name: file-storage
-              mountPath: /var/lib/storage/events
-          env:
-            - name: SUMO_ENDPOINT_DEFAULT_OTLP_EVENTS_SOURCE
-              valueFrom:
-                secretKeyRef:
-                  name: sumologic
-                  key: endpoint-events-otlp
-
-            - name: HTTP_PROXY
-              value: http://proxy.internal
-            - name: HTTPS_PROXY
-              value: https://proxy.internal
-            - name: NO_PROXY
-              value: http://non-proxy.internal
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP
-  volumeClaimTemplates:
-    - metadata:
-        name: file-storage
-      spec:
-        accessModes: [ReadWriteOnce]
-        storageClassName:
+      - name: otelcol
+        image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
+        imagePullPolicy: IfNotPresent
+        args:
+          - --config=/etc/otel/config.yaml
         resources:
+          limits:
+            cpu: 2000m
+            memory: 2Gi
           requests:
-            storage: 10Gi
+            cpu: 200m
+            memory: 500Mi
+        ports:
+        - name: metrics
+          containerPort: 8888
+          protocol: TCP
+        - name: pprof
+          containerPort: 1777
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 3
+        startupProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 60
+          periodSeconds: 3
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/otel/config.yaml
+          subPath: config.yaml
+        - name: file-storage
+          mountPath: /var/lib/storage/events
+        env:
+        - name: SUMO_ENDPOINT_DEFAULT_OTLP_EVENTS_SOURCE
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-events-otlp
+        
+        
+        - name: HTTP_PROXY
+          value: http://proxy.internal
+        - name: HTTPS_PROXY
+          value: https://proxy.internal
+        - name: NO_PROXY
+          value: http://non-proxy.internal
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+  volumeClaimTemplates:
+  - metadata:
+      name: file-storage
+    spec:
+      accessModes: [ReadWriteOnce]
+      storageClassName: 
+      resources:
+        requests:
+          storage: 10Gi
+

--- a/tests/helm/testdata/goldenfile/events_otc_statefulset/proxy.output.yaml
+++ b/tests/helm/testdata/goldenfile/events_otc_statefulset/proxy.output.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: '%CONFIG_CHECKSUM%'
+        checksum/config: "%CONFIG_CHECKSUM%"
       labels:
         app: RELEASE-NAME-sumologic-otelcol-events
         sumologic.com/scrape: "true"
@@ -36,107 +36,105 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - RELEASE-NAME-sumologic-otelcol-logs
-                  - RELEASE-NAME-sumologic-otelcol-metrics
-                  - RELEASE-NAME-sumologic-otelcol-events
-                  - RELEASE-NAME-sumologic-otelcol-instrumentation
-                - key: app
-                  operator: In
-                  values:
-                  - prometheus-operator-prometheus
-              topologyKey: "kubernetes.io/hostname"
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - RELEASE-NAME-sumologic-otelcol-logs
+                        - RELEASE-NAME-sumologic-otelcol-metrics
+                        - RELEASE-NAME-sumologic-otelcol-events
+                        - RELEASE-NAME-sumologic-otelcol-instrumentation
+                    - key: app
+                      operator: In
+                      values:
+                        - prometheus-operator-prometheus
+                topologyKey: "kubernetes.io/hostname"
       volumes:
-      - name: config-volume
-        configMap:
-          name: RELEASE-NAME-sumologic-otelcol-events
+        - name: config-volume
+          configMap:
+            name: RELEASE-NAME-sumologic-otelcol-events
       securityContext:
         fsGroup: 999
       containers:
-      - name: otelcol
-        image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
-        imagePullPolicy: IfNotPresent
-        args:
-          - --config=/etc/otel/config.yaml
-        resources:
-          limits:
-            cpu: 2000m
-            memory: 2Gi
-          requests:
-            cpu: 200m
-            memory: 500Mi
-        ports:
-        - name: metrics
-          containerPort: 8888
-          protocol: TCP
-        - name: pprof
-          containerPort: 1777
-          protocol: TCP
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 3
-          initialDelaySeconds: 15
-          periodSeconds: 15
-          timeoutSeconds: 10
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 3
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          timeoutSeconds: 3
-        startupProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 60
-          periodSeconds: 3
-        volumeMounts:
-        - name: config-volume
-          mountPath: /etc/otel/config.yaml
-          subPath: config.yaml
-        - name: file-storage
-          mountPath: /var/lib/storage/events
-        env:
-        - name: SUMO_ENDPOINT_DEFAULT_OTLP_EVENTS_SOURCE
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-events-otlp
-        
-        
-        - name: HTTP_PROXY
-          value: http://proxy.internal
-        - name: HTTPS_PROXY
-          value: https://proxy.internal
-        - name: NO_PROXY
-          value: http://non-proxy.internal
-        - name: MY_POD_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: MY_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-  volumeClaimTemplates:
-  - metadata:
-      name: file-storage
-    spec:
-      accessModes: [ReadWriteOnce]
-      storageClassName: 
-      resources:
-        requests:
-          storage: 10Gi
+        - name: otelcol
+          image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config=/etc/otel/config.yaml
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 200m
+              memory: 500Mi
+          ports:
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+            - name: pprof
+              containerPort: 1777
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 3
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 60
+            periodSeconds: 3
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/otel/config.yaml
+              subPath: config.yaml
+            - name: file-storage
+              mountPath: /var/lib/storage/events
+          env:
+            - name: SUMO_ENDPOINT_DEFAULT_OTLP_EVENTS_SOURCE
+              valueFrom:
+                secretKeyRef:
+                  name: sumologic
+                  key: endpoint-events-otlp
 
+            - name: HTTP_PROXY
+              value: http://proxy.internal
+            - name: HTTPS_PROXY
+              value: https://proxy.internal
+            - name: NO_PROXY
+              value: http://non-proxy.internal
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+  volumeClaimTemplates:
+    - metadata:
+        name: file-storage
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName:
+        resources:
+          requests:
+            storage: 10Gi

--- a/tests/helm/testdata/goldenfile/logs_otc_cloudwatch/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_cloudwatch/basic.output.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: '%CONFIG_CHECKSUM%'
+        checksum/config: "%CONFIG_CHECKSUM%"
       labels:
         app: RELEASE-NAME-sumologic-otelcloudwatch-logs-collector
         chart: "sumologic-%CURRENT_CHART_VERSION%"
@@ -27,80 +27,79 @@ spec:
     spec:
       serviceAccountName: RELEASE-NAME-sumologic-otelcol-logs-collector
       volumes:
-      - configMap:
-          defaultMode: 420
-          items:
-          - key: config.yaml
-            path: config.yaml
-          name: RELEASE-NAME-sumologic-otelcol-cloudwatch-collector
-        name: otelcol-config
-      - name: file-storage
-        persistentVolumeClaim:
-          claimName: file-storage-RELEASE-NAME-sumologic-otelcol-logs-0
+        - configMap:
+            defaultMode: 420
+            items:
+              - key: config.yaml
+                path: config.yaml
+            name: RELEASE-NAME-sumologic-otelcol-cloudwatch-collector
+          name: otelcol-config
+        - name: file-storage
+          persistentVolumeClaim:
+            claimName: file-storage-RELEASE-NAME-sumologic-otelcol-logs-0
       securityContext:
         fsGroup: 999
       containers:
-      - name: otelcol
-        image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
-        imagePullPolicy: IfNotPresent
-        args:
-          - --config=/etc/otelcol/config.yaml
-        resources:
-          limits:
-            cpu: 1000m
-            memory: 1Gi
-          requests:
-            cpu: 500m
-            memory: 768Mi
-        ports:
-        - name: metrics
-          containerPort: 8888
-          protocol: TCP
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 3
-          initialDelaySeconds: 15
-          periodSeconds: 15
-          timeoutSeconds: 10
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 3
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          timeoutSeconds: 3
-        startupProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 60
-          periodSeconds: 3
-        volumeMounts:
-        - mountPath: /etc/otelcol
-          name: otelcol-config
-        - mountPath: /var/lib/storage/otc
-          name: file-storage
-        env:
-        - name: LOGS_METADATA_SVC
-          valueFrom:
-            configMapKeyRef:
-              name: sumologic-configmap
-              key: metadataLogs
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: MY_POD_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: MY_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-
+        - name: otelcol
+          image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config=/etc/otelcol/config.yaml
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+            requests:
+              cpu: 500m
+              memory: 768Mi
+          ports:
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 3
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 60
+            periodSeconds: 3
+          volumeMounts:
+            - mountPath: /etc/otelcol
+              name: otelcol-config
+            - mountPath: /var/lib/storage/otc
+              name: file-storage
+          env:
+            - name: LOGS_METADATA_SVC
+              valueFrom:
+                configMapKeyRef:
+                  name: sumologic-configmap
+                  key: metadataLogs
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name

--- a/tests/helm/testdata/goldenfile/logs_otc_cloudwatch/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_cloudwatch/basic.output.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: "%CONFIG_CHECKSUM%"
+        checksum/config: '%CONFIG_CHECKSUM%'
       labels:
         app: RELEASE-NAME-sumologic-otelcloudwatch-logs-collector
         chart: "sumologic-%CURRENT_CHART_VERSION%"
@@ -27,74 +27,80 @@ spec:
     spec:
       serviceAccountName: RELEASE-NAME-sumologic-otelcol-logs-collector
       volumes:
-        - configMap:
-            defaultMode: 420
-            items:
-              - key: config.yaml
-                path: config.yaml
-            name: RELEASE-NAME-sumologic-otelcol-cloudwatch-collector
-          name: otelcol-config
-        - name: file-storage
-          persistentVolumeClaim:
-            claimName: file-storage-RELEASE-NAME-sumologic-otelcol-logs-0
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: config.yaml
+            path: config.yaml
+          name: RELEASE-NAME-sumologic-otelcol-cloudwatch-collector
+        name: otelcol-config
+      - name: file-storage
+        persistentVolumeClaim:
+          claimName: file-storage-RELEASE-NAME-sumologic-otelcol-logs-0
       securityContext:
         fsGroup: 999
       containers:
-        - name: otelcol
-          image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
-          imagePullPolicy: IfNotPresent
-          args:
-            - --config=/etc/otelcol/config.yaml
-          resources:
-            limits:
-              cpu: 1000m
-              memory: 1Gi
-            requests:
-              cpu: 500m
-              memory: 768Mi
-          ports:
-            - name: metrics
-              containerPort: 8888
-              protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 3
-            initialDelaySeconds: 15
-            periodSeconds: 15
-            timeoutSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 3
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 3
-          startupProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 60
-            periodSeconds: 3
-          volumeMounts:
-            - mountPath: /etc/otelcol
-              name: otelcol-config
-            - mountPath: /var/lib/storage/otc
-              name: file-storage
-          env:
-            - name: LOGS_METADATA_SVC
-              valueFrom:
-                configMapKeyRef:
-                  name: sumologic-configmap
-                  key: metadataLogs
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP
+      - name: otelcol
+        image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
+        imagePullPolicy: IfNotPresent
+        args:
+          - --config=/etc/otelcol/config.yaml
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 1Gi
+          requests:
+            cpu: 500m
+            memory: 768Mi
+        ports:
+        - name: metrics
+          containerPort: 8888
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 3
+        startupProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 60
+          periodSeconds: 3
+        volumeMounts:
+        - mountPath: /etc/otelcol
+          name: otelcol-config
+        - mountPath: /var/lib/storage/otc
+          name: file-storage
+        env:
+        - name: LOGS_METADATA_SVC
+          valueFrom:
+            configMapKeyRef:
+              name: sumologic-configmap
+              key: metadataLogs
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+

--- a/tests/helm/testdata/goldenfile/logs_otc_cloudwatch/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_cloudwatch/custom.output.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: '%CONFIG_CHECKSUM%'
+        checksum/config: "%CONFIG_CHECKSUM%"
       labels:
         app: RELEASE-NAME-sumologic-otelcloudwatch-logs-collector
         chart: "sumologic-%CURRENT_CHART_VERSION%"
@@ -27,75 +27,74 @@ spec:
     spec:
       serviceAccountName: RELEASE-NAME-sumologic-otelcol-logs-collector
       volumes:
-      - configMap:
-          defaultMode: 420
-          items:
-          - key: config.yaml
-            path: config.yaml
-          name: RELEASE-NAME-sumologic-otelcol-cloudwatch-collector
-        name: otelcol-config
+        - configMap:
+            defaultMode: 420
+            items:
+              - key: config.yaml
+                path: config.yaml
+            name: RELEASE-NAME-sumologic-otelcol-cloudwatch-collector
+          name: otelcol-config
       securityContext:
         fsGroup: 999
       containers:
-      - name: otelcol
-        image: "my_repository:my_tag"
-        imagePullPolicy: IfNotPresent
-        args:
-          - --config=/etc/otelcol/config.yaml
-        resources:
-          limits:
-            cpu: 1000m
-            memory: 1Gi
-          requests:
-            cpu: 500m
-            memory: 768Mi
-        ports:
-        - name: metrics
-          containerPort: 8888
-          protocol: TCP
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 3
-          initialDelaySeconds: 15
-          periodSeconds: 15
-          timeoutSeconds: 10
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 3
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          timeoutSeconds: 3
-        startupProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 60
-          periodSeconds: 3
-        volumeMounts:
-        - mountPath: /etc/otelcol
-          name: otelcol-config
-        env:
-        - name: LOGS_METADATA_SVC
-          valueFrom:
-            configMapKeyRef:
-              name: sumologic-configmap
-              key: metadataLogs
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: MY_POD_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: MY_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-
+        - name: otelcol
+          image: "my_repository:my_tag"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config=/etc/otelcol/config.yaml
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+            requests:
+              cpu: 500m
+              memory: 768Mi
+          ports:
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 3
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 60
+            periodSeconds: 3
+          volumeMounts:
+            - mountPath: /etc/otelcol
+              name: otelcol-config
+          env:
+            - name: LOGS_METADATA_SVC
+              valueFrom:
+                configMapKeyRef:
+                  name: sumologic-configmap
+                  key: metadataLogs
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name

--- a/tests/helm/testdata/goldenfile/logs_otc_cloudwatch/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_cloudwatch/custom.output.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: "%CONFIG_CHECKSUM%"
+        checksum/config: '%CONFIG_CHECKSUM%'
       labels:
         app: RELEASE-NAME-sumologic-otelcloudwatch-logs-collector
         chart: "sumologic-%CURRENT_CHART_VERSION%"
@@ -27,69 +27,75 @@ spec:
     spec:
       serviceAccountName: RELEASE-NAME-sumologic-otelcol-logs-collector
       volumes:
-        - configMap:
-            defaultMode: 420
-            items:
-              - key: config.yaml
-                path: config.yaml
-            name: RELEASE-NAME-sumologic-otelcol-cloudwatch-collector
-          name: otelcol-config
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: config.yaml
+            path: config.yaml
+          name: RELEASE-NAME-sumologic-otelcol-cloudwatch-collector
+        name: otelcol-config
       securityContext:
         fsGroup: 999
       containers:
-        - name: otelcol
-          image: "my_repository:my_tag"
-          imagePullPolicy: IfNotPresent
-          args:
-            - --config=/etc/otelcol/config.yaml
-          resources:
-            limits:
-              cpu: 1000m
-              memory: 1Gi
-            requests:
-              cpu: 500m
-              memory: 768Mi
-          ports:
-            - name: metrics
-              containerPort: 8888
-              protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 3
-            initialDelaySeconds: 15
-            periodSeconds: 15
-            timeoutSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 3
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 3
-          startupProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 60
-            periodSeconds: 3
-          volumeMounts:
-            - mountPath: /etc/otelcol
-              name: otelcol-config
-          env:
-            - name: LOGS_METADATA_SVC
-              valueFrom:
-                configMapKeyRef:
-                  name: sumologic-configmap
-                  key: metadataLogs
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP
+      - name: otelcol
+        image: "my_repository:my_tag"
+        imagePullPolicy: IfNotPresent
+        args:
+          - --config=/etc/otelcol/config.yaml
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 1Gi
+          requests:
+            cpu: 500m
+            memory: 768Mi
+        ports:
+        - name: metrics
+          containerPort: 8888
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 3
+        startupProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 60
+          periodSeconds: 3
+        volumeMounts:
+        - mountPath: /etc/otelcol
+          name: otelcol-config
+        env:
+        - name: LOGS_METADATA_SVC
+          valueFrom:
+            configMapKeyRef:
+              name: sumologic-configmap
+              key: metadataLogs
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+

--- a/tests/helm/testdata/goldenfile/logs_otc_daemonset/additional-complex.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_daemonset/additional-complex.output.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: '%CONFIG_CHECKSUM%'
+        checksum/config: "%CONFIG_CHECKSUM%"
         name: additionalPodAnnotation
       labels:
         app.kubernetes.io/name: RELEASE-NAME-sumologic-otelcol-logs-collector-linux
@@ -36,11 +36,11 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/os
-                operator: NotIn
-                values:
-                - windows
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: NotIn
+                    values:
+                      - windows
       tolerations:
         - effect: NoSchedule
           key: worker
@@ -52,130 +52,129 @@ spec:
         runAsUser: 0
       priorityClassName: "prio"
       containers:
-      - args:
-        - --config=/etc/otelcol/config.yaml
-        image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
-        imagePullPolicy: IfNotPresent
-        name: otelcol
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-        resources:
-          limits:
-            cpu: 6
-            memory: 1Gi
-          requests:
-            cpu: 2
-            memory: 32Mi
-        volumeMounts:
-        - mountPath: /etc/otelcol
-          name: otelcol-config
-        - mountPath: /var/log/pods
-          name: varlogpods
-          readOnly: true
-        - mountPath: /var/lib/docker/containers
-          name: varlibdockercontainers
-          readOnly: true
-        - mountPath: /var/lib/storage/otc
-          name: file-storage
-        - mountPath: /var/log/journal
-          name: varlogjournal
-          readOnly: true
-        - mountPath: /certs
-          name: es-certs
-          readOnly: true
-        env:
-        - name: LOGS_METADATA_SVC
-          valueFrom:
-            configMapKeyRef:
-              name: sumologic-configmap
-              key: metadataLogs
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: MY_POD_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: MY_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
+        - args:
+            - --config=/etc/otelcol/config.yaml
+          image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
+          imagePullPolicy: IfNotPresent
+          name: otelcol
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+          resources:
+            limits:
+              cpu: 6
+              memory: 1Gi
+            requests:
+              cpu: 2
+              memory: 32Mi
+          volumeMounts:
+            - mountPath: /etc/otelcol
+              name: otelcol-config
+            - mountPath: /var/log/pods
+              name: varlogpods
+              readOnly: true
+            - mountPath: /var/lib/docker/containers
+              name: varlibdockercontainers
+              readOnly: true
+            - mountPath: /var/lib/storage/otc
+              name: file-storage
+            - mountPath: /var/log/journal
+              name: varlogjournal
+              readOnly: true
+            - mountPath: /certs
+              name: es-certs
+              readOnly: true
+          env:
+            - name: LOGS_METADATA_SVC
+              valueFrom:
+                configMapKeyRef:
+                  name: sumologic-configmap
+                  key: metadataLogs
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
 
-        - name: VALUE_FROM_SECRET
-          valueFrom:
-            secretKeyRef:
-              key: secret_key
-              name: secret_name
-        securityContext:
-          capabilities:
-            drop:
-            - ALL
-          privileged: true
-        ports:
-        - name: pprof
-          containerPort: 1777
-          protocol: TCP
-        - name: metrics
-          containerPort: 8888
-          protocol: TCP
+            - name: VALUE_FROM_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: secret_key
+                  name: secret_name
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            privileged: true
+          ports:
+            - name: pprof
+              containerPort: 1777
+              protocol: TCP
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
       initContainers: # ensure the host path is owned by the otel user group
-      - name: changeowner
-        # yamllint disable-line rule:line-length
-        image: public.ecr.aws/sumologic/busybox:1.36.0
-        imagePullPolicy: IfNotPresent
-        securityContext:
-          capabilities:
-            add:
-            - CAP_CHOWN
-            drop:
-            - ALL
-          privileged: true
-        command:
-        - "sh"
-        - "-c"
-        - |
-          chown -R \
-            0:0 \
-            /var/lib/storage/otc
-        volumeMounts:
-        - mountPath: /var/lib/storage/otc
-          name: file-storage
+        - name: changeowner
+          # yamllint disable-line rule:line-length
+          image: public.ecr.aws/sumologic/busybox:1.36.0
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            capabilities:
+              add:
+                - CAP_CHOWN
+              drop:
+                - ALL
+            privileged: true
+          command:
+            - "sh"
+            - "-c"
+            - |
+              chown -R \
+                0:0 \
+                /var/lib/storage/otc
+          volumeMounts:
+            - mountPath: /var/lib/storage/otc
+              name: file-storage
       volumes:
-      - configMap:
-          defaultMode: 420
-          items:
-          - key: config.yaml
-            path: config.yaml
-          name: RELEASE-NAME-sumologic-otelcol-logs-collector
-        name: otelcol-config
-      - hostPath:
-          path: /var/log/pods
-          type: ""
-        name: varlogpods
-      - hostPath:
-          path: /var/lib/docker/containers
-          type: ""
-        name: varlibdockercontainers
-      - hostPath:
-          path: /var/lib/otc
-          type: DirectoryOrCreate
-        name: file-storage
-      - hostPath:
-          path: /var/log/journal/
-          type: ""
-        name: varlogjournal
-      - name: es-certs
-        secret:
-          defaultMode: 420
-          secretName: es-certs
+        - configMap:
+            defaultMode: 420
+            items:
+              - key: config.yaml
+                path: config.yaml
+            name: RELEASE-NAME-sumologic-otelcol-logs-collector
+          name: otelcol-config
+        - hostPath:
+            path: /var/log/pods
+            type: ""
+          name: varlogpods
+        - hostPath:
+            path: /var/lib/docker/containers
+            type: ""
+          name: varlibdockercontainers
+        - hostPath:
+            path: /var/lib/otc
+            type: DirectoryOrCreate
+          name: file-storage
+        - hostPath:
+            path: /var/log/journal/
+            type: ""
+          name: varlogjournal
+        - name: es-certs
+          secret:
+            defaultMode: 420
+            secretName: es-certs
       serviceAccountName: RELEASE-NAME-sumologic-otelcol-logs-collector
-

--- a/tests/helm/testdata/goldenfile/logs_otc_daemonset/additional-complex.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_daemonset/additional-complex.output.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: "%CONFIG_CHECKSUM%"
+        checksum/config: '%CONFIG_CHECKSUM%'
         name: additionalPodAnnotation
       labels:
         app.kubernetes.io/name: RELEASE-NAME-sumologic-otelcol-logs-collector-linux
@@ -36,11 +36,11 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-              - matchExpressions:
-                  - key: kubernetes.io/os
-                    operator: NotIn
-                    values:
-                      - windows
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: NotIn
+                values:
+                - windows
       tolerations:
         - effect: NoSchedule
           key: worker
@@ -52,124 +52,130 @@ spec:
         runAsUser: 0
       priorityClassName: "prio"
       containers:
-        - args:
-            - --config=/etc/otelcol/config.yaml
-          image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
-          imagePullPolicy: IfNotPresent
-          name: otelcol
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-          resources:
-            limits:
-              cpu: 6
-              memory: 1Gi
-            requests:
-              cpu: 2
-              memory: 32Mi
-          volumeMounts:
-            - mountPath: /etc/otelcol
-              name: otelcol-config
-            - mountPath: /var/log/pods
-              name: varlogpods
-              readOnly: true
-            - mountPath: /var/lib/docker/containers
-              name: varlibdockercontainers
-              readOnly: true
-            - mountPath: /var/lib/storage/otc
-              name: file-storage
-            - mountPath: /var/log/journal
-              name: varlogjournal
-              readOnly: true
-            - mountPath: /certs
-              name: es-certs
-              readOnly: true
-          env:
-            - name: LOGS_METADATA_SVC
-              valueFrom:
-                configMapKeyRef:
-                  name: sumologic-configmap
-                  key: metadataLogs
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP
-
-            - name: VALUE_FROM_SECRET
-              valueFrom:
-                secretKeyRef:
-                  key: secret_key
-                  name: secret_name
-          securityContext:
-            capabilities:
-              drop:
-                - ALL
-            privileged: true
-          ports:
-            - name: pprof
-              containerPort: 1777
-              protocol: TCP
-            - name: metrics
-              containerPort: 8888
-              protocol: TCP
-      initContainers: # ensure the host path is owned by the otel user group
-        - name: changeowner
-          # yamllint disable-line rule:line-length
-          image: public.ecr.aws/sumologic/busybox:1.36.0
-          imagePullPolicy: IfNotPresent
-          securityContext:
-            capabilities:
-              add:
-                - CAP_CHOWN
-              drop:
-                - ALL
-            privileged: true
-          command:
-            - "sh"
-            - "-c"
-            - |
-              chown -R \
-                0:0 \
-                /var/lib/storage/otc
-          volumeMounts:
-            - mountPath: /var/lib/storage/otc
-              name: file-storage
-      volumes:
-        - configMap:
-            defaultMode: 420
-            items:
-              - key: config.yaml
-                path: config.yaml
-            name: RELEASE-NAME-sumologic-otelcol-logs-collector
+      - args:
+        - --config=/etc/otelcol/config.yaml
+        image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
+        imagePullPolicy: IfNotPresent
+        name: otelcol
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+        resources:
+          limits:
+            cpu: 6
+            memory: 1Gi
+          requests:
+            cpu: 2
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/otelcol
           name: otelcol-config
-        - hostPath:
-            path: /var/log/pods
-            type: ""
+        - mountPath: /var/log/pods
           name: varlogpods
-        - hostPath:
-            path: /var/lib/docker/containers
-            type: ""
+          readOnly: true
+        - mountPath: /var/lib/docker/containers
           name: varlibdockercontainers
-        - hostPath:
-            path: /var/lib/otc
-            type: DirectoryOrCreate
+          readOnly: true
+        - mountPath: /var/lib/storage/otc
           name: file-storage
-        - hostPath:
-            path: /var/log/journal/
-            type: ""
+        - mountPath: /var/log/journal
           name: varlogjournal
-        - name: es-certs
-          secret:
-            defaultMode: 420
-            secretName: es-certs
+          readOnly: true
+        - mountPath: /certs
+          name: es-certs
+          readOnly: true
+        env:
+        - name: LOGS_METADATA_SVC
+          valueFrom:
+            configMapKeyRef:
+              name: sumologic-configmap
+              key: metadataLogs
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+
+        - name: VALUE_FROM_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: secret_key
+              name: secret_name
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+          privileged: true
+        ports:
+        - name: pprof
+          containerPort: 1777
+          protocol: TCP
+        - name: metrics
+          containerPort: 8888
+          protocol: TCP
+      initContainers: # ensure the host path is owned by the otel user group
+      - name: changeowner
+        # yamllint disable-line rule:line-length
+        image: public.ecr.aws/sumologic/busybox:1.36.0
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          capabilities:
+            add:
+            - CAP_CHOWN
+            drop:
+            - ALL
+          privileged: true
+        command:
+        - "sh"
+        - "-c"
+        - |
+          chown -R \
+            0:0 \
+            /var/lib/storage/otc
+        volumeMounts:
+        - mountPath: /var/lib/storage/otc
+          name: file-storage
+      volumes:
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: config.yaml
+            path: config.yaml
+          name: RELEASE-NAME-sumologic-otelcol-logs-collector
+        name: otelcol-config
+      - hostPath:
+          path: /var/log/pods
+          type: ""
+        name: varlogpods
+      - hostPath:
+          path: /var/lib/docker/containers
+          type: ""
+        name: varlibdockercontainers
+      - hostPath:
+          path: /var/lib/otc
+          type: DirectoryOrCreate
+        name: file-storage
+      - hostPath:
+          path: /var/log/journal/
+          type: ""
+        name: varlogjournal
+      - name: es-certs
+        secret:
+          defaultMode: 420
+          secretName: es-certs
       serviceAccountName: RELEASE-NAME-sumologic-otelcol-logs-collector
+

--- a/tests/helm/testdata/goldenfile/logs_otc_daemonset/additional.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_daemonset/additional.output.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: '%CONFIG_CHECKSUM%'
+        checksum/config: "%CONFIG_CHECKSUM%"
       labels:
         app.kubernetes.io/name: RELEASE-NAME-sumologic-otelcol-logs-collector-linux
         app.kubernetes.io/app-name: RELEASE-NAME-sumologic-otelcol-logs-collector
@@ -31,11 +31,11 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/os
-                operator: NotIn
-                values:
-                - windows
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: NotIn
+                    values:
+                      - windows
       tolerations:
         - effect: NoSchedule
           operator: Exists
@@ -45,115 +45,114 @@ spec:
         runAsUser: 0
       priorityClassName: "RELEASE-NAME-sumologic-priorityclass"
       containers:
-      - args:
-        - --config=/etc/otelcol/config.yaml
-        image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
-        imagePullPolicy: IfNotPresent
-        name: otelcol
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-        resources:
-          limits:
-            cpu: 6
-            memory: 1Gi
-          requests:
-            cpu: 2
-            memory: 32Mi
-        volumeMounts:
-        - mountPath: /etc/otelcol
-          name: otelcol-config
-        - mountPath: /var/log/pods
-          name: varlogpods
-          readOnly: true
-        - mountPath: /var/lib/docker/containers
-          name: varlibdockercontainers
-          readOnly: true
-        - mountPath: /var/lib/storage/otc
-          name: file-storage
-        - mountPath: /var/log/journal
-          name: varlogjournal
-          readOnly: true
-        env:
-        - name: LOGS_METADATA_SVC
-          valueFrom:
-            configMapKeyRef:
-              name: sumologic-configmap
-              key: metadataLogs
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: MY_POD_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: MY_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        securityContext:
-          capabilities:
-            drop:
-            - ALL
-        ports:
-        - name: pprof
-          containerPort: 1777
-          protocol: TCP
-        - name: metrics
-          containerPort: 8888
-          protocol: TCP
+        - args:
+            - --config=/etc/otelcol/config.yaml
+          image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
+          imagePullPolicy: IfNotPresent
+          name: otelcol
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+          resources:
+            limits:
+              cpu: 6
+              memory: 1Gi
+            requests:
+              cpu: 2
+              memory: 32Mi
+          volumeMounts:
+            - mountPath: /etc/otelcol
+              name: otelcol-config
+            - mountPath: /var/log/pods
+              name: varlogpods
+              readOnly: true
+            - mountPath: /var/lib/docker/containers
+              name: varlibdockercontainers
+              readOnly: true
+            - mountPath: /var/lib/storage/otc
+              name: file-storage
+            - mountPath: /var/log/journal
+              name: varlogjournal
+              readOnly: true
+          env:
+            - name: LOGS_METADATA_SVC
+              valueFrom:
+                configMapKeyRef:
+                  name: sumologic-configmap
+                  key: metadataLogs
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - name: pprof
+              containerPort: 1777
+              protocol: TCP
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
       initContainers: # ensure the host path is owned by the otel user group
-      - name: changeowner
-        # yamllint disable-line rule:line-length
-        image: public.ecr.aws/sumologic/busybox:1.36.0
-        imagePullPolicy: IfNotPresent
-        securityContext:
-          capabilities:
-            add:
-            - CAP_CHOWN
-            drop:
-            - ALL
-        command:
-        - "sh"
-        - "-c"
-        - |
-          chown -R \
-            0:0 \
-            /var/lib/storage/otc
-        volumeMounts:
-        - mountPath: /var/lib/storage/otc
-          name: file-storage
+        - name: changeowner
+          # yamllint disable-line rule:line-length
+          image: public.ecr.aws/sumologic/busybox:1.36.0
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            capabilities:
+              add:
+                - CAP_CHOWN
+              drop:
+                - ALL
+          command:
+            - "sh"
+            - "-c"
+            - |
+              chown -R \
+                0:0 \
+                /var/lib/storage/otc
+          volumeMounts:
+            - mountPath: /var/lib/storage/otc
+              name: file-storage
       volumes:
-      - configMap:
-          defaultMode: 420
-          items:
-          - key: config.yaml
-            path: config.yaml
-          name: RELEASE-NAME-sumologic-otelcol-logs-collector
-        name: otelcol-config
-      - hostPath:
-          path: /var/log/pods
-          type: ""
-        name: varlogpods
-      - hostPath:
-          path: /var/lib/docker/containers
-          type: ""
-        name: varlibdockercontainers
-      - hostPath:
-          path: /var/lib/otc
-          type: DirectoryOrCreate
-        name: file-storage
-      - hostPath:
-          path: /var/log/journal/
-          type: ""
-        name: varlogjournal
+        - configMap:
+            defaultMode: 420
+            items:
+              - key: config.yaml
+                path: config.yaml
+            name: RELEASE-NAME-sumologic-otelcol-logs-collector
+          name: otelcol-config
+        - hostPath:
+            path: /var/log/pods
+            type: ""
+          name: varlogpods
+        - hostPath:
+            path: /var/lib/docker/containers
+            type: ""
+          name: varlibdockercontainers
+        - hostPath:
+            path: /var/lib/otc
+            type: DirectoryOrCreate
+          name: file-storage
+        - hostPath:
+            path: /var/log/journal/
+            type: ""
+          name: varlogjournal
       serviceAccountName: RELEASE-NAME-sumologic-otelcol-logs-collector
-

--- a/tests/helm/testdata/goldenfile/logs_otc_daemonset/additional.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_daemonset/additional.output.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: "%CONFIG_CHECKSUM%"
+        checksum/config: '%CONFIG_CHECKSUM%'
       labels:
         app.kubernetes.io/name: RELEASE-NAME-sumologic-otelcol-logs-collector-linux
         app.kubernetes.io/app-name: RELEASE-NAME-sumologic-otelcol-logs-collector
@@ -31,11 +31,11 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-              - matchExpressions:
-                  - key: kubernetes.io/os
-                    operator: NotIn
-                    values:
-                      - windows
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: NotIn
+                values:
+                - windows
       tolerations:
         - effect: NoSchedule
           operator: Exists
@@ -45,109 +45,115 @@ spec:
         runAsUser: 0
       priorityClassName: "RELEASE-NAME-sumologic-priorityclass"
       containers:
-        - args:
-            - --config=/etc/otelcol/config.yaml
-          image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
-          imagePullPolicy: IfNotPresent
-          name: otelcol
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-          resources:
-            limits:
-              cpu: 6
-              memory: 1Gi
-            requests:
-              cpu: 2
-              memory: 32Mi
-          volumeMounts:
-            - mountPath: /etc/otelcol
-              name: otelcol-config
-            - mountPath: /var/log/pods
-              name: varlogpods
-              readOnly: true
-            - mountPath: /var/lib/docker/containers
-              name: varlibdockercontainers
-              readOnly: true
-            - mountPath: /var/lib/storage/otc
-              name: file-storage
-            - mountPath: /var/log/journal
-              name: varlogjournal
-              readOnly: true
-          env:
-            - name: LOGS_METADATA_SVC
-              valueFrom:
-                configMapKeyRef:
-                  name: sumologic-configmap
-                  key: metadataLogs
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP
-          securityContext:
-            capabilities:
-              drop:
-                - ALL
-          ports:
-            - name: pprof
-              containerPort: 1777
-              protocol: TCP
-            - name: metrics
-              containerPort: 8888
-              protocol: TCP
-      initContainers: # ensure the host path is owned by the otel user group
-        - name: changeowner
-          # yamllint disable-line rule:line-length
-          image: public.ecr.aws/sumologic/busybox:1.36.0
-          imagePullPolicy: IfNotPresent
-          securityContext:
-            capabilities:
-              add:
-                - CAP_CHOWN
-              drop:
-                - ALL
-          command:
-            - "sh"
-            - "-c"
-            - |
-              chown -R \
-                0:0 \
-                /var/lib/storage/otc
-          volumeMounts:
-            - mountPath: /var/lib/storage/otc
-              name: file-storage
-      volumes:
-        - configMap:
-            defaultMode: 420
-            items:
-              - key: config.yaml
-                path: config.yaml
-            name: RELEASE-NAME-sumologic-otelcol-logs-collector
+      - args:
+        - --config=/etc/otelcol/config.yaml
+        image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
+        imagePullPolicy: IfNotPresent
+        name: otelcol
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+        resources:
+          limits:
+            cpu: 6
+            memory: 1Gi
+          requests:
+            cpu: 2
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/otelcol
           name: otelcol-config
-        - hostPath:
-            path: /var/log/pods
-            type: ""
+        - mountPath: /var/log/pods
           name: varlogpods
-        - hostPath:
-            path: /var/lib/docker/containers
-            type: ""
+          readOnly: true
+        - mountPath: /var/lib/docker/containers
           name: varlibdockercontainers
-        - hostPath:
-            path: /var/lib/otc
-            type: DirectoryOrCreate
+          readOnly: true
+        - mountPath: /var/lib/storage/otc
           name: file-storage
-        - hostPath:
-            path: /var/log/journal/
-            type: ""
+        - mountPath: /var/log/journal
           name: varlogjournal
+          readOnly: true
+        env:
+        - name: LOGS_METADATA_SVC
+          valueFrom:
+            configMapKeyRef:
+              name: sumologic-configmap
+              key: metadataLogs
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+        ports:
+        - name: pprof
+          containerPort: 1777
+          protocol: TCP
+        - name: metrics
+          containerPort: 8888
+          protocol: TCP
+      initContainers: # ensure the host path is owned by the otel user group
+      - name: changeowner
+        # yamllint disable-line rule:line-length
+        image: public.ecr.aws/sumologic/busybox:1.36.0
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          capabilities:
+            add:
+            - CAP_CHOWN
+            drop:
+            - ALL
+        command:
+        - "sh"
+        - "-c"
+        - |
+          chown -R \
+            0:0 \
+            /var/lib/storage/otc
+        volumeMounts:
+        - mountPath: /var/lib/storage/otc
+          name: file-storage
+      volumes:
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: config.yaml
+            path: config.yaml
+          name: RELEASE-NAME-sumologic-otelcol-logs-collector
+        name: otelcol-config
+      - hostPath:
+          path: /var/log/pods
+          type: ""
+        name: varlogpods
+      - hostPath:
+          path: /var/lib/docker/containers
+          type: ""
+        name: varlibdockercontainers
+      - hostPath:
+          path: /var/lib/otc
+          type: DirectoryOrCreate
+        name: file-storage
+      - hostPath:
+          path: /var/log/journal/
+          type: ""
+        name: varlogjournal
       serviceAccountName: RELEASE-NAME-sumologic-otelcol-logs-collector
+

--- a/tests/helm/testdata/goldenfile/logs_otc_daemonset/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_daemonset/basic.output.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: "%CONFIG_CHECKSUM%"
+        checksum/config: '%CONFIG_CHECKSUM%'
       labels:
         app.kubernetes.io/name: RELEASE-NAME-sumologic-otelcol-logs-collector
         app.kubernetes.io/app-name: RELEASE-NAME-sumologic-otelcol-logs-collector
@@ -36,109 +36,115 @@ spec:
         runAsUser: 0
       priorityClassName: "RELEASE-NAME-sumologic-priorityclass"
       containers:
-        - args:
-            - --config=/etc/otelcol/config.yaml
-          image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
-          imagePullPolicy: IfNotPresent
-          name: otelcol
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-          resources:
-            limits:
-              cpu: 1000m
-              memory: 1Gi
-            requests:
-              cpu: 100m
-              memory: 32Mi
-          volumeMounts:
-            - mountPath: /etc/otelcol
-              name: otelcol-config
-            - mountPath: /var/log/pods
-              name: varlogpods
-              readOnly: true
-            - mountPath: /var/lib/docker/containers
-              name: varlibdockercontainers
-              readOnly: true
-            - mountPath: /var/lib/storage/otc
-              name: file-storage
-            - mountPath: /var/log/journal
-              name: varlogjournal
-              readOnly: true
-          env:
-            - name: LOGS_METADATA_SVC
-              valueFrom:
-                configMapKeyRef:
-                  name: sumologic-configmap
-                  key: metadataLogs
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP
-          securityContext:
-            capabilities:
-              drop:
-                - ALL
-          ports:
-            - name: pprof
-              containerPort: 1777
-              protocol: TCP
-            - name: metrics
-              containerPort: 8888
-              protocol: TCP
-      initContainers: # ensure the host path is owned by the otel user group
-        - name: changeowner
-          # yamllint disable-line rule:line-length
-          image: public.ecr.aws/sumologic/busybox:1.36.0
-          imagePullPolicy: IfNotPresent
-          securityContext:
-            capabilities:
-              add:
-                - CAP_CHOWN
-              drop:
-                - ALL
-          command:
-            - "sh"
-            - "-c"
-            - |
-              chown -R \
-                0:0 \
-                /var/lib/storage/otc
-          volumeMounts:
-            - mountPath: /var/lib/storage/otc
-              name: file-storage
-      volumes:
-        - configMap:
-            defaultMode: 420
-            items:
-              - key: config.yaml
-                path: config.yaml
-            name: RELEASE-NAME-sumologic-otelcol-logs-collector
+      - args:
+        - --config=/etc/otelcol/config.yaml
+        image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
+        imagePullPolicy: IfNotPresent
+        name: otelcol
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/otelcol
           name: otelcol-config
-        - hostPath:
-            path: /var/log/pods
-            type: ""
+        - mountPath: /var/log/pods
           name: varlogpods
-        - hostPath:
-            path: /var/lib/docker/containers
-            type: ""
+          readOnly: true
+        - mountPath: /var/lib/docker/containers
           name: varlibdockercontainers
-        - hostPath:
-            path: /var/lib/otc
-            type: DirectoryOrCreate
+          readOnly: true
+        - mountPath: /var/lib/storage/otc
           name: file-storage
-        - hostPath:
-            path: /var/log/journal/
-            type: ""
+        - mountPath: /var/log/journal
           name: varlogjournal
+          readOnly: true
+        env:
+        - name: LOGS_METADATA_SVC
+          valueFrom:
+            configMapKeyRef:
+              name: sumologic-configmap
+              key: metadataLogs
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+        ports:
+        - name: pprof
+          containerPort: 1777
+          protocol: TCP
+        - name: metrics
+          containerPort: 8888
+          protocol: TCP
+      initContainers: # ensure the host path is owned by the otel user group
+      - name: changeowner
+        # yamllint disable-line rule:line-length
+        image: public.ecr.aws/sumologic/busybox:1.36.0
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          capabilities:
+            add:
+            - CAP_CHOWN
+            drop:
+            - ALL
+        command:
+        - "sh"
+        - "-c"
+        - |
+          chown -R \
+            0:0 \
+            /var/lib/storage/otc
+        volumeMounts:
+        - mountPath: /var/lib/storage/otc
+          name: file-storage
+      volumes:
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: config.yaml
+            path: config.yaml
+          name: RELEASE-NAME-sumologic-otelcol-logs-collector
+        name: otelcol-config
+      - hostPath:
+          path: /var/log/pods
+          type: ""
+        name: varlogpods
+      - hostPath:
+          path: /var/lib/docker/containers
+          type: ""
+        name: varlibdockercontainers
+      - hostPath:
+          path: /var/lib/otc
+          type: DirectoryOrCreate
+        name: file-storage
+      - hostPath:
+          path: /var/log/journal/
+          type: ""
+        name: varlogjournal
       serviceAccountName: RELEASE-NAME-sumologic-otelcol-logs-collector
+

--- a/tests/helm/testdata/goldenfile/logs_otc_daemonset/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_daemonset/basic.output.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: '%CONFIG_CHECKSUM%'
+        checksum/config: "%CONFIG_CHECKSUM%"
       labels:
         app.kubernetes.io/name: RELEASE-NAME-sumologic-otelcol-logs-collector
         app.kubernetes.io/app-name: RELEASE-NAME-sumologic-otelcol-logs-collector
@@ -36,115 +36,114 @@ spec:
         runAsUser: 0
       priorityClassName: "RELEASE-NAME-sumologic-priorityclass"
       containers:
-      - args:
-        - --config=/etc/otelcol/config.yaml
-        image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
-        imagePullPolicy: IfNotPresent
-        name: otelcol
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-        resources:
-          limits:
-            cpu: 1000m
-            memory: 1Gi
-          requests:
-            cpu: 100m
-            memory: 32Mi
-        volumeMounts:
-        - mountPath: /etc/otelcol
-          name: otelcol-config
-        - mountPath: /var/log/pods
-          name: varlogpods
-          readOnly: true
-        - mountPath: /var/lib/docker/containers
-          name: varlibdockercontainers
-          readOnly: true
-        - mountPath: /var/lib/storage/otc
-          name: file-storage
-        - mountPath: /var/log/journal
-          name: varlogjournal
-          readOnly: true
-        env:
-        - name: LOGS_METADATA_SVC
-          valueFrom:
-            configMapKeyRef:
-              name: sumologic-configmap
-              key: metadataLogs
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: MY_POD_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: MY_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        securityContext:
-          capabilities:
-            drop:
-            - ALL
-        ports:
-        - name: pprof
-          containerPort: 1777
-          protocol: TCP
-        - name: metrics
-          containerPort: 8888
-          protocol: TCP
+        - args:
+            - --config=/etc/otelcol/config.yaml
+          image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
+          imagePullPolicy: IfNotPresent
+          name: otelcol
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+            requests:
+              cpu: 100m
+              memory: 32Mi
+          volumeMounts:
+            - mountPath: /etc/otelcol
+              name: otelcol-config
+            - mountPath: /var/log/pods
+              name: varlogpods
+              readOnly: true
+            - mountPath: /var/lib/docker/containers
+              name: varlibdockercontainers
+              readOnly: true
+            - mountPath: /var/lib/storage/otc
+              name: file-storage
+            - mountPath: /var/log/journal
+              name: varlogjournal
+              readOnly: true
+          env:
+            - name: LOGS_METADATA_SVC
+              valueFrom:
+                configMapKeyRef:
+                  name: sumologic-configmap
+                  key: metadataLogs
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - name: pprof
+              containerPort: 1777
+              protocol: TCP
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
       initContainers: # ensure the host path is owned by the otel user group
-      - name: changeowner
-        # yamllint disable-line rule:line-length
-        image: public.ecr.aws/sumologic/busybox:1.36.0
-        imagePullPolicy: IfNotPresent
-        securityContext:
-          capabilities:
-            add:
-            - CAP_CHOWN
-            drop:
-            - ALL
-        command:
-        - "sh"
-        - "-c"
-        - |
-          chown -R \
-            0:0 \
-            /var/lib/storage/otc
-        volumeMounts:
-        - mountPath: /var/lib/storage/otc
-          name: file-storage
+        - name: changeowner
+          # yamllint disable-line rule:line-length
+          image: public.ecr.aws/sumologic/busybox:1.36.0
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            capabilities:
+              add:
+                - CAP_CHOWN
+              drop:
+                - ALL
+          command:
+            - "sh"
+            - "-c"
+            - |
+              chown -R \
+                0:0 \
+                /var/lib/storage/otc
+          volumeMounts:
+            - mountPath: /var/lib/storage/otc
+              name: file-storage
       volumes:
-      - configMap:
-          defaultMode: 420
-          items:
-          - key: config.yaml
-            path: config.yaml
-          name: RELEASE-NAME-sumologic-otelcol-logs-collector
-        name: otelcol-config
-      - hostPath:
-          path: /var/log/pods
-          type: ""
-        name: varlogpods
-      - hostPath:
-          path: /var/lib/docker/containers
-          type: ""
-        name: varlibdockercontainers
-      - hostPath:
-          path: /var/lib/otc
-          type: DirectoryOrCreate
-        name: file-storage
-      - hostPath:
-          path: /var/log/journal/
-          type: ""
-        name: varlogjournal
+        - configMap:
+            defaultMode: 420
+            items:
+              - key: config.yaml
+                path: config.yaml
+            name: RELEASE-NAME-sumologic-otelcol-logs-collector
+          name: otelcol-config
+        - hostPath:
+            path: /var/log/pods
+            type: ""
+          name: varlogpods
+        - hostPath:
+            path: /var/lib/docker/containers
+            type: ""
+          name: varlibdockercontainers
+        - hostPath:
+            path: /var/lib/otc
+            type: DirectoryOrCreate
+          name: file-storage
+        - hostPath:
+            path: /var/log/journal/
+            type: ""
+          name: varlogjournal
       serviceAccountName: RELEASE-NAME-sumologic-otelcol-logs-collector
-

--- a/tests/helm/testdata/goldenfile/logs_otc_daemonset/complex.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_daemonset/complex.output.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: "%CONFIG_CHECKSUM%"
+        checksum/config: '%CONFIG_CHECKSUM%'
         someAnnotation: someValue
       labels:
         app.kubernetes.io/name: RELEASE-NAME-sumologic-otelcol-logs-collector
@@ -44,124 +44,130 @@ spec:
         runAsUser: 0
       priorityClassName: "prio"
       containers:
-        - args:
-            - --config=/etc/otelcol/config.yaml
-          image: "my_repository:my_tag"
-          imagePullPolicy: IfNotPresent
-          name: otelcol
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-          resources:
-            limits:
-              cpu: 1000m
-              memory: 1Gi
-            requests:
-              cpu: 100m
-              memory: 32Mi
-          volumeMounts:
-            - mountPath: /etc/otelcol
-              name: otelcol-config
-            - mountPath: /var/log/pods
-              name: varlogpods
-              readOnly: true
-            - mountPath: /var/lib/docker/containers
-              name: varlibdockercontainers
-              readOnly: true
-            - mountPath: /var/lib/storage/otc
-              name: file-storage
-            - mountPath: /var/log/journal
-              name: varlogjournal
-              readOnly: true
-            - mountPath: /certs
-              name: es-certs
-              readOnly: true
-          env:
-            - name: LOGS_METADATA_SVC
-              valueFrom:
-                configMapKeyRef:
-                  name: sumologic-configmap
-                  key: metadataLogs
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP
-
-            - name: VALUE_FROM_SECRET
-              valueFrom:
-                secretKeyRef:
-                  key: secret_key
-                  name: secret_name
-          securityContext:
-            capabilities:
-              drop:
-                - ALL
-            privileged: true
-          ports:
-            - name: pprof
-              containerPort: 1777
-              protocol: TCP
-            - name: metrics
-              containerPort: 8888
-              protocol: TCP
-      initContainers: # ensure the host path is owned by the otel user group
-        - name: changeowner
-          # yamllint disable-line rule:line-length
-          image: public.ecr.aws/sumologic/busybox:1.36.0
-          imagePullPolicy: IfNotPresent
-          securityContext:
-            capabilities:
-              add:
-                - CAP_CHOWN
-              drop:
-                - ALL
-            privileged: true
-          command:
-            - "sh"
-            - "-c"
-            - |
-              chown -R \
-                0:0 \
-                /var/lib/storage/otc
-          volumeMounts:
-            - mountPath: /var/lib/storage/otc
-              name: file-storage
-      volumes:
-        - configMap:
-            defaultMode: 420
-            items:
-              - key: config.yaml
-                path: config.yaml
-            name: RELEASE-NAME-sumologic-otelcol-logs-collector
+      - args:
+        - --config=/etc/otelcol/config.yaml
+        image: "my_repository:my_tag"
+        imagePullPolicy: IfNotPresent
+        name: otelcol
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/otelcol
           name: otelcol-config
-        - hostPath:
-            path: /var/log/pods
-            type: ""
+        - mountPath: /var/log/pods
           name: varlogpods
-        - hostPath:
-            path: /var/lib/docker/containers
-            type: ""
+          readOnly: true
+        - mountPath: /var/lib/docker/containers
           name: varlibdockercontainers
-        - hostPath:
-            path: /var/lib/otc
-            type: DirectoryOrCreate
+          readOnly: true
+        - mountPath: /var/lib/storage/otc
           name: file-storage
-        - hostPath:
-            path: /var/log/journal/
-            type: ""
+        - mountPath: /var/log/journal
           name: varlogjournal
-        - name: es-certs
-          secret:
-            defaultMode: 420
-            secretName: es-certs
+          readOnly: true
+        - mountPath: /certs
+          name: es-certs
+          readOnly: true
+        env:
+        - name: LOGS_METADATA_SVC
+          valueFrom:
+            configMapKeyRef:
+              name: sumologic-configmap
+              key: metadataLogs
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+
+        - name: VALUE_FROM_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: secret_key
+              name: secret_name
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+          privileged: true
+        ports:
+        - name: pprof
+          containerPort: 1777
+          protocol: TCP
+        - name: metrics
+          containerPort: 8888
+          protocol: TCP
+      initContainers: # ensure the host path is owned by the otel user group
+      - name: changeowner
+        # yamllint disable-line rule:line-length
+        image: public.ecr.aws/sumologic/busybox:1.36.0
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          capabilities:
+            add:
+            - CAP_CHOWN
+            drop:
+            - ALL
+          privileged: true
+        command:
+        - "sh"
+        - "-c"
+        - |
+          chown -R \
+            0:0 \
+            /var/lib/storage/otc
+        volumeMounts:
+        - mountPath: /var/lib/storage/otc
+          name: file-storage
+      volumes:
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: config.yaml
+            path: config.yaml
+          name: RELEASE-NAME-sumologic-otelcol-logs-collector
+        name: otelcol-config
+      - hostPath:
+          path: /var/log/pods
+          type: ""
+        name: varlogpods
+      - hostPath:
+          path: /var/lib/docker/containers
+          type: ""
+        name: varlibdockercontainers
+      - hostPath:
+          path: /var/lib/otc
+          type: DirectoryOrCreate
+        name: file-storage
+      - hostPath:
+          path: /var/log/journal/
+          type: ""
+        name: varlogjournal
+      - name: es-certs
+        secret:
+          defaultMode: 420
+          secretName: es-certs
       serviceAccountName: RELEASE-NAME-sumologic-otelcol-logs-collector
+

--- a/tests/helm/testdata/goldenfile/logs_otc_daemonset/complex.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_daemonset/complex.output.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: '%CONFIG_CHECKSUM%'
+        checksum/config: "%CONFIG_CHECKSUM%"
         someAnnotation: someValue
       labels:
         app.kubernetes.io/name: RELEASE-NAME-sumologic-otelcol-logs-collector
@@ -44,130 +44,129 @@ spec:
         runAsUser: 0
       priorityClassName: "prio"
       containers:
-      - args:
-        - --config=/etc/otelcol/config.yaml
-        image: "my_repository:my_tag"
-        imagePullPolicy: IfNotPresent
-        name: otelcol
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-        resources:
-          limits:
-            cpu: 1000m
-            memory: 1Gi
-          requests:
-            cpu: 100m
-            memory: 32Mi
-        volumeMounts:
-        - mountPath: /etc/otelcol
-          name: otelcol-config
-        - mountPath: /var/log/pods
-          name: varlogpods
-          readOnly: true
-        - mountPath: /var/lib/docker/containers
-          name: varlibdockercontainers
-          readOnly: true
-        - mountPath: /var/lib/storage/otc
-          name: file-storage
-        - mountPath: /var/log/journal
-          name: varlogjournal
-          readOnly: true
-        - mountPath: /certs
-          name: es-certs
-          readOnly: true
-        env:
-        - name: LOGS_METADATA_SVC
-          valueFrom:
-            configMapKeyRef:
-              name: sumologic-configmap
-              key: metadataLogs
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: MY_POD_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: MY_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
+        - args:
+            - --config=/etc/otelcol/config.yaml
+          image: "my_repository:my_tag"
+          imagePullPolicy: IfNotPresent
+          name: otelcol
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+            requests:
+              cpu: 100m
+              memory: 32Mi
+          volumeMounts:
+            - mountPath: /etc/otelcol
+              name: otelcol-config
+            - mountPath: /var/log/pods
+              name: varlogpods
+              readOnly: true
+            - mountPath: /var/lib/docker/containers
+              name: varlibdockercontainers
+              readOnly: true
+            - mountPath: /var/lib/storage/otc
+              name: file-storage
+            - mountPath: /var/log/journal
+              name: varlogjournal
+              readOnly: true
+            - mountPath: /certs
+              name: es-certs
+              readOnly: true
+          env:
+            - name: LOGS_METADATA_SVC
+              valueFrom:
+                configMapKeyRef:
+                  name: sumologic-configmap
+                  key: metadataLogs
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
 
-        - name: VALUE_FROM_SECRET
-          valueFrom:
-            secretKeyRef:
-              key: secret_key
-              name: secret_name
-        securityContext:
-          capabilities:
-            drop:
-            - ALL
-          privileged: true
-        ports:
-        - name: pprof
-          containerPort: 1777
-          protocol: TCP
-        - name: metrics
-          containerPort: 8888
-          protocol: TCP
+            - name: VALUE_FROM_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: secret_key
+                  name: secret_name
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            privileged: true
+          ports:
+            - name: pprof
+              containerPort: 1777
+              protocol: TCP
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
       initContainers: # ensure the host path is owned by the otel user group
-      - name: changeowner
-        # yamllint disable-line rule:line-length
-        image: public.ecr.aws/sumologic/busybox:1.36.0
-        imagePullPolicy: IfNotPresent
-        securityContext:
-          capabilities:
-            add:
-            - CAP_CHOWN
-            drop:
-            - ALL
-          privileged: true
-        command:
-        - "sh"
-        - "-c"
-        - |
-          chown -R \
-            0:0 \
-            /var/lib/storage/otc
-        volumeMounts:
-        - mountPath: /var/lib/storage/otc
-          name: file-storage
+        - name: changeowner
+          # yamllint disable-line rule:line-length
+          image: public.ecr.aws/sumologic/busybox:1.36.0
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            capabilities:
+              add:
+                - CAP_CHOWN
+              drop:
+                - ALL
+            privileged: true
+          command:
+            - "sh"
+            - "-c"
+            - |
+              chown -R \
+                0:0 \
+                /var/lib/storage/otc
+          volumeMounts:
+            - mountPath: /var/lib/storage/otc
+              name: file-storage
       volumes:
-      - configMap:
-          defaultMode: 420
-          items:
-          - key: config.yaml
-            path: config.yaml
-          name: RELEASE-NAME-sumologic-otelcol-logs-collector
-        name: otelcol-config
-      - hostPath:
-          path: /var/log/pods
-          type: ""
-        name: varlogpods
-      - hostPath:
-          path: /var/lib/docker/containers
-          type: ""
-        name: varlibdockercontainers
-      - hostPath:
-          path: /var/lib/otc
-          type: DirectoryOrCreate
-        name: file-storage
-      - hostPath:
-          path: /var/log/journal/
-          type: ""
-        name: varlogjournal
-      - name: es-certs
-        secret:
-          defaultMode: 420
-          secretName: es-certs
+        - configMap:
+            defaultMode: 420
+            items:
+              - key: config.yaml
+                path: config.yaml
+            name: RELEASE-NAME-sumologic-otelcol-logs-collector
+          name: otelcol-config
+        - hostPath:
+            path: /var/log/pods
+            type: ""
+          name: varlogpods
+        - hostPath:
+            path: /var/lib/docker/containers
+            type: ""
+          name: varlibdockercontainers
+        - hostPath:
+            path: /var/lib/otc
+            type: DirectoryOrCreate
+          name: file-storage
+        - hostPath:
+            path: /var/log/journal/
+            type: ""
+          name: varlogjournal
+        - name: es-certs
+          secret:
+            defaultMode: 420
+            secretName: es-certs
       serviceAccountName: RELEASE-NAME-sumologic-otelcol-logs-collector
-

--- a/tests/helm/testdata/goldenfile/logs_otc_windows/daemonset/additional-complex.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_windows/daemonset/additional-complex.output.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: '%CONFIG_CHECKSUM%'
+        checksum/config: "%CONFIG_CHECKSUM%"
         name: additionalPodAnnotation
       labels:
         app.kubernetes.io/name: RELEASE-NAME-sumologic-otellogswindows-logs-collector-linux
@@ -36,11 +36,11 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/os
-                operator: NotIn
-                values:
-                - windows
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: NotIn
+                    values:
+                      - windows
       tolerations:
         - effect: NoSchedule
           key: worker
@@ -48,7 +48,7 @@ spec:
           value: worker
       automountServiceAccountToken: false
       hostNetwork: true
-      dnsPolicy: "ClusterFirst"  # We need only in-cluser connections
+      dnsPolicy: "ClusterFirst" # We need only in-cluser connections
       securityContext:
         fsGroup: 0
         runAsGroup: 0
@@ -58,144 +58,143 @@ spec:
           runAsUserName: NT AUTHORITY\system
       priorityClassName: "prio"
       containers:
-      - command:
-        - "otelcol-sumo.exe"
-        args:
-        - --config=etc/otelcol/config.yaml
-        image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
-        imagePullPolicy: IfNotPresent
-        name: otelcol
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-        resources:
-          limits:
-            cpu: 6
-            memory: 1Gi
-          requests:
-            cpu: 2
-            memory: 32Mi
-        volumeMounts:
-        - mountPath: /etc/otelcol
-          name: otelcol-config
-        - mountPath: /var/log/pods
-          name: varlogpods
-          readOnly: true
-        - mountPath: /var/lib/docker/containers
-          name: varlibdockercontainers
-          readOnly: true
-        - mountPath: /var/lib/storage/otc
-          name: file-storage
-        - mountPath: /var/log/journal
-          name: varlogjournal
-          readOnly: true
-        - mountPath: /certs
-          name: es-certs
-          readOnly: true
-        env:
-        - name: LOGS_METADATA_SVC
-          valueFrom:
-            configMapKeyRef:
-              name: sumologic-configmap
-              key: metadataLogs
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: MY_POD_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: MY_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
+        - command:
+            - "otelcol-sumo.exe"
+          args:
+            - --config=etc/otelcol/config.yaml
+          image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
+          imagePullPolicy: IfNotPresent
+          name: otelcol
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+          resources:
+            limits:
+              cpu: 6
+              memory: 1Gi
+            requests:
+              cpu: 2
+              memory: 32Mi
+          volumeMounts:
+            - mountPath: /etc/otelcol
+              name: otelcol-config
+            - mountPath: /var/log/pods
+              name: varlogpods
+              readOnly: true
+            - mountPath: /var/lib/docker/containers
+              name: varlibdockercontainers
+              readOnly: true
+            - mountPath: /var/lib/storage/otc
+              name: file-storage
+            - mountPath: /var/log/journal
+              name: varlogjournal
+              readOnly: true
+            - mountPath: /certs
+              name: es-certs
+              readOnly: true
+          env:
+            - name: LOGS_METADATA_SVC
+              valueFrom:
+                configMapKeyRef:
+                  name: sumologic-configmap
+                  key: metadataLogs
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
 
-        - name: VALUE_FROM_SECRET
-          valueFrom:
-            secretKeyRef:
-              key: secret_key
-              name: secret_name
-        securityContext:
-          capabilities:
-            drop:
-            - ALL
-          privileged: true
-        ports:
-        - name: pprof
-          containerPort: 1777
-          protocol: TCP
-        - name: metrics
-          containerPort: 8888
-          protocol: TCP
+            - name: VALUE_FROM_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: secret_key
+                  name: secret_name
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            privileged: true
+          ports:
+            - name: pprof
+              containerPort: 1777
+              protocol: TCP
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
       initContainers:
-      - name: prepare  # create storage directory and adjust DNSes to allow connection with cluster. It adds cluster DNS server as primary DNS server
-        # yamllint disable-line rule:line-length
-        image: mcr.microsoft.com/windows/nanoserver:ltsc2019
-        imagePullPolicy: IfNotPresent
-        securityContext:
-          capabilities:
-            drop:
-            - ALL
-        command:
-        - "powershell.exe"
-        - "-Command"
-        - |
-          New-Item -ItemType Directory -Force -Path /var/lib/storage/otc;
-          Get-DnsClientServerAddress |
-          Where-Object { $_.ServerAddresses.Count -gt 0 -and $_.AddressFamily -eq 2 } |
-          ForEach-Object {
-            If ( -Not ($_.ServerAddresses.Contains("10.100.0.11")) ) {
-              $addresses = ,"10.100.0.11" + $_.ServerAddresses;
-              Set-DnsClientServerAddress -InterfaceIndex $_.InterfaceIndex -ServerAddresses $addresses
-            }
-            If ( -Not ($_.ServerAddresses.Contains("10.100.0.10")) ) {
-              $addresses = ,"10.100.0.10" + $_.ServerAddresses;
-              Set-DnsClientServerAddress -InterfaceIndex $_.InterfaceIndex -ServerAddresses $addresses
-            }
-          }
-        volumeMounts:
-        - mountPath: /var/lib/storage/otc
-          name: file-storage
+        - name: prepare # create storage directory and adjust DNSes to allow connection with cluster. It adds cluster DNS server as primary DNS server
+          # yamllint disable-line rule:line-length
+          image: mcr.microsoft.com/windows/nanoserver:ltsc2019
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - "powershell.exe"
+            - "-Command"
+            - |
+              New-Item -ItemType Directory -Force -Path /var/lib/storage/otc;
+              Get-DnsClientServerAddress |
+              Where-Object { $_.ServerAddresses.Count -gt 0 -and $_.AddressFamily -eq 2 } |
+              ForEach-Object {
+                If ( -Not ($_.ServerAddresses.Contains("10.100.0.11")) ) {
+                  $addresses = ,"10.100.0.11" + $_.ServerAddresses;
+                  Set-DnsClientServerAddress -InterfaceIndex $_.InterfaceIndex -ServerAddresses $addresses
+                }
+                If ( -Not ($_.ServerAddresses.Contains("10.100.0.10")) ) {
+                  $addresses = ,"10.100.0.10" + $_.ServerAddresses;
+                  Set-DnsClientServerAddress -InterfaceIndex $_.InterfaceIndex -ServerAddresses $addresses
+                }
+              }
+          volumeMounts:
+            - mountPath: /var/lib/storage/otc
+              name: file-storage
       volumes:
-      - configMap:
-          defaultMode: 420
-          items:
-          - key: config.yaml
-            path: config.yaml
-          name: RELEASE-NAME-sumologic-otelcol-windows-logs-collector
-        name: otelcol-config
-      - hostPath:
-          path: /var/log/pods
-          type: ""
-        name: varlogpods
-      - hostPath:
-          path: /var/lib/docker/containers
-          type: ""
-        name: varlibdockercontainers
-      - hostPath:
-          path: /var/lib/otc
-          type: DirectoryOrCreate
-        name: file-storage
-      - hostPath:
-          path: /var/log/journal/
-          type: ""
-        name: varlogjournal
-      - name: es-certs
-        secret:
-          defaultMode: 420
-          secretName: es-certs
+        - configMap:
+            defaultMode: 420
+            items:
+              - key: config.yaml
+                path: config.yaml
+            name: RELEASE-NAME-sumologic-otelcol-windows-logs-collector
+          name: otelcol-config
+        - hostPath:
+            path: /var/log/pods
+            type: ""
+          name: varlogpods
+        - hostPath:
+            path: /var/lib/docker/containers
+            type: ""
+          name: varlibdockercontainers
+        - hostPath:
+            path: /var/lib/otc
+            type: DirectoryOrCreate
+          name: file-storage
+        - hostPath:
+            path: /var/log/journal/
+            type: ""
+          name: varlogjournal
+        - name: es-certs
+          secret:
+            defaultMode: 420
+            secretName: es-certs
       serviceAccountName: RELEASE-NAME-sumologic-otelcol-logs-collector
   updateStrategy:
     rollingUpdate:
       maxSurge: 5
       maxUnavailable: 13
     type: RollingUpdate
-

--- a/tests/helm/testdata/goldenfile/logs_otc_windows/daemonset/additional-complex.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_windows/daemonset/additional-complex.output.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: "%CONFIG_CHECKSUM%"
+        checksum/config: '%CONFIG_CHECKSUM%'
         name: additionalPodAnnotation
       labels:
         app.kubernetes.io/name: RELEASE-NAME-sumologic-otellogswindows-logs-collector-linux
@@ -36,11 +36,11 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-              - matchExpressions:
-                  - key: kubernetes.io/os
-                    operator: NotIn
-                    values:
-                      - windows
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: NotIn
+                values:
+                - windows
       tolerations:
         - effect: NoSchedule
           key: worker
@@ -48,7 +48,7 @@ spec:
           value: worker
       automountServiceAccountToken: false
       hostNetwork: true
-      dnsPolicy: "ClusterFirst" # We need only in-cluser connections
+      dnsPolicy: "ClusterFirst"  # We need only in-cluser connections
       securityContext:
         fsGroup: 0
         runAsGroup: 0
@@ -58,138 +58,144 @@ spec:
           runAsUserName: NT AUTHORITY\system
       priorityClassName: "prio"
       containers:
-        - command:
-            - "otelcol-sumo.exe"
-          args:
-            - --config=etc/otelcol/config.yaml
-          image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
-          imagePullPolicy: IfNotPresent
-          name: otelcol
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-          resources:
-            limits:
-              cpu: 6
-              memory: 1Gi
-            requests:
-              cpu: 2
-              memory: 32Mi
-          volumeMounts:
-            - mountPath: /etc/otelcol
-              name: otelcol-config
-            - mountPath: /var/log/pods
-              name: varlogpods
-              readOnly: true
-            - mountPath: /var/lib/docker/containers
-              name: varlibdockercontainers
-              readOnly: true
-            - mountPath: /var/lib/storage/otc
-              name: file-storage
-            - mountPath: /var/log/journal
-              name: varlogjournal
-              readOnly: true
-            - mountPath: /certs
-              name: es-certs
-              readOnly: true
-          env:
-            - name: LOGS_METADATA_SVC
-              valueFrom:
-                configMapKeyRef:
-                  name: sumologic-configmap
-                  key: metadataLogs
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP
-
-            - name: VALUE_FROM_SECRET
-              valueFrom:
-                secretKeyRef:
-                  key: secret_key
-                  name: secret_name
-          securityContext:
-            capabilities:
-              drop:
-                - ALL
-            privileged: true
-          ports:
-            - name: pprof
-              containerPort: 1777
-              protocol: TCP
-            - name: metrics
-              containerPort: 8888
-              protocol: TCP
-      initContainers:
-        - name: prepare # create storage directory and adjust DNSes to allow connection with cluster. It adds cluster DNS server as primary DNS server
-          # yamllint disable-line rule:line-length
-          image: mcr.microsoft.com/windows/nanoserver:ltsc2019
-          imagePullPolicy: IfNotPresent
-          securityContext:
-            capabilities:
-              drop:
-                - ALL
-          command:
-            - "powershell.exe"
-            - "-Command"
-            - |
-              New-Item -ItemType Directory -Force -Path /var/lib/storage/otc;
-              Get-DnsClientServerAddress |
-              Where-Object { $_.ServerAddresses.Count -gt 0 -and $_.AddressFamily -eq 2 } |
-              ForEach-Object {
-                If ( -Not ($_.ServerAddresses.Contains("10.100.0.11")) ) {
-                  $addresses = ,"10.100.0.11" + $_.ServerAddresses;
-                  Set-DnsClientServerAddress -InterfaceIndex $_.InterfaceIndex -ServerAddresses $addresses
-                }
-                If ( -Not ($_.ServerAddresses.Contains("10.100.0.10")) ) {
-                  $addresses = ,"10.100.0.10" + $_.ServerAddresses;
-                  Set-DnsClientServerAddress -InterfaceIndex $_.InterfaceIndex -ServerAddresses $addresses
-                }
-              }
-          volumeMounts:
-            - mountPath: /var/lib/storage/otc
-              name: file-storage
-      volumes:
-        - configMap:
-            defaultMode: 420
-            items:
-              - key: config.yaml
-                path: config.yaml
-            name: RELEASE-NAME-sumologic-otelcol-windows-logs-collector
+      - command:
+        - "otelcol-sumo.exe"
+        args:
+        - --config=etc/otelcol/config.yaml
+        image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
+        imagePullPolicy: IfNotPresent
+        name: otelcol
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+        resources:
+          limits:
+            cpu: 6
+            memory: 1Gi
+          requests:
+            cpu: 2
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/otelcol
           name: otelcol-config
-        - hostPath:
-            path: /var/log/pods
-            type: ""
+        - mountPath: /var/log/pods
           name: varlogpods
-        - hostPath:
-            path: /var/lib/docker/containers
-            type: ""
+          readOnly: true
+        - mountPath: /var/lib/docker/containers
           name: varlibdockercontainers
-        - hostPath:
-            path: /var/lib/otc
-            type: DirectoryOrCreate
+          readOnly: true
+        - mountPath: /var/lib/storage/otc
           name: file-storage
-        - hostPath:
-            path: /var/log/journal/
-            type: ""
+        - mountPath: /var/log/journal
           name: varlogjournal
-        - name: es-certs
-          secret:
-            defaultMode: 420
-            secretName: es-certs
+          readOnly: true
+        - mountPath: /certs
+          name: es-certs
+          readOnly: true
+        env:
+        - name: LOGS_METADATA_SVC
+          valueFrom:
+            configMapKeyRef:
+              name: sumologic-configmap
+              key: metadataLogs
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+
+        - name: VALUE_FROM_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: secret_key
+              name: secret_name
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+          privileged: true
+        ports:
+        - name: pprof
+          containerPort: 1777
+          protocol: TCP
+        - name: metrics
+          containerPort: 8888
+          protocol: TCP
+      initContainers:
+      - name: prepare  # create storage directory and adjust DNSes to allow connection with cluster. It adds cluster DNS server as primary DNS server
+        # yamllint disable-line rule:line-length
+        image: mcr.microsoft.com/windows/nanoserver:ltsc2019
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+        command:
+        - "powershell.exe"
+        - "-Command"
+        - |
+          New-Item -ItemType Directory -Force -Path /var/lib/storage/otc;
+          Get-DnsClientServerAddress |
+          Where-Object { $_.ServerAddresses.Count -gt 0 -and $_.AddressFamily -eq 2 } |
+          ForEach-Object {
+            If ( -Not ($_.ServerAddresses.Contains("10.100.0.11")) ) {
+              $addresses = ,"10.100.0.11" + $_.ServerAddresses;
+              Set-DnsClientServerAddress -InterfaceIndex $_.InterfaceIndex -ServerAddresses $addresses
+            }
+            If ( -Not ($_.ServerAddresses.Contains("10.100.0.10")) ) {
+              $addresses = ,"10.100.0.10" + $_.ServerAddresses;
+              Set-DnsClientServerAddress -InterfaceIndex $_.InterfaceIndex -ServerAddresses $addresses
+            }
+          }
+        volumeMounts:
+        - mountPath: /var/lib/storage/otc
+          name: file-storage
+      volumes:
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: config.yaml
+            path: config.yaml
+          name: RELEASE-NAME-sumologic-otelcol-windows-logs-collector
+        name: otelcol-config
+      - hostPath:
+          path: /var/log/pods
+          type: ""
+        name: varlogpods
+      - hostPath:
+          path: /var/lib/docker/containers
+          type: ""
+        name: varlibdockercontainers
+      - hostPath:
+          path: /var/lib/otc
+          type: DirectoryOrCreate
+        name: file-storage
+      - hostPath:
+          path: /var/log/journal/
+          type: ""
+        name: varlogjournal
+      - name: es-certs
+        secret:
+          defaultMode: 420
+          secretName: es-certs
       serviceAccountName: RELEASE-NAME-sumologic-otelcol-logs-collector
   updateStrategy:
     rollingUpdate:
       maxSurge: 5
       maxUnavailable: 13
     type: RollingUpdate
+

--- a/tests/helm/testdata/goldenfile/logs_otc_windows/daemonset/additional.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_windows/daemonset/additional.output.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: "%CONFIG_CHECKSUM%"
+        checksum/config: '%CONFIG_CHECKSUM%'
       labels:
         app.kubernetes.io/name: RELEASE-NAME-sumologic-otellogswindows-logs-collector-linux
         app.kubernetes.io/app-name: RELEASE-NAME-sumologic-otelcol-logs-collector
@@ -31,132 +31,138 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-              - matchExpressions:
-                  - key: kubernetes.io/os
-                    operator: NotIn
-                    values:
-                      - windows
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: NotIn
+                values:
+                - windows
       tolerations:
         - effect: NoSchedule
           operator: Exists
       automountServiceAccountToken: false
       hostNetwork: true
-      dnsPolicy: "ClusterFirst" # We need only in-cluser connections
+      dnsPolicy: "ClusterFirst"  # We need only in-cluser connections
       securityContext:
         windowsOptions:
           hostProcess: true
           runAsUserName: NT AUTHORITY\system
       priorityClassName: "RELEASE-NAME-sumologic-priorityclass"
       containers:
-        - command:
-            - "otelcol-sumo.exe"
-          args:
-            - --config=etc/otelcol/config.yaml
-          image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
-          imagePullPolicy: IfNotPresent
-          name: otelcol
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-          resources:
-            limits:
-              cpu: 6
-              memory: 1Gi
-            requests:
-              cpu: 2
-              memory: 32Mi
-          volumeMounts:
-            - mountPath: /etc/otelcol
-              name: otelcol-config
-            - mountPath: /var/log/pods
-              name: varlogpods
-              readOnly: true
-            - mountPath: /var/lib/docker/containers
-              name: varlibdockercontainers
-              readOnly: true
-            - mountPath: /var/lib/storage/otc
-              name: file-storage
-            - mountPath: /var/log/journal
-              name: varlogjournal
-              readOnly: true
-          env:
-            - name: LOGS_METADATA_SVC
-              valueFrom:
-                configMapKeyRef:
-                  name: sumologic-configmap
-                  key: metadataLogs
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP
-          securityContext:
-            capabilities:
-              drop:
-                - ALL
-          ports:
-            - name: pprof
-              containerPort: 1777
-              protocol: TCP
-            - name: metrics
-              containerPort: 8888
-              protocol: TCP
-      initContainers:
-        - name: prepare # create storage directory and adjust DNSes to allow connection with cluster. It adds cluster DNS server as primary DNS server
-          # yamllint disable-line rule:line-length
-          image: mcr.microsoft.com/windows/nanoserver:ltsc2019
-          imagePullPolicy: IfNotPresent
-          securityContext:
-            capabilities:
-              drop:
-                - ALL
-          command:
-            - "powershell.exe"
-            - "-Command"
-            - |
-              New-Item -ItemType Directory -Force -Path /var/lib/storage/otc;
-              Get-DnsClientServerAddress |
-              Where-Object { $_.ServerAddresses.Count -gt 0 -and $_.AddressFamily -eq 2 } |
-              ForEach-Object {
-                If ( -Not ($_.ServerAddresses.Contains("10.100.0.10")) ) {
-                  $addresses = ,"10.100.0.10" + $_.ServerAddresses;
-                  Set-DnsClientServerAddress -InterfaceIndex $_.InterfaceIndex -ServerAddresses $addresses
-                }
-              }
-          volumeMounts:
-            - mountPath: /var/lib/storage/otc
-              name: file-storage
-      volumes:
-        - configMap:
-            defaultMode: 420
-            items:
-              - key: config.yaml
-                path: config.yaml
-            name: RELEASE-NAME-sumologic-otelcol-windows-logs-collector
+      - command:
+        - "otelcol-sumo.exe"
+        args:
+        - --config=etc/otelcol/config.yaml
+        image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
+        imagePullPolicy: IfNotPresent
+        name: otelcol
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+        resources:
+          limits:
+            cpu: 6
+            memory: 1Gi
+          requests:
+            cpu: 2
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/otelcol
           name: otelcol-config
-        - hostPath:
-            path: /var/log/pods
-            type: ""
+        - mountPath: /var/log/pods
           name: varlogpods
-        - hostPath:
-            path: /var/lib/docker/containers
-            type: ""
+          readOnly: true
+        - mountPath: /var/lib/docker/containers
           name: varlibdockercontainers
-        - hostPath:
-            path: /var/lib/otc
-            type: DirectoryOrCreate
+          readOnly: true
+        - mountPath: /var/lib/storage/otc
           name: file-storage
-        - hostPath:
-            path: /var/log/journal/
-            type: ""
+        - mountPath: /var/log/journal
           name: varlogjournal
+          readOnly: true
+        env:
+        - name: LOGS_METADATA_SVC
+          valueFrom:
+            configMapKeyRef:
+              name: sumologic-configmap
+              key: metadataLogs
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+        ports:
+        - name: pprof
+          containerPort: 1777
+          protocol: TCP
+        - name: metrics
+          containerPort: 8888
+          protocol: TCP
+      initContainers:
+      - name: prepare  # create storage directory and adjust DNSes to allow connection with cluster. It adds cluster DNS server as primary DNS server
+        # yamllint disable-line rule:line-length
+        image: mcr.microsoft.com/windows/nanoserver:ltsc2019
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+        command:
+        - "powershell.exe"
+        - "-Command"
+        - |
+          New-Item -ItemType Directory -Force -Path /var/lib/storage/otc;
+          Get-DnsClientServerAddress |
+          Where-Object { $_.ServerAddresses.Count -gt 0 -and $_.AddressFamily -eq 2 } |
+          ForEach-Object {
+            If ( -Not ($_.ServerAddresses.Contains("10.100.0.10")) ) {
+              $addresses = ,"10.100.0.10" + $_.ServerAddresses;
+              Set-DnsClientServerAddress -InterfaceIndex $_.InterfaceIndex -ServerAddresses $addresses
+            }
+          }
+        volumeMounts:
+        - mountPath: /var/lib/storage/otc
+          name: file-storage
+      volumes:
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: config.yaml
+            path: config.yaml
+          name: RELEASE-NAME-sumologic-otelcol-windows-logs-collector
+        name: otelcol-config
+      - hostPath:
+          path: /var/log/pods
+          type: ""
+        name: varlogpods
+      - hostPath:
+          path: /var/lib/docker/containers
+          type: ""
+        name: varlibdockercontainers
+      - hostPath:
+          path: /var/lib/otc
+          type: DirectoryOrCreate
+        name: file-storage
+      - hostPath:
+          path: /var/log/journal/
+          type: ""
+        name: varlogjournal
       serviceAccountName: RELEASE-NAME-sumologic-otelcol-logs-collector
+

--- a/tests/helm/testdata/goldenfile/logs_otc_windows/daemonset/additional.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_windows/daemonset/additional.output.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: '%CONFIG_CHECKSUM%'
+        checksum/config: "%CONFIG_CHECKSUM%"
       labels:
         app.kubernetes.io/name: RELEASE-NAME-sumologic-otellogswindows-logs-collector-linux
         app.kubernetes.io/app-name: RELEASE-NAME-sumologic-otelcol-logs-collector
@@ -31,138 +31,137 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/os
-                operator: NotIn
-                values:
-                - windows
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: NotIn
+                    values:
+                      - windows
       tolerations:
         - effect: NoSchedule
           operator: Exists
       automountServiceAccountToken: false
       hostNetwork: true
-      dnsPolicy: "ClusterFirst"  # We need only in-cluser connections
+      dnsPolicy: "ClusterFirst" # We need only in-cluser connections
       securityContext:
         windowsOptions:
           hostProcess: true
           runAsUserName: NT AUTHORITY\system
       priorityClassName: "RELEASE-NAME-sumologic-priorityclass"
       containers:
-      - command:
-        - "otelcol-sumo.exe"
-        args:
-        - --config=etc/otelcol/config.yaml
-        image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
-        imagePullPolicy: IfNotPresent
-        name: otelcol
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-        resources:
-          limits:
-            cpu: 6
-            memory: 1Gi
-          requests:
-            cpu: 2
-            memory: 32Mi
-        volumeMounts:
-        - mountPath: /etc/otelcol
-          name: otelcol-config
-        - mountPath: /var/log/pods
-          name: varlogpods
-          readOnly: true
-        - mountPath: /var/lib/docker/containers
-          name: varlibdockercontainers
-          readOnly: true
-        - mountPath: /var/lib/storage/otc
-          name: file-storage
-        - mountPath: /var/log/journal
-          name: varlogjournal
-          readOnly: true
-        env:
-        - name: LOGS_METADATA_SVC
-          valueFrom:
-            configMapKeyRef:
-              name: sumologic-configmap
-              key: metadataLogs
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: MY_POD_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: MY_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        securityContext:
-          capabilities:
-            drop:
-            - ALL
-        ports:
-        - name: pprof
-          containerPort: 1777
-          protocol: TCP
-        - name: metrics
-          containerPort: 8888
-          protocol: TCP
+        - command:
+            - "otelcol-sumo.exe"
+          args:
+            - --config=etc/otelcol/config.yaml
+          image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
+          imagePullPolicy: IfNotPresent
+          name: otelcol
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+          resources:
+            limits:
+              cpu: 6
+              memory: 1Gi
+            requests:
+              cpu: 2
+              memory: 32Mi
+          volumeMounts:
+            - mountPath: /etc/otelcol
+              name: otelcol-config
+            - mountPath: /var/log/pods
+              name: varlogpods
+              readOnly: true
+            - mountPath: /var/lib/docker/containers
+              name: varlibdockercontainers
+              readOnly: true
+            - mountPath: /var/lib/storage/otc
+              name: file-storage
+            - mountPath: /var/log/journal
+              name: varlogjournal
+              readOnly: true
+          env:
+            - name: LOGS_METADATA_SVC
+              valueFrom:
+                configMapKeyRef:
+                  name: sumologic-configmap
+                  key: metadataLogs
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - name: pprof
+              containerPort: 1777
+              protocol: TCP
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
       initContainers:
-      - name: prepare  # create storage directory and adjust DNSes to allow connection with cluster. It adds cluster DNS server as primary DNS server
-        # yamllint disable-line rule:line-length
-        image: mcr.microsoft.com/windows/nanoserver:ltsc2019
-        imagePullPolicy: IfNotPresent
-        securityContext:
-          capabilities:
-            drop:
-            - ALL
-        command:
-        - "powershell.exe"
-        - "-Command"
-        - |
-          New-Item -ItemType Directory -Force -Path /var/lib/storage/otc;
-          Get-DnsClientServerAddress |
-          Where-Object { $_.ServerAddresses.Count -gt 0 -and $_.AddressFamily -eq 2 } |
-          ForEach-Object {
-            If ( -Not ($_.ServerAddresses.Contains("10.100.0.10")) ) {
-              $addresses = ,"10.100.0.10" + $_.ServerAddresses;
-              Set-DnsClientServerAddress -InterfaceIndex $_.InterfaceIndex -ServerAddresses $addresses
-            }
-          }
-        volumeMounts:
-        - mountPath: /var/lib/storage/otc
-          name: file-storage
+        - name: prepare # create storage directory and adjust DNSes to allow connection with cluster. It adds cluster DNS server as primary DNS server
+          # yamllint disable-line rule:line-length
+          image: mcr.microsoft.com/windows/nanoserver:ltsc2019
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - "powershell.exe"
+            - "-Command"
+            - |
+              New-Item -ItemType Directory -Force -Path /var/lib/storage/otc;
+              Get-DnsClientServerAddress |
+              Where-Object { $_.ServerAddresses.Count -gt 0 -and $_.AddressFamily -eq 2 } |
+              ForEach-Object {
+                If ( -Not ($_.ServerAddresses.Contains("10.100.0.10")) ) {
+                  $addresses = ,"10.100.0.10" + $_.ServerAddresses;
+                  Set-DnsClientServerAddress -InterfaceIndex $_.InterfaceIndex -ServerAddresses $addresses
+                }
+              }
+          volumeMounts:
+            - mountPath: /var/lib/storage/otc
+              name: file-storage
       volumes:
-      - configMap:
-          defaultMode: 420
-          items:
-          - key: config.yaml
-            path: config.yaml
-          name: RELEASE-NAME-sumologic-otelcol-windows-logs-collector
-        name: otelcol-config
-      - hostPath:
-          path: /var/log/pods
-          type: ""
-        name: varlogpods
-      - hostPath:
-          path: /var/lib/docker/containers
-          type: ""
-        name: varlibdockercontainers
-      - hostPath:
-          path: /var/lib/otc
-          type: DirectoryOrCreate
-        name: file-storage
-      - hostPath:
-          path: /var/log/journal/
-          type: ""
-        name: varlogjournal
+        - configMap:
+            defaultMode: 420
+            items:
+              - key: config.yaml
+                path: config.yaml
+            name: RELEASE-NAME-sumologic-otelcol-windows-logs-collector
+          name: otelcol-config
+        - hostPath:
+            path: /var/log/pods
+            type: ""
+          name: varlogpods
+        - hostPath:
+            path: /var/lib/docker/containers
+            type: ""
+          name: varlibdockercontainers
+        - hostPath:
+            path: /var/lib/otc
+            type: DirectoryOrCreate
+          name: file-storage
+        - hostPath:
+            path: /var/log/journal/
+            type: ""
+          name: varlogjournal
       serviceAccountName: RELEASE-NAME-sumologic-otelcol-logs-collector
-

--- a/tests/helm/testdata/goldenfile/logs_otc_windows/daemonset/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_windows/daemonset/basic.output.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: "%CONFIG_CHECKSUM%"
+        checksum/config: '%CONFIG_CHECKSUM%'
       labels:
         app.kubernetes.io/name: RELEASE-NAME-sumologic-otellogswindows-logs-collector
         app.kubernetes.io/app-name: RELEASE-NAME-sumologic-otelcol-logs-collector
@@ -32,122 +32,128 @@ spec:
           operator: Exists
       automountServiceAccountToken: false
       hostNetwork: true
-      dnsPolicy: "ClusterFirst" # We need only in-cluser connections
+      dnsPolicy: "ClusterFirst"  # We need only in-cluser connections
       securityContext:
         windowsOptions:
           hostProcess: true
           runAsUserName: NT AUTHORITY\system
       priorityClassName: "RELEASE-NAME-sumologic-priorityclass"
       containers:
-        - command:
-            - "otelcol-sumo.exe"
-          args:
-            - --config=etc/otelcol/config.yaml
-          image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
-          imagePullPolicy: IfNotPresent
-          name: otelcol
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-          resources:
-            limits:
-              cpu: 1000m
-              memory: 1Gi
-            requests:
-              cpu: 100m
-              memory: 32Mi
-          volumeMounts:
-            - mountPath: /etc/otelcol
-              name: otelcol-config
-            - mountPath: /var/log/pods
-              name: varlogpods
-              readOnly: true
-            - mountPath: /var/lib/docker/containers
-              name: varlibdockercontainers
-              readOnly: true
-            - mountPath: /var/lib/storage/otc
-              name: file-storage
-            - mountPath: /var/log/journal
-              name: varlogjournal
-              readOnly: true
-          env:
-            - name: LOGS_METADATA_SVC
-              valueFrom:
-                configMapKeyRef:
-                  name: sumologic-configmap
-                  key: metadataLogs
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP
-          securityContext:
-            capabilities:
-              drop:
-                - ALL
-          ports:
-            - name: pprof
-              containerPort: 1777
-              protocol: TCP
-            - name: metrics
-              containerPort: 8888
-              protocol: TCP
-      initContainers:
-        - name: prepare # create storage directory and adjust DNSes to allow connection with cluster. It adds cluster DNS server as primary DNS server
-          # yamllint disable-line rule:line-length
-          image: mcr.microsoft.com/windows/nanoserver:ltsc2019
-          imagePullPolicy: IfNotPresent
-          securityContext:
-            capabilities:
-              drop:
-                - ALL
-          command:
-            - "powershell.exe"
-            - "-Command"
-            - |
-              New-Item -ItemType Directory -Force -Path /var/lib/storage/otc;
-              Get-DnsClientServerAddress |
-              Where-Object { $_.ServerAddresses.Count -gt 0 -and $_.AddressFamily -eq 2 } |
-              ForEach-Object {
-                If ( -Not ($_.ServerAddresses.Contains("10.100.0.10")) ) {
-                  $addresses = ,"10.100.0.10" + $_.ServerAddresses;
-                  Set-DnsClientServerAddress -InterfaceIndex $_.InterfaceIndex -ServerAddresses $addresses
-                }
-              }
-          volumeMounts:
-            - mountPath: /var/lib/storage/otc
-              name: file-storage
-      volumes:
-        - configMap:
-            defaultMode: 420
-            items:
-              - key: config.yaml
-                path: config.yaml
-            name: RELEASE-NAME-sumologic-otelcol-windows-logs-collector
+      - command:
+        - "otelcol-sumo.exe"
+        args:
+        - --config=etc/otelcol/config.yaml
+        image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
+        imagePullPolicy: IfNotPresent
+        name: otelcol
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/otelcol
           name: otelcol-config
-        - hostPath:
-            path: /var/log/pods
-            type: ""
+        - mountPath: /var/log/pods
           name: varlogpods
-        - hostPath:
-            path: /var/lib/docker/containers
-            type: ""
+          readOnly: true
+        - mountPath: /var/lib/docker/containers
           name: varlibdockercontainers
-        - hostPath:
-            path: /var/lib/otc
-            type: DirectoryOrCreate
+          readOnly: true
+        - mountPath: /var/lib/storage/otc
           name: file-storage
-        - hostPath:
-            path: /var/log/journal/
-            type: ""
+        - mountPath: /var/log/journal
           name: varlogjournal
+          readOnly: true
+        env:
+        - name: LOGS_METADATA_SVC
+          valueFrom:
+            configMapKeyRef:
+              name: sumologic-configmap
+              key: metadataLogs
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+        ports:
+        - name: pprof
+          containerPort: 1777
+          protocol: TCP
+        - name: metrics
+          containerPort: 8888
+          protocol: TCP
+      initContainers:
+      - name: prepare  # create storage directory and adjust DNSes to allow connection with cluster. It adds cluster DNS server as primary DNS server
+        # yamllint disable-line rule:line-length
+        image: mcr.microsoft.com/windows/nanoserver:ltsc2019
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+        command:
+        - "powershell.exe"
+        - "-Command"
+        - |
+          New-Item -ItemType Directory -Force -Path /var/lib/storage/otc;
+          Get-DnsClientServerAddress |
+          Where-Object { $_.ServerAddresses.Count -gt 0 -and $_.AddressFamily -eq 2 } |
+          ForEach-Object {
+            If ( -Not ($_.ServerAddresses.Contains("10.100.0.10")) ) {
+              $addresses = ,"10.100.0.10" + $_.ServerAddresses;
+              Set-DnsClientServerAddress -InterfaceIndex $_.InterfaceIndex -ServerAddresses $addresses
+            }
+          }
+        volumeMounts:
+        - mountPath: /var/lib/storage/otc
+          name: file-storage
+      volumes:
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: config.yaml
+            path: config.yaml
+          name: RELEASE-NAME-sumologic-otelcol-windows-logs-collector
+        name: otelcol-config
+      - hostPath:
+          path: /var/log/pods
+          type: ""
+        name: varlogpods
+      - hostPath:
+          path: /var/lib/docker/containers
+          type: ""
+        name: varlibdockercontainers
+      - hostPath:
+          path: /var/lib/otc
+          type: DirectoryOrCreate
+        name: file-storage
+      - hostPath:
+          path: /var/log/journal/
+          type: ""
+        name: varlogjournal
       serviceAccountName: RELEASE-NAME-sumologic-otelcol-logs-collector
+

--- a/tests/helm/testdata/goldenfile/logs_otc_windows/daemonset/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_windows/daemonset/basic.output.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: '%CONFIG_CHECKSUM%'
+        checksum/config: "%CONFIG_CHECKSUM%"
       labels:
         app.kubernetes.io/name: RELEASE-NAME-sumologic-otellogswindows-logs-collector
         app.kubernetes.io/app-name: RELEASE-NAME-sumologic-otelcol-logs-collector
@@ -32,128 +32,127 @@ spec:
           operator: Exists
       automountServiceAccountToken: false
       hostNetwork: true
-      dnsPolicy: "ClusterFirst"  # We need only in-cluser connections
+      dnsPolicy: "ClusterFirst" # We need only in-cluser connections
       securityContext:
         windowsOptions:
           hostProcess: true
           runAsUserName: NT AUTHORITY\system
       priorityClassName: "RELEASE-NAME-sumologic-priorityclass"
       containers:
-      - command:
-        - "otelcol-sumo.exe"
-        args:
-        - --config=etc/otelcol/config.yaml
-        image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
-        imagePullPolicy: IfNotPresent
-        name: otelcol
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-        resources:
-          limits:
-            cpu: 1000m
-            memory: 1Gi
-          requests:
-            cpu: 100m
-            memory: 32Mi
-        volumeMounts:
-        - mountPath: /etc/otelcol
-          name: otelcol-config
-        - mountPath: /var/log/pods
-          name: varlogpods
-          readOnly: true
-        - mountPath: /var/lib/docker/containers
-          name: varlibdockercontainers
-          readOnly: true
-        - mountPath: /var/lib/storage/otc
-          name: file-storage
-        - mountPath: /var/log/journal
-          name: varlogjournal
-          readOnly: true
-        env:
-        - name: LOGS_METADATA_SVC
-          valueFrom:
-            configMapKeyRef:
-              name: sumologic-configmap
-              key: metadataLogs
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: MY_POD_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: MY_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        securityContext:
-          capabilities:
-            drop:
-            - ALL
-        ports:
-        - name: pprof
-          containerPort: 1777
-          protocol: TCP
-        - name: metrics
-          containerPort: 8888
-          protocol: TCP
+        - command:
+            - "otelcol-sumo.exe"
+          args:
+            - --config=etc/otelcol/config.yaml
+          image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
+          imagePullPolicy: IfNotPresent
+          name: otelcol
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+            requests:
+              cpu: 100m
+              memory: 32Mi
+          volumeMounts:
+            - mountPath: /etc/otelcol
+              name: otelcol-config
+            - mountPath: /var/log/pods
+              name: varlogpods
+              readOnly: true
+            - mountPath: /var/lib/docker/containers
+              name: varlibdockercontainers
+              readOnly: true
+            - mountPath: /var/lib/storage/otc
+              name: file-storage
+            - mountPath: /var/log/journal
+              name: varlogjournal
+              readOnly: true
+          env:
+            - name: LOGS_METADATA_SVC
+              valueFrom:
+                configMapKeyRef:
+                  name: sumologic-configmap
+                  key: metadataLogs
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - name: pprof
+              containerPort: 1777
+              protocol: TCP
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
       initContainers:
-      - name: prepare  # create storage directory and adjust DNSes to allow connection with cluster. It adds cluster DNS server as primary DNS server
-        # yamllint disable-line rule:line-length
-        image: mcr.microsoft.com/windows/nanoserver:ltsc2019
-        imagePullPolicy: IfNotPresent
-        securityContext:
-          capabilities:
-            drop:
-            - ALL
-        command:
-        - "powershell.exe"
-        - "-Command"
-        - |
-          New-Item -ItemType Directory -Force -Path /var/lib/storage/otc;
-          Get-DnsClientServerAddress |
-          Where-Object { $_.ServerAddresses.Count -gt 0 -and $_.AddressFamily -eq 2 } |
-          ForEach-Object {
-            If ( -Not ($_.ServerAddresses.Contains("10.100.0.10")) ) {
-              $addresses = ,"10.100.0.10" + $_.ServerAddresses;
-              Set-DnsClientServerAddress -InterfaceIndex $_.InterfaceIndex -ServerAddresses $addresses
-            }
-          }
-        volumeMounts:
-        - mountPath: /var/lib/storage/otc
-          name: file-storage
+        - name: prepare # create storage directory and adjust DNSes to allow connection with cluster. It adds cluster DNS server as primary DNS server
+          # yamllint disable-line rule:line-length
+          image: mcr.microsoft.com/windows/nanoserver:ltsc2019
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - "powershell.exe"
+            - "-Command"
+            - |
+              New-Item -ItemType Directory -Force -Path /var/lib/storage/otc;
+              Get-DnsClientServerAddress |
+              Where-Object { $_.ServerAddresses.Count -gt 0 -and $_.AddressFamily -eq 2 } |
+              ForEach-Object {
+                If ( -Not ($_.ServerAddresses.Contains("10.100.0.10")) ) {
+                  $addresses = ,"10.100.0.10" + $_.ServerAddresses;
+                  Set-DnsClientServerAddress -InterfaceIndex $_.InterfaceIndex -ServerAddresses $addresses
+                }
+              }
+          volumeMounts:
+            - mountPath: /var/lib/storage/otc
+              name: file-storage
       volumes:
-      - configMap:
-          defaultMode: 420
-          items:
-          - key: config.yaml
-            path: config.yaml
-          name: RELEASE-NAME-sumologic-otelcol-windows-logs-collector
-        name: otelcol-config
-      - hostPath:
-          path: /var/log/pods
-          type: ""
-        name: varlogpods
-      - hostPath:
-          path: /var/lib/docker/containers
-          type: ""
-        name: varlibdockercontainers
-      - hostPath:
-          path: /var/lib/otc
-          type: DirectoryOrCreate
-        name: file-storage
-      - hostPath:
-          path: /var/log/journal/
-          type: ""
-        name: varlogjournal
+        - configMap:
+            defaultMode: 420
+            items:
+              - key: config.yaml
+                path: config.yaml
+            name: RELEASE-NAME-sumologic-otelcol-windows-logs-collector
+          name: otelcol-config
+        - hostPath:
+            path: /var/log/pods
+            type: ""
+          name: varlogpods
+        - hostPath:
+            path: /var/lib/docker/containers
+            type: ""
+          name: varlibdockercontainers
+        - hostPath:
+            path: /var/lib/otc
+            type: DirectoryOrCreate
+          name: file-storage
+        - hostPath:
+            path: /var/log/journal/
+            type: ""
+          name: varlogjournal
       serviceAccountName: RELEASE-NAME-sumologic-otelcol-logs-collector
-

--- a/tests/helm/testdata/goldenfile/logs_otc_windows/daemonset/complex.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_windows/daemonset/complex.output.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: "%CONFIG_CHECKSUM%"
+        checksum/config: '%CONFIG_CHECKSUM%'
         someAnnotation: someValue
       labels:
         app.kubernetes.io/name: RELEASE-NAME-sumologic-otellogswindows-logs-collector
@@ -40,7 +40,7 @@ spec:
           value: worker
       automountServiceAccountToken: false
       hostNetwork: true
-      dnsPolicy: "ClusterFirst" # We need only in-cluser connections
+      dnsPolicy: "ClusterFirst"  # We need only in-cluser connections
       securityContext:
         fsGroup: 0
         runAsGroup: 0
@@ -50,129 +50,135 @@ spec:
           runAsUserName: NT AUTHORITY\system
       priorityClassName: "prio"
       containers:
-        - command:
-            - "otelcol-sumo.exe"
-          args:
-            - --config=etc/otelcol/config.yaml
-          image: "my_repository:my_tag"
-          imagePullPolicy: IfNotPresent
-          name: otelcol
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-          resources:
-            limits:
-              cpu: 1000m
-              memory: 1Gi
-            requests:
-              cpu: 100m
-              memory: 32Mi
-          volumeMounts:
-            - mountPath: /etc/otelcol
-              name: otelcol-config
-            - mountPath: /var/log/pods
-              name: varlogpods
-              readOnly: true
-            - mountPath: /var/lib/docker/containers
-              name: varlibdockercontainers
-              readOnly: true
-            - mountPath: /var/lib/storage/otc
-              name: file-storage
-            - mountPath: /var/log/journal
-              name: varlogjournal
-              readOnly: true
-            - mountPath: /certs
-              name: es-certs
-              readOnly: true
-          env:
-            - name: LOGS_METADATA_SVC
-              valueFrom:
-                configMapKeyRef:
-                  name: sumologic-configmap
-                  key: metadataLogs
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP
-
-            - name: VALUE_FROM_SECRET
-              valueFrom:
-                secretKeyRef:
-                  key: secret_key
-                  name: secret_name
-          securityContext:
-            capabilities:
-              drop:
-                - ALL
-            privileged: true
-          ports:
-            - name: pprof
-              containerPort: 1777
-              protocol: TCP
-            - name: metrics
-              containerPort: 8888
-              protocol: TCP
-      initContainers:
-        - name: prepare # create storage directory and adjust DNSes to allow connection with cluster. It adds cluster DNS server as primary DNS server
-          # yamllint disable-line rule:line-length
-          image: mcr.microsoft.com/windows/nanoserver:ltsc2019
-          imagePullPolicy: IfNotPresent
-          securityContext:
-            capabilities:
-              drop:
-                - ALL
-          command:
-            - "powershell.exe"
-            - "-Command"
-            - |
-              New-Item -ItemType Directory -Force -Path /var/lib/storage/otc;
-              Get-DnsClientServerAddress |
-              Where-Object { $_.ServerAddresses.Count -gt 0 -and $_.AddressFamily -eq 2 } |
-              ForEach-Object {
-                If ( -Not ($_.ServerAddresses.Contains("10.100.0.10")) ) {
-                  $addresses = ,"10.100.0.10" + $_.ServerAddresses;
-                  Set-DnsClientServerAddress -InterfaceIndex $_.InterfaceIndex -ServerAddresses $addresses
-                }
-              }
-          volumeMounts:
-            - mountPath: /var/lib/storage/otc
-              name: file-storage
-      volumes:
-        - configMap:
-            defaultMode: 420
-            items:
-              - key: config.yaml
-                path: config.yaml
-            name: RELEASE-NAME-sumologic-otelcol-windows-logs-collector
+      - command:
+        - "otelcol-sumo.exe"
+        args:
+        - --config=etc/otelcol/config.yaml
+        image: "my_repository:my_tag"
+        imagePullPolicy: IfNotPresent
+        name: otelcol
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/otelcol
           name: otelcol-config
-        - hostPath:
-            path: /var/log/pods
-            type: ""
+        - mountPath: /var/log/pods
           name: varlogpods
-        - hostPath:
-            path: /var/lib/docker/containers
-            type: ""
+          readOnly: true
+        - mountPath: /var/lib/docker/containers
           name: varlibdockercontainers
-        - hostPath:
-            path: /var/lib/otc
-            type: DirectoryOrCreate
+          readOnly: true
+        - mountPath: /var/lib/storage/otc
           name: file-storage
-        - hostPath:
-            path: /var/log/journal/
-            type: ""
+        - mountPath: /var/log/journal
           name: varlogjournal
-        - name: es-certs
-          secret:
-            defaultMode: 420
-            secretName: es-certs
+          readOnly: true
+        - mountPath: /certs
+          name: es-certs
+          readOnly: true
+        env:
+        - name: LOGS_METADATA_SVC
+          valueFrom:
+            configMapKeyRef:
+              name: sumologic-configmap
+              key: metadataLogs
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+
+        - name: VALUE_FROM_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: secret_key
+              name: secret_name
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+          privileged: true
+        ports:
+        - name: pprof
+          containerPort: 1777
+          protocol: TCP
+        - name: metrics
+          containerPort: 8888
+          protocol: TCP
+      initContainers:
+      - name: prepare  # create storage directory and adjust DNSes to allow connection with cluster. It adds cluster DNS server as primary DNS server
+        # yamllint disable-line rule:line-length
+        image: mcr.microsoft.com/windows/nanoserver:ltsc2019
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+        command:
+        - "powershell.exe"
+        - "-Command"
+        - |
+          New-Item -ItemType Directory -Force -Path /var/lib/storage/otc;
+          Get-DnsClientServerAddress |
+          Where-Object { $_.ServerAddresses.Count -gt 0 -and $_.AddressFamily -eq 2 } |
+          ForEach-Object {
+            If ( -Not ($_.ServerAddresses.Contains("10.100.0.10")) ) {
+              $addresses = ,"10.100.0.10" + $_.ServerAddresses;
+              Set-DnsClientServerAddress -InterfaceIndex $_.InterfaceIndex -ServerAddresses $addresses
+            }
+          }
+        volumeMounts:
+        - mountPath: /var/lib/storage/otc
+          name: file-storage
+      volumes:
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: config.yaml
+            path: config.yaml
+          name: RELEASE-NAME-sumologic-otelcol-windows-logs-collector
+        name: otelcol-config
+      - hostPath:
+          path: /var/log/pods
+          type: ""
+        name: varlogpods
+      - hostPath:
+          path: /var/lib/docker/containers
+          type: ""
+        name: varlibdockercontainers
+      - hostPath:
+          path: /var/lib/otc
+          type: DirectoryOrCreate
+        name: file-storage
+      - hostPath:
+          path: /var/log/journal/
+          type: ""
+        name: varlogjournal
+      - name: es-certs
+        secret:
+          defaultMode: 420
+          secretName: es-certs
       serviceAccountName: RELEASE-NAME-sumologic-otelcol-logs-collector
+

--- a/tests/helm/testdata/goldenfile/logs_otc_windows/daemonset/complex.output.yaml
+++ b/tests/helm/testdata/goldenfile/logs_otc_windows/daemonset/complex.output.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: '%CONFIG_CHECKSUM%'
+        checksum/config: "%CONFIG_CHECKSUM%"
         someAnnotation: someValue
       labels:
         app.kubernetes.io/name: RELEASE-NAME-sumologic-otellogswindows-logs-collector
@@ -40,7 +40,7 @@ spec:
           value: worker
       automountServiceAccountToken: false
       hostNetwork: true
-      dnsPolicy: "ClusterFirst"  # We need only in-cluser connections
+      dnsPolicy: "ClusterFirst" # We need only in-cluser connections
       securityContext:
         fsGroup: 0
         runAsGroup: 0
@@ -50,135 +50,134 @@ spec:
           runAsUserName: NT AUTHORITY\system
       priorityClassName: "prio"
       containers:
-      - command:
-        - "otelcol-sumo.exe"
-        args:
-        - --config=etc/otelcol/config.yaml
-        image: "my_repository:my_tag"
-        imagePullPolicy: IfNotPresent
-        name: otelcol
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-        resources:
-          limits:
-            cpu: 1000m
-            memory: 1Gi
-          requests:
-            cpu: 100m
-            memory: 32Mi
-        volumeMounts:
-        - mountPath: /etc/otelcol
-          name: otelcol-config
-        - mountPath: /var/log/pods
-          name: varlogpods
-          readOnly: true
-        - mountPath: /var/lib/docker/containers
-          name: varlibdockercontainers
-          readOnly: true
-        - mountPath: /var/lib/storage/otc
-          name: file-storage
-        - mountPath: /var/log/journal
-          name: varlogjournal
-          readOnly: true
-        - mountPath: /certs
-          name: es-certs
-          readOnly: true
-        env:
-        - name: LOGS_METADATA_SVC
-          valueFrom:
-            configMapKeyRef:
-              name: sumologic-configmap
-              key: metadataLogs
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: MY_POD_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: MY_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
+        - command:
+            - "otelcol-sumo.exe"
+          args:
+            - --config=etc/otelcol/config.yaml
+          image: "my_repository:my_tag"
+          imagePullPolicy: IfNotPresent
+          name: otelcol
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+            requests:
+              cpu: 100m
+              memory: 32Mi
+          volumeMounts:
+            - mountPath: /etc/otelcol
+              name: otelcol-config
+            - mountPath: /var/log/pods
+              name: varlogpods
+              readOnly: true
+            - mountPath: /var/lib/docker/containers
+              name: varlibdockercontainers
+              readOnly: true
+            - mountPath: /var/lib/storage/otc
+              name: file-storage
+            - mountPath: /var/log/journal
+              name: varlogjournal
+              readOnly: true
+            - mountPath: /certs
+              name: es-certs
+              readOnly: true
+          env:
+            - name: LOGS_METADATA_SVC
+              valueFrom:
+                configMapKeyRef:
+                  name: sumologic-configmap
+                  key: metadataLogs
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
 
-        - name: VALUE_FROM_SECRET
-          valueFrom:
-            secretKeyRef:
-              key: secret_key
-              name: secret_name
-        securityContext:
-          capabilities:
-            drop:
-            - ALL
-          privileged: true
-        ports:
-        - name: pprof
-          containerPort: 1777
-          protocol: TCP
-        - name: metrics
-          containerPort: 8888
-          protocol: TCP
+            - name: VALUE_FROM_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: secret_key
+                  name: secret_name
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            privileged: true
+          ports:
+            - name: pprof
+              containerPort: 1777
+              protocol: TCP
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
       initContainers:
-      - name: prepare  # create storage directory and adjust DNSes to allow connection with cluster. It adds cluster DNS server as primary DNS server
-        # yamllint disable-line rule:line-length
-        image: mcr.microsoft.com/windows/nanoserver:ltsc2019
-        imagePullPolicy: IfNotPresent
-        securityContext:
-          capabilities:
-            drop:
-            - ALL
-        command:
-        - "powershell.exe"
-        - "-Command"
-        - |
-          New-Item -ItemType Directory -Force -Path /var/lib/storage/otc;
-          Get-DnsClientServerAddress |
-          Where-Object { $_.ServerAddresses.Count -gt 0 -and $_.AddressFamily -eq 2 } |
-          ForEach-Object {
-            If ( -Not ($_.ServerAddresses.Contains("10.100.0.10")) ) {
-              $addresses = ,"10.100.0.10" + $_.ServerAddresses;
-              Set-DnsClientServerAddress -InterfaceIndex $_.InterfaceIndex -ServerAddresses $addresses
-            }
-          }
-        volumeMounts:
-        - mountPath: /var/lib/storage/otc
-          name: file-storage
+        - name: prepare # create storage directory and adjust DNSes to allow connection with cluster. It adds cluster DNS server as primary DNS server
+          # yamllint disable-line rule:line-length
+          image: mcr.microsoft.com/windows/nanoserver:ltsc2019
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - "powershell.exe"
+            - "-Command"
+            - |
+              New-Item -ItemType Directory -Force -Path /var/lib/storage/otc;
+              Get-DnsClientServerAddress |
+              Where-Object { $_.ServerAddresses.Count -gt 0 -and $_.AddressFamily -eq 2 } |
+              ForEach-Object {
+                If ( -Not ($_.ServerAddresses.Contains("10.100.0.10")) ) {
+                  $addresses = ,"10.100.0.10" + $_.ServerAddresses;
+                  Set-DnsClientServerAddress -InterfaceIndex $_.InterfaceIndex -ServerAddresses $addresses
+                }
+              }
+          volumeMounts:
+            - mountPath: /var/lib/storage/otc
+              name: file-storage
       volumes:
-      - configMap:
-          defaultMode: 420
-          items:
-          - key: config.yaml
-            path: config.yaml
-          name: RELEASE-NAME-sumologic-otelcol-windows-logs-collector
-        name: otelcol-config
-      - hostPath:
-          path: /var/log/pods
-          type: ""
-        name: varlogpods
-      - hostPath:
-          path: /var/lib/docker/containers
-          type: ""
-        name: varlibdockercontainers
-      - hostPath:
-          path: /var/lib/otc
-          type: DirectoryOrCreate
-        name: file-storage
-      - hostPath:
-          path: /var/log/journal/
-          type: ""
-        name: varlogjournal
-      - name: es-certs
-        secret:
-          defaultMode: 420
-          secretName: es-certs
+        - configMap:
+            defaultMode: 420
+            items:
+              - key: config.yaml
+                path: config.yaml
+            name: RELEASE-NAME-sumologic-otelcol-windows-logs-collector
+          name: otelcol-config
+        - hostPath:
+            path: /var/log/pods
+            type: ""
+          name: varlogpods
+        - hostPath:
+            path: /var/lib/docker/containers
+            type: ""
+          name: varlibdockercontainers
+        - hostPath:
+            path: /var/lib/otc
+            type: DirectoryOrCreate
+          name: file-storage
+        - hostPath:
+            path: /var/log/journal/
+            type: ""
+          name: varlogjournal
+        - name: es-certs
+          secret:
+            defaultMode: 420
+            secretName: es-certs
       serviceAccountName: RELEASE-NAME-sumologic-otelcol-logs-collector
-

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc_statefulset/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc_statefulset/basic.output.yaml
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: "%CONFIG_CHECKSUM%"
+        checksum/config: '%CONFIG_CHECKSUM%'
       labels:
         app: RELEASE-NAME-sumologic-otelcol-logs
         chart: "sumologic-%CURRENT_CHART_VERSION%"
@@ -33,86 +33,93 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       volumes:
-        - name: config-volume
-          configMap:
-            name: RELEASE-NAME-sumologic-otelcol-logs
-        - name: tmp
-          emptyDir: {}
+      - name: config-volume
+        configMap:
+          name: RELEASE-NAME-sumologic-otelcol-logs
+      - name: tmp
+        emptyDir: {}
       securityContext:
         fsGroup: 999
       containers:
-        - name: otelcol
-          image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
-          imagePullPolicy: IfNotPresent
-          args:
-            - --config=/etc/otel/config.yaml
-          resources:
-            limits:
-              cpu: 1000m
-              memory: 1Gi
-            requests:
-              cpu: 500m
-              memory: 768Mi
-          ports:
-            - name: metrics
-              containerPort: 8888
-              protocol: TCP
-            - name: otlphttp
-              containerPort: 4318
-              protocol: TCP
-            - name: pprof
-              containerPort: 1777
-              protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 3
-            initialDelaySeconds: 15
-            periodSeconds: 15
-            timeoutSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 3
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 3
-          startupProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 60
-            periodSeconds: 3
-          volumeMounts:
-            - name: config-volume
-              mountPath: /etc/otel/config.yaml
-              subPath: config.yaml
-            - name: tmp
-              mountPath: /tmp
-            - name: file-storage
-              mountPath: /var/lib/storage/otc
-          env:
-            - name: SUMO_ENDPOINT_DEFAULT_OTLP_LOGS_SOURCE
-              valueFrom:
-                secretKeyRef:
-                  name: sumologic
-                  key: endpoint-logs-otlp
-
-            - name: NO_PROXY
-              value: kubernetes.default.svc
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP
-  volumeClaimTemplates:
-    - metadata:
-        name: file-storage
-      spec:
-        accessModes: [ReadWriteOnce]
-        storageClassName:
+      - name: otelcol
+        image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
+        imagePullPolicy: IfNotPresent
+        args:
+          - --config=/etc/otel/config.yaml
         resources:
+          limits:
+            cpu: 1000m
+            memory: 1Gi
           requests:
-            storage: 10Gi
+            cpu: 500m
+            memory: 768Mi
+        ports:
+        - name: metrics
+          containerPort: 8888
+          protocol: TCP
+        - name: otlphttp
+          containerPort: 4318
+          protocol: TCP
+        - name: pprof
+          containerPort: 1777
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 3
+        startupProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 60
+          periodSeconds: 3
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/otel/config.yaml
+          subPath: config.yaml
+        - name: tmp
+          mountPath: /tmp
+        - name: file-storage
+          mountPath: /var/lib/storage/otc
+        env:
+        - name: SUMO_ENDPOINT_DEFAULT_OTLP_LOGS_SOURCE
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-logs-otlp
+        
+        
+        - name: NO_PROXY
+          value: kubernetes.default.svc
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+  volumeClaimTemplates:
+  - metadata:
+      name: file-storage
+    spec:
+      accessModes: [ReadWriteOnce]
+      storageClassName: 
+      resources:
+        requests:
+          storage: 10Gi
+

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc_statefulset/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc_statefulset/basic.output.yaml
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: '%CONFIG_CHECKSUM%'
+        checksum/config: "%CONFIG_CHECKSUM%"
       labels:
         app: RELEASE-NAME-sumologic-otelcol-logs
         chart: "sumologic-%CURRENT_CHART_VERSION%"
@@ -33,93 +33,91 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       volumes:
-      - name: config-volume
-        configMap:
-          name: RELEASE-NAME-sumologic-otelcol-logs
-      - name: tmp
-        emptyDir: {}
+        - name: config-volume
+          configMap:
+            name: RELEASE-NAME-sumologic-otelcol-logs
+        - name: tmp
+          emptyDir: {}
       securityContext:
         fsGroup: 999
       containers:
-      - name: otelcol
-        image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
-        imagePullPolicy: IfNotPresent
-        args:
-          - --config=/etc/otel/config.yaml
-        resources:
-          limits:
-            cpu: 1000m
-            memory: 1Gi
-          requests:
-            cpu: 500m
-            memory: 768Mi
-        ports:
-        - name: metrics
-          containerPort: 8888
-          protocol: TCP
-        - name: otlphttp
-          containerPort: 4318
-          protocol: TCP
-        - name: pprof
-          containerPort: 1777
-          protocol: TCP
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 3
-          initialDelaySeconds: 15
-          periodSeconds: 15
-          timeoutSeconds: 10
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 3
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          timeoutSeconds: 3
-        startupProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 60
-          periodSeconds: 3
-        volumeMounts:
-        - name: config-volume
-          mountPath: /etc/otel/config.yaml
-          subPath: config.yaml
-        - name: tmp
-          mountPath: /tmp
-        - name: file-storage
-          mountPath: /var/lib/storage/otc
-        env:
-        - name: SUMO_ENDPOINT_DEFAULT_OTLP_LOGS_SOURCE
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-logs-otlp
-        
-        
-        - name: NO_PROXY
-          value: kubernetes.default.svc
-        - name: MY_POD_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: MY_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-  volumeClaimTemplates:
-  - metadata:
-      name: file-storage
-    spec:
-      accessModes: [ReadWriteOnce]
-      storageClassName: 
-      resources:
-        requests:
-          storage: 10Gi
+        - name: otelcol
+          image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config=/etc/otel/config.yaml
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+            requests:
+              cpu: 500m
+              memory: 768Mi
+          ports:
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+            - name: otlphttp
+              containerPort: 4318
+              protocol: TCP
+            - name: pprof
+              containerPort: 1777
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 3
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 60
+            periodSeconds: 3
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/otel/config.yaml
+              subPath: config.yaml
+            - name: tmp
+              mountPath: /tmp
+            - name: file-storage
+              mountPath: /var/lib/storage/otc
+          env:
+            - name: SUMO_ENDPOINT_DEFAULT_OTLP_LOGS_SOURCE
+              valueFrom:
+                secretKeyRef:
+                  name: sumologic
+                  key: endpoint-logs-otlp
 
+            - name: NO_PROXY
+              value: kubernetes.default.svc
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+  volumeClaimTemplates:
+    - metadata:
+        name: file-storage
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName:
+        resources:
+          requests:
+            storage: 10Gi

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc_statefulset/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc_statefulset/custom.output.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: '%CONFIG_CHECKSUM%'
+        checksum/config: "%CONFIG_CHECKSUM%"
         someAnnotation: someValue
       labels:
         app: RELEASE-NAME-sumologic-otelcol-logs
@@ -42,113 +42,111 @@ spec:
           operator: Equal
           value: worker
       volumes:
-      - name: config-volume
-        configMap:
-          name: RELEASE-NAME-sumologic-otelcol-logs
-      - name: tmp
-        emptyDir: {}
-      - name: es-certs
-        secret:
-          defaultMode: 420
-          secretName: es-certs
+        - name: config-volume
+          configMap:
+            name: RELEASE-NAME-sumologic-otelcol-logs
+        - name: tmp
+          emptyDir: {}
+        - name: es-certs
+          secret:
+            defaultMode: 420
+            secretName: es-certs
       securityContext:
         fsGroup: 999
       priorityClassName: "prio"
       containers:
-      - name: otelcol
-        image: "my_repository:my_tag"
-        imagePullPolicy: IfNotPresent
-        args:
-          - --config=/etc/otel/config.yaml
-          - --config=/etc/otel/test-config.yaml
-        resources:
-          limits:
-            cpu: 2000m
-            memory: 2Gi
-          requests:
-            cpu: 100m
-            memory: 777Mi
-        ports:
-        - name: metrics
-          containerPort: 8888
-          protocol: TCP
-        - name: otlphttp
-          containerPort: 4318
-          protocol: TCP
-        - name: pprof
-          containerPort: 1777
-          protocol: TCP
-        - containerPort: 4319
-          name: otlphttp2
-          protocol: TCP
-        - containerPort: 4320
-          name: otlphttp3
-          protocol: TCP
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 3
-          initialDelaySeconds: 15
-          periodSeconds: 15
-          timeoutSeconds: 10
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 3
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          timeoutSeconds: 3
-        startupProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 60
-          periodSeconds: 3
-        volumeMounts:
-        - name: config-volume
-          mountPath: /etc/otel/config.yaml
-          subPath: config.yaml
-        - name: tmp
-          mountPath: /tmp
-        - name: file-storage
-          mountPath: /var/lib/storage/otc
-        - mountPath: /certs
-          name: es-certs
-          readOnly: true
-        env:
-        - name: SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-logs
-        
-        
-        - name: NO_PROXY
-          value: kubernetes.default.svc
-        - name: MY_POD_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: MY_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: VALUE_FROM_SECRET
-          valueFrom:
-            secretKeyRef:
-              key: secret_key
-              name: secret_name
-  volumeClaimTemplates:
-  - metadata:
-      name: file-storage
-    spec:
-      accessModes: [ReadWriteOnce]
-      storageClassName: 
-      resources:
-        requests:
-          storage: 10Gi
+        - name: otelcol
+          image: "my_repository:my_tag"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config=/etc/otel/config.yaml
+            - --config=/etc/otel/test-config.yaml
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 100m
+              memory: 777Mi
+          ports:
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+            - name: otlphttp
+              containerPort: 4318
+              protocol: TCP
+            - name: pprof
+              containerPort: 1777
+              protocol: TCP
+            - containerPort: 4319
+              name: otlphttp2
+              protocol: TCP
+            - containerPort: 4320
+              name: otlphttp3
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 3
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 60
+            periodSeconds: 3
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/otel/config.yaml
+              subPath: config.yaml
+            - name: tmp
+              mountPath: /tmp
+            - name: file-storage
+              mountPath: /var/lib/storage/otc
+            - mountPath: /certs
+              name: es-certs
+              readOnly: true
+          env:
+            - name: SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE
+              valueFrom:
+                secretKeyRef:
+                  name: sumologic
+                  key: endpoint-logs
 
+            - name: NO_PROXY
+              value: kubernetes.default.svc
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: VALUE_FROM_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: secret_key
+                  name: secret_name
+  volumeClaimTemplates:
+    - metadata:
+        name: file-storage
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName:
+        resources:
+          requests:
+            storage: 10Gi

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc_statefulset/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc_statefulset/custom.output.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: "%CONFIG_CHECKSUM%"
+        checksum/config: '%CONFIG_CHECKSUM%'
         someAnnotation: someValue
       labels:
         app: RELEASE-NAME-sumologic-otelcol-logs
@@ -42,106 +42,113 @@ spec:
           operator: Equal
           value: worker
       volumes:
-        - name: config-volume
-          configMap:
-            name: RELEASE-NAME-sumologic-otelcol-logs
-        - name: tmp
-          emptyDir: {}
-        - name: es-certs
-          secret:
-            defaultMode: 420
-            secretName: es-certs
+      - name: config-volume
+        configMap:
+          name: RELEASE-NAME-sumologic-otelcol-logs
+      - name: tmp
+        emptyDir: {}
+      - name: es-certs
+        secret:
+          defaultMode: 420
+          secretName: es-certs
       securityContext:
         fsGroup: 999
       priorityClassName: "prio"
       containers:
-        - name: otelcol
-          image: "my_repository:my_tag"
-          imagePullPolicy: IfNotPresent
-          args:
-            - --config=/etc/otel/config.yaml
-            - --config=/etc/otel/test-config.yaml
-          resources:
-            limits:
-              cpu: 2000m
-              memory: 2Gi
-            requests:
-              cpu: 100m
-              memory: 777Mi
-          ports:
-            - name: metrics
-              containerPort: 8888
-              protocol: TCP
-            - name: otlphttp
-              containerPort: 4318
-              protocol: TCP
-            - name: pprof
-              containerPort: 1777
-              protocol: TCP
-            - containerPort: 4319
-              name: otlphttp2
-              protocol: TCP
-            - containerPort: 4320
-              name: otlphttp3
-              protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 3
-            initialDelaySeconds: 15
-            periodSeconds: 15
-            timeoutSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 3
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 3
-          startupProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 60
-            periodSeconds: 3
-          volumeMounts:
-            - name: config-volume
-              mountPath: /etc/otel/config.yaml
-              subPath: config.yaml
-            - name: tmp
-              mountPath: /tmp
-            - name: file-storage
-              mountPath: /var/lib/storage/otc
-            - mountPath: /certs
-              name: es-certs
-              readOnly: true
-          env:
-            - name: SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE
-              valueFrom:
-                secretKeyRef:
-                  name: sumologic
-                  key: endpoint-logs
-
-            - name: NO_PROXY
-              value: kubernetes.default.svc
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP
-            - name: VALUE_FROM_SECRET
-              valueFrom:
-                secretKeyRef:
-                  key: secret_key
-                  name: secret_name
-  volumeClaimTemplates:
-    - metadata:
-        name: file-storage
-      spec:
-        accessModes: [ReadWriteOnce]
-        storageClassName:
+      - name: otelcol
+        image: "my_repository:my_tag"
+        imagePullPolicy: IfNotPresent
+        args:
+          - --config=/etc/otel/config.yaml
+          - --config=/etc/otel/test-config.yaml
         resources:
+          limits:
+            cpu: 2000m
+            memory: 2Gi
           requests:
-            storage: 10Gi
+            cpu: 100m
+            memory: 777Mi
+        ports:
+        - name: metrics
+          containerPort: 8888
+          protocol: TCP
+        - name: otlphttp
+          containerPort: 4318
+          protocol: TCP
+        - name: pprof
+          containerPort: 1777
+          protocol: TCP
+        - containerPort: 4319
+          name: otlphttp2
+          protocol: TCP
+        - containerPort: 4320
+          name: otlphttp3
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 3
+        startupProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 60
+          periodSeconds: 3
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/otel/config.yaml
+          subPath: config.yaml
+        - name: tmp
+          mountPath: /tmp
+        - name: file-storage
+          mountPath: /var/lib/storage/otc
+        - mountPath: /certs
+          name: es-certs
+          readOnly: true
+        env:
+        - name: SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-logs
+        
+        
+        - name: NO_PROXY
+          value: kubernetes.default.svc
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: VALUE_FROM_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: secret_key
+              name: secret_name
+  volumeClaimTemplates:
+  - metadata:
+      name: file-storage
+    spec:
+      accessModes: [ReadWriteOnce]
+      storageClassName: 
+      resources:
+        requests:
+          storage: 10Gi
+

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc_statefulset/pvcpolicyenabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc_statefulset/pvcpolicyenabled.output.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: '%CONFIG_CHECKSUM%'
+        checksum/config: "%CONFIG_CHECKSUM%"
         someAnnotation: someValue
       labels:
         app: RELEASE-NAME-sumologic-otelcol-logs
@@ -39,113 +39,111 @@ spec:
           operator: Equal
           value: worker
       volumes:
-      - name: config-volume
-        configMap:
-          name: RELEASE-NAME-sumologic-otelcol-logs
-      - name: tmp
-        emptyDir: {}
-      - name: es-certs
-        secret:
-          defaultMode: 420
-          secretName: es-certs
+        - name: config-volume
+          configMap:
+            name: RELEASE-NAME-sumologic-otelcol-logs
+        - name: tmp
+          emptyDir: {}
+        - name: es-certs
+          secret:
+            defaultMode: 420
+            secretName: es-certs
       securityContext:
         fsGroup: 999
       priorityClassName: "prio"
       containers:
-      - name: otelcol
-        image: "my_repository:my_tag"
-        imagePullPolicy: IfNotPresent
-        args:
-          - --config=/etc/otel/config.yaml
-          - --config=/etc/otel/test-config.yaml
-        resources:
-          limits:
-            cpu: 2000m
-            memory: 2Gi
-          requests:
-            cpu: 100m
-            memory: 777Mi
-        ports:
-        - name: metrics
-          containerPort: 8888
-          protocol: TCP
-        - name: otlphttp
-          containerPort: 4318
-          protocol: TCP
-        - name: pprof
-          containerPort: 1777
-          protocol: TCP
-        - containerPort: 4319
-          name: otlphttp2
-          protocol: TCP
-        - containerPort: 4320
-          name: otlphttp3
-          protocol: TCP
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 3
-          initialDelaySeconds: 15
-          periodSeconds: 15
-          timeoutSeconds: 10
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 3
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          timeoutSeconds: 3
-        startupProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 60
-          periodSeconds: 3
-        volumeMounts:
-        - name: config-volume
-          mountPath: /etc/otel/config.yaml
-          subPath: config.yaml
-        - name: tmp
-          mountPath: /tmp
-        - name: file-storage
-          mountPath: /var/lib/storage/otc
-        - mountPath: /certs
-          name: es-certs
-          readOnly: true
-        env:
-        - name: SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-logs
-        
-        
-        - name: NO_PROXY
-          value: kubernetes.default.svc
-        - name: MY_POD_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: MY_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: VALUE_FROM_SECRET
-          valueFrom:
-            secretKeyRef:
-              key: secret_key
-              name: secret_name
-  volumeClaimTemplates:
-  - metadata:
-      name: file-storage
-    spec:
-      accessModes: [ReadWriteOnce]
-      storageClassName: 
-      resources:
-        requests:
-          storage: 10Gi
+        - name: otelcol
+          image: "my_repository:my_tag"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config=/etc/otel/config.yaml
+            - --config=/etc/otel/test-config.yaml
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 100m
+              memory: 777Mi
+          ports:
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+            - name: otlphttp
+              containerPort: 4318
+              protocol: TCP
+            - name: pprof
+              containerPort: 1777
+              protocol: TCP
+            - containerPort: 4319
+              name: otlphttp2
+              protocol: TCP
+            - containerPort: 4320
+              name: otlphttp3
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 3
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 60
+            periodSeconds: 3
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/otel/config.yaml
+              subPath: config.yaml
+            - name: tmp
+              mountPath: /tmp
+            - name: file-storage
+              mountPath: /var/lib/storage/otc
+            - mountPath: /certs
+              name: es-certs
+              readOnly: true
+          env:
+            - name: SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE
+              valueFrom:
+                secretKeyRef:
+                  name: sumologic
+                  key: endpoint-logs
 
+            - name: NO_PROXY
+              value: kubernetes.default.svc
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: VALUE_FROM_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: secret_key
+                  name: secret_name
+  volumeClaimTemplates:
+    - metadata:
+        name: file-storage
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName:
+        resources:
+          requests:
+            storage: 10Gi

--- a/tests/helm/testdata/goldenfile/metadata_logs_otc_statefulset/pvcpolicyenabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_logs_otc_statefulset/pvcpolicyenabled.output.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: "%CONFIG_CHECKSUM%"
+        checksum/config: '%CONFIG_CHECKSUM%'
         someAnnotation: someValue
       labels:
         app: RELEASE-NAME-sumologic-otelcol-logs
@@ -39,106 +39,113 @@ spec:
           operator: Equal
           value: worker
       volumes:
-        - name: config-volume
-          configMap:
-            name: RELEASE-NAME-sumologic-otelcol-logs
-        - name: tmp
-          emptyDir: {}
-        - name: es-certs
-          secret:
-            defaultMode: 420
-            secretName: es-certs
+      - name: config-volume
+        configMap:
+          name: RELEASE-NAME-sumologic-otelcol-logs
+      - name: tmp
+        emptyDir: {}
+      - name: es-certs
+        secret:
+          defaultMode: 420
+          secretName: es-certs
       securityContext:
         fsGroup: 999
       priorityClassName: "prio"
       containers:
-        - name: otelcol
-          image: "my_repository:my_tag"
-          imagePullPolicy: IfNotPresent
-          args:
-            - --config=/etc/otel/config.yaml
-            - --config=/etc/otel/test-config.yaml
-          resources:
-            limits:
-              cpu: 2000m
-              memory: 2Gi
-            requests:
-              cpu: 100m
-              memory: 777Mi
-          ports:
-            - name: metrics
-              containerPort: 8888
-              protocol: TCP
-            - name: otlphttp
-              containerPort: 4318
-              protocol: TCP
-            - name: pprof
-              containerPort: 1777
-              protocol: TCP
-            - containerPort: 4319
-              name: otlphttp2
-              protocol: TCP
-            - containerPort: 4320
-              name: otlphttp3
-              protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 3
-            initialDelaySeconds: 15
-            periodSeconds: 15
-            timeoutSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 3
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 3
-          startupProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 60
-            periodSeconds: 3
-          volumeMounts:
-            - name: config-volume
-              mountPath: /etc/otel/config.yaml
-              subPath: config.yaml
-            - name: tmp
-              mountPath: /tmp
-            - name: file-storage
-              mountPath: /var/lib/storage/otc
-            - mountPath: /certs
-              name: es-certs
-              readOnly: true
-          env:
-            - name: SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE
-              valueFrom:
-                secretKeyRef:
-                  name: sumologic
-                  key: endpoint-logs
-
-            - name: NO_PROXY
-              value: kubernetes.default.svc
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP
-            - name: VALUE_FROM_SECRET
-              valueFrom:
-                secretKeyRef:
-                  key: secret_key
-                  name: secret_name
-  volumeClaimTemplates:
-    - metadata:
-        name: file-storage
-      spec:
-        accessModes: [ReadWriteOnce]
-        storageClassName:
+      - name: otelcol
+        image: "my_repository:my_tag"
+        imagePullPolicy: IfNotPresent
+        args:
+          - --config=/etc/otel/config.yaml
+          - --config=/etc/otel/test-config.yaml
         resources:
+          limits:
+            cpu: 2000m
+            memory: 2Gi
           requests:
-            storage: 10Gi
+            cpu: 100m
+            memory: 777Mi
+        ports:
+        - name: metrics
+          containerPort: 8888
+          protocol: TCP
+        - name: otlphttp
+          containerPort: 4318
+          protocol: TCP
+        - name: pprof
+          containerPort: 1777
+          protocol: TCP
+        - containerPort: 4319
+          name: otlphttp2
+          protocol: TCP
+        - containerPort: 4320
+          name: otlphttp3
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 3
+        startupProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 60
+          periodSeconds: 3
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/otel/config.yaml
+          subPath: config.yaml
+        - name: tmp
+          mountPath: /tmp
+        - name: file-storage
+          mountPath: /var/lib/storage/otc
+        - mountPath: /certs
+          name: es-certs
+          readOnly: true
+        env:
+        - name: SUMO_ENDPOINT_DEFAULT_LOGS_SOURCE
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-logs
+        
+        
+        - name: NO_PROXY
+          value: kubernetes.default.svc
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: VALUE_FROM_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: secret_key
+              name: secret_name
+  volumeClaimTemplates:
+  - metadata:
+      name: file-storage
+    spec:
+      accessModes: [ReadWriteOnce]
+      storageClassName: 
+      resources:
+        requests:
+          storage: 10Gi
+

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc_statefulset/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc_statefulset/basic.output.yaml
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: '%CONFIG_CHECKSUM%'
+        checksum/config: "%CONFIG_CHECKSUM%"
       labels:
         app: RELEASE-NAME-sumologic-otelcol-metrics
         chart: "sumologic-%CURRENT_CHART_VERSION%"
@@ -35,113 +35,111 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - RELEASE-NAME-sumologic-otelcol-logs
-                  - RELEASE-NAME-sumologic-otelcol-metrics
-                  - RELEASE-NAME-sumologic-otelcol-events
-                  - RELEASE-NAME-sumologic-otelcol-instrumentation
-                - key: app
-                  operator: In
-                  values:
-                  - prometheus-operator-prometheus
-              topologyKey: "kubernetes.io/hostname"
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - RELEASE-NAME-sumologic-otelcol-logs
+                        - RELEASE-NAME-sumologic-otelcol-metrics
+                        - RELEASE-NAME-sumologic-otelcol-events
+                        - RELEASE-NAME-sumologic-otelcol-instrumentation
+                    - key: app
+                      operator: In
+                      values:
+                        - prometheus-operator-prometheus
+                topologyKey: "kubernetes.io/hostname"
       volumes:
-      - name: config-volume
-        configMap:
-          name: RELEASE-NAME-sumologic-otelcol-metrics
-      - name: tmp
-        emptyDir: {}
+        - name: config-volume
+          configMap:
+            name: RELEASE-NAME-sumologic-otelcol-metrics
+        - name: tmp
+          emptyDir: {}
       securityContext:
         fsGroup: 999
       containers:
-      - name: otelcol
-        image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
-        imagePullPolicy: IfNotPresent
-        args:
-          - --config=/etc/otel/config.yaml
-        resources:
-          limits:
-            cpu: 1000m
-            memory: 1Gi
-          requests:
-            cpu: 500m
-            memory: 768Mi
-        ports:
-        - name: otlphttp
-          containerPort: 4318
-          protocol: TCP
-        - name: prom-write
-          containerPort: 9888
-          protocol: TCP
-        - name: metrics
-          containerPort: 8888
-          protocol: TCP
-        - name: pprof
-          containerPort: 1777
-          protocol: TCP
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 3
-          initialDelaySeconds: 15
-          periodSeconds: 15
-          timeoutSeconds: 10
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 3
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          timeoutSeconds: 3
-        startupProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 60
-          periodSeconds: 3
-        volumeMounts:
-        - name: config-volume
-          mountPath: /etc/otel/config.yaml
-          subPath: config.yaml
-        - name: tmp
-          mountPath: /tmp
-        - name: file-storage
-          mountPath: /var/lib/storage/otc
-        env:
-        - name: SUMO_ENDPOINT_DEFAULT_OTLP_METRICS_SOURCE
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics-otlp
-        
-        
-        - name: NO_PROXY
-          value: kubernetes.default.svc
-        - name: MY_POD_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: MY_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-  volumeClaimTemplates:
-  - metadata:
-      name: file-storage
-    spec:
-      accessModes: [ReadWriteOnce]
-      storageClassName: 
-      resources:
-        requests:
-          storage: 10Gi
+        - name: otelcol
+          image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config=/etc/otel/config.yaml
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+            requests:
+              cpu: 500m
+              memory: 768Mi
+          ports:
+            - name: otlphttp
+              containerPort: 4318
+              protocol: TCP
+            - name: prom-write
+              containerPort: 9888
+              protocol: TCP
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+            - name: pprof
+              containerPort: 1777
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 3
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 60
+            periodSeconds: 3
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/otel/config.yaml
+              subPath: config.yaml
+            - name: tmp
+              mountPath: /tmp
+            - name: file-storage
+              mountPath: /var/lib/storage/otc
+          env:
+            - name: SUMO_ENDPOINT_DEFAULT_OTLP_METRICS_SOURCE
+              valueFrom:
+                secretKeyRef:
+                  name: sumologic
+                  key: endpoint-metrics-otlp
 
+            - name: NO_PROXY
+              value: kubernetes.default.svc
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+  volumeClaimTemplates:
+    - metadata:
+        name: file-storage
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName:
+        resources:
+          requests:
+            storage: 10Gi

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc_statefulset/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc_statefulset/basic.output.yaml
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: "%CONFIG_CHECKSUM%"
+        checksum/config: '%CONFIG_CHECKSUM%'
       labels:
         app: RELEASE-NAME-sumologic-otelcol-metrics
         chart: "sumologic-%CURRENT_CHART_VERSION%"
@@ -35,106 +35,113 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: app
-                      operator: In
-                      values:
-                        - RELEASE-NAME-sumologic-otelcol-logs
-                        - RELEASE-NAME-sumologic-otelcol-metrics
-                        - RELEASE-NAME-sumologic-otelcol-events
-                        - RELEASE-NAME-sumologic-otelcol-instrumentation
-                    - key: app
-                      operator: In
-                      values:
-                        - prometheus-operator-prometheus
-                topologyKey: "kubernetes.io/hostname"
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - RELEASE-NAME-sumologic-otelcol-logs
+                  - RELEASE-NAME-sumologic-otelcol-metrics
+                  - RELEASE-NAME-sumologic-otelcol-events
+                  - RELEASE-NAME-sumologic-otelcol-instrumentation
+                - key: app
+                  operator: In
+                  values:
+                  - prometheus-operator-prometheus
+              topologyKey: "kubernetes.io/hostname"
       volumes:
-        - name: config-volume
-          configMap:
-            name: RELEASE-NAME-sumologic-otelcol-metrics
-        - name: tmp
-          emptyDir: {}
+      - name: config-volume
+        configMap:
+          name: RELEASE-NAME-sumologic-otelcol-metrics
+      - name: tmp
+        emptyDir: {}
       securityContext:
         fsGroup: 999
       containers:
-        - name: otelcol
-          image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
-          imagePullPolicy: IfNotPresent
-          args:
-            - --config=/etc/otel/config.yaml
-          resources:
-            limits:
-              cpu: 1000m
-              memory: 1Gi
-            requests:
-              cpu: 500m
-              memory: 768Mi
-          ports:
-            - name: otlphttp
-              containerPort: 4318
-              protocol: TCP
-            - name: prom-write
-              containerPort: 9888
-              protocol: TCP
-            - name: metrics
-              containerPort: 8888
-              protocol: TCP
-            - name: pprof
-              containerPort: 1777
-              protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 3
-            initialDelaySeconds: 15
-            periodSeconds: 15
-            timeoutSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 3
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 3
-          startupProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 60
-            periodSeconds: 3
-          volumeMounts:
-            - name: config-volume
-              mountPath: /etc/otel/config.yaml
-              subPath: config.yaml
-            - name: tmp
-              mountPath: /tmp
-            - name: file-storage
-              mountPath: /var/lib/storage/otc
-          env:
-            - name: SUMO_ENDPOINT_DEFAULT_OTLP_METRICS_SOURCE
-              valueFrom:
-                secretKeyRef:
-                  name: sumologic
-                  key: endpoint-metrics-otlp
-
-            - name: NO_PROXY
-              value: kubernetes.default.svc
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP
-  volumeClaimTemplates:
-    - metadata:
-        name: file-storage
-      spec:
-        accessModes: [ReadWriteOnce]
-        storageClassName:
+      - name: otelcol
+        image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
+        imagePullPolicy: IfNotPresent
+        args:
+          - --config=/etc/otel/config.yaml
         resources:
+          limits:
+            cpu: 1000m
+            memory: 1Gi
           requests:
-            storage: 10Gi
+            cpu: 500m
+            memory: 768Mi
+        ports:
+        - name: otlphttp
+          containerPort: 4318
+          protocol: TCP
+        - name: prom-write
+          containerPort: 9888
+          protocol: TCP
+        - name: metrics
+          containerPort: 8888
+          protocol: TCP
+        - name: pprof
+          containerPort: 1777
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 3
+        startupProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 60
+          periodSeconds: 3
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/otel/config.yaml
+          subPath: config.yaml
+        - name: tmp
+          mountPath: /tmp
+        - name: file-storage
+          mountPath: /var/lib/storage/otc
+        env:
+        - name: SUMO_ENDPOINT_DEFAULT_OTLP_METRICS_SOURCE
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-metrics-otlp
+        
+        
+        - name: NO_PROXY
+          value: kubernetes.default.svc
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+  volumeClaimTemplates:
+  - metadata:
+      name: file-storage
+    spec:
+      accessModes: [ReadWriteOnce]
+      storageClassName: 
+      resources:
+        requests:
+          storage: 10Gi
+

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc_statefulset/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc_statefulset/custom.output.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: '%CONFIG_CHECKSUM%'
+        checksum/config: "%CONFIG_CHECKSUM%"
         someAnnotation: someValue
       labels:
         app: RELEASE-NAME-sumologic-otelcol-metrics
@@ -44,161 +44,159 @@ spec:
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - RELEASE-NAME-sumologic-otelcol-logs
-                - RELEASE-NAME-sumologic-otelcol-metrics
-                - RELEASE-NAME-sumologic-otelcol-events
-                - RELEASE-NAME-sumologic-otelcol-instrumentation
-              - key: app
-                operator: In
-                values:
-                - prometheus-operator-prometheus
-            topologyKey: "kubernetes.io/hostname"
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - RELEASE-NAME-sumologic-otelcol-logs
+                      - RELEASE-NAME-sumologic-otelcol-metrics
+                      - RELEASE-NAME-sumologic-otelcol-events
+                      - RELEASE-NAME-sumologic-otelcol-instrumentation
+                  - key: app
+                    operator: In
+                    values:
+                      - prometheus-operator-prometheus
+              topologyKey: "kubernetes.io/hostname"
 
       volumes:
-      - name: config-volume
-        configMap:
-          name: RELEASE-NAME-sumologic-otelcol-metrics
-      - name: tmp
-        emptyDir: {}
-      - name: es-certs
-        secret:
-          defaultMode: 420
-          secretName: es-certs
+        - name: config-volume
+          configMap:
+            name: RELEASE-NAME-sumologic-otelcol-metrics
+        - name: tmp
+          emptyDir: {}
+        - name: es-certs
+          secret:
+            defaultMode: 420
+            secretName: es-certs
       securityContext:
         fsGroup: 999
       priorityClassName: "prio"
       containers:
-      - name: otelcol
-        image: "my_repository:my_tag"
-        imagePullPolicy: IfNotPresent
-        args:
-          - --config=/etc/otel/config.yaml
-        resources:
-          limits:
-            cpu: 2000m
-            memory: 2Gi
-          requests:
-            cpu: 100m
-            memory: 777Mi
-        ports:
-        - name: otlphttp
-          containerPort: 4318
-          protocol: TCP
-        - name: prom-write
-          containerPort: 9888
-          protocol: TCP
-        - name: metrics
-          containerPort: 8888
-          protocol: TCP
-        - name: pprof
-          containerPort: 1777
-          protocol: TCP
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 3
-          initialDelaySeconds: 15
-          periodSeconds: 15
-          timeoutSeconds: 10
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 3
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          timeoutSeconds: 3
-        startupProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 60
-          periodSeconds: 3
-        volumeMounts:
-        - name: config-volume
-          mountPath: /etc/otel/config.yaml
-          subPath: config.yaml
-        - name: tmp
-          mountPath: /tmp
-        - name: file-storage
-          mountPath: /var/lib/storage/otc
-        - mountPath: /certs
-          name: es-certs
-          readOnly: true
-        env:
-        - name: SUMO_ENDPOINT_APISERVER_METRICS_SOURCE
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics-apiserver
-        - name: SUMO_ENDPOINT_CONTROL_PLANE_METRICS_SOURCE
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-control_plane_metrics_source
-        - name: SUMO_ENDPOINT_CONTROLLER_METRICS_SOURCE
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics-kube-controller-manager
-        - name: SUMO_ENDPOINT_DEFAULT_METRICS_SOURCE
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics
-        - name: SUMO_ENDPOINT_KUBELET_METRICS_SOURCE
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics-kubelet
-        - name: SUMO_ENDPOINT_NODE_METRICS_SOURCE
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics-node-exporter
-        - name: SUMO_ENDPOINT_SCHEDULER_METRICS_SOURCE
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics-kube-scheduler
-        - name: SUMO_ENDPOINT_STATE_METRICS_SOURCE
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics-kube-state
-        
-        
-        - name: NO_PROXY
-          value: kubernetes.default.svc
-        - name: MY_POD_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: MY_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
+        - name: otelcol
+          image: "my_repository:my_tag"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config=/etc/otel/config.yaml
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 100m
+              memory: 777Mi
+          ports:
+            - name: otlphttp
+              containerPort: 4318
+              protocol: TCP
+            - name: prom-write
+              containerPort: 9888
+              protocol: TCP
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+            - name: pprof
+              containerPort: 1777
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 3
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 60
+            periodSeconds: 3
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/otel/config.yaml
+              subPath: config.yaml
+            - name: tmp
+              mountPath: /tmp
+            - name: file-storage
+              mountPath: /var/lib/storage/otc
+            - mountPath: /certs
+              name: es-certs
+              readOnly: true
+          env:
+            - name: SUMO_ENDPOINT_APISERVER_METRICS_SOURCE
+              valueFrom:
+                secretKeyRef:
+                  name: sumologic
+                  key: endpoint-metrics-apiserver
+            - name: SUMO_ENDPOINT_CONTROL_PLANE_METRICS_SOURCE
+              valueFrom:
+                secretKeyRef:
+                  name: sumologic
+                  key: endpoint-control_plane_metrics_source
+            - name: SUMO_ENDPOINT_CONTROLLER_METRICS_SOURCE
+              valueFrom:
+                secretKeyRef:
+                  name: sumologic
+                  key: endpoint-metrics-kube-controller-manager
+            - name: SUMO_ENDPOINT_DEFAULT_METRICS_SOURCE
+              valueFrom:
+                secretKeyRef:
+                  name: sumologic
+                  key: endpoint-metrics
+            - name: SUMO_ENDPOINT_KUBELET_METRICS_SOURCE
+              valueFrom:
+                secretKeyRef:
+                  name: sumologic
+                  key: endpoint-metrics-kubelet
+            - name: SUMO_ENDPOINT_NODE_METRICS_SOURCE
+              valueFrom:
+                secretKeyRef:
+                  name: sumologic
+                  key: endpoint-metrics-node-exporter
+            - name: SUMO_ENDPOINT_SCHEDULER_METRICS_SOURCE
+              valueFrom:
+                secretKeyRef:
+                  name: sumologic
+                  key: endpoint-metrics-kube-scheduler
+            - name: SUMO_ENDPOINT_STATE_METRICS_SOURCE
+              valueFrom:
+                secretKeyRef:
+                  name: sumologic
+                  key: endpoint-metrics-kube-state
 
-        - name: VALUE_FROM_SECRET
-          valueFrom:
-            secretKeyRef:
-              key: secret_key
-              name: secret_name
+            - name: NO_PROXY
+              value: kubernetes.default.svc
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+
+            - name: VALUE_FROM_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: secret_key
+                  name: secret_name
   volumeClaimTemplates:
-  - metadata:
-      name: file-storage
-    spec:
-      accessModes: [ReadWriteOnce]
-      storageClassName: 
-      resources:
-        requests:
-          storage: 10Gi
-
+    - metadata:
+        name: file-storage
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName:
+        resources:
+          requests:
+            storage: 10Gi

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc_statefulset/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc_statefulset/custom.output.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: "%CONFIG_CHECKSUM%"
+        checksum/config: '%CONFIG_CHECKSUM%'
         someAnnotation: someValue
       labels:
         app: RELEASE-NAME-sumologic-otelcol-metrics
@@ -44,154 +44,161 @@ spec:
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                  - key: app
-                    operator: In
-                    values:
-                      - RELEASE-NAME-sumologic-otelcol-logs
-                      - RELEASE-NAME-sumologic-otelcol-metrics
-                      - RELEASE-NAME-sumologic-otelcol-events
-                      - RELEASE-NAME-sumologic-otelcol-instrumentation
-                  - key: app
-                    operator: In
-                    values:
-                      - prometheus-operator-prometheus
-              topologyKey: "kubernetes.io/hostname"
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - RELEASE-NAME-sumologic-otelcol-logs
+                - RELEASE-NAME-sumologic-otelcol-metrics
+                - RELEASE-NAME-sumologic-otelcol-events
+                - RELEASE-NAME-sumologic-otelcol-instrumentation
+              - key: app
+                operator: In
+                values:
+                - prometheus-operator-prometheus
+            topologyKey: "kubernetes.io/hostname"
 
       volumes:
-        - name: config-volume
-          configMap:
-            name: RELEASE-NAME-sumologic-otelcol-metrics
-        - name: tmp
-          emptyDir: {}
-        - name: es-certs
-          secret:
-            defaultMode: 420
-            secretName: es-certs
+      - name: config-volume
+        configMap:
+          name: RELEASE-NAME-sumologic-otelcol-metrics
+      - name: tmp
+        emptyDir: {}
+      - name: es-certs
+        secret:
+          defaultMode: 420
+          secretName: es-certs
       securityContext:
         fsGroup: 999
       priorityClassName: "prio"
       containers:
-        - name: otelcol
-          image: "my_repository:my_tag"
-          imagePullPolicy: IfNotPresent
-          args:
-            - --config=/etc/otel/config.yaml
-          resources:
-            limits:
-              cpu: 2000m
-              memory: 2Gi
-            requests:
-              cpu: 100m
-              memory: 777Mi
-          ports:
-            - name: otlphttp
-              containerPort: 4318
-              protocol: TCP
-            - name: prom-write
-              containerPort: 9888
-              protocol: TCP
-            - name: metrics
-              containerPort: 8888
-              protocol: TCP
-            - name: pprof
-              containerPort: 1777
-              protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 3
-            initialDelaySeconds: 15
-            periodSeconds: 15
-            timeoutSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 3
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 3
-          startupProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 60
-            periodSeconds: 3
-          volumeMounts:
-            - name: config-volume
-              mountPath: /etc/otel/config.yaml
-              subPath: config.yaml
-            - name: tmp
-              mountPath: /tmp
-            - name: file-storage
-              mountPath: /var/lib/storage/otc
-            - mountPath: /certs
-              name: es-certs
-              readOnly: true
-          env:
-            - name: SUMO_ENDPOINT_APISERVER_METRICS_SOURCE
-              valueFrom:
-                secretKeyRef:
-                  name: sumologic
-                  key: endpoint-metrics-apiserver
-            - name: SUMO_ENDPOINT_CONTROL_PLANE_METRICS_SOURCE
-              valueFrom:
-                secretKeyRef:
-                  name: sumologic
-                  key: endpoint-control_plane_metrics_source
-            - name: SUMO_ENDPOINT_CONTROLLER_METRICS_SOURCE
-              valueFrom:
-                secretKeyRef:
-                  name: sumologic
-                  key: endpoint-metrics-kube-controller-manager
-            - name: SUMO_ENDPOINT_DEFAULT_METRICS_SOURCE
-              valueFrom:
-                secretKeyRef:
-                  name: sumologic
-                  key: endpoint-metrics
-            - name: SUMO_ENDPOINT_KUBELET_METRICS_SOURCE
-              valueFrom:
-                secretKeyRef:
-                  name: sumologic
-                  key: endpoint-metrics-kubelet
-            - name: SUMO_ENDPOINT_NODE_METRICS_SOURCE
-              valueFrom:
-                secretKeyRef:
-                  name: sumologic
-                  key: endpoint-metrics-node-exporter
-            - name: SUMO_ENDPOINT_SCHEDULER_METRICS_SOURCE
-              valueFrom:
-                secretKeyRef:
-                  name: sumologic
-                  key: endpoint-metrics-kube-scheduler
-            - name: SUMO_ENDPOINT_STATE_METRICS_SOURCE
-              valueFrom:
-                secretKeyRef:
-                  name: sumologic
-                  key: endpoint-metrics-kube-state
-
-            - name: NO_PROXY
-              value: kubernetes.default.svc
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP
-
-            - name: VALUE_FROM_SECRET
-              valueFrom:
-                secretKeyRef:
-                  key: secret_key
-                  name: secret_name
-  volumeClaimTemplates:
-    - metadata:
-        name: file-storage
-      spec:
-        accessModes: [ReadWriteOnce]
-        storageClassName:
+      - name: otelcol
+        image: "my_repository:my_tag"
+        imagePullPolicy: IfNotPresent
+        args:
+          - --config=/etc/otel/config.yaml
         resources:
+          limits:
+            cpu: 2000m
+            memory: 2Gi
           requests:
-            storage: 10Gi
+            cpu: 100m
+            memory: 777Mi
+        ports:
+        - name: otlphttp
+          containerPort: 4318
+          protocol: TCP
+        - name: prom-write
+          containerPort: 9888
+          protocol: TCP
+        - name: metrics
+          containerPort: 8888
+          protocol: TCP
+        - name: pprof
+          containerPort: 1777
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 3
+        startupProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 60
+          periodSeconds: 3
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/otel/config.yaml
+          subPath: config.yaml
+        - name: tmp
+          mountPath: /tmp
+        - name: file-storage
+          mountPath: /var/lib/storage/otc
+        - mountPath: /certs
+          name: es-certs
+          readOnly: true
+        env:
+        - name: SUMO_ENDPOINT_APISERVER_METRICS_SOURCE
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-metrics-apiserver
+        - name: SUMO_ENDPOINT_CONTROL_PLANE_METRICS_SOURCE
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-control_plane_metrics_source
+        - name: SUMO_ENDPOINT_CONTROLLER_METRICS_SOURCE
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-metrics-kube-controller-manager
+        - name: SUMO_ENDPOINT_DEFAULT_METRICS_SOURCE
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-metrics
+        - name: SUMO_ENDPOINT_KUBELET_METRICS_SOURCE
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-metrics-kubelet
+        - name: SUMO_ENDPOINT_NODE_METRICS_SOURCE
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-metrics-node-exporter
+        - name: SUMO_ENDPOINT_SCHEDULER_METRICS_SOURCE
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-metrics-kube-scheduler
+        - name: SUMO_ENDPOINT_STATE_METRICS_SOURCE
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-metrics-kube-state
+        
+        
+        - name: NO_PROXY
+          value: kubernetes.default.svc
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+
+        - name: VALUE_FROM_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: secret_key
+              name: secret_name
+  volumeClaimTemplates:
+  - metadata:
+      name: file-storage
+    spec:
+      accessModes: [ReadWriteOnce]
+      storageClassName: 
+      resources:
+        requests:
+          storage: 10Gi
+

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc_statefulset/pvcpolicyenabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc_statefulset/pvcpolicyenabled.output.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: '%CONFIG_CHECKSUM%'
+        checksum/config: "%CONFIG_CHECKSUM%"
       labels:
         app: RELEASE-NAME-sumologic-otelcol-metrics
         chart: "sumologic-%CURRENT_CHART_VERSION%"
@@ -38,113 +38,111 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - RELEASE-NAME-sumologic-otelcol-logs
-                  - RELEASE-NAME-sumologic-otelcol-metrics
-                  - RELEASE-NAME-sumologic-otelcol-events
-                  - RELEASE-NAME-sumologic-otelcol-instrumentation
-                - key: app
-                  operator: In
-                  values:
-                  - prometheus-operator-prometheus
-              topologyKey: "kubernetes.io/hostname"
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - RELEASE-NAME-sumologic-otelcol-logs
+                        - RELEASE-NAME-sumologic-otelcol-metrics
+                        - RELEASE-NAME-sumologic-otelcol-events
+                        - RELEASE-NAME-sumologic-otelcol-instrumentation
+                    - key: app
+                      operator: In
+                      values:
+                        - prometheus-operator-prometheus
+                topologyKey: "kubernetes.io/hostname"
       volumes:
-      - name: config-volume
-        configMap:
-          name: RELEASE-NAME-sumologic-otelcol-metrics
-      - name: tmp
-        emptyDir: {}
+        - name: config-volume
+          configMap:
+            name: RELEASE-NAME-sumologic-otelcol-metrics
+        - name: tmp
+          emptyDir: {}
       securityContext:
         fsGroup: 999
       containers:
-      - name: otelcol
-        image: "my_repository:my_tag"
-        imagePullPolicy: IfNotPresent
-        args:
-          - --config=/etc/otel/config.yaml
-        resources:
-          limits:
-            cpu: 1000m
-            memory: 1Gi
-          requests:
-            cpu: 500m
-            memory: 768Mi
-        ports:
-        - name: otlphttp
-          containerPort: 4318
-          protocol: TCP
-        - name: prom-write
-          containerPort: 9888
-          protocol: TCP
-        - name: metrics
-          containerPort: 8888
-          protocol: TCP
-        - name: pprof
-          containerPort: 1777
-          protocol: TCP
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 3
-          initialDelaySeconds: 15
-          periodSeconds: 15
-          timeoutSeconds: 10
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 3
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          timeoutSeconds: 3
-        startupProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 60
-          periodSeconds: 3
-        volumeMounts:
-        - name: config-volume
-          mountPath: /etc/otel/config.yaml
-          subPath: config.yaml
-        - name: tmp
-          mountPath: /tmp
-        - name: file-storage
-          mountPath: /var/lib/storage/otc
-        env:
-        - name: SUMO_ENDPOINT_DEFAULT_OTLP_METRICS_SOURCE
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics-otlp
-        
-        
-        - name: NO_PROXY
-          value: kubernetes.default.svc
-        - name: MY_POD_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: MY_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-  volumeClaimTemplates:
-  - metadata:
-      name: file-storage
-    spec:
-      accessModes: [ReadWriteOnce]
-      storageClassName: 
-      resources:
-        requests:
-          storage: 10Gi
+        - name: otelcol
+          image: "my_repository:my_tag"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config=/etc/otel/config.yaml
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+            requests:
+              cpu: 500m
+              memory: 768Mi
+          ports:
+            - name: otlphttp
+              containerPort: 4318
+              protocol: TCP
+            - name: prom-write
+              containerPort: 9888
+              protocol: TCP
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+            - name: pprof
+              containerPort: 1777
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 3
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 60
+            periodSeconds: 3
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/otel/config.yaml
+              subPath: config.yaml
+            - name: tmp
+              mountPath: /tmp
+            - name: file-storage
+              mountPath: /var/lib/storage/otc
+          env:
+            - name: SUMO_ENDPOINT_DEFAULT_OTLP_METRICS_SOURCE
+              valueFrom:
+                secretKeyRef:
+                  name: sumologic
+                  key: endpoint-metrics-otlp
 
+            - name: NO_PROXY
+              value: kubernetes.default.svc
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+  volumeClaimTemplates:
+    - metadata:
+        name: file-storage
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName:
+        resources:
+          requests:
+            storage: 10Gi

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc_statefulset/pvcpolicyenabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc_statefulset/pvcpolicyenabled.output.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: "%CONFIG_CHECKSUM%"
+        checksum/config: '%CONFIG_CHECKSUM%'
       labels:
         app: RELEASE-NAME-sumologic-otelcol-metrics
         chart: "sumologic-%CURRENT_CHART_VERSION%"
@@ -38,106 +38,113 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: app
-                      operator: In
-                      values:
-                        - RELEASE-NAME-sumologic-otelcol-logs
-                        - RELEASE-NAME-sumologic-otelcol-metrics
-                        - RELEASE-NAME-sumologic-otelcol-events
-                        - RELEASE-NAME-sumologic-otelcol-instrumentation
-                    - key: app
-                      operator: In
-                      values:
-                        - prometheus-operator-prometheus
-                topologyKey: "kubernetes.io/hostname"
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - RELEASE-NAME-sumologic-otelcol-logs
+                  - RELEASE-NAME-sumologic-otelcol-metrics
+                  - RELEASE-NAME-sumologic-otelcol-events
+                  - RELEASE-NAME-sumologic-otelcol-instrumentation
+                - key: app
+                  operator: In
+                  values:
+                  - prometheus-operator-prometheus
+              topologyKey: "kubernetes.io/hostname"
       volumes:
-        - name: config-volume
-          configMap:
-            name: RELEASE-NAME-sumologic-otelcol-metrics
-        - name: tmp
-          emptyDir: {}
+      - name: config-volume
+        configMap:
+          name: RELEASE-NAME-sumologic-otelcol-metrics
+      - name: tmp
+        emptyDir: {}
       securityContext:
         fsGroup: 999
       containers:
-        - name: otelcol
-          image: "my_repository:my_tag"
-          imagePullPolicy: IfNotPresent
-          args:
-            - --config=/etc/otel/config.yaml
-          resources:
-            limits:
-              cpu: 1000m
-              memory: 1Gi
-            requests:
-              cpu: 500m
-              memory: 768Mi
-          ports:
-            - name: otlphttp
-              containerPort: 4318
-              protocol: TCP
-            - name: prom-write
-              containerPort: 9888
-              protocol: TCP
-            - name: metrics
-              containerPort: 8888
-              protocol: TCP
-            - name: pprof
-              containerPort: 1777
-              protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 3
-            initialDelaySeconds: 15
-            periodSeconds: 15
-            timeoutSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 3
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 3
-          startupProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 60
-            periodSeconds: 3
-          volumeMounts:
-            - name: config-volume
-              mountPath: /etc/otel/config.yaml
-              subPath: config.yaml
-            - name: tmp
-              mountPath: /tmp
-            - name: file-storage
-              mountPath: /var/lib/storage/otc
-          env:
-            - name: SUMO_ENDPOINT_DEFAULT_OTLP_METRICS_SOURCE
-              valueFrom:
-                secretKeyRef:
-                  name: sumologic
-                  key: endpoint-metrics-otlp
-
-            - name: NO_PROXY
-              value: kubernetes.default.svc
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP
-  volumeClaimTemplates:
-    - metadata:
-        name: file-storage
-      spec:
-        accessModes: [ReadWriteOnce]
-        storageClassName:
+      - name: otelcol
+        image: "my_repository:my_tag"
+        imagePullPolicy: IfNotPresent
+        args:
+          - --config=/etc/otel/config.yaml
         resources:
+          limits:
+            cpu: 1000m
+            memory: 1Gi
           requests:
-            storage: 10Gi
+            cpu: 500m
+            memory: 768Mi
+        ports:
+        - name: otlphttp
+          containerPort: 4318
+          protocol: TCP
+        - name: prom-write
+          containerPort: 9888
+          protocol: TCP
+        - name: metrics
+          containerPort: 8888
+          protocol: TCP
+        - name: pprof
+          containerPort: 1777
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 3
+        startupProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 60
+          periodSeconds: 3
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/otel/config.yaml
+          subPath: config.yaml
+        - name: tmp
+          mountPath: /tmp
+        - name: file-storage
+          mountPath: /var/lib/storage/otc
+        env:
+        - name: SUMO_ENDPOINT_DEFAULT_OTLP_METRICS_SOURCE
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-metrics-otlp
+        
+        
+        - name: NO_PROXY
+          value: kubernetes.default.svc
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+  volumeClaimTemplates:
+  - metadata:
+      name: file-storage
+    spec:
+      accessModes: [ReadWriteOnce]
+      storageClassName: 
+      resources:
+        requests:
+          storage: 10Gi
+

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
@@ -33,9 +33,7 @@ spec:
     serviceAccount: RELEASE-NAME-sumologic-metrics-targetallocator-sa
     nodeSelector:
       kubernetes.io/os: linux
-    resources:
-      
-      {}
+    resources: {}
   nodeSelector:
     kubernetes.io/os: linux
   autoscaler:
@@ -44,36 +42,34 @@ spec:
     targetCPUUtilization: 70
     targetMemoryUtilization: 70
   env:
-  - name: METADATA_METRICS_SVC
-    valueFrom:
-      configMapKeyRef:
-        name: sumologic-configmap
-        key: metadataMetrics
-  - name: NAMESPACE
-    valueFrom:
-      fieldRef:
-        fieldPath: metadata.namespace
-  - name: MY_POD_IP
-    valueFrom:
-      fieldRef:
-        apiVersion: v1
-        fieldPath: status.podIP
-  - name: MY_POD_NAME
-    valueFrom:
-      fieldRef:
-        apiVersion: v1
-        fieldPath: metadata.name
+    - name: METADATA_METRICS_SVC
+      valueFrom:
+        configMapKeyRef:
+          name: sumologic-configmap
+          key: metadataMetrics
+    - name: NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: MY_POD_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.podIP
+    - name: MY_POD_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
   podAnnotations:
     ## The operator adds this annotation by default, but we use our own ServiceMonitor
     prometheus.io/scrape: "false"
   podSecurityContext:
-    
     fsGroup: 999
   ports:
-  - name: pprof
-    port: 1777
+    - name: pprof
+      port: 1777
   resources:
-    
     limits:
       cpu: 1000m
       memory: 2Gi
@@ -81,15 +77,15 @@ spec:
       cpu: 100m
       memory: 768Mi
   volumes:
-  - name: tmp
-    emptyDir: {}
-  - name: file-storage
-    emptyDir: {}
+    - name: tmp
+      emptyDir: {}
+    - name: file-storage
+      emptyDir: {}
   volumeMounts:
-  - name: tmp
-    mountPath: /tmp
-  - name: file-storage
-    mountPath: /var/lib/storage/otc
+    - name: tmp
+      mountPath: /tmp
+    - name: file-storage
+      mountPath: /var/lib/storage/otc
   config:
     exporters:
       otlphttp:
@@ -121,177 +117,176 @@ spec:
       filter/drop_stale_datapoints:
         metrics:
           datapoint:
-          - flags == FLAG_NO_RECORDED_VALUE
+            - flags == FLAG_NO_RECORDED_VALUE
       transform/drop_unnecessary_attributes:
         error_mode: ignore
         metric_statements:
-        - context: resource
-          statements:
-          - delete_key(attributes, "http.scheme")
-          - delete_key(attributes, "net.host.name")
-          - delete_key(attributes, "net.host.port")
-          - delete_key(attributes, "service.instance.id")
-          - delete_matching_keys(attributes, "k8s.*")
+          - context: resource
+            statements:
+              - delete_key(attributes, "http.scheme")
+              - delete_key(attributes, "net.host.name")
+              - delete_key(attributes, "net.host.port")
+              - delete_key(attributes, "service.instance.id")
+              - delete_matching_keys(attributes, "k8s.*")
       transform/extract_sum_count_from_histograms:
         error_mode: ignore
         metric_statements:
-        - context: metric
-          statements:
-          - extract_sum_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM
-            or type == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
-          - extract_count_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM
-            or type == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
+          - context: metric
+            statements:
+              - extract_sum_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM or type ==
+                METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
+              - extract_count_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM or type ==
+                METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
     receivers:
       prometheus:
         config:
           global:
             scrape_interval: 30s
           scrape_configs:
-          - job_name: pod-annotations
-            kubernetes_sd_configs:
-            - role: pod
-            relabel_configs:
-            - action: keep
-              regex: true
-              source_labels:
-              - __meta_kubernetes_pod_annotation_prometheus_io_scrape
-            - action: replace
-              regex: (.+)
-              source_labels:
-              - __meta_kubernetes_pod_annotation_prometheus_io_path
-              target_label: __metrics_path__
-            - action: replace
-              regex: ([^:]+)(?::\d+)?;(\d+)
-              replacement: $1:$2
-              source_labels:
-              - __address__
-              - __meta_kubernetes_pod_annotation_prometheus_io_port
-              target_label: __address__
-            - action: replace
-              regex: (.*)
-              replacement: $1
-              separator: ;
-              source_labels:
-              - __metrics_path__
-              target_label: endpoint
-            - action: replace
-              source_labels:
-              - __meta_kubernetes_namespace
-              target_label: namespace
-            - action: labelmap
-              regex: __meta_kubernetes_pod_label_(.+)
-            - action: replace
-              regex: (.*)
-              replacement: $1
-              separator: ;
-              source_labels:
-              - __meta_kubernetes_pod_name
-              target_label: pod
-          - authorization:
-              credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-            honor_labels: true
-            job_name: kubelet
-            kubernetes_sd_configs:
-            - role: node
-            metric_relabel_configs:
-            - action: keep
-              regex: (?:kubelet_docker_operations_errors(?:|_total)|kubelet_(?:docker|runtime)_operations_duration_seconds_(?:count|sum)|kubelet_running_(?:container|pod)(?:_count|s)|kubelet_(:?docker|runtime)_operations_latency_microseconds(?:|_count|_sum))
-              source_labels:
-              - __name__
-            - action: labeldrop
-              regex: id
-            relabel_configs:
-            - source_labels:
-              - __meta_kubernetes_node_name
-              target_label: node
-            - replacement: https-metrics
-              target_label: endpoint
-            - action: replace
-              source_labels:
-              - __metrics_path__
-              target_label: metrics_path
-            - action: replace
-              source_labels:
-              - __address__
-              target_label: instance
-            scheme: https
-            tls_config:
-              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-              insecure_skip_verify: true
-          - authorization:
-              credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-            honor_labels: true
-            job_name: cadvisor
-            kubernetes_sd_configs:
-            - role: node
-            metric_relabel_configs:
-            - action: replace
-              regex: .*
-              replacement: kubelet
-              source_labels:
-              - __name__
-              target_label: job
-            - action: keep
-              regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes|container_cpu_cfs_throttled_seconds_total|container_network_receive_bytes_total|container_network_transmit_bytes_total)
-              source_labels:
-              - __name__
-            - action: drop
-              regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes);$
-              source_labels:
-              - __name__
-              - container
-            - action: labelmap
-              regex: container_name
-              replacement: container
-            - action: drop
-              regex: POD
-              source_labels:
-              - container
-            - action: labeldrop
-              regex: (id|name)
-            metrics_path: /metrics/cadvisor
-            relabel_configs:
-            - replacement: https-metrics
-              target_label: endpoint
-            - action: replace
-              source_labels:
-              - __metrics_path__
-              target_label: metrics_path
-            - action: replace
-              source_labels:
-              - __address__
-              target_label: instance
-            scheme: https
-            tls_config:
-              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-              insecure_skip_verify: true
+            - job_name: pod-annotations
+              kubernetes_sd_configs:
+                - role: pod
+              relabel_configs:
+                - action: keep
+                  regex: true
+                  source_labels:
+                    - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+                - action: replace
+                  regex: (.+)
+                  source_labels:
+                    - __meta_kubernetes_pod_annotation_prometheus_io_path
+                  target_label: __metrics_path__
+                - action: replace
+                  regex: ([^:]+)(?::\d+)?;(\d+)
+                  replacement: $1:$2
+                  source_labels:
+                    - __address__
+                    - __meta_kubernetes_pod_annotation_prometheus_io_port
+                  target_label: __address__
+                - action: replace
+                  regex: (.*)
+                  replacement: $1
+                  separator: ;
+                  source_labels:
+                    - __metrics_path__
+                  target_label: endpoint
+                - action: replace
+                  source_labels:
+                    - __meta_kubernetes_namespace
+                  target_label: namespace
+                - action: labelmap
+                  regex: __meta_kubernetes_pod_label_(.+)
+                - action: replace
+                  regex: (.*)
+                  replacement: $1
+                  separator: ;
+                  source_labels:
+                    - __meta_kubernetes_pod_name
+                  target_label: pod
+            - authorization:
+                credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              honor_labels: true
+              job_name: kubelet
+              kubernetes_sd_configs:
+                - role: node
+              metric_relabel_configs:
+                - action: keep
+                  regex: (?:kubelet_docker_operations_errors(?:|_total)|kubelet_(?:docker|runtime)_operations_duration_seconds_(?:count|sum)|kubelet_running_(?:container|pod)(?:_count|s)|kubelet_(:?docker|runtime)_operations_latency_microseconds(?:|_count|_sum))
+                  source_labels:
+                    - __name__
+                - action: labeldrop
+                  regex: id
+              relabel_configs:
+                - source_labels:
+                    - __meta_kubernetes_node_name
+                  target_label: node
+                - replacement: https-metrics
+                  target_label: endpoint
+                - action: replace
+                  source_labels:
+                    - __metrics_path__
+                  target_label: metrics_path
+                - action: replace
+                  source_labels:
+                    - __address__
+                  target_label: instance
+              scheme: https
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: true
+            - authorization:
+                credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              honor_labels: true
+              job_name: cadvisor
+              kubernetes_sd_configs:
+                - role: node
+              metric_relabel_configs:
+                - action: replace
+                  regex: .*
+                  replacement: kubelet
+                  source_labels:
+                    - __name__
+                  target_label: job
+                - action: keep
+                  regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes|container_cpu_cfs_throttled_seconds_total|container_network_receive_bytes_total|container_network_transmit_bytes_total)
+                  source_labels:
+                    - __name__
+                - action: drop
+                  regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes);$
+                  source_labels:
+                    - __name__
+                    - container
+                - action: labelmap
+                  regex: container_name
+                  replacement: container
+                - action: drop
+                  regex: POD
+                  source_labels:
+                    - container
+                - action: labeldrop
+                  regex: (id|name)
+              metrics_path: /metrics/cadvisor
+              relabel_configs:
+                - replacement: https-metrics
+                  target_label: endpoint
+                - action: replace
+                  source_labels:
+                    - __metrics_path__
+                  target_label: metrics_path
+                - action: replace
+                  source_labels:
+                    - __address__
+                  target_label: instance
+              scheme: https
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: true
     service:
       extensions:
-      - health_check
-      - pprof
-      - file_storage
+        - health_check
+        - pprof
+        - file_storage
       pipelines:
         metrics:
           exporters:
-          - otlphttp
+            - otlphttp
           processors:
-          - filter/drop_stale_datapoints
-          - transform/extract_sum_count_from_histograms
-          - transform/drop_unnecessary_attributes
+            - filter/drop_stale_datapoints
+            - transform/extract_sum_count_from_histograms
+            - transform/drop_unnecessary_attributes
           receivers:
-          - prometheus
+            - prometheus
       telemetry:
         logs:
           level: info
         metrics:
           level: normal
           readers:
-          - pull:
-              exporter:
-                prometheus:
-                  host: ${env:MY_POD_IP}
-                  port: 8888
-                  without_scope_info: true
-                  without_type_suffix: true
-                  without_units: true
-
+            - pull:
+                exporter:
+                  prometheus:
+                    host: ${env:MY_POD_IP}
+                    port: 8888
+                    without_scope_info: true
+                    without_type_suffix: true
+                    without_units: true

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/basic.output.yaml
@@ -33,7 +33,9 @@ spec:
     serviceAccount: RELEASE-NAME-sumologic-metrics-targetallocator-sa
     nodeSelector:
       kubernetes.io/os: linux
-    resources: {}
+    resources:
+      
+      {}
   nodeSelector:
     kubernetes.io/os: linux
   autoscaler:
@@ -42,29 +44,36 @@ spec:
     targetCPUUtilization: 70
     targetMemoryUtilization: 70
   env:
-    - name: METADATA_METRICS_SVC
-      valueFrom:
-        configMapKeyRef:
-          name: sumologic-configmap
-          key: metadataMetrics
-    - name: NAMESPACE
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.namespace
-    - name: MY_POD_IP
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: status.podIP
+  - name: METADATA_METRICS_SVC
+    valueFrom:
+      configMapKeyRef:
+        name: sumologic-configmap
+        key: metadataMetrics
+  - name: NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
+  - name: MY_POD_IP
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: status.podIP
+  - name: MY_POD_NAME
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: metadata.name
   podAnnotations:
     ## The operator adds this annotation by default, but we use our own ServiceMonitor
     prometheus.io/scrape: "false"
   podSecurityContext:
+    
     fsGroup: 999
   ports:
-    - name: pprof
-      port: 1777
+  - name: pprof
+    port: 1777
   resources:
+    
     limits:
       cpu: 1000m
       memory: 2Gi
@@ -72,15 +81,15 @@ spec:
       cpu: 100m
       memory: 768Mi
   volumes:
-    - name: tmp
-      emptyDir: {}
-    - name: file-storage
-      emptyDir: {}
+  - name: tmp
+    emptyDir: {}
+  - name: file-storage
+    emptyDir: {}
   volumeMounts:
-    - name: tmp
-      mountPath: /tmp
-    - name: file-storage
-      mountPath: /var/lib/storage/otc
+  - name: tmp
+    mountPath: /tmp
+  - name: file-storage
+    mountPath: /var/lib/storage/otc
   config:
     exporters:
       otlphttp:
@@ -112,176 +121,177 @@ spec:
       filter/drop_stale_datapoints:
         metrics:
           datapoint:
-            - flags == FLAG_NO_RECORDED_VALUE
+          - flags == FLAG_NO_RECORDED_VALUE
       transform/drop_unnecessary_attributes:
         error_mode: ignore
         metric_statements:
-          - context: resource
-            statements:
-              - delete_key(attributes, "http.scheme")
-              - delete_key(attributes, "net.host.name")
-              - delete_key(attributes, "net.host.port")
-              - delete_key(attributes, "service.instance.id")
-              - delete_matching_keys(attributes, "k8s.*")
+        - context: resource
+          statements:
+          - delete_key(attributes, "http.scheme")
+          - delete_key(attributes, "net.host.name")
+          - delete_key(attributes, "net.host.port")
+          - delete_key(attributes, "service.instance.id")
+          - delete_matching_keys(attributes, "k8s.*")
       transform/extract_sum_count_from_histograms:
         error_mode: ignore
         metric_statements:
-          - context: metric
-            statements:
-              - extract_sum_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM or type ==
-                METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
-              - extract_count_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM or type ==
-                METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
+        - context: metric
+          statements:
+          - extract_sum_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM
+            or type == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
+          - extract_count_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM
+            or type == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
     receivers:
       prometheus:
         config:
           global:
             scrape_interval: 30s
           scrape_configs:
-            - job_name: pod-annotations
-              kubernetes_sd_configs:
-                - role: pod
-              relabel_configs:
-                - action: keep
-                  regex: true
-                  source_labels:
-                    - __meta_kubernetes_pod_annotation_prometheus_io_scrape
-                - action: replace
-                  regex: (.+)
-                  source_labels:
-                    - __meta_kubernetes_pod_annotation_prometheus_io_path
-                  target_label: __metrics_path__
-                - action: replace
-                  regex: ([^:]+)(?::\d+)?;(\d+)
-                  replacement: $1:$2
-                  source_labels:
-                    - __address__
-                    - __meta_kubernetes_pod_annotation_prometheus_io_port
-                  target_label: __address__
-                - action: replace
-                  regex: (.*)
-                  replacement: $1
-                  separator: ;
-                  source_labels:
-                    - __metrics_path__
-                  target_label: endpoint
-                - action: replace
-                  source_labels:
-                    - __meta_kubernetes_namespace
-                  target_label: namespace
-                - action: labelmap
-                  regex: __meta_kubernetes_pod_label_(.+)
-                - action: replace
-                  regex: (.*)
-                  replacement: $1
-                  separator: ;
-                  source_labels:
-                    - __meta_kubernetes_pod_name
-                  target_label: pod
-            - authorization:
-                credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-              honor_labels: true
-              job_name: kubelet
-              kubernetes_sd_configs:
-                - role: node
-              metric_relabel_configs:
-                - action: keep
-                  regex: (?:kubelet_docker_operations_errors(?:|_total)|kubelet_(?:docker|runtime)_operations_duration_seconds_(?:count|sum)|kubelet_running_(?:container|pod)(?:_count|s)|kubelet_(:?docker|runtime)_operations_latency_microseconds(?:|_count|_sum))
-                  source_labels:
-                    - __name__
-                - action: labeldrop
-                  regex: id
-              relabel_configs:
-                - source_labels:
-                    - __meta_kubernetes_node_name
-                  target_label: node
-                - replacement: https-metrics
-                  target_label: endpoint
-                - action: replace
-                  source_labels:
-                    - __metrics_path__
-                  target_label: metrics_path
-                - action: replace
-                  source_labels:
-                    - __address__
-                  target_label: instance
-              scheme: https
-              tls_config:
-                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-                insecure_skip_verify: true
-            - authorization:
-                credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-              honor_labels: true
-              job_name: cadvisor
-              kubernetes_sd_configs:
-                - role: node
-              metric_relabel_configs:
-                - action: replace
-                  regex: .*
-                  replacement: kubelet
-                  source_labels:
-                    - __name__
-                  target_label: job
-                - action: keep
-                  regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes|container_cpu_cfs_throttled_seconds_total|container_network_receive_bytes_total|container_network_transmit_bytes_total)
-                  source_labels:
-                    - __name__
-                - action: drop
-                  regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes);$
-                  source_labels:
-                    - __name__
-                    - container
-                - action: labelmap
-                  regex: container_name
-                  replacement: container
-                - action: drop
-                  regex: POD
-                  source_labels:
-                    - container
-                - action: labeldrop
-                  regex: (id|name)
-              metrics_path: /metrics/cadvisor
-              relabel_configs:
-                - replacement: https-metrics
-                  target_label: endpoint
-                - action: replace
-                  source_labels:
-                    - __metrics_path__
-                  target_label: metrics_path
-                - action: replace
-                  source_labels:
-                    - __address__
-                  target_label: instance
-              scheme: https
-              tls_config:
-                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-                insecure_skip_verify: true
+          - job_name: pod-annotations
+            kubernetes_sd_configs:
+            - role: pod
+            relabel_configs:
+            - action: keep
+              regex: true
+              source_labels:
+              - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+            - action: replace
+              regex: (.+)
+              source_labels:
+              - __meta_kubernetes_pod_annotation_prometheus_io_path
+              target_label: __metrics_path__
+            - action: replace
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: $1:$2
+              source_labels:
+              - __address__
+              - __meta_kubernetes_pod_annotation_prometheus_io_port
+              target_label: __address__
+            - action: replace
+              regex: (.*)
+              replacement: $1
+              separator: ;
+              source_labels:
+              - __metrics_path__
+              target_label: endpoint
+            - action: replace
+              source_labels:
+              - __meta_kubernetes_namespace
+              target_label: namespace
+            - action: labelmap
+              regex: __meta_kubernetes_pod_label_(.+)
+            - action: replace
+              regex: (.*)
+              replacement: $1
+              separator: ;
+              source_labels:
+              - __meta_kubernetes_pod_name
+              target_label: pod
+          - authorization:
+              credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            honor_labels: true
+            job_name: kubelet
+            kubernetes_sd_configs:
+            - role: node
+            metric_relabel_configs:
+            - action: keep
+              regex: (?:kubelet_docker_operations_errors(?:|_total)|kubelet_(?:docker|runtime)_operations_duration_seconds_(?:count|sum)|kubelet_running_(?:container|pod)(?:_count|s)|kubelet_(:?docker|runtime)_operations_latency_microseconds(?:|_count|_sum))
+              source_labels:
+              - __name__
+            - action: labeldrop
+              regex: id
+            relabel_configs:
+            - source_labels:
+              - __meta_kubernetes_node_name
+              target_label: node
+            - replacement: https-metrics
+              target_label: endpoint
+            - action: replace
+              source_labels:
+              - __metrics_path__
+              target_label: metrics_path
+            - action: replace
+              source_labels:
+              - __address__
+              target_label: instance
+            scheme: https
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
+          - authorization:
+              credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            honor_labels: true
+            job_name: cadvisor
+            kubernetes_sd_configs:
+            - role: node
+            metric_relabel_configs:
+            - action: replace
+              regex: .*
+              replacement: kubelet
+              source_labels:
+              - __name__
+              target_label: job
+            - action: keep
+              regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes|container_cpu_cfs_throttled_seconds_total|container_network_receive_bytes_total|container_network_transmit_bytes_total)
+              source_labels:
+              - __name__
+            - action: drop
+              regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes);$
+              source_labels:
+              - __name__
+              - container
+            - action: labelmap
+              regex: container_name
+              replacement: container
+            - action: drop
+              regex: POD
+              source_labels:
+              - container
+            - action: labeldrop
+              regex: (id|name)
+            metrics_path: /metrics/cadvisor
+            relabel_configs:
+            - replacement: https-metrics
+              target_label: endpoint
+            - action: replace
+              source_labels:
+              - __metrics_path__
+              target_label: metrics_path
+            - action: replace
+              source_labels:
+              - __address__
+              target_label: instance
+            scheme: https
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
     service:
       extensions:
-        - health_check
-        - pprof
-        - file_storage
+      - health_check
+      - pprof
+      - file_storage
       pipelines:
         metrics:
           exporters:
-            - otlphttp
+          - otlphttp
           processors:
-            - filter/drop_stale_datapoints
-            - transform/extract_sum_count_from_histograms
-            - transform/drop_unnecessary_attributes
+          - filter/drop_stale_datapoints
+          - transform/extract_sum_count_from_histograms
+          - transform/drop_unnecessary_attributes
           receivers:
-            - prometheus
+          - prometheus
       telemetry:
         logs:
           level: info
         metrics:
           level: normal
           readers:
-            - pull:
-                exporter:
-                  prometheus:
-                    host: ${env:MY_POD_IP}
-                    port: 8888
-                    without_scope_info: true
-                    without_type_suffix: true
-                    without_units: true
+          - pull:
+              exporter:
+                prometheus:
+                  host: ${env:MY_POD_IP}
+                  port: 8888
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true
+

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
@@ -33,7 +33,9 @@ spec:
     serviceAccount: RELEASE-NAME-sumologic-metrics-targetallocator-sa
     nodeSelector:
       kubernetes.io/os: linux
-    resources: {}
+    resources:
+      
+      {}
   nodeSelector:
     kubernetes.io/os: linux
   autoscaler:
@@ -42,29 +44,36 @@ spec:
     targetCPUUtilization: 70
     targetMemoryUtilization: 70
   env:
-    - name: METADATA_METRICS_SVC
-      valueFrom:
-        configMapKeyRef:
-          name: sumologic-configmap
-          key: metadataMetrics
-    - name: NAMESPACE
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.namespace
-    - name: MY_POD_IP
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: status.podIP
+  - name: METADATA_METRICS_SVC
+    valueFrom:
+      configMapKeyRef:
+        name: sumologic-configmap
+        key: metadataMetrics
+  - name: NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
+  - name: MY_POD_IP
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: status.podIP
+  - name: MY_POD_NAME
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: metadata.name
   podAnnotations:
     ## The operator adds this annotation by default, but we use our own ServiceMonitor
     prometheus.io/scrape: "false"
   podSecurityContext:
+    
     fsGroup: 999
   ports:
-    - name: pprof
-      port: 1777
+  - name: pprof
+    port: 1777
   resources:
+    
     limits:
       cpu: 1000m
       memory: 2Gi
@@ -72,15 +81,15 @@ spec:
       cpu: 100m
       memory: 768Mi
   volumes:
-    - name: tmp
-      emptyDir: {}
-    - name: file-storage
-      emptyDir: {}
+  - name: tmp
+    emptyDir: {}
+  - name: file-storage
+    emptyDir: {}
   volumeMounts:
-    - name: tmp
-      mountPath: /tmp
-    - name: file-storage
-      mountPath: /var/lib/storage/otc
+  - name: tmp
+    mountPath: /tmp
+  - name: file-storage
+    mountPath: /var/lib/storage/otc
   config:
     exporters:
       otlphttp:
@@ -108,177 +117,178 @@ spec:
       filter/drop_stale_datapoints:
         metrics:
           datapoint:
-            - flags == FLAG_NO_RECORDED_VALUE
+          - flags == FLAG_NO_RECORDED_VALUE
       transform/drop_unnecessary_attributes:
         error_mode: ignore
         metric_statements:
-          - context: resource
-            statements:
-              - delete_key(attributes, "http.scheme")
-              - delete_key(attributes, "net.host.name")
-              - delete_key(attributes, "net.host.port")
-              - delete_key(attributes, "service.instance.id")
-              - delete_matching_keys(attributes, "k8s.*")
+        - context: resource
+          statements:
+          - delete_key(attributes, "http.scheme")
+          - delete_key(attributes, "net.host.name")
+          - delete_key(attributes, "net.host.port")
+          - delete_key(attributes, "service.instance.id")
+          - delete_matching_keys(attributes, "k8s.*")
       transform/extract_sum_count_from_histograms:
         error_mode: ignore
         metric_statements:
-          - context: metric
-            statements:
-              - extract_sum_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM or type ==
-                METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
-              - extract_count_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM or type ==
-                METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
+        - context: metric
+          statements:
+          - extract_sum_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM
+            or type == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
+          - extract_count_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM
+            or type == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
     receivers:
       prometheus:
         config:
           global:
             scrape_interval: 30s
           scrape_configs:
-            - job_name: pod-annotations
-              kubernetes_sd_configs:
-                - role: pod
-              relabel_configs:
-                - action: keep
-                  regex: true
-                  source_labels:
-                    - __meta_kubernetes_pod_annotation_prometheus_io_scrape
-                - action: replace
-                  regex: (.+)
-                  source_labels:
-                    - __meta_kubernetes_pod_annotation_prometheus_io_path
-                  target_label: __metrics_path__
-                - action: replace
-                  regex: ([^:]+)(?::\d+)?;(\d+)
-                  replacement: $1:$2
-                  source_labels:
-                    - __address__
-                    - __meta_kubernetes_pod_annotation_prometheus_io_port
-                  target_label: __address__
-                - action: replace
-                  regex: (.*)
-                  replacement: $1
-                  separator: ;
-                  source_labels:
-                    - __metrics_path__
-                  target_label: endpoint
-                - action: replace
-                  source_labels:
-                    - __meta_kubernetes_namespace
-                  target_label: namespace
-                - action: labelmap
-                  regex: __meta_kubernetes_pod_label_(.+)
-                - action: replace
-                  regex: (.*)
-                  replacement: $1
-                  separator: ;
-                  source_labels:
-                    - __meta_kubernetes_pod_name
-                  target_label: pod
-            - authorization:
-                credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-              honor_labels: true
-              job_name: kubelet
-              kubernetes_sd_configs:
-                - role: node
-              metric_relabel_configs:
-                - action: keep
-                  regex: (?:kubelet_docker_operations_errors(?:|_total)|kubelet_(?:docker|runtime)_operations_duration_seconds_(?:count|sum)|kubelet_running_(?:container|pod)(?:_count|s)|kubelet_(:?docker|runtime)_operations_latency_microseconds(?:|_count|_sum))
-                  source_labels:
-                    - __name__
-                - action: labeldrop
-                  regex: id
-              relabel_configs:
-                - source_labels:
-                    - __meta_kubernetes_node_name
-                  target_label: node
-                - replacement: https-metrics
-                  target_label: endpoint
-                - action: replace
-                  source_labels:
-                    - __metrics_path__
-                  target_label: metrics_path
-                - action: replace
-                  source_labels:
-                    - __address__
-                  target_label: instance
-              scheme: https
-              tls_config:
-                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-                insecure_skip_verify: true
-            - authorization:
-                credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-              honor_labels: true
-              job_name: cadvisor
-              kubernetes_sd_configs:
-                - role: node
-              metric_relabel_configs:
-                - action: replace
-                  regex: .*
-                  replacement: kubelet
-                  source_labels:
-                    - __name__
-                  target_label: job
-                - action: keep
-                  regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes|container_cpu_cfs_throttled_seconds_total|container_network_receive_bytes_total|container_network_transmit_bytes_total)
-                  source_labels:
-                    - __name__
-                - action: drop
-                  regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes);$
-                  source_labels:
-                    - __name__
-                    - container
-                - action: labelmap
-                  regex: container_name
-                  replacement: container
-                - action: drop
-                  regex: POD
-                  source_labels:
-                    - container
-                - action: labeldrop
-                  regex: (id|name)
-              metrics_path: /metrics/cadvisor
-              relabel_configs:
-                - replacement: https-metrics
-                  target_label: endpoint
-                - action: replace
-                  source_labels:
-                    - __metrics_path__
-                  target_label: metrics_path
-                - action: replace
-                  source_labels:
-                    - __address__
-                  target_label: instance
-              scheme: https
-              tls_config:
-                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-                insecure_skip_verify: true
+          - job_name: pod-annotations
+            kubernetes_sd_configs:
+            - role: pod
+            relabel_configs:
+            - action: keep
+              regex: true
+              source_labels:
+              - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+            - action: replace
+              regex: (.+)
+              source_labels:
+              - __meta_kubernetes_pod_annotation_prometheus_io_path
+              target_label: __metrics_path__
+            - action: replace
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: $1:$2
+              source_labels:
+              - __address__
+              - __meta_kubernetes_pod_annotation_prometheus_io_port
+              target_label: __address__
+            - action: replace
+              regex: (.*)
+              replacement: $1
+              separator: ;
+              source_labels:
+              - __metrics_path__
+              target_label: endpoint
+            - action: replace
+              source_labels:
+              - __meta_kubernetes_namespace
+              target_label: namespace
+            - action: labelmap
+              regex: __meta_kubernetes_pod_label_(.+)
+            - action: replace
+              regex: (.*)
+              replacement: $1
+              separator: ;
+              source_labels:
+              - __meta_kubernetes_pod_name
+              target_label: pod
+          - authorization:
+              credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            honor_labels: true
+            job_name: kubelet
+            kubernetes_sd_configs:
+            - role: node
+            metric_relabel_configs:
+            - action: keep
+              regex: (?:kubelet_docker_operations_errors(?:|_total)|kubelet_(?:docker|runtime)_operations_duration_seconds_(?:count|sum)|kubelet_running_(?:container|pod)(?:_count|s)|kubelet_(:?docker|runtime)_operations_latency_microseconds(?:|_count|_sum))
+              source_labels:
+              - __name__
+            - action: labeldrop
+              regex: id
+            relabel_configs:
+            - source_labels:
+              - __meta_kubernetes_node_name
+              target_label: node
+            - replacement: https-metrics
+              target_label: endpoint
+            - action: replace
+              source_labels:
+              - __metrics_path__
+              target_label: metrics_path
+            - action: replace
+              source_labels:
+              - __address__
+              target_label: instance
+            scheme: https
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
+          - authorization:
+              credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            honor_labels: true
+            job_name: cadvisor
+            kubernetes_sd_configs:
+            - role: node
+            metric_relabel_configs:
+            - action: replace
+              regex: .*
+              replacement: kubelet
+              source_labels:
+              - __name__
+              target_label: job
+            - action: keep
+              regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes|container_cpu_cfs_throttled_seconds_total|container_network_receive_bytes_total|container_network_transmit_bytes_total)
+              source_labels:
+              - __name__
+            - action: drop
+              regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes);$
+              source_labels:
+              - __name__
+              - container
+            - action: labelmap
+              regex: container_name
+              replacement: container
+            - action: drop
+              regex: POD
+              source_labels:
+              - container
+            - action: labeldrop
+              regex: (id|name)
+            metrics_path: /metrics/cadvisor
+            relabel_configs:
+            - replacement: https-metrics
+              target_label: endpoint
+            - action: replace
+              source_labels:
+              - __metrics_path__
+              target_label: metrics_path
+            - action: replace
+              source_labels:
+              - __address__
+              target_label: instance
+            scheme: https
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
     service:
       extensions:
-        - health_check
-        - pprof
-        - file_storage
+      - health_check
+      - pprof
+      - file_storage
       pipelines:
         metrics:
           exporters:
-            - otlphttp
+          - otlphttp
           processors:
-            - batch
-            - filter/drop_stale_datapoints
-            - transform/extract_sum_count_from_histograms
-            - transform/drop_unnecessary_attributes
+          - batch
+          - filter/drop_stale_datapoints
+          - transform/extract_sum_count_from_histograms
+          - transform/drop_unnecessary_attributes
           receivers:
-            - prometheus
+          - prometheus
       telemetry:
         logs:
           level: info
         metrics:
           level: normal
           readers:
-            - pull:
-                exporter:
-                  prometheus:
-                    host: ${env:MY_POD_IP}
-                    port: 8888
-                    without_scope_info: true
-                    without_type_suffix: true
-                    without_units: true
+          - pull:
+              exporter:
+                prometheus:
+                  host: ${env:MY_POD_IP}
+                  port: 8888
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true
+

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/custom.output.yaml
@@ -33,9 +33,7 @@ spec:
     serviceAccount: RELEASE-NAME-sumologic-metrics-targetallocator-sa
     nodeSelector:
       kubernetes.io/os: linux
-    resources:
-      
-      {}
+    resources: {}
   nodeSelector:
     kubernetes.io/os: linux
   autoscaler:
@@ -44,36 +42,34 @@ spec:
     targetCPUUtilization: 70
     targetMemoryUtilization: 70
   env:
-  - name: METADATA_METRICS_SVC
-    valueFrom:
-      configMapKeyRef:
-        name: sumologic-configmap
-        key: metadataMetrics
-  - name: NAMESPACE
-    valueFrom:
-      fieldRef:
-        fieldPath: metadata.namespace
-  - name: MY_POD_IP
-    valueFrom:
-      fieldRef:
-        apiVersion: v1
-        fieldPath: status.podIP
-  - name: MY_POD_NAME
-    valueFrom:
-      fieldRef:
-        apiVersion: v1
-        fieldPath: metadata.name
+    - name: METADATA_METRICS_SVC
+      valueFrom:
+        configMapKeyRef:
+          name: sumologic-configmap
+          key: metadataMetrics
+    - name: NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: MY_POD_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.podIP
+    - name: MY_POD_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
   podAnnotations:
     ## The operator adds this annotation by default, but we use our own ServiceMonitor
     prometheus.io/scrape: "false"
   podSecurityContext:
-    
     fsGroup: 999
   ports:
-  - name: pprof
-    port: 1777
+    - name: pprof
+      port: 1777
   resources:
-    
     limits:
       cpu: 1000m
       memory: 2Gi
@@ -81,15 +77,15 @@ spec:
       cpu: 100m
       memory: 768Mi
   volumes:
-  - name: tmp
-    emptyDir: {}
-  - name: file-storage
-    emptyDir: {}
+    - name: tmp
+      emptyDir: {}
+    - name: file-storage
+      emptyDir: {}
   volumeMounts:
-  - name: tmp
-    mountPath: /tmp
-  - name: file-storage
-    mountPath: /var/lib/storage/otc
+    - name: tmp
+      mountPath: /tmp
+    - name: file-storage
+      mountPath: /var/lib/storage/otc
   config:
     exporters:
       otlphttp:
@@ -117,178 +113,177 @@ spec:
       filter/drop_stale_datapoints:
         metrics:
           datapoint:
-          - flags == FLAG_NO_RECORDED_VALUE
+            - flags == FLAG_NO_RECORDED_VALUE
       transform/drop_unnecessary_attributes:
         error_mode: ignore
         metric_statements:
-        - context: resource
-          statements:
-          - delete_key(attributes, "http.scheme")
-          - delete_key(attributes, "net.host.name")
-          - delete_key(attributes, "net.host.port")
-          - delete_key(attributes, "service.instance.id")
-          - delete_matching_keys(attributes, "k8s.*")
+          - context: resource
+            statements:
+              - delete_key(attributes, "http.scheme")
+              - delete_key(attributes, "net.host.name")
+              - delete_key(attributes, "net.host.port")
+              - delete_key(attributes, "service.instance.id")
+              - delete_matching_keys(attributes, "k8s.*")
       transform/extract_sum_count_from_histograms:
         error_mode: ignore
         metric_statements:
-        - context: metric
-          statements:
-          - extract_sum_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM
-            or type == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
-          - extract_count_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM
-            or type == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
+          - context: metric
+            statements:
+              - extract_sum_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM or type ==
+                METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
+              - extract_count_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM or type ==
+                METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
     receivers:
       prometheus:
         config:
           global:
             scrape_interval: 30s
           scrape_configs:
-          - job_name: pod-annotations
-            kubernetes_sd_configs:
-            - role: pod
-            relabel_configs:
-            - action: keep
-              regex: true
-              source_labels:
-              - __meta_kubernetes_pod_annotation_prometheus_io_scrape
-            - action: replace
-              regex: (.+)
-              source_labels:
-              - __meta_kubernetes_pod_annotation_prometheus_io_path
-              target_label: __metrics_path__
-            - action: replace
-              regex: ([^:]+)(?::\d+)?;(\d+)
-              replacement: $1:$2
-              source_labels:
-              - __address__
-              - __meta_kubernetes_pod_annotation_prometheus_io_port
-              target_label: __address__
-            - action: replace
-              regex: (.*)
-              replacement: $1
-              separator: ;
-              source_labels:
-              - __metrics_path__
-              target_label: endpoint
-            - action: replace
-              source_labels:
-              - __meta_kubernetes_namespace
-              target_label: namespace
-            - action: labelmap
-              regex: __meta_kubernetes_pod_label_(.+)
-            - action: replace
-              regex: (.*)
-              replacement: $1
-              separator: ;
-              source_labels:
-              - __meta_kubernetes_pod_name
-              target_label: pod
-          - authorization:
-              credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-            honor_labels: true
-            job_name: kubelet
-            kubernetes_sd_configs:
-            - role: node
-            metric_relabel_configs:
-            - action: keep
-              regex: (?:kubelet_docker_operations_errors(?:|_total)|kubelet_(?:docker|runtime)_operations_duration_seconds_(?:count|sum)|kubelet_running_(?:container|pod)(?:_count|s)|kubelet_(:?docker|runtime)_operations_latency_microseconds(?:|_count|_sum))
-              source_labels:
-              - __name__
-            - action: labeldrop
-              regex: id
-            relabel_configs:
-            - source_labels:
-              - __meta_kubernetes_node_name
-              target_label: node
-            - replacement: https-metrics
-              target_label: endpoint
-            - action: replace
-              source_labels:
-              - __metrics_path__
-              target_label: metrics_path
-            - action: replace
-              source_labels:
-              - __address__
-              target_label: instance
-            scheme: https
-            tls_config:
-              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-              insecure_skip_verify: true
-          - authorization:
-              credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-            honor_labels: true
-            job_name: cadvisor
-            kubernetes_sd_configs:
-            - role: node
-            metric_relabel_configs:
-            - action: replace
-              regex: .*
-              replacement: kubelet
-              source_labels:
-              - __name__
-              target_label: job
-            - action: keep
-              regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes|container_cpu_cfs_throttled_seconds_total|container_network_receive_bytes_total|container_network_transmit_bytes_total)
-              source_labels:
-              - __name__
-            - action: drop
-              regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes);$
-              source_labels:
-              - __name__
-              - container
-            - action: labelmap
-              regex: container_name
-              replacement: container
-            - action: drop
-              regex: POD
-              source_labels:
-              - container
-            - action: labeldrop
-              regex: (id|name)
-            metrics_path: /metrics/cadvisor
-            relabel_configs:
-            - replacement: https-metrics
-              target_label: endpoint
-            - action: replace
-              source_labels:
-              - __metrics_path__
-              target_label: metrics_path
-            - action: replace
-              source_labels:
-              - __address__
-              target_label: instance
-            scheme: https
-            tls_config:
-              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-              insecure_skip_verify: true
+            - job_name: pod-annotations
+              kubernetes_sd_configs:
+                - role: pod
+              relabel_configs:
+                - action: keep
+                  regex: true
+                  source_labels:
+                    - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+                - action: replace
+                  regex: (.+)
+                  source_labels:
+                    - __meta_kubernetes_pod_annotation_prometheus_io_path
+                  target_label: __metrics_path__
+                - action: replace
+                  regex: ([^:]+)(?::\d+)?;(\d+)
+                  replacement: $1:$2
+                  source_labels:
+                    - __address__
+                    - __meta_kubernetes_pod_annotation_prometheus_io_port
+                  target_label: __address__
+                - action: replace
+                  regex: (.*)
+                  replacement: $1
+                  separator: ;
+                  source_labels:
+                    - __metrics_path__
+                  target_label: endpoint
+                - action: replace
+                  source_labels:
+                    - __meta_kubernetes_namespace
+                  target_label: namespace
+                - action: labelmap
+                  regex: __meta_kubernetes_pod_label_(.+)
+                - action: replace
+                  regex: (.*)
+                  replacement: $1
+                  separator: ;
+                  source_labels:
+                    - __meta_kubernetes_pod_name
+                  target_label: pod
+            - authorization:
+                credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              honor_labels: true
+              job_name: kubelet
+              kubernetes_sd_configs:
+                - role: node
+              metric_relabel_configs:
+                - action: keep
+                  regex: (?:kubelet_docker_operations_errors(?:|_total)|kubelet_(?:docker|runtime)_operations_duration_seconds_(?:count|sum)|kubelet_running_(?:container|pod)(?:_count|s)|kubelet_(:?docker|runtime)_operations_latency_microseconds(?:|_count|_sum))
+                  source_labels:
+                    - __name__
+                - action: labeldrop
+                  regex: id
+              relabel_configs:
+                - source_labels:
+                    - __meta_kubernetes_node_name
+                  target_label: node
+                - replacement: https-metrics
+                  target_label: endpoint
+                - action: replace
+                  source_labels:
+                    - __metrics_path__
+                  target_label: metrics_path
+                - action: replace
+                  source_labels:
+                    - __address__
+                  target_label: instance
+              scheme: https
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: true
+            - authorization:
+                credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              honor_labels: true
+              job_name: cadvisor
+              kubernetes_sd_configs:
+                - role: node
+              metric_relabel_configs:
+                - action: replace
+                  regex: .*
+                  replacement: kubelet
+                  source_labels:
+                    - __name__
+                  target_label: job
+                - action: keep
+                  regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes|container_cpu_cfs_throttled_seconds_total|container_network_receive_bytes_total|container_network_transmit_bytes_total)
+                  source_labels:
+                    - __name__
+                - action: drop
+                  regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes);$
+                  source_labels:
+                    - __name__
+                    - container
+                - action: labelmap
+                  regex: container_name
+                  replacement: container
+                - action: drop
+                  regex: POD
+                  source_labels:
+                    - container
+                - action: labeldrop
+                  regex: (id|name)
+              metrics_path: /metrics/cadvisor
+              relabel_configs:
+                - replacement: https-metrics
+                  target_label: endpoint
+                - action: replace
+                  source_labels:
+                    - __metrics_path__
+                  target_label: metrics_path
+                - action: replace
+                  source_labels:
+                    - __address__
+                  target_label: instance
+              scheme: https
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: true
     service:
       extensions:
-      - health_check
-      - pprof
-      - file_storage
+        - health_check
+        - pprof
+        - file_storage
       pipelines:
         metrics:
           exporters:
-          - otlphttp
+            - otlphttp
           processors:
-          - batch
-          - filter/drop_stale_datapoints
-          - transform/extract_sum_count_from_histograms
-          - transform/drop_unnecessary_attributes
+            - batch
+            - filter/drop_stale_datapoints
+            - transform/extract_sum_count_from_histograms
+            - transform/drop_unnecessary_attributes
           receivers:
-          - prometheus
+            - prometheus
       telemetry:
         logs:
           level: info
         metrics:
           level: normal
           readers:
-          - pull:
-              exporter:
-                prometheus:
-                  host: ${env:MY_POD_IP}
-                  port: 8888
-                  without_scope_info: true
-                  without_type_suffix: true
-                  without_units: true
-
+            - pull:
+                exporter:
+                  prometheus:
+                    host: ${env:MY_POD_IP}
+                    port: 8888
+                    without_scope_info: true
+                    without_type_suffix: true
+                    without_units: true

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/debug.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/debug.output.yaml
@@ -33,9 +33,7 @@ spec:
     serviceAccount: RELEASE-NAME-sumologic-metrics-targetallocator-sa
     nodeSelector:
       kubernetes.io/os: linux
-    resources:
-      
-      {}
+    resources: {}
   nodeSelector:
     kubernetes.io/os: linux
   autoscaler:
@@ -44,50 +42,47 @@ spec:
     targetCPUUtilization: 70
     targetMemoryUtilization: 70
     behavior:
-
       scaleDown:
         policies:
-        - periodSeconds: 60
-          type: Percent
-          value: 100
+          - periodSeconds: 60
+            type: Percent
+            value: 100
         stabilizationWindowSeconds: 60
       scaleUp:
         policies:
-        - periodSeconds: 60
-          type: Percent
-          value: 100
+          - periodSeconds: 60
+            type: Percent
+            value: 100
         stabilizationWindowSeconds: 60
   env:
-  - name: METADATA_METRICS_SVC
-    valueFrom:
-      configMapKeyRef:
-        name: sumologic-configmap
-        key: metadataMetrics
-  - name: NAMESPACE
-    valueFrom:
-      fieldRef:
-        fieldPath: metadata.namespace
-  - name: MY_POD_IP
-    valueFrom:
-      fieldRef:
-        apiVersion: v1
-        fieldPath: status.podIP
-  - name: MY_POD_NAME
-    valueFrom:
-      fieldRef:
-        apiVersion: v1
-        fieldPath: metadata.name
+    - name: METADATA_METRICS_SVC
+      valueFrom:
+        configMapKeyRef:
+          name: sumologic-configmap
+          key: metadataMetrics
+    - name: NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: MY_POD_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.podIP
+    - name: MY_POD_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
   podAnnotations:
     ## The operator adds this annotation by default, but we use our own ServiceMonitor
     prometheus.io/scrape: "false"
   podSecurityContext:
-    
     fsGroup: 999
   ports:
-  - name: pprof
-    port: 1777
+    - name: pprof
+      port: 1777
   resources:
-    
     limits:
       cpu: 1000m
       memory: 2Gi
@@ -95,15 +90,15 @@ spec:
       cpu: 100m
       memory: 768Mi
   volumes:
-  - name: tmp
-    emptyDir: {}
-  - name: file-storage
-    emptyDir: {}
+    - name: tmp
+      emptyDir: {}
+    - name: file-storage
+      emptyDir: {}
   volumeMounts:
-  - name: tmp
-    mountPath: /tmp
-  - name: file-storage
-    mountPath: /var/lib/storage/otc
+    - name: tmp
+      mountPath: /tmp
+    - name: file-storage
+      mountPath: /var/lib/storage/otc
   config:
     exporters:
       debug:
@@ -137,178 +132,177 @@ spec:
       filter/drop_stale_datapoints:
         metrics:
           datapoint:
-          - flags == FLAG_NO_RECORDED_VALUE
+            - flags == FLAG_NO_RECORDED_VALUE
       transform/drop_unnecessary_attributes:
         error_mode: ignore
         metric_statements:
-        - context: resource
-          statements:
-          - delete_key(attributes, "http.scheme")
-          - delete_key(attributes, "net.host.name")
-          - delete_key(attributes, "net.host.port")
-          - delete_key(attributes, "service.instance.id")
-          - delete_matching_keys(attributes, "k8s.*")
+          - context: resource
+            statements:
+              - delete_key(attributes, "http.scheme")
+              - delete_key(attributes, "net.host.name")
+              - delete_key(attributes, "net.host.port")
+              - delete_key(attributes, "service.instance.id")
+              - delete_matching_keys(attributes, "k8s.*")
       transform/extract_sum_count_from_histograms:
         error_mode: ignore
         metric_statements:
-        - context: metric
-          statements:
-          - extract_sum_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM
-            or type == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
-          - extract_count_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM
-            or type == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
+          - context: metric
+            statements:
+              - extract_sum_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM or type ==
+                METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
+              - extract_count_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM or type ==
+                METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
     receivers:
       prometheus:
         config:
           global:
             scrape_interval: 30s
           scrape_configs:
-          - job_name: pod-annotations
-            kubernetes_sd_configs:
-            - role: pod
-            relabel_configs:
-            - action: keep
-              regex: true
-              source_labels:
-              - __meta_kubernetes_pod_annotation_prometheus_io_scrape
-            - action: replace
-              regex: (.+)
-              source_labels:
-              - __meta_kubernetes_pod_annotation_prometheus_io_path
-              target_label: __metrics_path__
-            - action: replace
-              regex: ([^:]+)(?::\d+)?;(\d+)
-              replacement: $1:$2
-              source_labels:
-              - __address__
-              - __meta_kubernetes_pod_annotation_prometheus_io_port
-              target_label: __address__
-            - action: replace
-              regex: (.*)
-              replacement: $1
-              separator: ;
-              source_labels:
-              - __metrics_path__
-              target_label: endpoint
-            - action: replace
-              source_labels:
-              - __meta_kubernetes_namespace
-              target_label: namespace
-            - action: labelmap
-              regex: __meta_kubernetes_pod_label_(.+)
-            - action: replace
-              regex: (.*)
-              replacement: $1
-              separator: ;
-              source_labels:
-              - __meta_kubernetes_pod_name
-              target_label: pod
-          - authorization:
-              credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-            honor_labels: true
-            job_name: kubelet
-            kubernetes_sd_configs:
-            - role: node
-            metric_relabel_configs:
-            - action: keep
-              regex: (?:kubelet_docker_operations_errors(?:|_total)|kubelet_(?:docker|runtime)_operations_duration_seconds_(?:count|sum)|kubelet_running_(?:container|pod)(?:_count|s)|kubelet_(:?docker|runtime)_operations_latency_microseconds(?:|_count|_sum))
-              source_labels:
-              - __name__
-            - action: labeldrop
-              regex: id
-            relabel_configs:
-            - source_labels:
-              - __meta_kubernetes_node_name
-              target_label: node
-            - replacement: https-metrics
-              target_label: endpoint
-            - action: replace
-              source_labels:
-              - __metrics_path__
-              target_label: metrics_path
-            - action: replace
-              source_labels:
-              - __address__
-              target_label: instance
-            scheme: https
-            tls_config:
-              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-              insecure_skip_verify: true
-          - authorization:
-              credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-            honor_labels: true
-            job_name: cadvisor
-            kubernetes_sd_configs:
-            - role: node
-            metric_relabel_configs:
-            - action: replace
-              regex: .*
-              replacement: kubelet
-              source_labels:
-              - __name__
-              target_label: job
-            - action: keep
-              regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes|container_cpu_cfs_throttled_seconds_total|container_network_receive_bytes_total|container_network_transmit_bytes_total)
-              source_labels:
-              - __name__
-            - action: drop
-              regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes);$
-              source_labels:
-              - __name__
-              - container
-            - action: labelmap
-              regex: container_name
-              replacement: container
-            - action: drop
-              regex: POD
-              source_labels:
-              - container
-            - action: labeldrop
-              regex: (id|name)
-            metrics_path: /metrics/cadvisor
-            relabel_configs:
-            - replacement: https-metrics
-              target_label: endpoint
-            - action: replace
-              source_labels:
-              - __metrics_path__
-              target_label: metrics_path
-            - action: replace
-              source_labels:
-              - __address__
-              target_label: instance
-            scheme: https
-            tls_config:
-              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-              insecure_skip_verify: true
+            - job_name: pod-annotations
+              kubernetes_sd_configs:
+                - role: pod
+              relabel_configs:
+                - action: keep
+                  regex: true
+                  source_labels:
+                    - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+                - action: replace
+                  regex: (.+)
+                  source_labels:
+                    - __meta_kubernetes_pod_annotation_prometheus_io_path
+                  target_label: __metrics_path__
+                - action: replace
+                  regex: ([^:]+)(?::\d+)?;(\d+)
+                  replacement: $1:$2
+                  source_labels:
+                    - __address__
+                    - __meta_kubernetes_pod_annotation_prometheus_io_port
+                  target_label: __address__
+                - action: replace
+                  regex: (.*)
+                  replacement: $1
+                  separator: ;
+                  source_labels:
+                    - __metrics_path__
+                  target_label: endpoint
+                - action: replace
+                  source_labels:
+                    - __meta_kubernetes_namespace
+                  target_label: namespace
+                - action: labelmap
+                  regex: __meta_kubernetes_pod_label_(.+)
+                - action: replace
+                  regex: (.*)
+                  replacement: $1
+                  separator: ;
+                  source_labels:
+                    - __meta_kubernetes_pod_name
+                  target_label: pod
+            - authorization:
+                credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              honor_labels: true
+              job_name: kubelet
+              kubernetes_sd_configs:
+                - role: node
+              metric_relabel_configs:
+                - action: keep
+                  regex: (?:kubelet_docker_operations_errors(?:|_total)|kubelet_(?:docker|runtime)_operations_duration_seconds_(?:count|sum)|kubelet_running_(?:container|pod)(?:_count|s)|kubelet_(:?docker|runtime)_operations_latency_microseconds(?:|_count|_sum))
+                  source_labels:
+                    - __name__
+                - action: labeldrop
+                  regex: id
+              relabel_configs:
+                - source_labels:
+                    - __meta_kubernetes_node_name
+                  target_label: node
+                - replacement: https-metrics
+                  target_label: endpoint
+                - action: replace
+                  source_labels:
+                    - __metrics_path__
+                  target_label: metrics_path
+                - action: replace
+                  source_labels:
+                    - __address__
+                  target_label: instance
+              scheme: https
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: true
+            - authorization:
+                credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              honor_labels: true
+              job_name: cadvisor
+              kubernetes_sd_configs:
+                - role: node
+              metric_relabel_configs:
+                - action: replace
+                  regex: .*
+                  replacement: kubelet
+                  source_labels:
+                    - __name__
+                  target_label: job
+                - action: keep
+                  regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes|container_cpu_cfs_throttled_seconds_total|container_network_receive_bytes_total|container_network_transmit_bytes_total)
+                  source_labels:
+                    - __name__
+                - action: drop
+                  regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes);$
+                  source_labels:
+                    - __name__
+                    - container
+                - action: labelmap
+                  regex: container_name
+                  replacement: container
+                - action: drop
+                  regex: POD
+                  source_labels:
+                    - container
+                - action: labeldrop
+                  regex: (id|name)
+              metrics_path: /metrics/cadvisor
+              relabel_configs:
+                - replacement: https-metrics
+                  target_label: endpoint
+                - action: replace
+                  source_labels:
+                    - __metrics_path__
+                  target_label: metrics_path
+                - action: replace
+                  source_labels:
+                    - __address__
+                  target_label: instance
+              scheme: https
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: true
     service:
       extensions:
-      - health_check
-      - pprof
-      - file_storage
+        - health_check
+        - pprof
+        - file_storage
       pipelines:
         metrics:
           exporters:
-          - debug
-          - otlphttp
+            - debug
+            - otlphttp
           processors:
-          - filter/drop_stale_datapoints
-          - transform/extract_sum_count_from_histograms
-          - transform/drop_unnecessary_attributes
+            - filter/drop_stale_datapoints
+            - transform/extract_sum_count_from_histograms
+            - transform/drop_unnecessary_attributes
           receivers:
-          - prometheus
+            - prometheus
       telemetry:
         logs:
           level: info
         metrics:
           level: normal
           readers:
-          - pull:
-              exporter:
-                prometheus:
-                  host: ${env:MY_POD_IP}
-                  port: 8888
-                  without_scope_info: true
-                  without_type_suffix: true
-                  without_units: true
-
+            - pull:
+                exporter:
+                  prometheus:
+                    host: ${env:MY_POD_IP}
+                    port: 8888
+                    without_scope_info: true
+                    without_type_suffix: true
+                    without_units: true

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/debug.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/debug.output.yaml
@@ -33,7 +33,9 @@ spec:
     serviceAccount: RELEASE-NAME-sumologic-metrics-targetallocator-sa
     nodeSelector:
       kubernetes.io/os: linux
-    resources: {}
+    resources:
+      
+      {}
   nodeSelector:
     kubernetes.io/os: linux
   autoscaler:
@@ -42,42 +44,50 @@ spec:
     targetCPUUtilization: 70
     targetMemoryUtilization: 70
     behavior:
+
       scaleDown:
         policies:
-          - periodSeconds: 60
-            type: Percent
-            value: 100
+        - periodSeconds: 60
+          type: Percent
+          value: 100
         stabilizationWindowSeconds: 60
       scaleUp:
         policies:
-          - periodSeconds: 60
-            type: Percent
-            value: 100
+        - periodSeconds: 60
+          type: Percent
+          value: 100
         stabilizationWindowSeconds: 60
   env:
-    - name: METADATA_METRICS_SVC
-      valueFrom:
-        configMapKeyRef:
-          name: sumologic-configmap
-          key: metadataMetrics
-    - name: NAMESPACE
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.namespace
-    - name: MY_POD_IP
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: status.podIP
+  - name: METADATA_METRICS_SVC
+    valueFrom:
+      configMapKeyRef:
+        name: sumologic-configmap
+        key: metadataMetrics
+  - name: NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
+  - name: MY_POD_IP
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: status.podIP
+  - name: MY_POD_NAME
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: metadata.name
   podAnnotations:
     ## The operator adds this annotation by default, but we use our own ServiceMonitor
     prometheus.io/scrape: "false"
   podSecurityContext:
+    
     fsGroup: 999
   ports:
-    - name: pprof
-      port: 1777
+  - name: pprof
+    port: 1777
   resources:
+    
     limits:
       cpu: 1000m
       memory: 2Gi
@@ -85,15 +95,15 @@ spec:
       cpu: 100m
       memory: 768Mi
   volumes:
-    - name: tmp
-      emptyDir: {}
-    - name: file-storage
-      emptyDir: {}
+  - name: tmp
+    emptyDir: {}
+  - name: file-storage
+    emptyDir: {}
   volumeMounts:
-    - name: tmp
-      mountPath: /tmp
-    - name: file-storage
-      mountPath: /var/lib/storage/otc
+  - name: tmp
+    mountPath: /tmp
+  - name: file-storage
+    mountPath: /var/lib/storage/otc
   config:
     exporters:
       debug:
@@ -127,177 +137,178 @@ spec:
       filter/drop_stale_datapoints:
         metrics:
           datapoint:
-            - flags == FLAG_NO_RECORDED_VALUE
+          - flags == FLAG_NO_RECORDED_VALUE
       transform/drop_unnecessary_attributes:
         error_mode: ignore
         metric_statements:
-          - context: resource
-            statements:
-              - delete_key(attributes, "http.scheme")
-              - delete_key(attributes, "net.host.name")
-              - delete_key(attributes, "net.host.port")
-              - delete_key(attributes, "service.instance.id")
-              - delete_matching_keys(attributes, "k8s.*")
+        - context: resource
+          statements:
+          - delete_key(attributes, "http.scheme")
+          - delete_key(attributes, "net.host.name")
+          - delete_key(attributes, "net.host.port")
+          - delete_key(attributes, "service.instance.id")
+          - delete_matching_keys(attributes, "k8s.*")
       transform/extract_sum_count_from_histograms:
         error_mode: ignore
         metric_statements:
-          - context: metric
-            statements:
-              - extract_sum_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM or type ==
-                METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
-              - extract_count_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM or type ==
-                METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
+        - context: metric
+          statements:
+          - extract_sum_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM
+            or type == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
+          - extract_count_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM
+            or type == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
     receivers:
       prometheus:
         config:
           global:
             scrape_interval: 30s
           scrape_configs:
-            - job_name: pod-annotations
-              kubernetes_sd_configs:
-                - role: pod
-              relabel_configs:
-                - action: keep
-                  regex: true
-                  source_labels:
-                    - __meta_kubernetes_pod_annotation_prometheus_io_scrape
-                - action: replace
-                  regex: (.+)
-                  source_labels:
-                    - __meta_kubernetes_pod_annotation_prometheus_io_path
-                  target_label: __metrics_path__
-                - action: replace
-                  regex: ([^:]+)(?::\d+)?;(\d+)
-                  replacement: $1:$2
-                  source_labels:
-                    - __address__
-                    - __meta_kubernetes_pod_annotation_prometheus_io_port
-                  target_label: __address__
-                - action: replace
-                  regex: (.*)
-                  replacement: $1
-                  separator: ;
-                  source_labels:
-                    - __metrics_path__
-                  target_label: endpoint
-                - action: replace
-                  source_labels:
-                    - __meta_kubernetes_namespace
-                  target_label: namespace
-                - action: labelmap
-                  regex: __meta_kubernetes_pod_label_(.+)
-                - action: replace
-                  regex: (.*)
-                  replacement: $1
-                  separator: ;
-                  source_labels:
-                    - __meta_kubernetes_pod_name
-                  target_label: pod
-            - authorization:
-                credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-              honor_labels: true
-              job_name: kubelet
-              kubernetes_sd_configs:
-                - role: node
-              metric_relabel_configs:
-                - action: keep
-                  regex: (?:kubelet_docker_operations_errors(?:|_total)|kubelet_(?:docker|runtime)_operations_duration_seconds_(?:count|sum)|kubelet_running_(?:container|pod)(?:_count|s)|kubelet_(:?docker|runtime)_operations_latency_microseconds(?:|_count|_sum))
-                  source_labels:
-                    - __name__
-                - action: labeldrop
-                  regex: id
-              relabel_configs:
-                - source_labels:
-                    - __meta_kubernetes_node_name
-                  target_label: node
-                - replacement: https-metrics
-                  target_label: endpoint
-                - action: replace
-                  source_labels:
-                    - __metrics_path__
-                  target_label: metrics_path
-                - action: replace
-                  source_labels:
-                    - __address__
-                  target_label: instance
-              scheme: https
-              tls_config:
-                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-                insecure_skip_verify: true
-            - authorization:
-                credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-              honor_labels: true
-              job_name: cadvisor
-              kubernetes_sd_configs:
-                - role: node
-              metric_relabel_configs:
-                - action: replace
-                  regex: .*
-                  replacement: kubelet
-                  source_labels:
-                    - __name__
-                  target_label: job
-                - action: keep
-                  regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes|container_cpu_cfs_throttled_seconds_total|container_network_receive_bytes_total|container_network_transmit_bytes_total)
-                  source_labels:
-                    - __name__
-                - action: drop
-                  regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes);$
-                  source_labels:
-                    - __name__
-                    - container
-                - action: labelmap
-                  regex: container_name
-                  replacement: container
-                - action: drop
-                  regex: POD
-                  source_labels:
-                    - container
-                - action: labeldrop
-                  regex: (id|name)
-              metrics_path: /metrics/cadvisor
-              relabel_configs:
-                - replacement: https-metrics
-                  target_label: endpoint
-                - action: replace
-                  source_labels:
-                    - __metrics_path__
-                  target_label: metrics_path
-                - action: replace
-                  source_labels:
-                    - __address__
-                  target_label: instance
-              scheme: https
-              tls_config:
-                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-                insecure_skip_verify: true
+          - job_name: pod-annotations
+            kubernetes_sd_configs:
+            - role: pod
+            relabel_configs:
+            - action: keep
+              regex: true
+              source_labels:
+              - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+            - action: replace
+              regex: (.+)
+              source_labels:
+              - __meta_kubernetes_pod_annotation_prometheus_io_path
+              target_label: __metrics_path__
+            - action: replace
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: $1:$2
+              source_labels:
+              - __address__
+              - __meta_kubernetes_pod_annotation_prometheus_io_port
+              target_label: __address__
+            - action: replace
+              regex: (.*)
+              replacement: $1
+              separator: ;
+              source_labels:
+              - __metrics_path__
+              target_label: endpoint
+            - action: replace
+              source_labels:
+              - __meta_kubernetes_namespace
+              target_label: namespace
+            - action: labelmap
+              regex: __meta_kubernetes_pod_label_(.+)
+            - action: replace
+              regex: (.*)
+              replacement: $1
+              separator: ;
+              source_labels:
+              - __meta_kubernetes_pod_name
+              target_label: pod
+          - authorization:
+              credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            honor_labels: true
+            job_name: kubelet
+            kubernetes_sd_configs:
+            - role: node
+            metric_relabel_configs:
+            - action: keep
+              regex: (?:kubelet_docker_operations_errors(?:|_total)|kubelet_(?:docker|runtime)_operations_duration_seconds_(?:count|sum)|kubelet_running_(?:container|pod)(?:_count|s)|kubelet_(:?docker|runtime)_operations_latency_microseconds(?:|_count|_sum))
+              source_labels:
+              - __name__
+            - action: labeldrop
+              regex: id
+            relabel_configs:
+            - source_labels:
+              - __meta_kubernetes_node_name
+              target_label: node
+            - replacement: https-metrics
+              target_label: endpoint
+            - action: replace
+              source_labels:
+              - __metrics_path__
+              target_label: metrics_path
+            - action: replace
+              source_labels:
+              - __address__
+              target_label: instance
+            scheme: https
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
+          - authorization:
+              credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            honor_labels: true
+            job_name: cadvisor
+            kubernetes_sd_configs:
+            - role: node
+            metric_relabel_configs:
+            - action: replace
+              regex: .*
+              replacement: kubelet
+              source_labels:
+              - __name__
+              target_label: job
+            - action: keep
+              regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes|container_cpu_cfs_throttled_seconds_total|container_network_receive_bytes_total|container_network_transmit_bytes_total)
+              source_labels:
+              - __name__
+            - action: drop
+              regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes);$
+              source_labels:
+              - __name__
+              - container
+            - action: labelmap
+              regex: container_name
+              replacement: container
+            - action: drop
+              regex: POD
+              source_labels:
+              - container
+            - action: labeldrop
+              regex: (id|name)
+            metrics_path: /metrics/cadvisor
+            relabel_configs:
+            - replacement: https-metrics
+              target_label: endpoint
+            - action: replace
+              source_labels:
+              - __metrics_path__
+              target_label: metrics_path
+            - action: replace
+              source_labels:
+              - __address__
+              target_label: instance
+            scheme: https
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
     service:
       extensions:
-        - health_check
-        - pprof
-        - file_storage
+      - health_check
+      - pprof
+      - file_storage
       pipelines:
         metrics:
           exporters:
-            - debug
-            - otlphttp
+          - debug
+          - otlphttp
           processors:
-            - filter/drop_stale_datapoints
-            - transform/extract_sum_count_from_histograms
-            - transform/drop_unnecessary_attributes
+          - filter/drop_stale_datapoints
+          - transform/extract_sum_count_from_histograms
+          - transform/drop_unnecessary_attributes
           receivers:
-            - prometheus
+          - prometheus
       telemetry:
         logs:
           level: info
         metrics:
           level: normal
           readers:
-            - pull:
-                exporter:
-                  prometheus:
-                    host: ${env:MY_POD_IP}
-                    port: 8888
-                    without_scope_info: true
-                    without_type_suffix: true
-                    without_units: true
+          - pull:
+              exporter:
+                prometheus:
+                  host: ${env:MY_POD_IP}
+                  port: 8888
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true
+

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/kubelet.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/kubelet.output.yaml
@@ -33,7 +33,9 @@ spec:
     serviceAccount: RELEASE-NAME-sumologic-metrics-targetallocator-sa
     nodeSelector:
       kubernetes.io/os: linux
-    resources: {}
+    resources:
+      
+      {}
   nodeSelector:
     kubernetes.io/os: linux
   autoscaler:
@@ -42,29 +44,36 @@ spec:
     targetCPUUtilization: 70
     targetMemoryUtilization: 70
   env:
-    - name: METADATA_METRICS_SVC
-      valueFrom:
-        configMapKeyRef:
-          name: sumologic-configmap
-          key: metadataMetrics
-    - name: NAMESPACE
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.namespace
-    - name: MY_POD_IP
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: status.podIP
+  - name: METADATA_METRICS_SVC
+    valueFrom:
+      configMapKeyRef:
+        name: sumologic-configmap
+        key: metadataMetrics
+  - name: NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
+  - name: MY_POD_IP
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: status.podIP
+  - name: MY_POD_NAME
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: metadata.name
   podAnnotations:
     ## The operator adds this annotation by default, but we use our own ServiceMonitor
     prometheus.io/scrape: "false"
   podSecurityContext:
+    
     fsGroup: 999
   ports:
-    - name: pprof
-      port: 1777
+  - name: pprof
+    port: 1777
   resources:
+    
     limits:
       cpu: 1000m
       memory: 2Gi
@@ -72,15 +81,15 @@ spec:
       cpu: 100m
       memory: 768Mi
   volumes:
-    - name: tmp
-      emptyDir: {}
-    - name: file-storage
-      emptyDir: {}
+  - name: tmp
+    emptyDir: {}
+  - name: file-storage
+    emptyDir: {}
   volumeMounts:
-    - name: tmp
-      mountPath: /tmp
-    - name: file-storage
-      mountPath: /var/lib/storage/otc
+  - name: tmp
+    mountPath: /tmp
+  - name: file-storage
+    mountPath: /var/lib/storage/otc
   config:
     exporters:
       otlphttp:
@@ -112,176 +121,177 @@ spec:
       filter/drop_stale_datapoints:
         metrics:
           datapoint:
-            - flags == FLAG_NO_RECORDED_VALUE
+          - flags == FLAG_NO_RECORDED_VALUE
       transform/drop_unnecessary_attributes:
         error_mode: ignore
         metric_statements:
-          - context: resource
-            statements:
-              - delete_key(attributes, "http.scheme")
-              - delete_key(attributes, "net.host.name")
-              - delete_key(attributes, "net.host.port")
-              - delete_key(attributes, "service.instance.id")
-              - delete_matching_keys(attributes, "k8s.*")
+        - context: resource
+          statements:
+          - delete_key(attributes, "http.scheme")
+          - delete_key(attributes, "net.host.name")
+          - delete_key(attributes, "net.host.port")
+          - delete_key(attributes, "service.instance.id")
+          - delete_matching_keys(attributes, "k8s.*")
       transform/extract_sum_count_from_histograms:
         error_mode: ignore
         metric_statements:
-          - context: metric
-            statements:
-              - extract_sum_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM or type ==
-                METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
-              - extract_count_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM or type ==
-                METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
+        - context: metric
+          statements:
+          - extract_sum_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM
+            or type == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
+          - extract_count_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM
+            or type == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
     receivers:
       prometheus:
         config:
           global:
             scrape_interval: 30s
           scrape_configs:
-            - job_name: pod-annotations
-              kubernetes_sd_configs:
-                - role: pod
-              relabel_configs:
-                - action: keep
-                  regex: true
-                  source_labels:
-                    - __meta_kubernetes_pod_annotation_prometheus_io_scrape
-                - action: replace
-                  regex: (.+)
-                  source_labels:
-                    - __meta_kubernetes_pod_annotation_prometheus_io_path
-                  target_label: __metrics_path__
-                - action: replace
-                  regex: ([^:]+)(?::\d+)?;(\d+)
-                  replacement: $1:$2
-                  source_labels:
-                    - __address__
-                    - __meta_kubernetes_pod_annotation_prometheus_io_port
-                  target_label: __address__
-                - action: replace
-                  regex: (.*)
-                  replacement: $1
-                  separator: ;
-                  source_labels:
-                    - __metrics_path__
-                  target_label: endpoint
-                - action: replace
-                  source_labels:
-                    - __meta_kubernetes_namespace
-                  target_label: namespace
-                - action: labelmap
-                  regex: __meta_kubernetes_pod_label_(.+)
-                - action: replace
-                  regex: (.*)
-                  replacement: $1
-                  separator: ;
-                  source_labels:
-                    - __meta_kubernetes_pod_name
-                  target_label: pod
-            - authorization:
-                credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-              honor_labels: true
-              job_name: kubelet
-              kubernetes_sd_configs:
-                - role: node
-              metric_relabel_configs:
-                - action: keep
-                  regex: kubelet_running_pods
-                  source_labels:
-                    - __name__
-                - action: labeldrop
-                  regex: id
-              relabel_configs:
-                - source_labels:
-                    - __meta_kubernetes_node_name
-                  target_label: node
-                - replacement: https-metrics
-                  target_label: endpoint
-                - action: replace
-                  source_labels:
-                    - __metrics_path__
-                  target_label: metrics_path
-                - action: replace
-                  source_labels:
-                    - __address__
-                  target_label: instance
-              scheme: https
-              tls_config:
-                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-                insecure_skip_verify: true
-            - authorization:
-                credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-              honor_labels: true
-              job_name: cadvisor
-              kubernetes_sd_configs:
-                - role: node
-              metric_relabel_configs:
-                - action: replace
-                  regex: .*
-                  replacement: kubelet
-                  source_labels:
-                    - __name__
-                  target_label: job
-                - action: keep
-                  regex: container_cpu_usage_total
-                  source_labels:
-                    - __name__
-                - action: drop
-                  regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes);$
-                  source_labels:
-                    - __name__
-                    - container
-                - action: labelmap
-                  regex: container_name
-                  replacement: container
-                - action: drop
-                  regex: POD
-                  source_labels:
-                    - container
-                - action: labeldrop
-                  regex: (id|name)
-              metrics_path: /metrics/cadvisor
-              relabel_configs:
-                - replacement: https-metrics
-                  target_label: endpoint
-                - action: replace
-                  source_labels:
-                    - __metrics_path__
-                  target_label: metrics_path
-                - action: replace
-                  source_labels:
-                    - __address__
-                  target_label: instance
-              scheme: https
-              tls_config:
-                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-                insecure_skip_verify: true
+          - job_name: pod-annotations
+            kubernetes_sd_configs:
+            - role: pod
+            relabel_configs:
+            - action: keep
+              regex: true
+              source_labels:
+              - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+            - action: replace
+              regex: (.+)
+              source_labels:
+              - __meta_kubernetes_pod_annotation_prometheus_io_path
+              target_label: __metrics_path__
+            - action: replace
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: $1:$2
+              source_labels:
+              - __address__
+              - __meta_kubernetes_pod_annotation_prometheus_io_port
+              target_label: __address__
+            - action: replace
+              regex: (.*)
+              replacement: $1
+              separator: ;
+              source_labels:
+              - __metrics_path__
+              target_label: endpoint
+            - action: replace
+              source_labels:
+              - __meta_kubernetes_namespace
+              target_label: namespace
+            - action: labelmap
+              regex: __meta_kubernetes_pod_label_(.+)
+            - action: replace
+              regex: (.*)
+              replacement: $1
+              separator: ;
+              source_labels:
+              - __meta_kubernetes_pod_name
+              target_label: pod
+          - authorization:
+              credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            honor_labels: true
+            job_name: kubelet
+            kubernetes_sd_configs:
+            - role: node
+            metric_relabel_configs:
+            - action: keep
+              regex: kubelet_running_pods
+              source_labels:
+              - __name__
+            - action: labeldrop
+              regex: id
+            relabel_configs:
+            - source_labels:
+              - __meta_kubernetes_node_name
+              target_label: node
+            - replacement: https-metrics
+              target_label: endpoint
+            - action: replace
+              source_labels:
+              - __metrics_path__
+              target_label: metrics_path
+            - action: replace
+              source_labels:
+              - __address__
+              target_label: instance
+            scheme: https
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
+          - authorization:
+              credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            honor_labels: true
+            job_name: cadvisor
+            kubernetes_sd_configs:
+            - role: node
+            metric_relabel_configs:
+            - action: replace
+              regex: .*
+              replacement: kubelet
+              source_labels:
+              - __name__
+              target_label: job
+            - action: keep
+              regex: container_cpu_usage_total
+              source_labels:
+              - __name__
+            - action: drop
+              regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes);$
+              source_labels:
+              - __name__
+              - container
+            - action: labelmap
+              regex: container_name
+              replacement: container
+            - action: drop
+              regex: POD
+              source_labels:
+              - container
+            - action: labeldrop
+              regex: (id|name)
+            metrics_path: /metrics/cadvisor
+            relabel_configs:
+            - replacement: https-metrics
+              target_label: endpoint
+            - action: replace
+              source_labels:
+              - __metrics_path__
+              target_label: metrics_path
+            - action: replace
+              source_labels:
+              - __address__
+              target_label: instance
+            scheme: https
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
     service:
       extensions:
-        - health_check
-        - pprof
-        - file_storage
+      - health_check
+      - pprof
+      - file_storage
       pipelines:
         metrics:
           exporters:
-            - otlphttp
+          - otlphttp
           processors:
-            - filter/drop_stale_datapoints
-            - transform/extract_sum_count_from_histograms
-            - transform/drop_unnecessary_attributes
+          - filter/drop_stale_datapoints
+          - transform/extract_sum_count_from_histograms
+          - transform/drop_unnecessary_attributes
           receivers:
-            - prometheus
+          - prometheus
       telemetry:
         logs:
           level: info
         metrics:
           level: normal
           readers:
-            - pull:
-                exporter:
-                  prometheus:
-                    host: ${env:MY_POD_IP}
-                    port: 8888
-                    without_scope_info: true
-                    without_type_suffix: true
-                    without_units: true
+          - pull:
+              exporter:
+                prometheus:
+                  host: ${env:MY_POD_IP}
+                  port: 8888
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true
+

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/kubelet.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/kubelet.output.yaml
@@ -33,9 +33,7 @@ spec:
     serviceAccount: RELEASE-NAME-sumologic-metrics-targetallocator-sa
     nodeSelector:
       kubernetes.io/os: linux
-    resources:
-      
-      {}
+    resources: {}
   nodeSelector:
     kubernetes.io/os: linux
   autoscaler:
@@ -44,36 +42,34 @@ spec:
     targetCPUUtilization: 70
     targetMemoryUtilization: 70
   env:
-  - name: METADATA_METRICS_SVC
-    valueFrom:
-      configMapKeyRef:
-        name: sumologic-configmap
-        key: metadataMetrics
-  - name: NAMESPACE
-    valueFrom:
-      fieldRef:
-        fieldPath: metadata.namespace
-  - name: MY_POD_IP
-    valueFrom:
-      fieldRef:
-        apiVersion: v1
-        fieldPath: status.podIP
-  - name: MY_POD_NAME
-    valueFrom:
-      fieldRef:
-        apiVersion: v1
-        fieldPath: metadata.name
+    - name: METADATA_METRICS_SVC
+      valueFrom:
+        configMapKeyRef:
+          name: sumologic-configmap
+          key: metadataMetrics
+    - name: NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: MY_POD_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.podIP
+    - name: MY_POD_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
   podAnnotations:
     ## The operator adds this annotation by default, but we use our own ServiceMonitor
     prometheus.io/scrape: "false"
   podSecurityContext:
-    
     fsGroup: 999
   ports:
-  - name: pprof
-    port: 1777
+    - name: pprof
+      port: 1777
   resources:
-    
     limits:
       cpu: 1000m
       memory: 2Gi
@@ -81,15 +77,15 @@ spec:
       cpu: 100m
       memory: 768Mi
   volumes:
-  - name: tmp
-    emptyDir: {}
-  - name: file-storage
-    emptyDir: {}
+    - name: tmp
+      emptyDir: {}
+    - name: file-storage
+      emptyDir: {}
   volumeMounts:
-  - name: tmp
-    mountPath: /tmp
-  - name: file-storage
-    mountPath: /var/lib/storage/otc
+    - name: tmp
+      mountPath: /tmp
+    - name: file-storage
+      mountPath: /var/lib/storage/otc
   config:
     exporters:
       otlphttp:
@@ -121,177 +117,176 @@ spec:
       filter/drop_stale_datapoints:
         metrics:
           datapoint:
-          - flags == FLAG_NO_RECORDED_VALUE
+            - flags == FLAG_NO_RECORDED_VALUE
       transform/drop_unnecessary_attributes:
         error_mode: ignore
         metric_statements:
-        - context: resource
-          statements:
-          - delete_key(attributes, "http.scheme")
-          - delete_key(attributes, "net.host.name")
-          - delete_key(attributes, "net.host.port")
-          - delete_key(attributes, "service.instance.id")
-          - delete_matching_keys(attributes, "k8s.*")
+          - context: resource
+            statements:
+              - delete_key(attributes, "http.scheme")
+              - delete_key(attributes, "net.host.name")
+              - delete_key(attributes, "net.host.port")
+              - delete_key(attributes, "service.instance.id")
+              - delete_matching_keys(attributes, "k8s.*")
       transform/extract_sum_count_from_histograms:
         error_mode: ignore
         metric_statements:
-        - context: metric
-          statements:
-          - extract_sum_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM
-            or type == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
-          - extract_count_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM
-            or type == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
+          - context: metric
+            statements:
+              - extract_sum_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM or type ==
+                METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
+              - extract_count_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM or type ==
+                METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
     receivers:
       prometheus:
         config:
           global:
             scrape_interval: 30s
           scrape_configs:
-          - job_name: pod-annotations
-            kubernetes_sd_configs:
-            - role: pod
-            relabel_configs:
-            - action: keep
-              regex: true
-              source_labels:
-              - __meta_kubernetes_pod_annotation_prometheus_io_scrape
-            - action: replace
-              regex: (.+)
-              source_labels:
-              - __meta_kubernetes_pod_annotation_prometheus_io_path
-              target_label: __metrics_path__
-            - action: replace
-              regex: ([^:]+)(?::\d+)?;(\d+)
-              replacement: $1:$2
-              source_labels:
-              - __address__
-              - __meta_kubernetes_pod_annotation_prometheus_io_port
-              target_label: __address__
-            - action: replace
-              regex: (.*)
-              replacement: $1
-              separator: ;
-              source_labels:
-              - __metrics_path__
-              target_label: endpoint
-            - action: replace
-              source_labels:
-              - __meta_kubernetes_namespace
-              target_label: namespace
-            - action: labelmap
-              regex: __meta_kubernetes_pod_label_(.+)
-            - action: replace
-              regex: (.*)
-              replacement: $1
-              separator: ;
-              source_labels:
-              - __meta_kubernetes_pod_name
-              target_label: pod
-          - authorization:
-              credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-            honor_labels: true
-            job_name: kubelet
-            kubernetes_sd_configs:
-            - role: node
-            metric_relabel_configs:
-            - action: keep
-              regex: kubelet_running_pods
-              source_labels:
-              - __name__
-            - action: labeldrop
-              regex: id
-            relabel_configs:
-            - source_labels:
-              - __meta_kubernetes_node_name
-              target_label: node
-            - replacement: https-metrics
-              target_label: endpoint
-            - action: replace
-              source_labels:
-              - __metrics_path__
-              target_label: metrics_path
-            - action: replace
-              source_labels:
-              - __address__
-              target_label: instance
-            scheme: https
-            tls_config:
-              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-              insecure_skip_verify: true
-          - authorization:
-              credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-            honor_labels: true
-            job_name: cadvisor
-            kubernetes_sd_configs:
-            - role: node
-            metric_relabel_configs:
-            - action: replace
-              regex: .*
-              replacement: kubelet
-              source_labels:
-              - __name__
-              target_label: job
-            - action: keep
-              regex: container_cpu_usage_total
-              source_labels:
-              - __name__
-            - action: drop
-              regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes);$
-              source_labels:
-              - __name__
-              - container
-            - action: labelmap
-              regex: container_name
-              replacement: container
-            - action: drop
-              regex: POD
-              source_labels:
-              - container
-            - action: labeldrop
-              regex: (id|name)
-            metrics_path: /metrics/cadvisor
-            relabel_configs:
-            - replacement: https-metrics
-              target_label: endpoint
-            - action: replace
-              source_labels:
-              - __metrics_path__
-              target_label: metrics_path
-            - action: replace
-              source_labels:
-              - __address__
-              target_label: instance
-            scheme: https
-            tls_config:
-              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-              insecure_skip_verify: true
+            - job_name: pod-annotations
+              kubernetes_sd_configs:
+                - role: pod
+              relabel_configs:
+                - action: keep
+                  regex: true
+                  source_labels:
+                    - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+                - action: replace
+                  regex: (.+)
+                  source_labels:
+                    - __meta_kubernetes_pod_annotation_prometheus_io_path
+                  target_label: __metrics_path__
+                - action: replace
+                  regex: ([^:]+)(?::\d+)?;(\d+)
+                  replacement: $1:$2
+                  source_labels:
+                    - __address__
+                    - __meta_kubernetes_pod_annotation_prometheus_io_port
+                  target_label: __address__
+                - action: replace
+                  regex: (.*)
+                  replacement: $1
+                  separator: ;
+                  source_labels:
+                    - __metrics_path__
+                  target_label: endpoint
+                - action: replace
+                  source_labels:
+                    - __meta_kubernetes_namespace
+                  target_label: namespace
+                - action: labelmap
+                  regex: __meta_kubernetes_pod_label_(.+)
+                - action: replace
+                  regex: (.*)
+                  replacement: $1
+                  separator: ;
+                  source_labels:
+                    - __meta_kubernetes_pod_name
+                  target_label: pod
+            - authorization:
+                credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              honor_labels: true
+              job_name: kubelet
+              kubernetes_sd_configs:
+                - role: node
+              metric_relabel_configs:
+                - action: keep
+                  regex: kubelet_running_pods
+                  source_labels:
+                    - __name__
+                - action: labeldrop
+                  regex: id
+              relabel_configs:
+                - source_labels:
+                    - __meta_kubernetes_node_name
+                  target_label: node
+                - replacement: https-metrics
+                  target_label: endpoint
+                - action: replace
+                  source_labels:
+                    - __metrics_path__
+                  target_label: metrics_path
+                - action: replace
+                  source_labels:
+                    - __address__
+                  target_label: instance
+              scheme: https
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: true
+            - authorization:
+                credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              honor_labels: true
+              job_name: cadvisor
+              kubernetes_sd_configs:
+                - role: node
+              metric_relabel_configs:
+                - action: replace
+                  regex: .*
+                  replacement: kubelet
+                  source_labels:
+                    - __name__
+                  target_label: job
+                - action: keep
+                  regex: container_cpu_usage_total
+                  source_labels:
+                    - __name__
+                - action: drop
+                  regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes);$
+                  source_labels:
+                    - __name__
+                    - container
+                - action: labelmap
+                  regex: container_name
+                  replacement: container
+                - action: drop
+                  regex: POD
+                  source_labels:
+                    - container
+                - action: labeldrop
+                  regex: (id|name)
+              metrics_path: /metrics/cadvisor
+              relabel_configs:
+                - replacement: https-metrics
+                  target_label: endpoint
+                - action: replace
+                  source_labels:
+                    - __metrics_path__
+                  target_label: metrics_path
+                - action: replace
+                  source_labels:
+                    - __address__
+                  target_label: instance
+              scheme: https
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: true
     service:
       extensions:
-      - health_check
-      - pprof
-      - file_storage
+        - health_check
+        - pprof
+        - file_storage
       pipelines:
         metrics:
           exporters:
-          - otlphttp
+            - otlphttp
           processors:
-          - filter/drop_stale_datapoints
-          - transform/extract_sum_count_from_histograms
-          - transform/drop_unnecessary_attributes
+            - filter/drop_stale_datapoints
+            - transform/extract_sum_count_from_histograms
+            - transform/drop_unnecessary_attributes
           receivers:
-          - prometheus
+            - prometheus
       telemetry:
         logs:
           level: info
         metrics:
           level: normal
           readers:
-          - pull:
-              exporter:
-                prometheus:
-                  host: ${env:MY_POD_IP}
-                  port: 8888
-                  without_scope_info: true
-                  without_type_suffix: true
-                  without_units: true
-
+            - pull:
+                exporter:
+                  prometheus:
+                    host: ${env:MY_POD_IP}
+                    port: 8888
+                    without_scope_info: true
+                    without_type_suffix: true
+                    without_units: true

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/single_layer_pipeline.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/single_layer_pipeline.output.yaml
@@ -33,9 +33,7 @@ spec:
     serviceAccount: RELEASE-NAME-sumologic-metrics-targetallocator-sa
     nodeSelector:
       kubernetes.io/os: linux
-    resources:
-      
-      {}
+    resources: {}
   nodeSelector:
     kubernetes.io/os: linux
   autoscaler:
@@ -44,42 +42,39 @@ spec:
     targetCPUUtilization: 70
     targetMemoryUtilization: 70
   env:
-  - name: SUMO_ENDPOINT_DEFAULT_OTLP_METRICS_SOURCE
-    valueFrom:
-      secretKeyRef:
-        name: sumologic
-        key: endpoint-metrics-otlp
-  
-  
-  - name: NO_PROXY
-    value: kubernetes.default.svc
-  - name: NAMESPACE
-    valueFrom:
-      fieldRef:
-        fieldPath: metadata.namespace
-  - name: MY_POD_IP
-    valueFrom:
-      fieldRef:
-        apiVersion: v1
-        fieldPath: status.podIP
-  - name: MY_POD_NAME
-    valueFrom:
-      fieldRef:
-        apiVersion: v1
-        fieldPath: metadata.name
+    - name: SUMO_ENDPOINT_DEFAULT_OTLP_METRICS_SOURCE
+      valueFrom:
+        secretKeyRef:
+          name: sumologic
+          key: endpoint-metrics-otlp
+
+    - name: NO_PROXY
+      value: kubernetes.default.svc
+    - name: NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: MY_POD_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.podIP
+    - name: MY_POD_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
   podAnnotations:
     ## The operator adds this annotation by default, but we use our own ServiceMonitor
     prometheus.io/scrape: "false"
   podSecurityContext:
-    
     fsGroup: 999
   ports:
-  - name: pprof
-    port: 1777
-  - name: metrics-rw
-    port: 9888
+    - name: pprof
+      port: 1777
+    - name: metrics-rw
+      port: 9888
   resources:
-    
     limits:
       cpu: 1000m
       memory: 2Gi
@@ -97,26 +92,26 @@ spec:
     timeoutSeconds: 3
     failureThreshold: 3
   volumes:
-  - name: tmp
-    emptyDir: {}
+    - name: tmp
+      emptyDir: {}
   volumeMounts:
-  - name: tmp
-    mountPath: /tmp
-  - name: file-storage
-    mountPath: /var/lib/storage/otc
+    - name: tmp
+      mountPath: /tmp
+    - name: file-storage
+      mountPath: /var/lib/storage/otc
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: Retain
     whenScaled: Retain
   volumeClaimTemplates:
-  - metadata:
-      name: file-storage
-      labels:
-        sumologic.com/component: metrics-collector
-    spec:
-      accessModes: [ReadWriteOnce]
-      resources:
-        requests:
-          storage: 10Gi
+    - metadata:
+        name: file-storage
+        labels:
+          sumologic.com/component: metrics-collector
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 10Gi
   config:
     connectors:
       forward: {}
@@ -156,51 +151,51 @@ spec:
       filter/drop_stale_datapoints:
         metrics:
           datapoint:
-          - flags == FLAG_NO_RECORDED_VALUE
+            - flags == FLAG_NO_RECORDED_VALUE
       filter/drop_unnecessary_metrics:
         error_mode: ignore
         metrics:
           metric:
-          - resource.attributes["job"] != "pod-annotations" and IsMatch(name, "scrape_.*")
-          - (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM or type
-            == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY
-            or IsMatch(name, ".*_bucket"))
-          - IsMatch(name, "^otelcol[._](k8s[._]pod[._]association|otelsvc_k8s_(pod_added|pod_updated|pod_table_size|pod_deleted|ip_lookup_miss))$")
-          - IsMatch(name, "^otelcol[._].*k8s.*")
+            - resource.attributes["job"] != "pod-annotations" and IsMatch(name, "scrape_.*")
+            - (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM or type == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type ==
+              METRIC_DATA_TYPE_SUMMARY or IsMatch(name, ".*_bucket"))
+            - IsMatch(name,
+              "^otelcol[._](k8s[._]pod[._]association|otelsvc_k8s_(pod_added|pod_updated|pod_table_size|pod_deleted|ip_lookup_miss))$")
+            - IsMatch(name, "^otelcol[._].*k8s.*")
       groupbyattrs:
         keys:
-        - container
-        - namespace
-        - pod
-        - service
+          - container
+          - namespace
+          - pod
+          - service
       groupbyattrs/group_by_name:
         keys:
-        - __name__
-        - job
+          - __name__
+          - job
       k8sattributes:
         auth_type: serviceAccount
         extract:
           labels:
-          - from: pod
-            key_regex: (.*)
-            tag_name: pod_labels_$$1
+            - from: pod
+              key_regex: (.*)
+              tag_name: pod_labels_$$1
           metadata:
-          - k8s.pod.name
-          - k8s.deployment.name
-          - k8s.daemonset.name
-          - k8s.replicaset.name
-          - k8s.statefulset.name
-          - k8s.namespace.name
-          - k8s.node.name
-          - service.name
-          - service.namespace
+            - k8s.pod.name
+            - k8s.deployment.name
+            - k8s.daemonset.name
+            - k8s.replicaset.name
+            - k8s.statefulset.name
+            - k8s.namespace.name
+            - k8s.node.name
+            - service.name
+            - service.namespace
         passthrough: false
         pod_association:
-        - sources:
-          - from: resource_attribute
-            name: k8s.pod.name
-          - from: resource_attribute
-            name: k8s.namespace.name
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.name
+              - from: resource_attribute
+                name: k8s.namespace.name
         wait_for_metadata: true
         wait_for_metadata_timeout: 10s
       memory_limiter:
@@ -209,60 +204,60 @@ spec:
         spike_limit_percentage: 20
       metricstransform:
         transforms:
-        - action: update
-          include: ^prometheus_remote_write_(.*)$$
-          match_type: regexp
-          new_name: $$1
+          - action: update
+            include: ^prometheus_remote_write_(.*)$$
+            match_type: regexp
+            new_name: $$1
       resource:
         attributes:
-        - action: upsert
-          from_attribute: namespace
-          key: k8s.namespace.name
-        - action: delete
-          key: namespace
-        - action: upsert
-          from_attribute: pod
-          key: k8s.pod.name
-        - action: delete
-          key: pod
-        - action: upsert
-          from_attribute: container
-          key: k8s.container.name
-        - action: delete
-          key: container
-        - action: upsert
-          from_attribute: node
-          key: k8s.node.name
-        - action: delete
-          key: node
-        - action: upsert
-          from_attribute: service
-          key: prometheus_service
-        - action: delete
-          key: service
-        - action: upsert
-          from_attribute: service.name
-          key: job
-        - action: delete
-          key: service.name
-        - action: upsert
-          key: _origin
-          value: kubernetes
-        - action: upsert
-          key: cluster
-          value: kubernetes
+          - action: upsert
+            from_attribute: namespace
+            key: k8s.namespace.name
+          - action: delete
+            key: namespace
+          - action: upsert
+            from_attribute: pod
+            key: k8s.pod.name
+          - action: delete
+            key: pod
+          - action: upsert
+            from_attribute: container
+            key: k8s.container.name
+          - action: delete
+            key: container
+          - action: upsert
+            from_attribute: node
+            key: k8s.node.name
+          - action: delete
+            key: node
+          - action: upsert
+            from_attribute: service
+            key: prometheus_service
+          - action: delete
+            key: service
+          - action: upsert
+            from_attribute: service.name
+            key: job
+          - action: delete
+            key: service.name
+          - action: upsert
+            key: _origin
+            value: kubernetes
+          - action: upsert
+            key: cluster
+            value: kubernetes
       resource/delete_source_metadata:
         attributes:
-        - action: delete
-          key: _sourceCategory
-        - action: delete
-          key: _sourceHost
-        - action: delete
-          key: _sourceName
+          - action: delete
+            key: _sourceCategory
+          - action: delete
+            key: _sourceHost
+          - action: delete
+            key: _sourceName
       resource/remove_k8s_pod_pod_name:
         attributes:
-        - action: delete
-          key: k8s.pod.pod_name
+          - action: delete
+            key: k8s.pod.pod_name
       source:
         collector: kubernetes
         exclude:
@@ -272,209 +267,208 @@ spec:
       transform/drop_unnecessary_attributes:
         error_mode: ignore
         metric_statements:
-        - context: resource
-          statements:
-          - delete_key(attributes, "http.scheme")
-          - delete_key(attributes, "net.host.name")
-          - delete_key(attributes, "net.host.port")
-          - delete_key(attributes, "service.instance.id")
-          - delete_matching_keys(attributes, "k8s.*")
+          - context: resource
+            statements:
+              - delete_key(attributes, "http.scheme")
+              - delete_key(attributes, "net.host.name")
+              - delete_key(attributes, "net.host.port")
+              - delete_key(attributes, "service.instance.id")
+              - delete_matching_keys(attributes, "k8s.*")
       transform/extract_sum_count_from_histograms:
         error_mode: ignore
         metric_statements:
-        - context: metric
-          statements:
-          - extract_sum_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM
-            or type == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
-          - extract_count_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM
-            or type == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
+          - context: metric
+            statements:
+              - extract_sum_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM or type ==
+                METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
+              - extract_count_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM or type ==
+                METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
       transform/remove_name:
         error_mode: ignore
         metric_statements:
-        - context: resource
-          statements:
-          - delete_key(attributes, "__name__")
+          - context: resource
+            statements:
+              - delete_key(attributes, "__name__")
       transform/set_name:
         error_mode: ignore
         metric_statements:
-        - context: datapoint
-          statements:
-          - set(attributes["__name__"], metric.name) where IsMatch(metric.name, "^cloudprovider_.*")
+          - context: datapoint
+            statements:
+              - set(attributes["__name__"], metric.name) where IsMatch(metric.name, "^cloudprovider_.*")
     receivers:
       prometheus:
         config:
           global:
             scrape_interval: 30s
           scrape_configs:
-          - job_name: pod-annotations
-            kubernetes_sd_configs:
-            - role: pod
-            relabel_configs:
-            - action: keep
-              regex: true
-              source_labels:
-              - __meta_kubernetes_pod_annotation_prometheus_io_scrape
-            - action: replace
-              regex: (.+)
-              source_labels:
-              - __meta_kubernetes_pod_annotation_prometheus_io_path
-              target_label: __metrics_path__
-            - action: replace
-              regex: ([^:]+)(?::\d+)?;(\d+)
-              replacement: $1:$2
-              source_labels:
-              - __address__
-              - __meta_kubernetes_pod_annotation_prometheus_io_port
-              target_label: __address__
-            - action: replace
-              regex: (.*)
-              replacement: $1
-              separator: ;
-              source_labels:
-              - __metrics_path__
-              target_label: endpoint
-            - action: replace
-              source_labels:
-              - __meta_kubernetes_namespace
-              target_label: namespace
-            - action: labelmap
-              regex: __meta_kubernetes_pod_label_(.+)
-            - action: replace
-              regex: (.*)
-              replacement: $1
-              separator: ;
-              source_labels:
-              - __meta_kubernetes_pod_name
-              target_label: pod
-          - authorization:
-              credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-            honor_labels: true
-            job_name: kubelet
-            kubernetes_sd_configs:
-            - role: node
-            metric_relabel_configs:
-            - action: keep
-              regex: (?:kubelet_docker_operations_errors(?:|_total)|kubelet_(?:docker|runtime)_operations_duration_seconds_(?:count|sum)|kubelet_running_(?:container|pod)(?:_count|s)|kubelet_(:?docker|runtime)_operations_latency_microseconds(?:|_count|_sum))
-              source_labels:
-              - __name__
-            - action: labeldrop
-              regex: id
-            relabel_configs:
-            - source_labels:
-              - __meta_kubernetes_node_name
-              target_label: node
-            - replacement: https-metrics
-              target_label: endpoint
-            - action: replace
-              source_labels:
-              - __metrics_path__
-              target_label: metrics_path
-            - action: replace
-              source_labels:
-              - __address__
-              target_label: instance
-            scheme: https
-            tls_config:
-              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-              insecure_skip_verify: true
-          - authorization:
-              credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-            honor_labels: true
-            job_name: cadvisor
-            kubernetes_sd_configs:
-            - role: node
-            metric_relabel_configs:
-            - action: replace
-              regex: .*
-              replacement: kubelet
-              source_labels:
-              - __name__
-              target_label: job
-            - action: keep
-              regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes|container_cpu_cfs_throttled_seconds_total|container_network_receive_bytes_total|container_network_transmit_bytes_total)
-              source_labels:
-              - __name__
-            - action: drop
-              regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes);$
-              source_labels:
-              - __name__
-              - container
-            - action: labelmap
-              regex: container_name
-              replacement: container
-            - action: drop
-              regex: POD
-              source_labels:
-              - container
-            - action: labeldrop
-              regex: (id|name)
-            metrics_path: /metrics/cadvisor
-            relabel_configs:
-            - replacement: https-metrics
-              target_label: endpoint
-            - action: replace
-              source_labels:
-              - __metrics_path__
-              target_label: metrics_path
-            - action: replace
-              source_labels:
-              - __address__
-              target_label: instance
-            scheme: https
-            tls_config:
-              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-              insecure_skip_verify: true
+            - job_name: pod-annotations
+              kubernetes_sd_configs:
+                - role: pod
+              relabel_configs:
+                - action: keep
+                  regex: true
+                  source_labels:
+                    - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+                - action: replace
+                  regex: (.+)
+                  source_labels:
+                    - __meta_kubernetes_pod_annotation_prometheus_io_path
+                  target_label: __metrics_path__
+                - action: replace
+                  regex: ([^:]+)(?::\d+)?;(\d+)
+                  replacement: $1:$2
+                  source_labels:
+                    - __address__
+                    - __meta_kubernetes_pod_annotation_prometheus_io_port
+                  target_label: __address__
+                - action: replace
+                  regex: (.*)
+                  replacement: $1
+                  separator: ;
+                  source_labels:
+                    - __metrics_path__
+                  target_label: endpoint
+                - action: replace
+                  source_labels:
+                    - __meta_kubernetes_namespace
+                  target_label: namespace
+                - action: labelmap
+                  regex: __meta_kubernetes_pod_label_(.+)
+                - action: replace
+                  regex: (.*)
+                  replacement: $1
+                  separator: ;
+                  source_labels:
+                    - __meta_kubernetes_pod_name
+                  target_label: pod
+            - authorization:
+                credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              honor_labels: true
+              job_name: kubelet
+              kubernetes_sd_configs:
+                - role: node
+              metric_relabel_configs:
+                - action: keep
+                  regex: (?:kubelet_docker_operations_errors(?:|_total)|kubelet_(?:docker|runtime)_operations_duration_seconds_(?:count|sum)|kubelet_running_(?:container|pod)(?:_count|s)|kubelet_(:?docker|runtime)_operations_latency_microseconds(?:|_count|_sum))
+                  source_labels:
+                    - __name__
+                - action: labeldrop
+                  regex: id
+              relabel_configs:
+                - source_labels:
+                    - __meta_kubernetes_node_name
+                  target_label: node
+                - replacement: https-metrics
+                  target_label: endpoint
+                - action: replace
+                  source_labels:
+                    - __metrics_path__
+                  target_label: metrics_path
+                - action: replace
+                  source_labels:
+                    - __address__
+                  target_label: instance
+              scheme: https
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: true
+            - authorization:
+                credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              honor_labels: true
+              job_name: cadvisor
+              kubernetes_sd_configs:
+                - role: node
+              metric_relabel_configs:
+                - action: replace
+                  regex: .*
+                  replacement: kubelet
+                  source_labels:
+                    - __name__
+                  target_label: job
+                - action: keep
+                  regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes|container_cpu_cfs_throttled_seconds_total|container_network_receive_bytes_total|container_network_transmit_bytes_total)
+                  source_labels:
+                    - __name__
+                - action: drop
+                  regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes);$
+                  source_labels:
+                    - __name__
+                    - container
+                - action: labelmap
+                  regex: container_name
+                  replacement: container
+                - action: drop
+                  regex: POD
+                  source_labels:
+                    - container
+                - action: labeldrop
+                  regex: (id|name)
+              metrics_path: /metrics/cadvisor
+              relabel_configs:
+                - replacement: https-metrics
+                  target_label: endpoint
+                - action: replace
+                  source_labels:
+                    - __metrics_path__
+                  target_label: metrics_path
+                - action: replace
+                  source_labels:
+                    - __address__
+                  target_label: instance
+              scheme: https
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: true
       prometheusremotewrite:
         endpoint: ${env:MY_POD_IP}:9888
         read_timeout: 1m
         write_timeout: 1m
     service:
       extensions:
-      - health_check
-      - pprof
-      - file_storage
+        - health_check
+        - pprof
+        - file_storage
       pipelines:
         metrics:
           exporters:
-          - sumologic/default
+            - sumologic/default
           processors:
-          - memory_limiter
-          - metricstransform
-          - groupbyattrs
-          - resource
-          - k8sattributes
-          - source
-          - sumologic
-          - resource/remove_k8s_pod_pod_name
-          - resource/delete_source_metadata
-          - transform/set_name
-          - groupbyattrs/group_by_name
-          - transform/remove_name
-          - filter/drop_unnecessary_metrics
+            - memory_limiter
+            - metricstransform
+            - groupbyattrs
+            - resource
+            - k8sattributes
+            - source
+            - sumologic
+            - resource/remove_k8s_pod_pod_name
+            - resource/delete_source_metadata
+            - transform/set_name
+            - groupbyattrs/group_by_name
+            - transform/remove_name
+            - filter/drop_unnecessary_metrics
           receivers:
-          - forward
-          - prometheusremotewrite
+            - forward
+            - prometheusremotewrite
         metrics/collector:
           exporters:
-          - forward
+            - forward
           processors:
-          - filter/drop_stale_datapoints
-          - transform/extract_sum_count_from_histograms
-          - transform/drop_unnecessary_attributes
+            - filter/drop_stale_datapoints
+            - transform/extract_sum_count_from_histograms
+            - transform/drop_unnecessary_attributes
           receivers:
-          - prometheus
+            - prometheus
       telemetry:
         logs:
           level: info
         metrics:
           level: normal
           readers:
-          - pull:
-              exporter:
-                prometheus:
-                  host: ${env:MY_POD_IP}
-                  port: 8888
-                  without_scope_info: true
-                  without_type_suffix: true
-                  without_units: true
-
+            - pull:
+                exporter:
+                  prometheus:
+                    host: ${env:MY_POD_IP}
+                    port: 8888
+                    without_scope_info: true
+                    without_type_suffix: true
+                    without_units: true

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/single_layer_pipeline.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/single_layer_pipeline.output.yaml
@@ -33,7 +33,9 @@ spec:
     serviceAccount: RELEASE-NAME-sumologic-metrics-targetallocator-sa
     nodeSelector:
       kubernetes.io/os: linux
-    resources: {}
+    resources:
+      
+      {}
   nodeSelector:
     kubernetes.io/os: linux
   autoscaler:
@@ -42,34 +44,42 @@ spec:
     targetCPUUtilization: 70
     targetMemoryUtilization: 70
   env:
-    - name: SUMO_ENDPOINT_DEFAULT_OTLP_METRICS_SOURCE
-      valueFrom:
-        secretKeyRef:
-          name: sumologic
-          key: endpoint-metrics-otlp
-
-    - name: NO_PROXY
-      value: kubernetes.default.svc
-    - name: NAMESPACE
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.namespace
-    - name: MY_POD_IP
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: status.podIP
+  - name: SUMO_ENDPOINT_DEFAULT_OTLP_METRICS_SOURCE
+    valueFrom:
+      secretKeyRef:
+        name: sumologic
+        key: endpoint-metrics-otlp
+  
+  
+  - name: NO_PROXY
+    value: kubernetes.default.svc
+  - name: NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
+  - name: MY_POD_IP
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: status.podIP
+  - name: MY_POD_NAME
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: metadata.name
   podAnnotations:
     ## The operator adds this annotation by default, but we use our own ServiceMonitor
     prometheus.io/scrape: "false"
   podSecurityContext:
+    
     fsGroup: 999
   ports:
-    - name: pprof
-      port: 1777
-    - name: metrics-rw
-      port: 9888
+  - name: pprof
+    port: 1777
+  - name: metrics-rw
+    port: 9888
   resources:
+    
     limits:
       cpu: 1000m
       memory: 2Gi
@@ -87,26 +97,26 @@ spec:
     timeoutSeconds: 3
     failureThreshold: 3
   volumes:
-    - name: tmp
-      emptyDir: {}
+  - name: tmp
+    emptyDir: {}
   volumeMounts:
-    - name: tmp
-      mountPath: /tmp
-    - name: file-storage
-      mountPath: /var/lib/storage/otc
+  - name: tmp
+    mountPath: /tmp
+  - name: file-storage
+    mountPath: /var/lib/storage/otc
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: Retain
     whenScaled: Retain
   volumeClaimTemplates:
-    - metadata:
-        name: file-storage
-        labels:
-          sumologic.com/component: metrics-collector
-      spec:
-        accessModes: [ReadWriteOnce]
-        resources:
-          requests:
-            storage: 10Gi
+  - metadata:
+      name: file-storage
+      labels:
+        sumologic.com/component: metrics-collector
+    spec:
+      accessModes: [ReadWriteOnce]
+      resources:
+        requests:
+          storage: 10Gi
   config:
     connectors:
       forward: {}
@@ -146,51 +156,51 @@ spec:
       filter/drop_stale_datapoints:
         metrics:
           datapoint:
-            - flags == FLAG_NO_RECORDED_VALUE
+          - flags == FLAG_NO_RECORDED_VALUE
       filter/drop_unnecessary_metrics:
         error_mode: ignore
         metrics:
           metric:
-            - resource.attributes["job"] != "pod-annotations" and IsMatch(name, "scrape_.*")
-            - (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM or type == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type ==
-              METRIC_DATA_TYPE_SUMMARY or IsMatch(name, ".*_bucket"))
-            - IsMatch(name,
-              "^otelcol[._](k8s[._]pod[._]association|otelsvc_k8s_(pod_added|pod_updated|pod_table_size|pod_deleted|ip_lookup_miss))$")
-            - IsMatch(name, "^otelcol[._].*k8s.*")
+          - resource.attributes["job"] != "pod-annotations" and IsMatch(name, "scrape_.*")
+          - (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM or type
+            == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY
+            or IsMatch(name, ".*_bucket"))
+          - IsMatch(name, "^otelcol[._](k8s[._]pod[._]association|otelsvc_k8s_(pod_added|pod_updated|pod_table_size|pod_deleted|ip_lookup_miss))$")
+          - IsMatch(name, "^otelcol[._].*k8s.*")
       groupbyattrs:
         keys:
-          - container
-          - namespace
-          - pod
-          - service
+        - container
+        - namespace
+        - pod
+        - service
       groupbyattrs/group_by_name:
         keys:
-          - __name__
-          - job
+        - __name__
+        - job
       k8sattributes:
         auth_type: serviceAccount
         extract:
           labels:
-            - from: pod
-              key_regex: (.*)
-              tag_name: pod_labels_$$1
+          - from: pod
+            key_regex: (.*)
+            tag_name: pod_labels_$$1
           metadata:
-            - k8s.pod.name
-            - k8s.deployment.name
-            - k8s.daemonset.name
-            - k8s.replicaset.name
-            - k8s.statefulset.name
-            - k8s.namespace.name
-            - k8s.node.name
-            - service.name
-            - service.namespace
+          - k8s.pod.name
+          - k8s.deployment.name
+          - k8s.daemonset.name
+          - k8s.replicaset.name
+          - k8s.statefulset.name
+          - k8s.namespace.name
+          - k8s.node.name
+          - service.name
+          - service.namespace
         passthrough: false
         pod_association:
-          - sources:
-              - from: resource_attribute
-                name: k8s.pod.name
-              - from: resource_attribute
-                name: k8s.namespace.name
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.name
+          - from: resource_attribute
+            name: k8s.namespace.name
         wait_for_metadata: true
         wait_for_metadata_timeout: 10s
       memory_limiter:
@@ -199,60 +209,60 @@ spec:
         spike_limit_percentage: 20
       metricstransform:
         transforms:
-          - action: update
-            include: ^prometheus_remote_write_(.*)$$
-            match_type: regexp
-            new_name: $$1
+        - action: update
+          include: ^prometheus_remote_write_(.*)$$
+          match_type: regexp
+          new_name: $$1
       resource:
         attributes:
-          - action: upsert
-            from_attribute: namespace
-            key: k8s.namespace.name
-          - action: delete
-            key: namespace
-          - action: upsert
-            from_attribute: pod
-            key: k8s.pod.name
-          - action: delete
-            key: pod
-          - action: upsert
-            from_attribute: container
-            key: k8s.container.name
-          - action: delete
-            key: container
-          - action: upsert
-            from_attribute: node
-            key: k8s.node.name
-          - action: delete
-            key: node
-          - action: upsert
-            from_attribute: service
-            key: prometheus_service
-          - action: delete
-            key: service
-          - action: upsert
-            from_attribute: service.name
-            key: job
-          - action: delete
-            key: service.name
-          - action: upsert
-            key: _origin
-            value: kubernetes
-          - action: upsert
-            key: cluster
-            value: kubernetes
+        - action: upsert
+          from_attribute: namespace
+          key: k8s.namespace.name
+        - action: delete
+          key: namespace
+        - action: upsert
+          from_attribute: pod
+          key: k8s.pod.name
+        - action: delete
+          key: pod
+        - action: upsert
+          from_attribute: container
+          key: k8s.container.name
+        - action: delete
+          key: container
+        - action: upsert
+          from_attribute: node
+          key: k8s.node.name
+        - action: delete
+          key: node
+        - action: upsert
+          from_attribute: service
+          key: prometheus_service
+        - action: delete
+          key: service
+        - action: upsert
+          from_attribute: service.name
+          key: job
+        - action: delete
+          key: service.name
+        - action: upsert
+          key: _origin
+          value: kubernetes
+        - action: upsert
+          key: cluster
+          value: kubernetes
       resource/delete_source_metadata:
         attributes:
-          - action: delete
-            key: _sourceCategory
-          - action: delete
-            key: _sourceHost
-          - action: delete
-            key: _sourceName
+        - action: delete
+          key: _sourceCategory
+        - action: delete
+          key: _sourceHost
+        - action: delete
+          key: _sourceName
       resource/remove_k8s_pod_pod_name:
         attributes:
-          - action: delete
-            key: k8s.pod.pod_name
+        - action: delete
+          key: k8s.pod.pod_name
       source:
         collector: kubernetes
         exclude:
@@ -262,208 +272,209 @@ spec:
       transform/drop_unnecessary_attributes:
         error_mode: ignore
         metric_statements:
-          - context: resource
-            statements:
-              - delete_key(attributes, "http.scheme")
-              - delete_key(attributes, "net.host.name")
-              - delete_key(attributes, "net.host.port")
-              - delete_key(attributes, "service.instance.id")
-              - delete_matching_keys(attributes, "k8s.*")
+        - context: resource
+          statements:
+          - delete_key(attributes, "http.scheme")
+          - delete_key(attributes, "net.host.name")
+          - delete_key(attributes, "net.host.port")
+          - delete_key(attributes, "service.instance.id")
+          - delete_matching_keys(attributes, "k8s.*")
       transform/extract_sum_count_from_histograms:
         error_mode: ignore
         metric_statements:
-          - context: metric
-            statements:
-              - extract_sum_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM or type ==
-                METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
-              - extract_count_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM or type ==
-                METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
+        - context: metric
+          statements:
+          - extract_sum_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM
+            or type == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
+          - extract_count_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM
+            or type == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
       transform/remove_name:
         error_mode: ignore
         metric_statements:
-          - context: resource
-            statements:
-              - delete_key(attributes, "__name__")
+        - context: resource
+          statements:
+          - delete_key(attributes, "__name__")
       transform/set_name:
         error_mode: ignore
         metric_statements:
-          - context: datapoint
-            statements:
-              - set(attributes["__name__"], metric.name) where IsMatch(metric.name, "^cloudprovider_.*")
+        - context: datapoint
+          statements:
+          - set(attributes["__name__"], metric.name) where IsMatch(metric.name, "^cloudprovider_.*")
     receivers:
       prometheus:
         config:
           global:
             scrape_interval: 30s
           scrape_configs:
-            - job_name: pod-annotations
-              kubernetes_sd_configs:
-                - role: pod
-              relabel_configs:
-                - action: keep
-                  regex: true
-                  source_labels:
-                    - __meta_kubernetes_pod_annotation_prometheus_io_scrape
-                - action: replace
-                  regex: (.+)
-                  source_labels:
-                    - __meta_kubernetes_pod_annotation_prometheus_io_path
-                  target_label: __metrics_path__
-                - action: replace
-                  regex: ([^:]+)(?::\d+)?;(\d+)
-                  replacement: $1:$2
-                  source_labels:
-                    - __address__
-                    - __meta_kubernetes_pod_annotation_prometheus_io_port
-                  target_label: __address__
-                - action: replace
-                  regex: (.*)
-                  replacement: $1
-                  separator: ;
-                  source_labels:
-                    - __metrics_path__
-                  target_label: endpoint
-                - action: replace
-                  source_labels:
-                    - __meta_kubernetes_namespace
-                  target_label: namespace
-                - action: labelmap
-                  regex: __meta_kubernetes_pod_label_(.+)
-                - action: replace
-                  regex: (.*)
-                  replacement: $1
-                  separator: ;
-                  source_labels:
-                    - __meta_kubernetes_pod_name
-                  target_label: pod
-            - authorization:
-                credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-              honor_labels: true
-              job_name: kubelet
-              kubernetes_sd_configs:
-                - role: node
-              metric_relabel_configs:
-                - action: keep
-                  regex: (?:kubelet_docker_operations_errors(?:|_total)|kubelet_(?:docker|runtime)_operations_duration_seconds_(?:count|sum)|kubelet_running_(?:container|pod)(?:_count|s)|kubelet_(:?docker|runtime)_operations_latency_microseconds(?:|_count|_sum))
-                  source_labels:
-                    - __name__
-                - action: labeldrop
-                  regex: id
-              relabel_configs:
-                - source_labels:
-                    - __meta_kubernetes_node_name
-                  target_label: node
-                - replacement: https-metrics
-                  target_label: endpoint
-                - action: replace
-                  source_labels:
-                    - __metrics_path__
-                  target_label: metrics_path
-                - action: replace
-                  source_labels:
-                    - __address__
-                  target_label: instance
-              scheme: https
-              tls_config:
-                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-                insecure_skip_verify: true
-            - authorization:
-                credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-              honor_labels: true
-              job_name: cadvisor
-              kubernetes_sd_configs:
-                - role: node
-              metric_relabel_configs:
-                - action: replace
-                  regex: .*
-                  replacement: kubelet
-                  source_labels:
-                    - __name__
-                  target_label: job
-                - action: keep
-                  regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes|container_cpu_cfs_throttled_seconds_total|container_network_receive_bytes_total|container_network_transmit_bytes_total)
-                  source_labels:
-                    - __name__
-                - action: drop
-                  regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes);$
-                  source_labels:
-                    - __name__
-                    - container
-                - action: labelmap
-                  regex: container_name
-                  replacement: container
-                - action: drop
-                  regex: POD
-                  source_labels:
-                    - container
-                - action: labeldrop
-                  regex: (id|name)
-              metrics_path: /metrics/cadvisor
-              relabel_configs:
-                - replacement: https-metrics
-                  target_label: endpoint
-                - action: replace
-                  source_labels:
-                    - __metrics_path__
-                  target_label: metrics_path
-                - action: replace
-                  source_labels:
-                    - __address__
-                  target_label: instance
-              scheme: https
-              tls_config:
-                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-                insecure_skip_verify: true
+          - job_name: pod-annotations
+            kubernetes_sd_configs:
+            - role: pod
+            relabel_configs:
+            - action: keep
+              regex: true
+              source_labels:
+              - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+            - action: replace
+              regex: (.+)
+              source_labels:
+              - __meta_kubernetes_pod_annotation_prometheus_io_path
+              target_label: __metrics_path__
+            - action: replace
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: $1:$2
+              source_labels:
+              - __address__
+              - __meta_kubernetes_pod_annotation_prometheus_io_port
+              target_label: __address__
+            - action: replace
+              regex: (.*)
+              replacement: $1
+              separator: ;
+              source_labels:
+              - __metrics_path__
+              target_label: endpoint
+            - action: replace
+              source_labels:
+              - __meta_kubernetes_namespace
+              target_label: namespace
+            - action: labelmap
+              regex: __meta_kubernetes_pod_label_(.+)
+            - action: replace
+              regex: (.*)
+              replacement: $1
+              separator: ;
+              source_labels:
+              - __meta_kubernetes_pod_name
+              target_label: pod
+          - authorization:
+              credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            honor_labels: true
+            job_name: kubelet
+            kubernetes_sd_configs:
+            - role: node
+            metric_relabel_configs:
+            - action: keep
+              regex: (?:kubelet_docker_operations_errors(?:|_total)|kubelet_(?:docker|runtime)_operations_duration_seconds_(?:count|sum)|kubelet_running_(?:container|pod)(?:_count|s)|kubelet_(:?docker|runtime)_operations_latency_microseconds(?:|_count|_sum))
+              source_labels:
+              - __name__
+            - action: labeldrop
+              regex: id
+            relabel_configs:
+            - source_labels:
+              - __meta_kubernetes_node_name
+              target_label: node
+            - replacement: https-metrics
+              target_label: endpoint
+            - action: replace
+              source_labels:
+              - __metrics_path__
+              target_label: metrics_path
+            - action: replace
+              source_labels:
+              - __address__
+              target_label: instance
+            scheme: https
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
+          - authorization:
+              credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            honor_labels: true
+            job_name: cadvisor
+            kubernetes_sd_configs:
+            - role: node
+            metric_relabel_configs:
+            - action: replace
+              regex: .*
+              replacement: kubelet
+              source_labels:
+              - __name__
+              target_label: job
+            - action: keep
+              regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes|container_cpu_cfs_throttled_seconds_total|container_network_receive_bytes_total|container_network_transmit_bytes_total)
+              source_labels:
+              - __name__
+            - action: drop
+              regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes);$
+              source_labels:
+              - __name__
+              - container
+            - action: labelmap
+              regex: container_name
+              replacement: container
+            - action: drop
+              regex: POD
+              source_labels:
+              - container
+            - action: labeldrop
+              regex: (id|name)
+            metrics_path: /metrics/cadvisor
+            relabel_configs:
+            - replacement: https-metrics
+              target_label: endpoint
+            - action: replace
+              source_labels:
+              - __metrics_path__
+              target_label: metrics_path
+            - action: replace
+              source_labels:
+              - __address__
+              target_label: instance
+            scheme: https
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
       prometheusremotewrite:
         endpoint: ${env:MY_POD_IP}:9888
         read_timeout: 1m
         write_timeout: 1m
     service:
       extensions:
-        - health_check
-        - pprof
-        - file_storage
+      - health_check
+      - pprof
+      - file_storage
       pipelines:
         metrics:
           exporters:
-            - sumologic/default
+          - sumologic/default
           processors:
-            - memory_limiter
-            - metricstransform
-            - groupbyattrs
-            - resource
-            - k8sattributes
-            - source
-            - sumologic
-            - resource/remove_k8s_pod_pod_name
-            - resource/delete_source_metadata
-            - transform/set_name
-            - groupbyattrs/group_by_name
-            - transform/remove_name
-            - filter/drop_unnecessary_metrics
+          - memory_limiter
+          - metricstransform
+          - groupbyattrs
+          - resource
+          - k8sattributes
+          - source
+          - sumologic
+          - resource/remove_k8s_pod_pod_name
+          - resource/delete_source_metadata
+          - transform/set_name
+          - groupbyattrs/group_by_name
+          - transform/remove_name
+          - filter/drop_unnecessary_metrics
           receivers:
-            - forward
-            - prometheusremotewrite
+          - forward
+          - prometheusremotewrite
         metrics/collector:
           exporters:
-            - forward
+          - forward
           processors:
-            - filter/drop_stale_datapoints
-            - transform/extract_sum_count_from_histograms
-            - transform/drop_unnecessary_attributes
+          - filter/drop_stale_datapoints
+          - transform/extract_sum_count_from_histograms
+          - transform/drop_unnecessary_attributes
           receivers:
-            - prometheus
+          - prometheus
       telemetry:
         logs:
           level: info
         metrics:
           level: normal
           readers:
-            - pull:
-                exporter:
-                  prometheus:
-                    host: ${env:MY_POD_IP}
-                    port: 8888
-                    without_scope_info: true
-                    without_type_suffix: true
-                    without_units: true
+          - pull:
+              exporter:
+                prometheus:
+                  host: ${env:MY_POD_IP}
+                  port: 8888
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true
+

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/single_layer_pipeline_extras.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/single_layer_pipeline_extras.output.yaml
@@ -33,7 +33,9 @@ spec:
     serviceAccount: RELEASE-NAME-sumologic-metrics-targetallocator-sa
     nodeSelector:
       kubernetes.io/os: linux
-    resources: {}
+    resources:
+      
+      {}
   nodeSelector:
     kubernetes.io/os: linux
   autoscaler:
@@ -42,37 +44,45 @@ spec:
     targetCPUUtilization: 70
     targetMemoryUtilization: 70
   env:
-    - name: SUMO_ENDPOINT_DEFAULT_OTLP_METRICS_SOURCE
-      valueFrom:
-        secretKeyRef:
-          name: sumologic
-          key: endpoint-metrics-otlp
+  - name: SUMO_ENDPOINT_DEFAULT_OTLP_METRICS_SOURCE
+    valueFrom:
+      secretKeyRef:
+        name: sumologic
+        key: endpoint-metrics-otlp
+  
+  
+  - name: NO_PROXY
+    value: kubernetes.default.svc
 
-    - name: NO_PROXY
-      value: kubernetes.default.svc
-
-    - name: MY_CUSTOM_KEY
-      value: secret123
-    - name: NAMESPACE
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.namespace
-    - name: MY_POD_IP
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: status.podIP
+  - name: MY_CUSTOM_KEY
+    value: secret123
+  - name: NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
+  - name: MY_POD_IP
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: status.podIP
+  - name: MY_POD_NAME
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: metadata.name
   podAnnotations:
     ## The operator adds this annotation by default, but we use our own ServiceMonitor
     prometheus.io/scrape: "false"
   podSecurityContext:
+    
     fsGroup: 999
   ports:
-    - name: pprof
-      port: 1777
-    - name: metrics-rw
-      port: 9888
+  - name: pprof
+    port: 1777
+  - name: metrics-rw
+    port: 9888
   resources:
+    
     limits:
       cpu: 1000m
       memory: 2Gi
@@ -90,33 +100,33 @@ spec:
     timeoutSeconds: 3
     failureThreshold: 3
   volumes:
-    - name: tmp
-      emptyDir: {}
+  - name: tmp
+    emptyDir: {}
 
-    - name: custom-certs
-      secret:
-        secretName: my-tls-secret
+  - name: custom-certs
+    secret:
+      secretName: my-tls-secret
   volumeMounts:
-    - name: tmp
-      mountPath: /tmp
-    - name: file-storage
-      mountPath: /var/lib/storage/otc
+  - name: tmp
+    mountPath: /tmp
+  - name: file-storage
+    mountPath: /var/lib/storage/otc
 
-    - mountPath: /etc/ssl/custom
-      name: custom-certs
+  - mountPath: /etc/ssl/custom
+    name: custom-certs
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: Retain
     whenScaled: Retain
   volumeClaimTemplates:
-    - metadata:
-        name: file-storage
-        labels:
-          sumologic.com/component: metrics-collector
-      spec:
-        accessModes: [ReadWriteOnce]
-        resources:
-          requests:
-            storage: 10Gi
+  - metadata:
+      name: file-storage
+      labels:
+        sumologic.com/component: metrics-collector
+    spec:
+      accessModes: [ReadWriteOnce]
+      resources:
+        requests:
+          storage: 10Gi
   config:
     connectors:
       forward: {}
@@ -156,51 +166,51 @@ spec:
       filter/drop_stale_datapoints:
         metrics:
           datapoint:
-            - flags == FLAG_NO_RECORDED_VALUE
+          - flags == FLAG_NO_RECORDED_VALUE
       filter/drop_unnecessary_metrics:
         error_mode: ignore
         metrics:
           metric:
-            - resource.attributes["job"] != "pod-annotations" and IsMatch(name, "scrape_.*")
-            - (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM or type == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type ==
-              METRIC_DATA_TYPE_SUMMARY or IsMatch(name, ".*_bucket"))
-            - IsMatch(name,
-              "^otelcol[._](k8s[._]pod[._]association|otelsvc_k8s_(pod_added|pod_updated|pod_table_size|pod_deleted|ip_lookup_miss))$")
-            - IsMatch(name, "^otelcol[._].*k8s.*")
+          - resource.attributes["job"] != "pod-annotations" and IsMatch(name, "scrape_.*")
+          - (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM or type
+            == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY
+            or IsMatch(name, ".*_bucket"))
+          - IsMatch(name, "^otelcol[._](k8s[._]pod[._]association|otelsvc_k8s_(pod_added|pod_updated|pod_table_size|pod_deleted|ip_lookup_miss))$")
+          - IsMatch(name, "^otelcol[._].*k8s.*")
       groupbyattrs:
         keys:
-          - container
-          - namespace
-          - pod
-          - service
+        - container
+        - namespace
+        - pod
+        - service
       groupbyattrs/group_by_name:
         keys:
-          - __name__
-          - job
+        - __name__
+        - job
       k8sattributes:
         auth_type: serviceAccount
         extract:
           labels:
-            - from: pod
-              key_regex: (.*)
-              tag_name: pod_labels_$$1
+          - from: pod
+            key_regex: (.*)
+            tag_name: pod_labels_$$1
           metadata:
-            - k8s.pod.name
-            - k8s.deployment.name
-            - k8s.daemonset.name
-            - k8s.replicaset.name
-            - k8s.statefulset.name
-            - k8s.namespace.name
-            - k8s.node.name
-            - service.name
-            - service.namespace
+          - k8s.pod.name
+          - k8s.deployment.name
+          - k8s.daemonset.name
+          - k8s.replicaset.name
+          - k8s.statefulset.name
+          - k8s.namespace.name
+          - k8s.node.name
+          - service.name
+          - service.namespace
         passthrough: false
         pod_association:
-          - sources:
-              - from: resource_attribute
-                name: k8s.pod.name
-              - from: resource_attribute
-                name: k8s.namespace.name
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.name
+          - from: resource_attribute
+            name: k8s.namespace.name
         wait_for_metadata: true
         wait_for_metadata_timeout: 10s
       memory_limiter:
@@ -209,60 +219,60 @@ spec:
         spike_limit_percentage: 20
       metricstransform:
         transforms:
-          - action: update
-            include: ^prometheus_remote_write_(.*)$$
-            match_type: regexp
-            new_name: $$1
+        - action: update
+          include: ^prometheus_remote_write_(.*)$$
+          match_type: regexp
+          new_name: $$1
       resource:
         attributes:
-          - action: upsert
-            from_attribute: namespace
-            key: k8s.namespace.name
-          - action: delete
-            key: namespace
-          - action: upsert
-            from_attribute: pod
-            key: k8s.pod.name
-          - action: delete
-            key: pod
-          - action: upsert
-            from_attribute: container
-            key: k8s.container.name
-          - action: delete
-            key: container
-          - action: upsert
-            from_attribute: node
-            key: k8s.node.name
-          - action: delete
-            key: node
-          - action: upsert
-            from_attribute: service
-            key: prometheus_service
-          - action: delete
-            key: service
-          - action: upsert
-            from_attribute: service.name
-            key: job
-          - action: delete
-            key: service.name
-          - action: upsert
-            key: _origin
-            value: kubernetes
-          - action: upsert
-            key: cluster
-            value: kubernetes
+        - action: upsert
+          from_attribute: namespace
+          key: k8s.namespace.name
+        - action: delete
+          key: namespace
+        - action: upsert
+          from_attribute: pod
+          key: k8s.pod.name
+        - action: delete
+          key: pod
+        - action: upsert
+          from_attribute: container
+          key: k8s.container.name
+        - action: delete
+          key: container
+        - action: upsert
+          from_attribute: node
+          key: k8s.node.name
+        - action: delete
+          key: node
+        - action: upsert
+          from_attribute: service
+          key: prometheus_service
+        - action: delete
+          key: service
+        - action: upsert
+          from_attribute: service.name
+          key: job
+        - action: delete
+          key: service.name
+        - action: upsert
+          key: _origin
+          value: kubernetes
+        - action: upsert
+          key: cluster
+          value: kubernetes
       resource/delete_source_metadata:
         attributes:
-          - action: delete
-            key: _sourceCategory
-          - action: delete
-            key: _sourceHost
-          - action: delete
-            key: _sourceName
+        - action: delete
+          key: _sourceCategory
+        - action: delete
+          key: _sourceHost
+        - action: delete
+          key: _sourceName
       resource/remove_k8s_pod_pod_name:
         attributes:
-          - action: delete
-            key: k8s.pod.pod_name
+        - action: delete
+          key: k8s.pod.pod_name
       source:
         collector: kubernetes
         exclude:
@@ -272,208 +282,209 @@ spec:
       transform/drop_unnecessary_attributes:
         error_mode: ignore
         metric_statements:
-          - context: resource
-            statements:
-              - delete_key(attributes, "http.scheme")
-              - delete_key(attributes, "net.host.name")
-              - delete_key(attributes, "net.host.port")
-              - delete_key(attributes, "service.instance.id")
-              - delete_matching_keys(attributes, "k8s.*")
+        - context: resource
+          statements:
+          - delete_key(attributes, "http.scheme")
+          - delete_key(attributes, "net.host.name")
+          - delete_key(attributes, "net.host.port")
+          - delete_key(attributes, "service.instance.id")
+          - delete_matching_keys(attributes, "k8s.*")
       transform/extract_sum_count_from_histograms:
         error_mode: ignore
         metric_statements:
-          - context: metric
-            statements:
-              - extract_sum_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM or type ==
-                METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
-              - extract_count_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM or type ==
-                METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
+        - context: metric
+          statements:
+          - extract_sum_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM
+            or type == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
+          - extract_count_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM
+            or type == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
       transform/remove_name:
         error_mode: ignore
         metric_statements:
-          - context: resource
-            statements:
-              - delete_key(attributes, "__name__")
+        - context: resource
+          statements:
+          - delete_key(attributes, "__name__")
       transform/set_name:
         error_mode: ignore
         metric_statements:
-          - context: datapoint
-            statements:
-              - set(attributes["__name__"], metric.name) where IsMatch(metric.name, "^cloudprovider_.*")
+        - context: datapoint
+          statements:
+          - set(attributes["__name__"], metric.name) where IsMatch(metric.name, "^cloudprovider_.*")
     receivers:
       prometheus:
         config:
           global:
             scrape_interval: 30s
           scrape_configs:
-            - job_name: pod-annotations
-              kubernetes_sd_configs:
-                - role: pod
-              relabel_configs:
-                - action: keep
-                  regex: true
-                  source_labels:
-                    - __meta_kubernetes_pod_annotation_prometheus_io_scrape
-                - action: replace
-                  regex: (.+)
-                  source_labels:
-                    - __meta_kubernetes_pod_annotation_prometheus_io_path
-                  target_label: __metrics_path__
-                - action: replace
-                  regex: ([^:]+)(?::\d+)?;(\d+)
-                  replacement: $1:$2
-                  source_labels:
-                    - __address__
-                    - __meta_kubernetes_pod_annotation_prometheus_io_port
-                  target_label: __address__
-                - action: replace
-                  regex: (.*)
-                  replacement: $1
-                  separator: ;
-                  source_labels:
-                    - __metrics_path__
-                  target_label: endpoint
-                - action: replace
-                  source_labels:
-                    - __meta_kubernetes_namespace
-                  target_label: namespace
-                - action: labelmap
-                  regex: __meta_kubernetes_pod_label_(.+)
-                - action: replace
-                  regex: (.*)
-                  replacement: $1
-                  separator: ;
-                  source_labels:
-                    - __meta_kubernetes_pod_name
-                  target_label: pod
-            - authorization:
-                credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-              honor_labels: true
-              job_name: kubelet
-              kubernetes_sd_configs:
-                - role: node
-              metric_relabel_configs:
-                - action: keep
-                  regex: (?:kubelet_docker_operations_errors(?:|_total)|kubelet_(?:docker|runtime)_operations_duration_seconds_(?:count|sum)|kubelet_running_(?:container|pod)(?:_count|s)|kubelet_(:?docker|runtime)_operations_latency_microseconds(?:|_count|_sum))
-                  source_labels:
-                    - __name__
-                - action: labeldrop
-                  regex: id
-              relabel_configs:
-                - source_labels:
-                    - __meta_kubernetes_node_name
-                  target_label: node
-                - replacement: https-metrics
-                  target_label: endpoint
-                - action: replace
-                  source_labels:
-                    - __metrics_path__
-                  target_label: metrics_path
-                - action: replace
-                  source_labels:
-                    - __address__
-                  target_label: instance
-              scheme: https
-              tls_config:
-                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-                insecure_skip_verify: true
-            - authorization:
-                credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-              honor_labels: true
-              job_name: cadvisor
-              kubernetes_sd_configs:
-                - role: node
-              metric_relabel_configs:
-                - action: replace
-                  regex: .*
-                  replacement: kubelet
-                  source_labels:
-                    - __name__
-                  target_label: job
-                - action: keep
-                  regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes|container_cpu_cfs_throttled_seconds_total|container_network_receive_bytes_total|container_network_transmit_bytes_total)
-                  source_labels:
-                    - __name__
-                - action: drop
-                  regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes);$
-                  source_labels:
-                    - __name__
-                    - container
-                - action: labelmap
-                  regex: container_name
-                  replacement: container
-                - action: drop
-                  regex: POD
-                  source_labels:
-                    - container
-                - action: labeldrop
-                  regex: (id|name)
-              metrics_path: /metrics/cadvisor
-              relabel_configs:
-                - replacement: https-metrics
-                  target_label: endpoint
-                - action: replace
-                  source_labels:
-                    - __metrics_path__
-                  target_label: metrics_path
-                - action: replace
-                  source_labels:
-                    - __address__
-                  target_label: instance
-              scheme: https
-              tls_config:
-                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-                insecure_skip_verify: true
+          - job_name: pod-annotations
+            kubernetes_sd_configs:
+            - role: pod
+            relabel_configs:
+            - action: keep
+              regex: true
+              source_labels:
+              - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+            - action: replace
+              regex: (.+)
+              source_labels:
+              - __meta_kubernetes_pod_annotation_prometheus_io_path
+              target_label: __metrics_path__
+            - action: replace
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: $1:$2
+              source_labels:
+              - __address__
+              - __meta_kubernetes_pod_annotation_prometheus_io_port
+              target_label: __address__
+            - action: replace
+              regex: (.*)
+              replacement: $1
+              separator: ;
+              source_labels:
+              - __metrics_path__
+              target_label: endpoint
+            - action: replace
+              source_labels:
+              - __meta_kubernetes_namespace
+              target_label: namespace
+            - action: labelmap
+              regex: __meta_kubernetes_pod_label_(.+)
+            - action: replace
+              regex: (.*)
+              replacement: $1
+              separator: ;
+              source_labels:
+              - __meta_kubernetes_pod_name
+              target_label: pod
+          - authorization:
+              credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            honor_labels: true
+            job_name: kubelet
+            kubernetes_sd_configs:
+            - role: node
+            metric_relabel_configs:
+            - action: keep
+              regex: (?:kubelet_docker_operations_errors(?:|_total)|kubelet_(?:docker|runtime)_operations_duration_seconds_(?:count|sum)|kubelet_running_(?:container|pod)(?:_count|s)|kubelet_(:?docker|runtime)_operations_latency_microseconds(?:|_count|_sum))
+              source_labels:
+              - __name__
+            - action: labeldrop
+              regex: id
+            relabel_configs:
+            - source_labels:
+              - __meta_kubernetes_node_name
+              target_label: node
+            - replacement: https-metrics
+              target_label: endpoint
+            - action: replace
+              source_labels:
+              - __metrics_path__
+              target_label: metrics_path
+            - action: replace
+              source_labels:
+              - __address__
+              target_label: instance
+            scheme: https
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
+          - authorization:
+              credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            honor_labels: true
+            job_name: cadvisor
+            kubernetes_sd_configs:
+            - role: node
+            metric_relabel_configs:
+            - action: replace
+              regex: .*
+              replacement: kubelet
+              source_labels:
+              - __name__
+              target_label: job
+            - action: keep
+              regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes|container_cpu_cfs_throttled_seconds_total|container_network_receive_bytes_total|container_network_transmit_bytes_total)
+              source_labels:
+              - __name__
+            - action: drop
+              regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes);$
+              source_labels:
+              - __name__
+              - container
+            - action: labelmap
+              regex: container_name
+              replacement: container
+            - action: drop
+              regex: POD
+              source_labels:
+              - container
+            - action: labeldrop
+              regex: (id|name)
+            metrics_path: /metrics/cadvisor
+            relabel_configs:
+            - replacement: https-metrics
+              target_label: endpoint
+            - action: replace
+              source_labels:
+              - __metrics_path__
+              target_label: metrics_path
+            - action: replace
+              source_labels:
+              - __address__
+              target_label: instance
+            scheme: https
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
       prometheusremotewrite:
         endpoint: ${env:MY_POD_IP}:9888
         read_timeout: 1m
         write_timeout: 1m
     service:
       extensions:
-        - health_check
-        - pprof
-        - file_storage
+      - health_check
+      - pprof
+      - file_storage
       pipelines:
         metrics:
           exporters:
-            - sumologic/default
+          - sumologic/default
           processors:
-            - memory_limiter
-            - metricstransform
-            - groupbyattrs
-            - resource
-            - k8sattributes
-            - source
-            - sumologic
-            - resource/remove_k8s_pod_pod_name
-            - resource/delete_source_metadata
-            - transform/set_name
-            - groupbyattrs/group_by_name
-            - transform/remove_name
-            - filter/drop_unnecessary_metrics
+          - memory_limiter
+          - metricstransform
+          - groupbyattrs
+          - resource
+          - k8sattributes
+          - source
+          - sumologic
+          - resource/remove_k8s_pod_pod_name
+          - resource/delete_source_metadata
+          - transform/set_name
+          - groupbyattrs/group_by_name
+          - transform/remove_name
+          - filter/drop_unnecessary_metrics
           receivers:
-            - forward
-            - prometheusremotewrite
+          - forward
+          - prometheusremotewrite
         metrics/collector:
           exporters:
-            - forward
+          - forward
           processors:
-            - filter/drop_stale_datapoints
-            - transform/extract_sum_count_from_histograms
-            - transform/drop_unnecessary_attributes
+          - filter/drop_stale_datapoints
+          - transform/extract_sum_count_from_histograms
+          - transform/drop_unnecessary_attributes
           receivers:
-            - prometheus
+          - prometheus
       telemetry:
         logs:
           level: info
         metrics:
           level: normal
           readers:
-            - pull:
-                exporter:
-                  prometheus:
-                    host: ${env:MY_POD_IP}
-                    port: 8888
-                    without_scope_info: true
-                    without_type_suffix: true
-                    without_units: true
+          - pull:
+              exporter:
+                prometheus:
+                  host: ${env:MY_POD_IP}
+                  port: 8888
+                  without_scope_info: true
+                  without_type_suffix: true
+                  without_units: true
+

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/single_layer_pipeline_extras.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/single_layer_pipeline_extras.output.yaml
@@ -33,9 +33,7 @@ spec:
     serviceAccount: RELEASE-NAME-sumologic-metrics-targetallocator-sa
     nodeSelector:
       kubernetes.io/os: linux
-    resources:
-      
-      {}
+    resources: {}
   nodeSelector:
     kubernetes.io/os: linux
   autoscaler:
@@ -44,45 +42,42 @@ spec:
     targetCPUUtilization: 70
     targetMemoryUtilization: 70
   env:
-  - name: SUMO_ENDPOINT_DEFAULT_OTLP_METRICS_SOURCE
-    valueFrom:
-      secretKeyRef:
-        name: sumologic
-        key: endpoint-metrics-otlp
-  
-  
-  - name: NO_PROXY
-    value: kubernetes.default.svc
+    - name: SUMO_ENDPOINT_DEFAULT_OTLP_METRICS_SOURCE
+      valueFrom:
+        secretKeyRef:
+          name: sumologic
+          key: endpoint-metrics-otlp
 
-  - name: MY_CUSTOM_KEY
-    value: secret123
-  - name: NAMESPACE
-    valueFrom:
-      fieldRef:
-        fieldPath: metadata.namespace
-  - name: MY_POD_IP
-    valueFrom:
-      fieldRef:
-        apiVersion: v1
-        fieldPath: status.podIP
-  - name: MY_POD_NAME
-    valueFrom:
-      fieldRef:
-        apiVersion: v1
-        fieldPath: metadata.name
+    - name: NO_PROXY
+      value: kubernetes.default.svc
+
+    - name: MY_CUSTOM_KEY
+      value: secret123
+    - name: NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: MY_POD_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.podIP
+    - name: MY_POD_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
   podAnnotations:
     ## The operator adds this annotation by default, but we use our own ServiceMonitor
     prometheus.io/scrape: "false"
   podSecurityContext:
-    
     fsGroup: 999
   ports:
-  - name: pprof
-    port: 1777
-  - name: metrics-rw
-    port: 9888
+    - name: pprof
+      port: 1777
+    - name: metrics-rw
+      port: 9888
   resources:
-    
     limits:
       cpu: 1000m
       memory: 2Gi
@@ -100,33 +95,33 @@ spec:
     timeoutSeconds: 3
     failureThreshold: 3
   volumes:
-  - name: tmp
-    emptyDir: {}
+    - name: tmp
+      emptyDir: {}
 
-  - name: custom-certs
-    secret:
-      secretName: my-tls-secret
+    - name: custom-certs
+      secret:
+        secretName: my-tls-secret
   volumeMounts:
-  - name: tmp
-    mountPath: /tmp
-  - name: file-storage
-    mountPath: /var/lib/storage/otc
+    - name: tmp
+      mountPath: /tmp
+    - name: file-storage
+      mountPath: /var/lib/storage/otc
 
-  - mountPath: /etc/ssl/custom
-    name: custom-certs
+    - mountPath: /etc/ssl/custom
+      name: custom-certs
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: Retain
     whenScaled: Retain
   volumeClaimTemplates:
-  - metadata:
-      name: file-storage
-      labels:
-        sumologic.com/component: metrics-collector
-    spec:
-      accessModes: [ReadWriteOnce]
-      resources:
-        requests:
-          storage: 10Gi
+    - metadata:
+        name: file-storage
+        labels:
+          sumologic.com/component: metrics-collector
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 10Gi
   config:
     connectors:
       forward: {}
@@ -166,51 +161,51 @@ spec:
       filter/drop_stale_datapoints:
         metrics:
           datapoint:
-          - flags == FLAG_NO_RECORDED_VALUE
+            - flags == FLAG_NO_RECORDED_VALUE
       filter/drop_unnecessary_metrics:
         error_mode: ignore
         metrics:
           metric:
-          - resource.attributes["job"] != "pod-annotations" and IsMatch(name, "scrape_.*")
-          - (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM or type
-            == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY
-            or IsMatch(name, ".*_bucket"))
-          - IsMatch(name, "^otelcol[._](k8s[._]pod[._]association|otelsvc_k8s_(pod_added|pod_updated|pod_table_size|pod_deleted|ip_lookup_miss))$")
-          - IsMatch(name, "^otelcol[._].*k8s.*")
+            - resource.attributes["job"] != "pod-annotations" and IsMatch(name, "scrape_.*")
+            - (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM or type == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type ==
+              METRIC_DATA_TYPE_SUMMARY or IsMatch(name, ".*_bucket"))
+            - IsMatch(name,
+              "^otelcol[._](k8s[._]pod[._]association|otelsvc_k8s_(pod_added|pod_updated|pod_table_size|pod_deleted|ip_lookup_miss))$")
+            - IsMatch(name, "^otelcol[._].*k8s.*")
       groupbyattrs:
         keys:
-        - container
-        - namespace
-        - pod
-        - service
+          - container
+          - namespace
+          - pod
+          - service
       groupbyattrs/group_by_name:
         keys:
-        - __name__
-        - job
+          - __name__
+          - job
       k8sattributes:
         auth_type: serviceAccount
         extract:
           labels:
-          - from: pod
-            key_regex: (.*)
-            tag_name: pod_labels_$$1
+            - from: pod
+              key_regex: (.*)
+              tag_name: pod_labels_$$1
           metadata:
-          - k8s.pod.name
-          - k8s.deployment.name
-          - k8s.daemonset.name
-          - k8s.replicaset.name
-          - k8s.statefulset.name
-          - k8s.namespace.name
-          - k8s.node.name
-          - service.name
-          - service.namespace
+            - k8s.pod.name
+            - k8s.deployment.name
+            - k8s.daemonset.name
+            - k8s.replicaset.name
+            - k8s.statefulset.name
+            - k8s.namespace.name
+            - k8s.node.name
+            - service.name
+            - service.namespace
         passthrough: false
         pod_association:
-        - sources:
-          - from: resource_attribute
-            name: k8s.pod.name
-          - from: resource_attribute
-            name: k8s.namespace.name
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.name
+              - from: resource_attribute
+                name: k8s.namespace.name
         wait_for_metadata: true
         wait_for_metadata_timeout: 10s
       memory_limiter:
@@ -219,60 +214,60 @@ spec:
         spike_limit_percentage: 20
       metricstransform:
         transforms:
-        - action: update
-          include: ^prometheus_remote_write_(.*)$$
-          match_type: regexp
-          new_name: $$1
+          - action: update
+            include: ^prometheus_remote_write_(.*)$$
+            match_type: regexp
+            new_name: $$1
       resource:
         attributes:
-        - action: upsert
-          from_attribute: namespace
-          key: k8s.namespace.name
-        - action: delete
-          key: namespace
-        - action: upsert
-          from_attribute: pod
-          key: k8s.pod.name
-        - action: delete
-          key: pod
-        - action: upsert
-          from_attribute: container
-          key: k8s.container.name
-        - action: delete
-          key: container
-        - action: upsert
-          from_attribute: node
-          key: k8s.node.name
-        - action: delete
-          key: node
-        - action: upsert
-          from_attribute: service
-          key: prometheus_service
-        - action: delete
-          key: service
-        - action: upsert
-          from_attribute: service.name
-          key: job
-        - action: delete
-          key: service.name
-        - action: upsert
-          key: _origin
-          value: kubernetes
-        - action: upsert
-          key: cluster
-          value: kubernetes
+          - action: upsert
+            from_attribute: namespace
+            key: k8s.namespace.name
+          - action: delete
+            key: namespace
+          - action: upsert
+            from_attribute: pod
+            key: k8s.pod.name
+          - action: delete
+            key: pod
+          - action: upsert
+            from_attribute: container
+            key: k8s.container.name
+          - action: delete
+            key: container
+          - action: upsert
+            from_attribute: node
+            key: k8s.node.name
+          - action: delete
+            key: node
+          - action: upsert
+            from_attribute: service
+            key: prometheus_service
+          - action: delete
+            key: service
+          - action: upsert
+            from_attribute: service.name
+            key: job
+          - action: delete
+            key: service.name
+          - action: upsert
+            key: _origin
+            value: kubernetes
+          - action: upsert
+            key: cluster
+            value: kubernetes
       resource/delete_source_metadata:
         attributes:
-        - action: delete
-          key: _sourceCategory
-        - action: delete
-          key: _sourceHost
-        - action: delete
-          key: _sourceName
+          - action: delete
+            key: _sourceCategory
+          - action: delete
+            key: _sourceHost
+          - action: delete
+            key: _sourceName
       resource/remove_k8s_pod_pod_name:
         attributes:
-        - action: delete
-          key: k8s.pod.pod_name
+          - action: delete
+            key: k8s.pod.pod_name
       source:
         collector: kubernetes
         exclude:
@@ -282,209 +277,208 @@ spec:
       transform/drop_unnecessary_attributes:
         error_mode: ignore
         metric_statements:
-        - context: resource
-          statements:
-          - delete_key(attributes, "http.scheme")
-          - delete_key(attributes, "net.host.name")
-          - delete_key(attributes, "net.host.port")
-          - delete_key(attributes, "service.instance.id")
-          - delete_matching_keys(attributes, "k8s.*")
+          - context: resource
+            statements:
+              - delete_key(attributes, "http.scheme")
+              - delete_key(attributes, "net.host.name")
+              - delete_key(attributes, "net.host.port")
+              - delete_key(attributes, "service.instance.id")
+              - delete_matching_keys(attributes, "k8s.*")
       transform/extract_sum_count_from_histograms:
         error_mode: ignore
         metric_statements:
-        - context: metric
-          statements:
-          - extract_sum_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM
-            or type == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
-          - extract_count_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM
-            or type == METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
+          - context: metric
+            statements:
+              - extract_sum_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM or type ==
+                METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
+              - extract_count_metric(true) where (not IsMatch(name, "^$")) and (type == METRIC_DATA_TYPE_HISTOGRAM or type ==
+                METRIC_DATA_TYPE_EXPONENTIAL_HISTOGRAM or type == METRIC_DATA_TYPE_SUMMARY)
       transform/remove_name:
         error_mode: ignore
         metric_statements:
-        - context: resource
-          statements:
-          - delete_key(attributes, "__name__")
+          - context: resource
+            statements:
+              - delete_key(attributes, "__name__")
       transform/set_name:
         error_mode: ignore
         metric_statements:
-        - context: datapoint
-          statements:
-          - set(attributes["__name__"], metric.name) where IsMatch(metric.name, "^cloudprovider_.*")
+          - context: datapoint
+            statements:
+              - set(attributes["__name__"], metric.name) where IsMatch(metric.name, "^cloudprovider_.*")
     receivers:
       prometheus:
         config:
           global:
             scrape_interval: 30s
           scrape_configs:
-          - job_name: pod-annotations
-            kubernetes_sd_configs:
-            - role: pod
-            relabel_configs:
-            - action: keep
-              regex: true
-              source_labels:
-              - __meta_kubernetes_pod_annotation_prometheus_io_scrape
-            - action: replace
-              regex: (.+)
-              source_labels:
-              - __meta_kubernetes_pod_annotation_prometheus_io_path
-              target_label: __metrics_path__
-            - action: replace
-              regex: ([^:]+)(?::\d+)?;(\d+)
-              replacement: $1:$2
-              source_labels:
-              - __address__
-              - __meta_kubernetes_pod_annotation_prometheus_io_port
-              target_label: __address__
-            - action: replace
-              regex: (.*)
-              replacement: $1
-              separator: ;
-              source_labels:
-              - __metrics_path__
-              target_label: endpoint
-            - action: replace
-              source_labels:
-              - __meta_kubernetes_namespace
-              target_label: namespace
-            - action: labelmap
-              regex: __meta_kubernetes_pod_label_(.+)
-            - action: replace
-              regex: (.*)
-              replacement: $1
-              separator: ;
-              source_labels:
-              - __meta_kubernetes_pod_name
-              target_label: pod
-          - authorization:
-              credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-            honor_labels: true
-            job_name: kubelet
-            kubernetes_sd_configs:
-            - role: node
-            metric_relabel_configs:
-            - action: keep
-              regex: (?:kubelet_docker_operations_errors(?:|_total)|kubelet_(?:docker|runtime)_operations_duration_seconds_(?:count|sum)|kubelet_running_(?:container|pod)(?:_count|s)|kubelet_(:?docker|runtime)_operations_latency_microseconds(?:|_count|_sum))
-              source_labels:
-              - __name__
-            - action: labeldrop
-              regex: id
-            relabel_configs:
-            - source_labels:
-              - __meta_kubernetes_node_name
-              target_label: node
-            - replacement: https-metrics
-              target_label: endpoint
-            - action: replace
-              source_labels:
-              - __metrics_path__
-              target_label: metrics_path
-            - action: replace
-              source_labels:
-              - __address__
-              target_label: instance
-            scheme: https
-            tls_config:
-              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-              insecure_skip_verify: true
-          - authorization:
-              credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-            honor_labels: true
-            job_name: cadvisor
-            kubernetes_sd_configs:
-            - role: node
-            metric_relabel_configs:
-            - action: replace
-              regex: .*
-              replacement: kubelet
-              source_labels:
-              - __name__
-              target_label: job
-            - action: keep
-              regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes|container_cpu_cfs_throttled_seconds_total|container_network_receive_bytes_total|container_network_transmit_bytes_total)
-              source_labels:
-              - __name__
-            - action: drop
-              regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes);$
-              source_labels:
-              - __name__
-              - container
-            - action: labelmap
-              regex: container_name
-              replacement: container
-            - action: drop
-              regex: POD
-              source_labels:
-              - container
-            - action: labeldrop
-              regex: (id|name)
-            metrics_path: /metrics/cadvisor
-            relabel_configs:
-            - replacement: https-metrics
-              target_label: endpoint
-            - action: replace
-              source_labels:
-              - __metrics_path__
-              target_label: metrics_path
-            - action: replace
-              source_labels:
-              - __address__
-              target_label: instance
-            scheme: https
-            tls_config:
-              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-              insecure_skip_verify: true
+            - job_name: pod-annotations
+              kubernetes_sd_configs:
+                - role: pod
+              relabel_configs:
+                - action: keep
+                  regex: true
+                  source_labels:
+                    - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+                - action: replace
+                  regex: (.+)
+                  source_labels:
+                    - __meta_kubernetes_pod_annotation_prometheus_io_path
+                  target_label: __metrics_path__
+                - action: replace
+                  regex: ([^:]+)(?::\d+)?;(\d+)
+                  replacement: $1:$2
+                  source_labels:
+                    - __address__
+                    - __meta_kubernetes_pod_annotation_prometheus_io_port
+                  target_label: __address__
+                - action: replace
+                  regex: (.*)
+                  replacement: $1
+                  separator: ;
+                  source_labels:
+                    - __metrics_path__
+                  target_label: endpoint
+                - action: replace
+                  source_labels:
+                    - __meta_kubernetes_namespace
+                  target_label: namespace
+                - action: labelmap
+                  regex: __meta_kubernetes_pod_label_(.+)
+                - action: replace
+                  regex: (.*)
+                  replacement: $1
+                  separator: ;
+                  source_labels:
+                    - __meta_kubernetes_pod_name
+                  target_label: pod
+            - authorization:
+                credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              honor_labels: true
+              job_name: kubelet
+              kubernetes_sd_configs:
+                - role: node
+              metric_relabel_configs:
+                - action: keep
+                  regex: (?:kubelet_docker_operations_errors(?:|_total)|kubelet_(?:docker|runtime)_operations_duration_seconds_(?:count|sum)|kubelet_running_(?:container|pod)(?:_count|s)|kubelet_(:?docker|runtime)_operations_latency_microseconds(?:|_count|_sum))
+                  source_labels:
+                    - __name__
+                - action: labeldrop
+                  regex: id
+              relabel_configs:
+                - source_labels:
+                    - __meta_kubernetes_node_name
+                  target_label: node
+                - replacement: https-metrics
+                  target_label: endpoint
+                - action: replace
+                  source_labels:
+                    - __metrics_path__
+                  target_label: metrics_path
+                - action: replace
+                  source_labels:
+                    - __address__
+                  target_label: instance
+              scheme: https
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: true
+            - authorization:
+                credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              honor_labels: true
+              job_name: cadvisor
+              kubernetes_sd_configs:
+                - role: node
+              metric_relabel_configs:
+                - action: replace
+                  regex: .*
+                  replacement: kubelet
+                  source_labels:
+                    - __name__
+                  target_label: job
+                - action: keep
+                  regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes|container_cpu_cfs_throttled_seconds_total|container_network_receive_bytes_total|container_network_transmit_bytes_total)
+                  source_labels:
+                    - __name__
+                - action: drop
+                  regex: (?:container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_usage_bytes|container_fs_limit_bytes);$
+                  source_labels:
+                    - __name__
+                    - container
+                - action: labelmap
+                  regex: container_name
+                  replacement: container
+                - action: drop
+                  regex: POD
+                  source_labels:
+                    - container
+                - action: labeldrop
+                  regex: (id|name)
+              metrics_path: /metrics/cadvisor
+              relabel_configs:
+                - replacement: https-metrics
+                  target_label: endpoint
+                - action: replace
+                  source_labels:
+                    - __metrics_path__
+                  target_label: metrics_path
+                - action: replace
+                  source_labels:
+                    - __address__
+                  target_label: instance
+              scheme: https
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: true
       prometheusremotewrite:
         endpoint: ${env:MY_POD_IP}:9888
         read_timeout: 1m
         write_timeout: 1m
     service:
       extensions:
-      - health_check
-      - pprof
-      - file_storage
+        - health_check
+        - pprof
+        - file_storage
       pipelines:
         metrics:
           exporters:
-          - sumologic/default
+            - sumologic/default
           processors:
-          - memory_limiter
-          - metricstransform
-          - groupbyattrs
-          - resource
-          - k8sattributes
-          - source
-          - sumologic
-          - resource/remove_k8s_pod_pod_name
-          - resource/delete_source_metadata
-          - transform/set_name
-          - groupbyattrs/group_by_name
-          - transform/remove_name
-          - filter/drop_unnecessary_metrics
+            - memory_limiter
+            - metricstransform
+            - groupbyattrs
+            - resource
+            - k8sattributes
+            - source
+            - sumologic
+            - resource/remove_k8s_pod_pod_name
+            - resource/delete_source_metadata
+            - transform/set_name
+            - groupbyattrs/group_by_name
+            - transform/remove_name
+            - filter/drop_unnecessary_metrics
           receivers:
-          - forward
-          - prometheusremotewrite
+            - forward
+            - prometheusremotewrite
         metrics/collector:
           exporters:
-          - forward
+            - forward
           processors:
-          - filter/drop_stale_datapoints
-          - transform/extract_sum_count_from_histograms
-          - transform/drop_unnecessary_attributes
+            - filter/drop_stale_datapoints
+            - transform/extract_sum_count_from_histograms
+            - transform/drop_unnecessary_attributes
           receivers:
-          - prometheus
+            - prometheus
       telemetry:
         logs:
           level: info
         metrics:
           level: normal
           readers:
-          - pull:
-              exporter:
-                prometheus:
-                  host: ${env:MY_POD_IP}
-                  port: 8888
-                  without_scope_info: true
-                  without_type_suffix: true
-                  without_units: true
-
+            - pull:
+                exporter:
+                  prometheus:
+                    host: ${env:MY_POD_IP}
+                    port: 8888
+                    without_scope_info: true
+                    without_type_suffix: true
+                    without_units: true

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-statefulset/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-statefulset/basic.output.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: '%CONFIG_CHECKSUM%'
+        checksum/config: "%CONFIG_CHECKSUM%"
       labels:
         app: RELEASE-NAME-sumologic-otelcol-instrumentation
         chart: "sumologic-%CURRENT_CHART_VERSION%"
@@ -33,22 +33,22 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - RELEASE-NAME-sumologic-otelcol-logs
-                  - RELEASE-NAME-sumologic-otelcol-metrics
-                  - RELEASE-NAME-sumologic-otelcol-events
-                  - RELEASE-NAME-sumologic-otelcol-instrumentation
-                - key: app
-                  operator: In
-                  values:
-                  - prometheus-operator-prometheus
-              topologyKey: "kubernetes.io/hostname"
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - RELEASE-NAME-sumologic-otelcol-logs
+                        - RELEASE-NAME-sumologic-otelcol-metrics
+                        - RELEASE-NAME-sumologic-otelcol-events
+                        - RELEASE-NAME-sumologic-otelcol-instrumentation
+                    - key: app
+                      operator: In
+                      values:
+                        - prometheus-operator-prometheus
+                topologyKey: "kubernetes.io/hostname"
       volumes:
         - configMap:
             name: RELEASE-NAME-sumologic-otelcol-instrumentation
@@ -56,75 +56,74 @@ spec:
       securityContext:
         fsGroup: 999
       containers:
-      - name: otelcol
-        image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
-        imagePullPolicy: IfNotPresent
-        args:
-          - "--config=/conf/otelcol.instrumentation.conf.yaml"
-        resources:
-          limits:
-            cpu: 2000m
-            memory: 4Gi
-          requests:
-            cpu: 500m
-            memory: 768Mi
-        ports:
-        - name: pprof
-          containerPort: 1777
-          protocol: TCP
-        - containerPort: 5778  # Default endpoint for Jaeger Sampling.
-        - containerPort: 6831  # Default endpoint for Jaeger Thrift Compact receiver.
-          protocol: UDP
-        - containerPort: 6832  # Default endpoint for Jaeger Thrift Binary receiver.
-          protocol: UDP
-        - containerPort: 8888  # Default endpoint for querying metrics.
-        - containerPort: 9411  # Default endpoint for Zipkin receiver.
-        - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
-        - containerPort: 14267 # Default endpoint for Jaeger TChannel receiver.
-        - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
-        - containerPort: 4317  # Default endpoint for OTLP receiver.
-        - containerPort: 4318  # Default endpoint for OTLP HTTP receiver.
-        - containerPort: 55681 # Default endpoint for OTLP HTTP receiver. (deprecated)
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 3
-          initialDelaySeconds: 15
-          periodSeconds: 15
-          timeoutSeconds: 10
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 3
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          timeoutSeconds: 3
-        startupProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 60
-          periodSeconds: 3
-        volumeMounts:
-        - name: otelcolinstrumentation-config-vol
-          mountPath: /conf
-        env:
-        - name: SUMO_ENDPOINT_DEFAULT_OTLP_METRICS_SOURCE
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics-otlp
-        
-        - name: MY_POD_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: MY_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
+        - name: otelcol
+          image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--config=/conf/otelcol.instrumentation.conf.yaml"
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 4Gi
+            requests:
+              cpu: 500m
+              memory: 768Mi
+          ports:
+            - name: pprof
+              containerPort: 1777
+              protocol: TCP
+            - containerPort: 5778 # Default endpoint for Jaeger Sampling.
+            - containerPort: 6831 # Default endpoint for Jaeger Thrift Compact receiver.
+              protocol: UDP
+            - containerPort: 6832 # Default endpoint for Jaeger Thrift Binary receiver.
+              protocol: UDP
+            - containerPort: 8888 # Default endpoint for querying metrics.
+            - containerPort: 9411 # Default endpoint for Zipkin receiver.
+            - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
+            - containerPort: 14267 # Default endpoint for Jaeger TChannel receiver.
+            - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
+            - containerPort: 4317 # Default endpoint for OTLP receiver.
+            - containerPort: 4318 # Default endpoint for OTLP HTTP receiver.
+            - containerPort: 55681 # Default endpoint for OTLP HTTP receiver. (deprecated)
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 3
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 60
+            periodSeconds: 3
+          volumeMounts:
+            - name: otelcolinstrumentation-config-vol
+              mountPath: /conf
+          env:
+            - name: SUMO_ENDPOINT_DEFAULT_OTLP_METRICS_SOURCE
+              valueFrom:
+                secretKeyRef:
+                  name: sumologic
+                  key: endpoint-metrics-otlp
 
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-statefulset/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-statefulset/basic.output.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: "%CONFIG_CHECKSUM%"
+        checksum/config: '%CONFIG_CHECKSUM%'
       labels:
         app: RELEASE-NAME-sumologic-otelcol-instrumentation
         chart: "sumologic-%CURRENT_CHART_VERSION%"
@@ -33,22 +33,22 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: app
-                      operator: In
-                      values:
-                        - RELEASE-NAME-sumologic-otelcol-logs
-                        - RELEASE-NAME-sumologic-otelcol-metrics
-                        - RELEASE-NAME-sumologic-otelcol-events
-                        - RELEASE-NAME-sumologic-otelcol-instrumentation
-                    - key: app
-                      operator: In
-                      values:
-                        - prometheus-operator-prometheus
-                topologyKey: "kubernetes.io/hostname"
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - RELEASE-NAME-sumologic-otelcol-logs
+                  - RELEASE-NAME-sumologic-otelcol-metrics
+                  - RELEASE-NAME-sumologic-otelcol-events
+                  - RELEASE-NAME-sumologic-otelcol-instrumentation
+                - key: app
+                  operator: In
+                  values:
+                  - prometheus-operator-prometheus
+              topologyKey: "kubernetes.io/hostname"
       volumes:
         - configMap:
             name: RELEASE-NAME-sumologic-otelcol-instrumentation
@@ -56,69 +56,75 @@ spec:
       securityContext:
         fsGroup: 999
       containers:
-        - name: otelcol
-          image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
-          imagePullPolicy: IfNotPresent
-          args:
-            - "--config=/conf/otelcol.instrumentation.conf.yaml"
-          resources:
-            limits:
-              cpu: 2000m
-              memory: 4Gi
-            requests:
-              cpu: 500m
-              memory: 768Mi
-          ports:
-            - name: pprof
-              containerPort: 1777
-              protocol: TCP
-            - containerPort: 5778 # Default endpoint for Jaeger Sampling.
-            - containerPort: 6831 # Default endpoint for Jaeger Thrift Compact receiver.
-              protocol: UDP
-            - containerPort: 6832 # Default endpoint for Jaeger Thrift Binary receiver.
-              protocol: UDP
-            - containerPort: 8888 # Default endpoint for querying metrics.
-            - containerPort: 9411 # Default endpoint for Zipkin receiver.
-            - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
-            - containerPort: 14267 # Default endpoint for Jaeger TChannel receiver.
-            - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
-            - containerPort: 4317 # Default endpoint for OTLP receiver.
-            - containerPort: 4318 # Default endpoint for OTLP HTTP receiver.
-            - containerPort: 55681 # Default endpoint for OTLP HTTP receiver. (deprecated)
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 3
-            initialDelaySeconds: 15
-            periodSeconds: 15
-            timeoutSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 3
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 3
-          startupProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 60
-            periodSeconds: 3
-          volumeMounts:
-            - name: otelcolinstrumentation-config-vol
-              mountPath: /conf
-          env:
-            - name: SUMO_ENDPOINT_DEFAULT_OTLP_METRICS_SOURCE
-              valueFrom:
-                secretKeyRef:
-                  name: sumologic
-                  key: endpoint-metrics-otlp
+      - name: otelcol
+        image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
+        imagePullPolicy: IfNotPresent
+        args:
+          - "--config=/conf/otelcol.instrumentation.conf.yaml"
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 4Gi
+          requests:
+            cpu: 500m
+            memory: 768Mi
+        ports:
+        - name: pprof
+          containerPort: 1777
+          protocol: TCP
+        - containerPort: 5778  # Default endpoint for Jaeger Sampling.
+        - containerPort: 6831  # Default endpoint for Jaeger Thrift Compact receiver.
+          protocol: UDP
+        - containerPort: 6832  # Default endpoint for Jaeger Thrift Binary receiver.
+          protocol: UDP
+        - containerPort: 8888  # Default endpoint for querying metrics.
+        - containerPort: 9411  # Default endpoint for Zipkin receiver.
+        - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
+        - containerPort: 14267 # Default endpoint for Jaeger TChannel receiver.
+        - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
+        - containerPort: 4317  # Default endpoint for OTLP receiver.
+        - containerPort: 4318  # Default endpoint for OTLP HTTP receiver.
+        - containerPort: 55681 # Default endpoint for OTLP HTTP receiver. (deprecated)
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 3
+        startupProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 60
+          periodSeconds: 3
+        volumeMounts:
+        - name: otelcolinstrumentation-config-vol
+          mountPath: /conf
+        env:
+        - name: SUMO_ENDPOINT_DEFAULT_OTLP_METRICS_SOURCE
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-metrics-otlp
+        
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
 
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-statefulset/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-statefulset/custom.output.yaml
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: "%CONFIG_CHECKSUM%"
+        checksum/config: '%CONFIG_CHECKSUM%'
       labels:
         app: RELEASE-NAME-sumologic-otelcol-instrumentation
         chart: "sumologic-%CURRENT_CHART_VERSION%"
@@ -34,22 +34,22 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: app
-                      operator: In
-                      values:
-                        - RELEASE-NAME-sumologic-otelcol-logs
-                        - RELEASE-NAME-sumologic-otelcol-metrics
-                        - RELEASE-NAME-sumologic-otelcol-events
-                        - RELEASE-NAME-sumologic-otelcol-instrumentation
-                    - key: app
-                      operator: In
-                      values:
-                        - prometheus-operator-prometheus
-                topologyKey: "kubernetes.io/hostname"
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - RELEASE-NAME-sumologic-otelcol-logs
+                  - RELEASE-NAME-sumologic-otelcol-metrics
+                  - RELEASE-NAME-sumologic-otelcol-events
+                  - RELEASE-NAME-sumologic-otelcol-instrumentation
+                - key: app
+                  operator: In
+                  values:
+                  - prometheus-operator-prometheus
+              topologyKey: "kubernetes.io/hostname"
       volumes:
         - configMap:
             name: RELEASE-NAME-sumologic-otelcol-instrumentation
@@ -57,69 +57,75 @@ spec:
       securityContext:
         fsGroup: 999
       containers:
-        - name: otelcol
-          image: "my_repository:my_tag"
-          imagePullPolicy: IfNotPresent
-          args:
-            - "--config=/conf/otelcol.instrumentation.conf.yaml"
-          resources:
-            limits:
-              cpu: 2000m
-              memory: 4Gi
-            requests:
-              cpu: 500m
-              memory: 768Mi
-          ports:
-            - name: pprof
-              containerPort: 1777
-              protocol: TCP
-            - containerPort: 5778 # Default endpoint for Jaeger Sampling.
-            - containerPort: 6831 # Default endpoint for Jaeger Thrift Compact receiver.
-              protocol: UDP
-            - containerPort: 6832 # Default endpoint for Jaeger Thrift Binary receiver.
-              protocol: UDP
-            - containerPort: 8888 # Default endpoint for querying metrics.
-            - containerPort: 9411 # Default endpoint for Zipkin receiver.
-            - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
-            - containerPort: 14267 # Default endpoint for Jaeger TChannel receiver.
-            - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
-            - containerPort: 4317 # Default endpoint for OTLP receiver.
-            - containerPort: 4318 # Default endpoint for OTLP HTTP receiver.
-            - containerPort: 55681 # Default endpoint for OTLP HTTP receiver. (deprecated)
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 3
-            initialDelaySeconds: 15
-            periodSeconds: 15
-            timeoutSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 3
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 3
-          startupProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 60
-            periodSeconds: 3
-          volumeMounts:
-            - name: otelcolinstrumentation-config-vol
-              mountPath: /conf
-          env:
-            - name: SUMO_ENDPOINT_DEFAULT_OTLP_METRICS_SOURCE
-              valueFrom:
-                secretKeyRef:
-                  name: sumologic
-                  key: endpoint-metrics-otlp
+      - name: otelcol
+        image: "my_repository:my_tag"
+        imagePullPolicy: IfNotPresent
+        args:
+          - "--config=/conf/otelcol.instrumentation.conf.yaml"
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 4Gi
+          requests:
+            cpu: 500m
+            memory: 768Mi
+        ports:
+        - name: pprof
+          containerPort: 1777
+          protocol: TCP
+        - containerPort: 5778  # Default endpoint for Jaeger Sampling.
+        - containerPort: 6831  # Default endpoint for Jaeger Thrift Compact receiver.
+          protocol: UDP
+        - containerPort: 6832  # Default endpoint for Jaeger Thrift Binary receiver.
+          protocol: UDP
+        - containerPort: 8888  # Default endpoint for querying metrics.
+        - containerPort: 9411  # Default endpoint for Zipkin receiver.
+        - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
+        - containerPort: 14267 # Default endpoint for Jaeger TChannel receiver.
+        - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
+        - containerPort: 4317  # Default endpoint for OTLP receiver.
+        - containerPort: 4318  # Default endpoint for OTLP HTTP receiver.
+        - containerPort: 55681 # Default endpoint for OTLP HTTP receiver. (deprecated)
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          initialDelaySeconds: 15
+          periodSeconds: 15
+          timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 3
+        startupProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 60
+          periodSeconds: 3
+        volumeMounts:
+        - name: otelcolinstrumentation-config-vol
+          mountPath: /conf
+        env:
+        - name: SUMO_ENDPOINT_DEFAULT_OTLP_METRICS_SOURCE
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-metrics-otlp
+        
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
 
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP

--- a/tests/helm/testdata/goldenfile/otelcol-instrumentation-statefulset/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/otelcol-instrumentation-statefulset/custom.output.yaml
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: '%CONFIG_CHECKSUM%'
+        checksum/config: "%CONFIG_CHECKSUM%"
       labels:
         app: RELEASE-NAME-sumologic-otelcol-instrumentation
         chart: "sumologic-%CURRENT_CHART_VERSION%"
@@ -34,22 +34,22 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - RELEASE-NAME-sumologic-otelcol-logs
-                  - RELEASE-NAME-sumologic-otelcol-metrics
-                  - RELEASE-NAME-sumologic-otelcol-events
-                  - RELEASE-NAME-sumologic-otelcol-instrumentation
-                - key: app
-                  operator: In
-                  values:
-                  - prometheus-operator-prometheus
-              topologyKey: "kubernetes.io/hostname"
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - RELEASE-NAME-sumologic-otelcol-logs
+                        - RELEASE-NAME-sumologic-otelcol-metrics
+                        - RELEASE-NAME-sumologic-otelcol-events
+                        - RELEASE-NAME-sumologic-otelcol-instrumentation
+                    - key: app
+                      operator: In
+                      values:
+                        - prometheus-operator-prometheus
+                topologyKey: "kubernetes.io/hostname"
       volumes:
         - configMap:
             name: RELEASE-NAME-sumologic-otelcol-instrumentation
@@ -57,75 +57,74 @@ spec:
       securityContext:
         fsGroup: 999
       containers:
-      - name: otelcol
-        image: "my_repository:my_tag"
-        imagePullPolicy: IfNotPresent
-        args:
-          - "--config=/conf/otelcol.instrumentation.conf.yaml"
-        resources:
-          limits:
-            cpu: 2000m
-            memory: 4Gi
-          requests:
-            cpu: 500m
-            memory: 768Mi
-        ports:
-        - name: pprof
-          containerPort: 1777
-          protocol: TCP
-        - containerPort: 5778  # Default endpoint for Jaeger Sampling.
-        - containerPort: 6831  # Default endpoint for Jaeger Thrift Compact receiver.
-          protocol: UDP
-        - containerPort: 6832  # Default endpoint for Jaeger Thrift Binary receiver.
-          protocol: UDP
-        - containerPort: 8888  # Default endpoint for querying metrics.
-        - containerPort: 9411  # Default endpoint for Zipkin receiver.
-        - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
-        - containerPort: 14267 # Default endpoint for Jaeger TChannel receiver.
-        - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
-        - containerPort: 4317  # Default endpoint for OTLP receiver.
-        - containerPort: 4318  # Default endpoint for OTLP HTTP receiver.
-        - containerPort: 55681 # Default endpoint for OTLP HTTP receiver. (deprecated)
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 3
-          initialDelaySeconds: 15
-          periodSeconds: 15
-          timeoutSeconds: 10
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 3
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          timeoutSeconds: 3
-        startupProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 60
-          periodSeconds: 3
-        volumeMounts:
-        - name: otelcolinstrumentation-config-vol
-          mountPath: /conf
-        env:
-        - name: SUMO_ENDPOINT_DEFAULT_OTLP_METRICS_SOURCE
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics-otlp
-        
-        - name: MY_POD_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: MY_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
+        - name: otelcol
+          image: "my_repository:my_tag"
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--config=/conf/otelcol.instrumentation.conf.yaml"
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 4Gi
+            requests:
+              cpu: 500m
+              memory: 768Mi
+          ports:
+            - name: pprof
+              containerPort: 1777
+              protocol: TCP
+            - containerPort: 5778 # Default endpoint for Jaeger Sampling.
+            - containerPort: 6831 # Default endpoint for Jaeger Thrift Compact receiver.
+              protocol: UDP
+            - containerPort: 6832 # Default endpoint for Jaeger Thrift Binary receiver.
+              protocol: UDP
+            - containerPort: 8888 # Default endpoint for querying metrics.
+            - containerPort: 9411 # Default endpoint for Zipkin receiver.
+            - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
+            - containerPort: 14267 # Default endpoint for Jaeger TChannel receiver.
+            - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
+            - containerPort: 4317 # Default endpoint for OTLP receiver.
+            - containerPort: 4318 # Default endpoint for OTLP HTTP receiver.
+            - containerPort: 55681 # Default endpoint for OTLP HTTP receiver. (deprecated)
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 3
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 60
+            periodSeconds: 3
+          volumeMounts:
+            - name: otelcolinstrumentation-config-vol
+              mountPath: /conf
+          env:
+            - name: SUMO_ENDPOINT_DEFAULT_OTLP_METRICS_SOURCE
+              valueFrom:
+                secretKeyRef:
+                  name: sumologic
+                  key: endpoint-metrics-otlp
 
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name

--- a/tests/helm/testdata/goldenfile/traces-gateway-deployment/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-gateway-deployment/basic.output.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: "%CONFIG_CHECKSUM%"
+        checksum/config: '%CONFIG_CHECKSUM%'
       labels:
         app: RELEASE-NAME-sumologic-traces-gateway
         component: RELEASE-NAME-sumologic-traces-gateway-component
@@ -36,83 +36,90 @@ spec:
       # the agent will have a chance to retry when collector is ready.
       restartPolicy: Always
       containers:
-        - name: otelcol
-          image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
-          imagePullPolicy: IfNotPresent
-          args:
-            - "--config=/conf/traces.gateway.conf.yaml"
-          env:
-            - name: GOGC
-              value: "80"
-            - name: SUMO_ENDPOINT_DEFAULT_OTLP_TRACES_SOURCE
-              valueFrom:
-                secretKeyRef:
-                  name: sumologic
-                  key: endpoint-traces-otlp
-
-            - name: SUMO_ENDPOINT_DEFAULT_OTLP_METRICS_SOURCE
-              valueFrom:
-                secretKeyRef:
-                  name: sumologic
-                  key: endpoint-metrics-otlp
-
-            - name: NO_PROXY
-              value: kubernetes.default.svc
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP
-          resources:
-            limits:
-              cpu: 1000m
-              memory: 2Gi
-            requests:
-              cpu: 50m
-              memory: 196Mi
-          ports:
-            - name: pprof
-              containerPort: 1777
-              protocol: TCP
-            - containerPort: 5778 # Default endpoint for Jaeger Sampling.
-            - containerPort: 6831 # Default endpoint for Jaeger Thrift Compact receiver.
-              protocol: UDP
-            - containerPort: 6832 # Default endpoint for Jaeger Thrift Binary receiver.
-              protocol: UDP
-            - containerPort: 8888 # Default endpoint for querying metrics.
-            - containerPort: 9411 # Default endpoint for Zipkin receiver.
-            - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
-            - containerPort: 14267 # Default endpoint for Jaeger TChannel receiver.
-            - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
-            - containerPort: 4317 # Default endpoint for OTLP receiver.
-            - containerPort: 4318 # Default endpoint for OTLP HTTP receiver.
-            - containerPort: 55680 # Old endpoint for OTLP gRPC receiver.
-            - containerPort: 55681 # Default endpoint for OTLP HTTP receiver. (deprecated)
-          volumeMounts:
-            - name: tracesgateway-config-vol
-              mountPath: /conf
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 3
-            periodSeconds: 15
-            timeoutSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 3
-            periodSeconds: 10
-            timeoutSeconds: 3
-          startupProbe:
-            httpGet:
-              path: /
-              port: 13133
-            failureThreshold: 60
-            periodSeconds: 5
-            timeoutSeconds: 3
+      - name: otelcol
+        image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
+        imagePullPolicy: IfNotPresent
+        args:
+          - "--config=/conf/traces.gateway.conf.yaml"
+        env:
+        - name: GOGC
+          value: "80"
+        - name: SUMO_ENDPOINT_DEFAULT_OTLP_TRACES_SOURCE
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-traces-otlp
+        
+        - name: SUMO_ENDPOINT_DEFAULT_OTLP_METRICS_SOURCE
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-metrics-otlp
+        
+        
+        - name: NO_PROXY
+          value: kubernetes.default.svc
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 2Gi
+          requests:
+            cpu: 50m
+            memory: 196Mi
+        ports:
+        - name: pprof
+          containerPort: 1777
+          protocol: TCP
+        - containerPort: 5778  # Default endpoint for Jaeger Sampling.
+        - containerPort: 6831  # Default endpoint for Jaeger Thrift Compact receiver.
+          protocol: UDP
+        - containerPort: 6832  # Default endpoint for Jaeger Thrift Binary receiver.
+          protocol: UDP
+        - containerPort: 8888  # Default endpoint for querying metrics.
+        - containerPort: 9411  # Default endpoint for Zipkin receiver.
+        - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
+        - containerPort: 14267 # Default endpoint for Jaeger TChannel receiver.
+        - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
+        - containerPort: 4317  # Default endpoint for OTLP receiver.
+        - containerPort: 4318  # Default endpoint for OTLP HTTP receiver.
+        - containerPort: 55680 # Old endpoint for OTLP gRPC receiver.
+        - containerPort: 55681 # Default endpoint for OTLP HTTP receiver. (deprecated)
+        volumeMounts:
+        - name: tracesgateway-config-vol
+          mountPath: /conf
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          periodSeconds: 15
+          timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          periodSeconds: 10
+          timeoutSeconds: 3
+        startupProbe:
+          httpGet:
+            path: /
+            port: 13133
+          failureThreshold: 60
+          periodSeconds: 5
+          timeoutSeconds: 3
       volumes:
         - configMap:
             name: RELEASE-NAME-sumologic-traces-gateway
           name: tracesgateway-config-vol
+

--- a/tests/helm/testdata/goldenfile/traces-gateway-deployment/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-gateway-deployment/basic.output.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: '%CONFIG_CHECKSUM%'
+        checksum/config: "%CONFIG_CHECKSUM%"
       labels:
         app: RELEASE-NAME-sumologic-traces-gateway
         component: RELEASE-NAME-sumologic-traces-gateway-component
@@ -36,90 +36,88 @@ spec:
       # the agent will have a chance to retry when collector is ready.
       restartPolicy: Always
       containers:
-      - name: otelcol
-        image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
-        imagePullPolicy: IfNotPresent
-        args:
-          - "--config=/conf/traces.gateway.conf.yaml"
-        env:
-        - name: GOGC
-          value: "80"
-        - name: SUMO_ENDPOINT_DEFAULT_OTLP_TRACES_SOURCE
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-traces-otlp
-        
-        - name: SUMO_ENDPOINT_DEFAULT_OTLP_METRICS_SOURCE
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics-otlp
-        
-        
-        - name: NO_PROXY
-          value: kubernetes.default.svc
-        - name: MY_POD_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: MY_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        resources:
-          limits:
-            cpu: 1000m
-            memory: 2Gi
-          requests:
-            cpu: 50m
-            memory: 196Mi
-        ports:
-        - name: pprof
-          containerPort: 1777
-          protocol: TCP
-        - containerPort: 5778  # Default endpoint for Jaeger Sampling.
-        - containerPort: 6831  # Default endpoint for Jaeger Thrift Compact receiver.
-          protocol: UDP
-        - containerPort: 6832  # Default endpoint for Jaeger Thrift Binary receiver.
-          protocol: UDP
-        - containerPort: 8888  # Default endpoint for querying metrics.
-        - containerPort: 9411  # Default endpoint for Zipkin receiver.
-        - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
-        - containerPort: 14267 # Default endpoint for Jaeger TChannel receiver.
-        - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
-        - containerPort: 4317  # Default endpoint for OTLP receiver.
-        - containerPort: 4318  # Default endpoint for OTLP HTTP receiver.
-        - containerPort: 55680 # Old endpoint for OTLP gRPC receiver.
-        - containerPort: 55681 # Default endpoint for OTLP HTTP receiver. (deprecated)
-        volumeMounts:
-        - name: tracesgateway-config-vol
-          mountPath: /conf
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 3
-          periodSeconds: 15
-          timeoutSeconds: 10
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 3
-          periodSeconds: 10
-          timeoutSeconds: 3
-        startupProbe:
-          httpGet:
-            path: /
-            port: 13133
-          failureThreshold: 60
-          periodSeconds: 5
-          timeoutSeconds: 3
+        - name: otelcol
+          image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--config=/conf/traces.gateway.conf.yaml"
+          env:
+            - name: GOGC
+              value: "80"
+            - name: SUMO_ENDPOINT_DEFAULT_OTLP_TRACES_SOURCE
+              valueFrom:
+                secretKeyRef:
+                  name: sumologic
+                  key: endpoint-traces-otlp
+
+            - name: SUMO_ENDPOINT_DEFAULT_OTLP_METRICS_SOURCE
+              valueFrom:
+                secretKeyRef:
+                  name: sumologic
+                  key: endpoint-metrics-otlp
+
+            - name: NO_PROXY
+              value: kubernetes.default.svc
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 2Gi
+            requests:
+              cpu: 50m
+              memory: 196Mi
+          ports:
+            - name: pprof
+              containerPort: 1777
+              protocol: TCP
+            - containerPort: 5778 # Default endpoint for Jaeger Sampling.
+            - containerPort: 6831 # Default endpoint for Jaeger Thrift Compact receiver.
+              protocol: UDP
+            - containerPort: 6832 # Default endpoint for Jaeger Thrift Binary receiver.
+              protocol: UDP
+            - containerPort: 8888 # Default endpoint for querying metrics.
+            - containerPort: 9411 # Default endpoint for Zipkin receiver.
+            - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
+            - containerPort: 14267 # Default endpoint for Jaeger TChannel receiver.
+            - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
+            - containerPort: 4317 # Default endpoint for OTLP receiver.
+            - containerPort: 4318 # Default endpoint for OTLP HTTP receiver.
+            - containerPort: 55680 # Old endpoint for OTLP gRPC receiver.
+            - containerPort: 55681 # Default endpoint for OTLP HTTP receiver. (deprecated)
+          volumeMounts:
+            - name: tracesgateway-config-vol
+              mountPath: /conf
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 3
+            periodSeconds: 15
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 3
+            periodSeconds: 10
+            timeoutSeconds: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: 13133
+            failureThreshold: 60
+            periodSeconds: 5
+            timeoutSeconds: 3
       volumes:
         - configMap:
             name: RELEASE-NAME-sumologic-traces-gateway
           name: tracesgateway-config-vol
-

--- a/tests/helm/testdata/goldenfile/traces-gateway-deployment/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-gateway-deployment/custom.output.yaml
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: "%CONFIG_CHECKSUM%"
+        checksum/config: '%CONFIG_CHECKSUM%'
       labels:
         app: RELEASE-NAME-sumologic-traces-gateway
         component: RELEASE-NAME-sumologic-traces-gateway-component
@@ -37,83 +37,90 @@ spec:
       # the agent will have a chance to retry when collector is ready.
       restartPolicy: Always
       containers:
-        - name: otelcol
-          image: "my_repository:my_tag"
-          imagePullPolicy: IfNotPresent
-          args:
-            - "--config=/conf/traces.gateway.conf.yaml"
-          env:
-            - name: GOGC
-              value: "80"
-            - name: SUMO_ENDPOINT_DEFAULT_TRACES_SOURCE
-              valueFrom:
-                secretKeyRef:
-                  name: sumologic
-                  key: endpoint-traces
-
-            - name: SUMO_ENDPOINT_DEFAULT_OTLP_METRICS_SOURCE
-              valueFrom:
-                secretKeyRef:
-                  name: sumologic
-                  key: endpoint-metrics-otlp
-
-            - name: NO_PROXY
-              value: kubernetes.default.svc
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP
-          resources:
-            limits:
-              cpu: 1000m
-              memory: 2Gi
-            requests:
-              cpu: 50m
-              memory: 196Mi
-          ports:
-            - name: pprof
-              containerPort: 1777
-              protocol: TCP
-            - containerPort: 5778 # Default endpoint for Jaeger Sampling.
-            - containerPort: 6831 # Default endpoint for Jaeger Thrift Compact receiver.
-              protocol: UDP
-            - containerPort: 6832 # Default endpoint for Jaeger Thrift Binary receiver.
-              protocol: UDP
-            - containerPort: 8888 # Default endpoint for querying metrics.
-            - containerPort: 9411 # Default endpoint for Zipkin receiver.
-            - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
-            - containerPort: 14267 # Default endpoint for Jaeger TChannel receiver.
-            - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
-            - containerPort: 4317 # Default endpoint for OTLP receiver.
-            - containerPort: 4318 # Default endpoint for OTLP HTTP receiver.
-            - containerPort: 55680 # Old endpoint for OTLP gRPC receiver.
-            - containerPort: 55681 # Default endpoint for OTLP HTTP receiver. (deprecated)
-          volumeMounts:
-            - name: tracesgateway-config-vol
-              mountPath: /conf
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 3
-            periodSeconds: 15
-            timeoutSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-            failureThreshold: 3
-            periodSeconds: 10
-            timeoutSeconds: 3
-          startupProbe:
-            httpGet:
-              path: /
-              port: 13133
-            failureThreshold: 60
-            periodSeconds: 5
-            timeoutSeconds: 3
+      - name: otelcol
+        image: "my_repository:my_tag"
+        imagePullPolicy: IfNotPresent
+        args:
+          - "--config=/conf/traces.gateway.conf.yaml"
+        env:
+        - name: GOGC
+          value: "80"
+        - name: SUMO_ENDPOINT_DEFAULT_TRACES_SOURCE
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-traces
+        
+        - name: SUMO_ENDPOINT_DEFAULT_OTLP_METRICS_SOURCE
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-metrics-otlp
+        
+        
+        - name: NO_PROXY
+          value: kubernetes.default.svc
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 2Gi
+          requests:
+            cpu: 50m
+            memory: 196Mi
+        ports:
+        - name: pprof
+          containerPort: 1777
+          protocol: TCP
+        - containerPort: 5778  # Default endpoint for Jaeger Sampling.
+        - containerPort: 6831  # Default endpoint for Jaeger Thrift Compact receiver.
+          protocol: UDP
+        - containerPort: 6832  # Default endpoint for Jaeger Thrift Binary receiver.
+          protocol: UDP
+        - containerPort: 8888  # Default endpoint for querying metrics.
+        - containerPort: 9411  # Default endpoint for Zipkin receiver.
+        - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
+        - containerPort: 14267 # Default endpoint for Jaeger TChannel receiver.
+        - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
+        - containerPort: 4317  # Default endpoint for OTLP receiver.
+        - containerPort: 4318  # Default endpoint for OTLP HTTP receiver.
+        - containerPort: 55680 # Old endpoint for OTLP gRPC receiver.
+        - containerPort: 55681 # Default endpoint for OTLP HTTP receiver. (deprecated)
+        volumeMounts:
+        - name: tracesgateway-config-vol
+          mountPath: /conf
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          periodSeconds: 15
+          timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+          failureThreshold: 3
+          periodSeconds: 10
+          timeoutSeconds: 3
+        startupProbe:
+          httpGet:
+            path: /
+            port: 13133
+          failureThreshold: 60
+          periodSeconds: 5
+          timeoutSeconds: 3
       volumes:
         - configMap:
             name: RELEASE-NAME-sumologic-traces-gateway
           name: tracesgateway-config-vol
+

--- a/tests/helm/testdata/goldenfile/traces-gateway-deployment/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-gateway-deployment/custom.output.yaml
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: '%CONFIG_CHECKSUM%'
+        checksum/config: "%CONFIG_CHECKSUM%"
       labels:
         app: RELEASE-NAME-sumologic-traces-gateway
         component: RELEASE-NAME-sumologic-traces-gateway-component
@@ -37,90 +37,88 @@ spec:
       # the agent will have a chance to retry when collector is ready.
       restartPolicy: Always
       containers:
-      - name: otelcol
-        image: "my_repository:my_tag"
-        imagePullPolicy: IfNotPresent
-        args:
-          - "--config=/conf/traces.gateway.conf.yaml"
-        env:
-        - name: GOGC
-          value: "80"
-        - name: SUMO_ENDPOINT_DEFAULT_TRACES_SOURCE
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-traces
-        
-        - name: SUMO_ENDPOINT_DEFAULT_OTLP_METRICS_SOURCE
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-metrics-otlp
-        
-        
-        - name: NO_PROXY
-          value: kubernetes.default.svc
-        - name: MY_POD_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: MY_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        resources:
-          limits:
-            cpu: 1000m
-            memory: 2Gi
-          requests:
-            cpu: 50m
-            memory: 196Mi
-        ports:
-        - name: pprof
-          containerPort: 1777
-          protocol: TCP
-        - containerPort: 5778  # Default endpoint for Jaeger Sampling.
-        - containerPort: 6831  # Default endpoint for Jaeger Thrift Compact receiver.
-          protocol: UDP
-        - containerPort: 6832  # Default endpoint for Jaeger Thrift Binary receiver.
-          protocol: UDP
-        - containerPort: 8888  # Default endpoint for querying metrics.
-        - containerPort: 9411  # Default endpoint for Zipkin receiver.
-        - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
-        - containerPort: 14267 # Default endpoint for Jaeger TChannel receiver.
-        - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
-        - containerPort: 4317  # Default endpoint for OTLP receiver.
-        - containerPort: 4318  # Default endpoint for OTLP HTTP receiver.
-        - containerPort: 55680 # Old endpoint for OTLP gRPC receiver.
-        - containerPort: 55681 # Default endpoint for OTLP HTTP receiver. (deprecated)
-        volumeMounts:
-        - name: tracesgateway-config-vol
-          mountPath: /conf
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 3
-          periodSeconds: 15
-          timeoutSeconds: 10
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-          failureThreshold: 3
-          periodSeconds: 10
-          timeoutSeconds: 3
-        startupProbe:
-          httpGet:
-            path: /
-            port: 13133
-          failureThreshold: 60
-          periodSeconds: 5
-          timeoutSeconds: 3
+        - name: otelcol
+          image: "my_repository:my_tag"
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--config=/conf/traces.gateway.conf.yaml"
+          env:
+            - name: GOGC
+              value: "80"
+            - name: SUMO_ENDPOINT_DEFAULT_TRACES_SOURCE
+              valueFrom:
+                secretKeyRef:
+                  name: sumologic
+                  key: endpoint-traces
+
+            - name: SUMO_ENDPOINT_DEFAULT_OTLP_METRICS_SOURCE
+              valueFrom:
+                secretKeyRef:
+                  name: sumologic
+                  key: endpoint-metrics-otlp
+
+            - name: NO_PROXY
+              value: kubernetes.default.svc
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 2Gi
+            requests:
+              cpu: 50m
+              memory: 196Mi
+          ports:
+            - name: pprof
+              containerPort: 1777
+              protocol: TCP
+            - containerPort: 5778 # Default endpoint for Jaeger Sampling.
+            - containerPort: 6831 # Default endpoint for Jaeger Thrift Compact receiver.
+              protocol: UDP
+            - containerPort: 6832 # Default endpoint for Jaeger Thrift Binary receiver.
+              protocol: UDP
+            - containerPort: 8888 # Default endpoint for querying metrics.
+            - containerPort: 9411 # Default endpoint for Zipkin receiver.
+            - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
+            - containerPort: 14267 # Default endpoint for Jaeger TChannel receiver.
+            - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
+            - containerPort: 4317 # Default endpoint for OTLP receiver.
+            - containerPort: 4318 # Default endpoint for OTLP HTTP receiver.
+            - containerPort: 55680 # Old endpoint for OTLP gRPC receiver.
+            - containerPort: 55681 # Default endpoint for OTLP HTTP receiver. (deprecated)
+          volumeMounts:
+            - name: tracesgateway-config-vol
+              mountPath: /conf
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 3
+            periodSeconds: 15
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 3
+            periodSeconds: 10
+            timeoutSeconds: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: 13133
+            failureThreshold: 60
+            periodSeconds: 5
+            timeoutSeconds: 3
       volumes:
         - configMap:
             name: RELEASE-NAME-sumologic-traces-gateway
           name: tracesgateway-config-vol
-

--- a/tests/helm/testdata/goldenfile/traces-sampler-deployment/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-sampler-deployment/basic.output.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: "%CONFIG_CHECKSUM%"
+        checksum/config: '%CONFIG_CHECKSUM%'
       labels:
         app: RELEASE-NAME-sumologic-traces-sampler
         chart: "sumologic-%CURRENT_CHART_VERSION%"
@@ -31,68 +31,75 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       containers:
-        - name: otelcol
-          image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
-          imagePullPolicy: IfNotPresent
-          args:
-            - --config=/conf/traces.sampler.conf.yaml
-          env:
-            - name: GOGC
-              value: "80"
-            - name: SUMO_ENDPOINT_DEFAULT_OTLP_TRACES_SOURCE
-              valueFrom:
-                secretKeyRef:
-                  name: sumologic
-                  key: endpoint-traces-otlp
-
-            - name: NO_PROXY
-              value: kubernetes.default.svc
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP
-          resources:
-            limits:
-              cpu: 2000m
-              memory: 4Gi
-            requests:
-              cpu: 200m
-              memory: 384Mi
-          ports:
-            - name: pprof
-              containerPort: 1777
-              protocol: TCP
-            - containerPort: 5778 # Default endpoint for Jaeger Sampling.
-            - containerPort: 6831 # Default endpoint for Jaeger Thrift Compact receiver.
-              protocol: UDP
-            - containerPort: 6832 # Default endpoint for Jaeger Thrift Binary receiver.
-              protocol: UDP
-            - containerPort: 8888 # Default endpoint for querying metrics.
-            - containerPort: 9411 # Default endpoint for Zipkin receiver.
-            - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
-            - containerPort: 14267 # Default endpoint for Jaeger TChannel receiver.
-            - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
-            - containerPort: 4317 # Default endpoint for OTLP gRPC receiver.
-            - containerPort: 4318 # Default endpoint for OTLP HTTP receiver.
-            - containerPort: 55680 # Old endpoint for OTLP gRPC receiver.
-            - containerPort: 55681 # Default endpoint for OTLP HTTP receiver. (deprecated)
-          volumeMounts:
-            - name: otel-collector-config-vol
-              mountPath: /conf
-            - name: tmp
-              mountPath: /tmp
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
+      - name: otelcol
+        image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
+        imagePullPolicy: IfNotPresent
+        args:
+          - --config=/conf/traces.sampler.conf.yaml
+        env:
+        - name: GOGC
+          value: "80"
+        - name: SUMO_ENDPOINT_DEFAULT_OTLP_TRACES_SOURCE
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-traces-otlp
+        
+        
+        - name: NO_PROXY
+          value: kubernetes.default.svc
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 4Gi
+          requests:
+            cpu: 200m
+            memory: 384Mi
+        ports:
+        - name: pprof
+          containerPort: 1777
+          protocol: TCP
+        - containerPort: 5778  # Default endpoint for Jaeger Sampling.
+        - containerPort: 6831  # Default endpoint for Jaeger Thrift Compact receiver.
+          protocol: UDP
+        - containerPort: 6832  # Default endpoint for Jaeger Thrift Binary receiver.
+          protocol: UDP
+        - containerPort: 8888  # Default endpoint for querying metrics.
+        - containerPort: 9411  # Default endpoint for Zipkin receiver.
+        - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
+        - containerPort: 14267 # Default endpoint for Jaeger TChannel receiver.
+        - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
+        - containerPort: 4317  # Default endpoint for OTLP gRPC receiver.
+        - containerPort: 4318  # Default endpoint for OTLP HTTP receiver.
+        - containerPort: 55680 # Old endpoint for OTLP gRPC receiver.
+        - containerPort: 55681 # Default endpoint for OTLP HTTP receiver. (deprecated)
+        volumeMounts:
+        - name: otel-collector-config-vol
+          mountPath: /conf
+        - name: tmp
+          mountPath: /tmp
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
       volumes:
         - configMap:
             name: RELEASE-NAME-sumologic-traces-sampler
           name: otel-collector-config-vol
         - name: tmp
           emptyDir: {}
+

--- a/tests/helm/testdata/goldenfile/traces-sampler-deployment/basic.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-sampler-deployment/basic.output.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: '%CONFIG_CHECKSUM%'
+        checksum/config: "%CONFIG_CHECKSUM%"
       labels:
         app: RELEASE-NAME-sumologic-traces-sampler
         chart: "sumologic-%CURRENT_CHART_VERSION%"
@@ -31,75 +31,73 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       containers:
-      - name: otelcol
-        image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
-        imagePullPolicy: IfNotPresent
-        args:
-          - --config=/conf/traces.sampler.conf.yaml
-        env:
-        - name: GOGC
-          value: "80"
-        - name: SUMO_ENDPOINT_DEFAULT_OTLP_TRACES_SOURCE
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-traces-otlp
-        
-        
-        - name: NO_PROXY
-          value: kubernetes.default.svc
-        - name: MY_POD_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: MY_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        resources:
-          limits:
-            cpu: 2000m
-            memory: 4Gi
-          requests:
-            cpu: 200m
-            memory: 384Mi
-        ports:
-        - name: pprof
-          containerPort: 1777
-          protocol: TCP
-        - containerPort: 5778  # Default endpoint for Jaeger Sampling.
-        - containerPort: 6831  # Default endpoint for Jaeger Thrift Compact receiver.
-          protocol: UDP
-        - containerPort: 6832  # Default endpoint for Jaeger Thrift Binary receiver.
-          protocol: UDP
-        - containerPort: 8888  # Default endpoint for querying metrics.
-        - containerPort: 9411  # Default endpoint for Zipkin receiver.
-        - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
-        - containerPort: 14267 # Default endpoint for Jaeger TChannel receiver.
-        - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
-        - containerPort: 4317  # Default endpoint for OTLP gRPC receiver.
-        - containerPort: 4318  # Default endpoint for OTLP HTTP receiver.
-        - containerPort: 55680 # Old endpoint for OTLP gRPC receiver.
-        - containerPort: 55681 # Default endpoint for OTLP HTTP receiver. (deprecated)
-        volumeMounts:
-        - name: otel-collector-config-vol
-          mountPath: /conf
-        - name: tmp
-          mountPath: /tmp
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
+        - name: otelcol
+          image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config=/conf/traces.sampler.conf.yaml
+          env:
+            - name: GOGC
+              value: "80"
+            - name: SUMO_ENDPOINT_DEFAULT_OTLP_TRACES_SOURCE
+              valueFrom:
+                secretKeyRef:
+                  name: sumologic
+                  key: endpoint-traces-otlp
+
+            - name: NO_PROXY
+              value: kubernetes.default.svc
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 4Gi
+            requests:
+              cpu: 200m
+              memory: 384Mi
+          ports:
+            - name: pprof
+              containerPort: 1777
+              protocol: TCP
+            - containerPort: 5778 # Default endpoint for Jaeger Sampling.
+            - containerPort: 6831 # Default endpoint for Jaeger Thrift Compact receiver.
+              protocol: UDP
+            - containerPort: 6832 # Default endpoint for Jaeger Thrift Binary receiver.
+              protocol: UDP
+            - containerPort: 8888 # Default endpoint for querying metrics.
+            - containerPort: 9411 # Default endpoint for Zipkin receiver.
+            - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
+            - containerPort: 14267 # Default endpoint for Jaeger TChannel receiver.
+            - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
+            - containerPort: 4317 # Default endpoint for OTLP gRPC receiver.
+            - containerPort: 4318 # Default endpoint for OTLP HTTP receiver.
+            - containerPort: 55680 # Old endpoint for OTLP gRPC receiver.
+            - containerPort: 55681 # Default endpoint for OTLP HTTP receiver. (deprecated)
+          volumeMounts:
+            - name: otel-collector-config-vol
+              mountPath: /conf
+            - name: tmp
+              mountPath: /tmp
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
       volumes:
         - configMap:
             name: RELEASE-NAME-sumologic-traces-sampler
           name: otel-collector-config-vol
         - name: tmp
           emptyDir: {}
-

--- a/tests/helm/testdata/goldenfile/traces-sampler-deployment/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-sampler-deployment/custom.output.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: '%CONFIG_CHECKSUM%'
+        checksum/config: "%CONFIG_CHECKSUM%"
       labels:
         app: RELEASE-NAME-sumologic-traces-sampler
         chart: "sumologic-%CURRENT_CHART_VERSION%"
@@ -31,75 +31,73 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       containers:
-      - name: otelcol
-        image: "my_repository:my_tag"
-        imagePullPolicy: IfNotPresent
-        args:
-          - --config=/conf/traces.sampler.conf.yaml
-        env:
-        - name: GOGC
-          value: "80"
-        - name: SUMO_ENDPOINT_DEFAULT_TRACES_SOURCE
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-traces
-        
-        
-        - name: NO_PROXY
-          value: kubernetes.default.svc
-        - name: MY_POD_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: MY_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        resources:
-          limits:
-            cpu: 2000m
-            memory: 4Gi
-          requests:
-            cpu: 200m
-            memory: 384Mi
-        ports:
-        - name: pprof
-          containerPort: 1777
-          protocol: TCP
-        - containerPort: 5778  # Default endpoint for Jaeger Sampling.
-        - containerPort: 6831  # Default endpoint for Jaeger Thrift Compact receiver.
-          protocol: UDP
-        - containerPort: 6832  # Default endpoint for Jaeger Thrift Binary receiver.
-          protocol: UDP
-        - containerPort: 8888  # Default endpoint for querying metrics.
-        - containerPort: 9411  # Default endpoint for Zipkin receiver.
-        - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
-        - containerPort: 14267 # Default endpoint for Jaeger TChannel receiver.
-        - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
-        - containerPort: 4317  # Default endpoint for OTLP gRPC receiver.
-        - containerPort: 4318  # Default endpoint for OTLP HTTP receiver.
-        - containerPort: 55680 # Old endpoint for OTLP gRPC receiver.
-        - containerPort: 55681 # Default endpoint for OTLP HTTP receiver. (deprecated)
-        volumeMounts:
-        - name: otel-collector-config-vol
-          mountPath: /conf
-        - name: tmp
-          mountPath: /tmp
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
+        - name: otelcol
+          image: "my_repository:my_tag"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config=/conf/traces.sampler.conf.yaml
+          env:
+            - name: GOGC
+              value: "80"
+            - name: SUMO_ENDPOINT_DEFAULT_TRACES_SOURCE
+              valueFrom:
+                secretKeyRef:
+                  name: sumologic
+                  key: endpoint-traces
+
+            - name: NO_PROXY
+              value: kubernetes.default.svc
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 4Gi
+            requests:
+              cpu: 200m
+              memory: 384Mi
+          ports:
+            - name: pprof
+              containerPort: 1777
+              protocol: TCP
+            - containerPort: 5778 # Default endpoint for Jaeger Sampling.
+            - containerPort: 6831 # Default endpoint for Jaeger Thrift Compact receiver.
+              protocol: UDP
+            - containerPort: 6832 # Default endpoint for Jaeger Thrift Binary receiver.
+              protocol: UDP
+            - containerPort: 8888 # Default endpoint for querying metrics.
+            - containerPort: 9411 # Default endpoint for Zipkin receiver.
+            - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
+            - containerPort: 14267 # Default endpoint for Jaeger TChannel receiver.
+            - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
+            - containerPort: 4317 # Default endpoint for OTLP gRPC receiver.
+            - containerPort: 4318 # Default endpoint for OTLP HTTP receiver.
+            - containerPort: 55680 # Old endpoint for OTLP gRPC receiver.
+            - containerPort: 55681 # Default endpoint for OTLP HTTP receiver. (deprecated)
+          volumeMounts:
+            - name: otel-collector-config-vol
+              mountPath: /conf
+            - name: tmp
+              mountPath: /tmp
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
       volumes:
         - configMap:
             name: RELEASE-NAME-sumologic-traces-sampler
           name: otel-collector-config-vol
         - name: tmp
           emptyDir: {}
-

--- a/tests/helm/testdata/goldenfile/traces-sampler-deployment/custom.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-sampler-deployment/custom.output.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: "%CONFIG_CHECKSUM%"
+        checksum/config: '%CONFIG_CHECKSUM%'
       labels:
         app: RELEASE-NAME-sumologic-traces-sampler
         chart: "sumologic-%CURRENT_CHART_VERSION%"
@@ -31,68 +31,75 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       containers:
-        - name: otelcol
-          image: "my_repository:my_tag"
-          imagePullPolicy: IfNotPresent
-          args:
-            - --config=/conf/traces.sampler.conf.yaml
-          env:
-            - name: GOGC
-              value: "80"
-            - name: SUMO_ENDPOINT_DEFAULT_TRACES_SOURCE
-              valueFrom:
-                secretKeyRef:
-                  name: sumologic
-                  key: endpoint-traces
-
-            - name: NO_PROXY
-              value: kubernetes.default.svc
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP
-          resources:
-            limits:
-              cpu: 2000m
-              memory: 4Gi
-            requests:
-              cpu: 200m
-              memory: 384Mi
-          ports:
-            - name: pprof
-              containerPort: 1777
-              protocol: TCP
-            - containerPort: 5778 # Default endpoint for Jaeger Sampling.
-            - containerPort: 6831 # Default endpoint for Jaeger Thrift Compact receiver.
-              protocol: UDP
-            - containerPort: 6832 # Default endpoint for Jaeger Thrift Binary receiver.
-              protocol: UDP
-            - containerPort: 8888 # Default endpoint for querying metrics.
-            - containerPort: 9411 # Default endpoint for Zipkin receiver.
-            - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
-            - containerPort: 14267 # Default endpoint for Jaeger TChannel receiver.
-            - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
-            - containerPort: 4317 # Default endpoint for OTLP gRPC receiver.
-            - containerPort: 4318 # Default endpoint for OTLP HTTP receiver.
-            - containerPort: 55680 # Old endpoint for OTLP gRPC receiver.
-            - containerPort: 55681 # Default endpoint for OTLP HTTP receiver. (deprecated)
-          volumeMounts:
-            - name: otel-collector-config-vol
-              mountPath: /conf
-            - name: tmp
-              mountPath: /tmp
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
+      - name: otelcol
+        image: "my_repository:my_tag"
+        imagePullPolicy: IfNotPresent
+        args:
+          - --config=/conf/traces.sampler.conf.yaml
+        env:
+        - name: GOGC
+          value: "80"
+        - name: SUMO_ENDPOINT_DEFAULT_TRACES_SOURCE
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-traces
+        
+        
+        - name: NO_PROXY
+          value: kubernetes.default.svc
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 4Gi
+          requests:
+            cpu: 200m
+            memory: 384Mi
+        ports:
+        - name: pprof
+          containerPort: 1777
+          protocol: TCP
+        - containerPort: 5778  # Default endpoint for Jaeger Sampling.
+        - containerPort: 6831  # Default endpoint for Jaeger Thrift Compact receiver.
+          protocol: UDP
+        - containerPort: 6832  # Default endpoint for Jaeger Thrift Binary receiver.
+          protocol: UDP
+        - containerPort: 8888  # Default endpoint for querying metrics.
+        - containerPort: 9411  # Default endpoint for Zipkin receiver.
+        - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
+        - containerPort: 14267 # Default endpoint for Jaeger TChannel receiver.
+        - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
+        - containerPort: 4317  # Default endpoint for OTLP gRPC receiver.
+        - containerPort: 4318  # Default endpoint for OTLP HTTP receiver.
+        - containerPort: 55680 # Old endpoint for OTLP gRPC receiver.
+        - containerPort: 55681 # Default endpoint for OTLP HTTP receiver. (deprecated)
+        volumeMounts:
+        - name: otel-collector-config-vol
+          mountPath: /conf
+        - name: tmp
+          mountPath: /tmp
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
       volumes:
         - configMap:
             name: RELEASE-NAME-sumologic-traces-sampler
           name: otel-collector-config-vol
         - name: tmp
           emptyDir: {}
+

--- a/tests/helm/testdata/goldenfile/traces-sampler-deployment/persistence-enabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-sampler-deployment/persistence-enabled.output.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: "%CONFIG_CHECKSUM%"
+        checksum/config: '%CONFIG_CHECKSUM%'
       labels:
         app: RELEASE-NAME-sumologic-traces-sampler
         chart: "sumologic-%CURRENT_CHART_VERSION%"
@@ -31,67 +31,73 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       containers:
-        - name: otelcol
-          image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
-          imagePullPolicy: IfNotPresent
-          args:
-            - --config=/conf/traces.sampler.conf.yaml
-          env:
-            - name: GOGC
-              value: "80"
-            - name: SUMO_ENDPOINT_DEFAULT_OTLP_TRACES_SOURCE
-              valueFrom:
-                secretKeyRef:
-                  name: sumologic
-                  key: endpoint-traces-otlp
-
-            - name: NO_PROXY
-              value: kubernetes.default.svc
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP
-          resources:
-            limits:
-              cpu: 2000m
-              memory: 4Gi
-            requests:
-              cpu: 200m
-              memory: 384Mi
-          ports:
-            - name: pprof
-              containerPort: 1777
-              protocol: TCP
-            - containerPort: 5778 # Default endpoint for Jaeger Sampling.
-            - containerPort: 6831 # Default endpoint for Jaeger Thrift Compact receiver.
-              protocol: UDP
-            - containerPort: 6832 # Default endpoint for Jaeger Thrift Binary receiver.
-              protocol: UDP
-            - containerPort: 8888 # Default endpoint for querying metrics.
-            - containerPort: 9411 # Default endpoint for Zipkin receiver.
-            - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
-            - containerPort: 14267 # Default endpoint for Jaeger TChannel receiver.
-            - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
-            - containerPort: 4317 # Default endpoint for OTLP gRPC receiver.
-            - containerPort: 4318 # Default endpoint for OTLP HTTP receiver.
-            - containerPort: 55680 # Old endpoint for OTLP gRPC receiver.
-            - containerPort: 55681 # Default endpoint for OTLP HTTP receiver. (deprecated)
-          volumeMounts:
-            - name: otel-collector-config-vol
-              mountPath: /conf
-            - name: tmp
-              mountPath: /tmp
-            - name: file-storage
-              mountPath: /var/lib/storage/tracessampler
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 13133 # Health Check extension default port.
+      - name: otelcol
+        image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
+        imagePullPolicy: IfNotPresent
+        args:
+          - --config=/conf/traces.sampler.conf.yaml
+        env:
+        - name: GOGC
+          value: "80"
+        - name: SUMO_ENDPOINT_DEFAULT_OTLP_TRACES_SOURCE
+          valueFrom:
+            secretKeyRef:
+              name: sumologic
+              key: endpoint-traces-otlp
+        
+        
+        - name: NO_PROXY
+          value: kubernetes.default.svc
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 4Gi
+          requests:
+            cpu: 200m
+            memory: 384Mi
+        ports:
+        - name: pprof
+          containerPort: 1777
+          protocol: TCP
+        - containerPort: 5778  # Default endpoint for Jaeger Sampling.
+        - containerPort: 6831  # Default endpoint for Jaeger Thrift Compact receiver.
+          protocol: UDP
+        - containerPort: 6832  # Default endpoint for Jaeger Thrift Binary receiver.
+          protocol: UDP
+        - containerPort: 8888  # Default endpoint for querying metrics.
+        - containerPort: 9411  # Default endpoint for Zipkin receiver.
+        - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
+        - containerPort: 14267 # Default endpoint for Jaeger TChannel receiver.
+        - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
+        - containerPort: 4317  # Default endpoint for OTLP gRPC receiver.
+        - containerPort: 4318  # Default endpoint for OTLP HTTP receiver.
+        - containerPort: 55680 # Old endpoint for OTLP gRPC receiver.
+        - containerPort: 55681 # Default endpoint for OTLP HTTP receiver. (deprecated)
+        volumeMounts:
+        - name: otel-collector-config-vol
+          mountPath: /conf
+        - name: tmp
+          mountPath: /tmp
+        - name: file-storage
+          mountPath: /var/lib/storage/tracessampler
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 13133 # Health Check extension default port.
       volumes:
         - configMap:
             name: RELEASE-NAME-sumologic-traces-sampler
@@ -101,11 +107,12 @@ spec:
         - name: file-storage
           mountPath: /var/lib/storage/tracessampler
   volumeClaimTemplates:
-    - metadata:
-        name: file-storage
-      spec:
-        accessModes: [ReadWriteOnce]
-        storageClassName:
-        resources:
-          requests:
-            storage: 1Gi
+  - metadata:
+      name: file-storage
+    spec:
+      accessModes: [ReadWriteOnce]
+      storageClassName: 
+      resources:
+        requests:
+          storage: 1Gi
+

--- a/tests/helm/testdata/goldenfile/traces-sampler-deployment/persistence-enabled.output.yaml
+++ b/tests/helm/testdata/goldenfile/traces-sampler-deployment/persistence-enabled.output.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: '%CONFIG_CHECKSUM%'
+        checksum/config: "%CONFIG_CHECKSUM%"
       labels:
         app: RELEASE-NAME-sumologic-traces-sampler
         chart: "sumologic-%CURRENT_CHART_VERSION%"
@@ -31,73 +31,72 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       containers:
-      - name: otelcol
-        image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
-        imagePullPolicy: IfNotPresent
-        args:
-          - --config=/conf/traces.sampler.conf.yaml
-        env:
-        - name: GOGC
-          value: "80"
-        - name: SUMO_ENDPOINT_DEFAULT_OTLP_TRACES_SOURCE
-          valueFrom:
-            secretKeyRef:
-              name: sumologic
-              key: endpoint-traces-otlp
-        
-        
-        - name: NO_PROXY
-          value: kubernetes.default.svc
-        - name: MY_POD_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: MY_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        resources:
-          limits:
-            cpu: 2000m
-            memory: 4Gi
-          requests:
-            cpu: 200m
-            memory: 384Mi
-        ports:
-        - name: pprof
-          containerPort: 1777
-          protocol: TCP
-        - containerPort: 5778  # Default endpoint for Jaeger Sampling.
-        - containerPort: 6831  # Default endpoint for Jaeger Thrift Compact receiver.
-          protocol: UDP
-        - containerPort: 6832  # Default endpoint for Jaeger Thrift Binary receiver.
-          protocol: UDP
-        - containerPort: 8888  # Default endpoint for querying metrics.
-        - containerPort: 9411  # Default endpoint for Zipkin receiver.
-        - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
-        - containerPort: 14267 # Default endpoint for Jaeger TChannel receiver.
-        - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
-        - containerPort: 4317  # Default endpoint for OTLP gRPC receiver.
-        - containerPort: 4318  # Default endpoint for OTLP HTTP receiver.
-        - containerPort: 55680 # Old endpoint for OTLP gRPC receiver.
-        - containerPort: 55681 # Default endpoint for OTLP HTTP receiver. (deprecated)
-        volumeMounts:
-        - name: otel-collector-config-vol
-          mountPath: /conf
-        - name: tmp
-          mountPath: /tmp
-        - name: file-storage
-          mountPath: /var/lib/storage/tracessampler
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 13133 # Health Check extension default port.
+        - name: otelcol
+          image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.155.0-sumo-0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config=/conf/traces.sampler.conf.yaml
+          env:
+            - name: GOGC
+              value: "80"
+            - name: SUMO_ENDPOINT_DEFAULT_OTLP_TRACES_SOURCE
+              valueFrom:
+                secretKeyRef:
+                  name: sumologic
+                  key: endpoint-traces-otlp
+
+            - name: NO_PROXY
+              value: kubernetes.default.svc
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 4Gi
+            requests:
+              cpu: 200m
+              memory: 384Mi
+          ports:
+            - name: pprof
+              containerPort: 1777
+              protocol: TCP
+            - containerPort: 5778 # Default endpoint for Jaeger Sampling.
+            - containerPort: 6831 # Default endpoint for Jaeger Thrift Compact receiver.
+              protocol: UDP
+            - containerPort: 6832 # Default endpoint for Jaeger Thrift Binary receiver.
+              protocol: UDP
+            - containerPort: 8888 # Default endpoint for querying metrics.
+            - containerPort: 9411 # Default endpoint for Zipkin receiver.
+            - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
+            - containerPort: 14267 # Default endpoint for Jaeger TChannel receiver.
+            - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
+            - containerPort: 4317 # Default endpoint for OTLP gRPC receiver.
+            - containerPort: 4318 # Default endpoint for OTLP HTTP receiver.
+            - containerPort: 55680 # Old endpoint for OTLP gRPC receiver.
+            - containerPort: 55681 # Default endpoint for OTLP HTTP receiver. (deprecated)
+          volumeMounts:
+            - name: otel-collector-config-vol
+              mountPath: /conf
+            - name: tmp
+              mountPath: /tmp
+            - name: file-storage
+              mountPath: /var/lib/storage/tracessampler
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
       volumes:
         - configMap:
             name: RELEASE-NAME-sumologic-traces-sampler
@@ -107,12 +106,11 @@ spec:
         - name: file-storage
           mountPath: /var/lib/storage/tracessampler
   volumeClaimTemplates:
-  - metadata:
-      name: file-storage
-    spec:
-      accessModes: [ReadWriteOnce]
-      storageClassName: 
-      resources:
-        requests:
-          storage: 1Gi
-
+    - metadata:
+        name: file-storage
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName:
+        resources:
+          requests:
+            storage: 1Gi


### PR DESCRIPTION
Use collector_name field in sumologic extension to override name since default hostname has 2 cons
1. collector name more than 128 characters - This is already extended to 256 chars and fixed in backend. This is an enhancement in k8s side to make collector name more simpler. Instead of default hostname detected by sumo extension, override it with collector_name param by setting pod name from env variables.

2. collector name collision in multi cluster environment. Consider a user who has 30 different clusters where they use same release name and namespace for sumologic k8s. Now pod name generated by all such clusters will be of format 
`{pod-name}.{service-name}.{namespace}.svc.cluster.local`
This might collide, so better approach would be adding `podname+clusterName` which will always be unique.

Old collector name: `my-sumologic-sumologic-otelcol-events-0.my-sumologic-sumologic-otelcol-events-headless.sumologic3.svc.cluster.local`

new name: `my-sumologic-sumologic-otelcol-events-0-Kubernetes_cluster_sumo_extension17`


tested in local and ensured collector name is set properly:

<img width="1478" height="826" alt="Screenshot 2026-07-24 at 6 40 05 PM" src="https://github.com/user-attachments/assets/2f2d7bb1-1be8-423b-a5ff-a8625ca9d199" />



### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [x] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features
