### PR TITLE
fix: use max(3, input) for minReplicas when singleLayerPipeline is enabled

### DIFF
--- a/.changelog/4284.fixed.txt
+++ b/.changelog/4284.fixed.txt
@@ -1,0 +1,1 @@
+fix: use max(3, input) for minReplicas when singleLayerPipeline is enabled

--- a/deploy/helm/sumologic/templates/metrics/collector/otelcol/opentelemetrycollector.yaml
+++ b/deploy/helm/sumologic/templates/metrics/collector/otelcol/opentelemetrycollector.yaml
@@ -107,7 +107,7 @@ spec:
   autoscaler:
     maxReplicas: {{ .Values.sumologic.metrics.collector.otelcol.autoscaling.maxReplicas }}
 {{- if eq (include "metrics.collector.singleLayerPipeline.enabled" .) "true" }}
-    minReplicas: 3
+    minReplicas: {{ max 3 (int .Values.sumologic.metrics.collector.otelcol.autoscaling.minReplicas) }}
 {{- else }}
     minReplicas: {{ .Values.sumologic.metrics.collector.otelcol.autoscaling.minReplicas }}
 {{- end }}

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/single_layer_pipeline.input.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/single_layer_pipeline.input.yaml
@@ -5,3 +5,5 @@ sumologic:
       otelcol:
         singleLayerPipeline:
           enabled: true
+        autoscaling:
+          minReplicas: 5

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/single_layer_pipeline.output.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/single_layer_pipeline.output.yaml
@@ -38,7 +38,7 @@ spec:
     kubernetes.io/os: linux
   autoscaler:
     maxReplicas: 10
-    minReplicas: 3
+    minReplicas: 5
     targetCPUUtilization: 70
     targetMemoryUtilization: 70
   env:

--- a/tests/helm/testdata/goldenfile/metrics_collector_otc/single_layer_pipeline_extras.input.yaml
+++ b/tests/helm/testdata/goldenfile/metrics_collector_otc/single_layer_pipeline_extras.input.yaml
@@ -5,6 +5,8 @@ sumologic:
       otelcol:
         singleLayerPipeline:
           enabled: true
+        autoscaling:
+          minReplicas: 1
         extraEnvVars:
           - name: MY_CUSTOM_KEY
             value: secret123


### PR DESCRIPTION
Previously minReplicas was hardcoded to 3 when singleLayerPipeline was enabled, ignoring any user-provided value higher than 3. Now it respects the user's input when it exceeds the minimum floor of 3.

The floor is kept to 3 so even if the user configures 1 as minReplica when singleLayerPIpeline is enabled, it will spin up 3 replicas. In singleLayerPipeline, metadata layer is removed which used to act as HA layer, now that responsibility belongs to collector level itself. 

<!---
Describe your PR here
-->

### Checklist

<!---
Remove items which don't apply to your PR.

You can add a changelog entry by running `make add-changelog-entry`
See [/docs/dev.md] for more details
-->

- [ ] Changelog updated or skip changelog label added
- [ ] Documentation updated
- [ ] Template tests added for new features
- [ ] Integration tests added or modified for major features
