### PR TITLE
ci: sync latest tag for images using semver-only configs

### DIFF
--- a/ci/skopeo/busybox.yaml
+++ b/ci/skopeo/busybox.yaml
@@ -1,3 +1,6 @@
 docker.io:
+  images:
+    busybox:
+      - latest
   images-by-semver:
     busybox: ">= 1.36.0"

--- a/ci/skopeo/kube-rbac-proxy.yaml
+++ b/ci/skopeo/kube-rbac-proxy.yaml
@@ -1,3 +1,6 @@
 quay.io:
+  images:
+    brancz/kube-rbac-proxy:
+      - latest
   images-by-semver:
     brancz/kube-rbac-proxy: ">= 0.5.0"

--- a/ci/skopeo/metrics-server.yaml
+++ b/ci/skopeo/metrics-server.yaml
@@ -1,3 +1,6 @@
 registry.k8s.io:
+  images:
+    metrics-server/metrics-server:
+      - latest
   images-by-semver:
     metrics-server/metrics-server: ">= 0.8.0"

--- a/ci/skopeo/node-exporter.yaml
+++ b/ci/skopeo/node-exporter.yaml
@@ -1,3 +1,6 @@
 quay.io:
+  images:
+    prometheus/node-exporter:
+      - latest
   images-by-semver:
     prometheus/node-exporter: ">= 0.18.0"

--- a/ci/skopeo/prometheus.yaml
+++ b/ci/skopeo/prometheus.yaml
@@ -1,3 +1,6 @@
 quay.io:
+  images:
+    prometheus/prometheus:
+      - latest
   images-by-semver:
     prometheus/prometheus: ">= 2.8.0"

--- a/ci/skopeo/telegraf-operator.yaml
+++ b/ci/skopeo/telegraf-operator.yaml
@@ -1,3 +1,6 @@
 quay.io:
+  images:
+    influxdb/telegraf-operator:
+      - latest
   images-by-semver:
     influxdb/telegraf-operator: ">= 1.3.0"

--- a/ci/skopeo/telegraf.yaml
+++ b/ci/skopeo/telegraf.yaml
@@ -1,3 +1,6 @@
 docker.io:
+  images:
+    telegraf:
+      - latest
   images-by-semver:
     telegraf: ">= 0.13.1"

--- a/ci/skopeo/thanos.yaml
+++ b/ci/skopeo/thanos.yaml
@@ -1,3 +1,6 @@
 quay.io:
+  images:
+    thanos/thanos:
+      - latest
   images-by-semver:
     thanos/thanos: ">= 0.11.0"


### PR DESCRIPTION
## Summary

- Add explicit `latest` tag syncing to all skopeo configs that previously only used `images-by-semver`

## Problem

The `images-by-semver` filter in skopeo YAML configs only matches tags that are valid semver strings (e.g., `1.36.0`, `0.11.0`). The `latest` tag is not a semver string, so it was never picked up by the sync workflow. This caused the `latest` tag in our ECR/DockerHub mirrors to become stale (e.g., `gallery.ecr.aws/sumologic/busybox:latest` was 2 years old).

## Fix

Added an `images` section with `- latest` alongside the existing `images-by-semver` filter for all 8 affected configs:
- `busybox.yaml`
- `kube-rbac-proxy.yaml`
- `metrics-server.yaml`
- `node-exporter.yaml`
- `prometheus.yaml`
- `telegraf-operator.yaml`
- `telegraf.yaml`
- `thanos.yaml`

Images that already used `images: []` (which syncs all tags including `latest`) were not affected:
- autoinstrumentation-*, falco-*, kube-state-metrics, nginx-unprivileged, opentelemetry-operator, prometheus-config-reloader, prometheus-operator

## Note

If a source registry does not publish a `latest` tag for a given image, skopeo will log a warning but continue due to the `--keep-going` flag in `ci/sync-repository.sh`.

## Test plan

- [ ] Manually trigger the sync workflow for one image (e.g., busybox) and verify `latest` is synced to ECR/DockerHub
- [ ] Verify the `latest` tag on `gallery.ecr.aws/sumologic/busybox` is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)