### PR TITLE
ci: support patch release branches in PR checks workflow

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -6,6 +6,7 @@ on:
       - main
       - "release-v[0-9]+"
       - "release-v[0-9]+.[0-9]+"
+      - "release-v[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   docs-changed:


### PR DESCRIPTION
## Summary
- Add `release-v[0-9]+.[0-9]+.[0-9]+` branch pattern to the `pull_requests.yml` workflow trigger so CI runs on PRs targeting patch release branches (e.g., `release-v4.21.1`).

## Test plan
- [ ] Verify CI triggers on PRs targeting `release-v4.21.1`