### PR TITLE
feat: use properties.content_type for source type detection

### DIFF
--- a/.changelog/4309.added.txt
+++ b/.changelog/4309.added.txt
@@ -1,0 +1,1 @@
+feat: use properties.content_type for OTLP source detection instead of key name suffix, and gate env var injection on create flag

--- a/deploy/helm/sumologic/conf/setup/sources.tf.json
+++ b/deploy/helm/sumologic/conf/setup/sources.tf.json
@@ -13,7 +13,8 @@
       {{- if and (hasKey $ctx.sumologic $type) (hasKey (index $ctx.sumologic $type) "sourceType") -}}
         {{- $sourceType = (index $ctx.sumologic $type "sourceType") -}}
       {{- end -}}
-      {{- $isOtlpSource := hasSuffix "-otlp" $key -}}
+      {{- $sourceContentType := (($source).properties).content_type | default "" -}}
+      {{- $isOtlpSource := eq $sourceContentType "Otlp" -}}
       {{- $matchesSourceType := or (and $isOtlpSource (eq $sourceType "otlp")) (and (not $isOtlpSource) (eq $sourceType "http")) -}}
       {{- if and (eq (include "terraform.sources.to_create" (dict "Context" $ctx "Type" $type "Name" $key)) "true") $matchesSourceType }}
         {{- $resourceName := (include "terraform.sources.name" (dict "Name" $key "Type" $type)) -}}

--- a/deploy/helm/sumologic/templates/_helpers/_common.tpl
+++ b/deploy/helm/sumologic/templates/_helpers/_common.tpl
@@ -397,12 +397,14 @@ Example:
 {{- $ctx := .Context -}}
 {{- $type := .Type -}}
 {{- range $name, $source := (index .Context.sumologic.collector.sources $type) -}}
+{{- if eq (include "terraform.sources.to_create" (dict "Context" $ctx "Type" $type "Name" $name)) "true" -}}
 {{- $signalTypeConfig := index $ctx.sumologic $type -}}
 {{- $signalSourceType := $signalTypeConfig.sourceType | default "otlp" -}}
 {{- $sourceContentType := (($source).properties).content_type | default "" -}}
 {{- $isOtlpSource := eq $sourceContentType "Otlp" -}}
 {{- if or (and $isOtlpSource (eq $signalSourceType "otlp")) (and (not $isOtlpSource) (eq $signalSourceType "http")) -}}
 {{- include "kubernetes.sources.env" (dict "Context" $ctx "Type" $type  "Name" $name ) -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc_statefulset/create_false_source.input.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc_statefulset/create_false_source.input.yaml
@@ -1,0 +1,17 @@
+sumologic:
+  useExporterBatching: true
+  metrics:
+    sourceType: otlp
+  collector:
+    sources:
+      metrics:
+        default-otlp:
+          name: metrics-otlp
+          config-name: endpoint-metrics-otlp
+          properties:
+            content_type: Otlp
+        disabled-source:
+          name: disabled-metrics
+          create: false
+          properties:
+            content_type: Otlp

--- a/tests/helm/testdata/goldenfile/metadata_metrics_otc_statefulset/create_false_source.output.yaml
+++ b/tests/helm/testdata/goldenfile/metadata_metrics_otc_statefulset/create_false_source.output.yaml
@@ -1,0 +1,145 @@
+---
+# Source: sumologic/templates/metrics/otelcol/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: RELEASE-NAME-sumologic-otelcol-metrics
+  namespace: sumologic
+  labels:
+    app: RELEASE-NAME-sumologic-otelcol-metrics
+    chart: "sumologic-%CURRENT_CHART_VERSION%"
+    release: "RELEASE-NAME"
+    heritage: "Helm"
+spec:
+  selector:
+    matchLabels:
+      app: RELEASE-NAME-sumologic-otelcol-metrics
+  serviceName: RELEASE-NAME-sumologic-otelcol-metrics-headless
+  podManagementPolicy: "Parallel"
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Retain
+    whenScaled: Retain
+  template:
+    metadata:
+      annotations:
+        checksum/config: "%CONFIG_CHECKSUM%"
+      labels:
+        app: RELEASE-NAME-sumologic-otelcol-metrics
+        chart: "sumologic-%CURRENT_CHART_VERSION%"
+        release: "RELEASE-NAME"
+        heritage: "Helm"
+    spec:
+      serviceAccountName: RELEASE-NAME-sumologic
+      nodeSelector:
+        kubernetes.io/os: linux
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - RELEASE-NAME-sumologic-otelcol-logs
+                        - RELEASE-NAME-sumologic-otelcol-metrics
+                        - RELEASE-NAME-sumologic-otelcol-events
+                        - RELEASE-NAME-sumologic-otelcol-instrumentation
+                    - key: app
+                      operator: In
+                      values:
+                        - prometheus-operator-prometheus
+                topologyKey: "kubernetes.io/hostname"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: RELEASE-NAME-sumologic-otelcol-metrics
+        - name: tmp
+          emptyDir: {}
+      securityContext:
+        fsGroup: 999
+      containers:
+        - name: otelcol
+          image: "public.ecr.aws/sumologic/sumologic-otel-collector:0.157.0-sumo-0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config=/etc/otel/config.yaml
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+            requests:
+              cpu: 500m
+              memory: 768Mi
+          ports:
+            - name: otlphttp
+              containerPort: 4318
+              protocol: TCP
+            - name: prom-write
+              containerPort: 9888
+              protocol: TCP
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+            - name: pprof
+              containerPort: 1777
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 3
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+          startupProbe:
+            httpGet:
+              path: /
+              port: 13133 # Health Check extension default port.
+            failureThreshold: 60
+            periodSeconds: 3
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/otel/config.yaml
+              subPath: config.yaml
+            - name: tmp
+              mountPath: /tmp
+            - name: file-storage
+              mountPath: /var/lib/storage/otc
+          env:
+            - name: SUMO_ENDPOINT_DEFAULT_OTLP_METRICS_SOURCE
+              valueFrom:
+                secretKeyRef:
+                  name: sumologic
+                  key: endpoint-metrics-otlp
+
+            - name: NO_PROXY
+              value: kubernetes.default.svc
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+  volumeClaimTemplates:
+    - metadata:
+        name: file-storage
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName:
+        resources:
+          requests:
+            storage: 10Gi

--- a/tests/helm/testdata/goldenfile/terraform/always_create_sources.input.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/always_create_sources.input.yaml
@@ -1,0 +1,23 @@
+sumologic:
+  useExporterBatching: true
+  metrics:
+    sourceType: otlp
+  collector:
+    sources:
+      metrics:
+        default-otlp:
+          name: metrics-otlp
+          config-name: endpoint-metrics-otlp
+          properties:
+            content_type: Otlp
+        custom-http-source:
+          name: custom-http-metrics
+        custom-otlp-via-property:
+          name: custom-otlp-metrics
+          properties:
+            content_type: Otlp
+        disabled-otlp-source:
+          name: disabled-otlp-metrics
+          create: false
+          properties:
+            content_type: Otlp

--- a/tests/helm/testdata/goldenfile/terraform/always_create_sources.output.yaml
+++ b/tests/helm/testdata/goldenfile/terraform/always_create_sources.output.yaml
@@ -1,0 +1,944 @@
+---
+# Source: sumologic/templates/setup/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: RELEASE-NAME-sumologic-setup
+  namespace: sumologic
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "2"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  labels:
+    app: RELEASE-NAME-sumologic
+    chart: "sumologic-%CURRENT_CHART_VERSION%"
+    release: "RELEASE-NAME"
+    heritage: "Helm"
+data:
+  custom.sh: |
+    #!/bin/bash
+    #
+    # This script copies files from /customer-scripts to /scripts/<dirname> basing on the filename
+    #
+    # Example file structure:
+    #
+    # /customer-scripts
+    # ├── dir1_main.tf
+    # ├── dir1_setup.sh
+    # ├── dir2_list.txt
+    # └── dir2_setup.sh
+    #
+    # Expected structure:
+    #
+    # /scripts
+    # ├── dir1
+    # │   ├── main.tf
+    # │   └── setup.sh
+    # └── dir2
+    #     ├── list.txt
+    #     └── setup.sh
+    #
+    # shellcheck disable=SC2010
+    # extract target directory names from the file names using _ as separator
+
+    set -euo pipefail
+
+    err_report() {
+        echo "Custom script error on line $1"
+        exit 1
+    }
+    trap 'err_report $LINENO' ERR
+
+    declare -a dirs
+    ls -1 /customer-scripts 2>/dev/null | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq | read -ar dirs || true
+    for dir in "${dirs[@]}"; do
+      # Skip 'terraform' directory as it's handled earlier in setup.sh
+      # (pre-init.sh and terraformrc are processed before terraform init)
+      if [[ "${dir}" == "terraform" ]]; then
+        echo "Skipping 'terraform' directory (already processed by setup.sh)"
+        continue
+      fi
+
+      target="/scripts/${dir}"
+      mkdir "${target}"
+      # Get files for given directory and take only filename part (after first _)
+      declare -a files
+      ls -1 /customer-scripts 2>/dev/null | grep _ | grep -oE '^.*?_' | sed 's/_//g' | sort | uniq | read -ar files || true
+      for file in "${files[@]}"; do
+        cp "/customer-scripts/${dir}_${file}" "${target}/${file}"
+      done
+
+      if [[ ! -f "${target}/setup.sh" ]]; then
+        echo "You're missing setup.sh script in custom scripts directory: '${dir}'"
+        continue
+      fi
+
+      cd "${target}" && bash setup.sh
+    done
+  dashboards.sh: |
+    #!/bin/bash
+
+    set -euo pipefail
+
+    SUMOLOGIC_ACCESSID=${SUMOLOGIC_ACCESSID:=""}
+    readonly SUMOLOGIC_ACCESSID
+    SUMOLOGIC_ACCESSKEY=${SUMOLOGIC_ACCESSKEY:=""}
+    readonly SUMOLOGIC_ACCESSKEY
+    SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL:=""}
+    readonly SUMOLOGIC_BASE_URL
+
+    INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
+    K8S_FOLDER_NAME="Kubernetes"
+    K8S_APP_UUID="162ceac7-166a-4475-8427-65e170ae9837"
+
+    function load_dashboards_folder_id() {
+      local ADMIN_FOLDER_JOB_ID
+      ADMIN_FOLDER_JOB_ID="$(curl -XGET -s \
+              -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+              -H "isAdminMode: true" \
+              "${SUMOLOGIC_BASE_URL}"v2/content/folders/adminRecommended | jq '.id' | tr -d '"' )"
+      readonly ADMIN_FOLDER_JOB_ID
+
+      local ADMIN_FOLDER_JOB_STATUS
+      ADMIN_FOLDER_JOB_STATUS="InProgress"
+      while [[ "${ADMIN_FOLDER_JOB_STATUS}" = "InProgress" ]]; do
+        ADMIN_FOLDER_JOB_STATUS="$(curl -XGET -s \
+              -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+              "${SUMOLOGIC_BASE_URL}"v2/content/folders/adminRecommended/"${ADMIN_FOLDER_JOB_ID}"/status | jq '.status' | tr -d '"' )"
+
+        sleep 1
+      done
+
+      if [[ "${ADMIN_FOLDER_JOB_STATUS}" != "Success" ]]; then
+        echo "Could not fetch data from the \"Admin Recommended\" content folder. The K8s Dashboards won't be installed."
+        echo "You can still install them manually:"
+        echo "https://www.sumologic.com/help/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
+        exit 1
+      fi
+
+      local ADMIN_FOLDER
+      ADMIN_FOLDER="$(curl -XGET -s \
+              -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+              -H "isAdminMode: true" \
+              "${SUMOLOGIC_BASE_URL}"v2/content/folders/adminRecommended/"${ADMIN_FOLDER_JOB_ID}"/result )"
+      readonly ADMIN_FOLDER
+
+      local ADMIN_FOLDER_CHILDREN
+      ADMIN_FOLDER_CHILDREN="$( echo "${ADMIN_FOLDER}" | jq '.children[]')"
+      readonly ADMIN_FOLDER_CHILDREN
+
+      local ADMIN_FOLDER_ID
+      ADMIN_FOLDER_ID="$( echo "${ADMIN_FOLDER}" | jq '.id' | tr -d '"')"
+      readonly ADMIN_FOLDER_ID
+
+      INTEGRATIONS_FOLDER_ID="$( echo "${ADMIN_FOLDER_CHILDREN}" | \
+                jq -r "select(.name == \"${INTEGRATIONS_FOLDER_NAME}\") | .id" )"
+
+      if [[ -z "${INTEGRATIONS_FOLDER_ID}" ]]; then
+        INTEGRATIONS_FOLDER_ID="$(curl -XPOST -s \
+                -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+                -H "isAdminMode: true" \
+                -H "Content-Type: application/json" \
+                -d "{\"name\":\"${INTEGRATIONS_FOLDER_NAME}\",\"parentId\":\"${ADMIN_FOLDER_ID}\",\"description\":\"Content provided by the Sumo Logic integrations.\"}" \
+                "${SUMOLOGIC_BASE_URL}"v2/content/folders | \
+                jq -r " .id" )"
+      fi
+
+      local INTEGRATIONS_FOLDER_CHILDREN
+      INTEGRATIONS_FOLDER_CHILDREN="$(curl -XGET -s \
+                -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+                -H "isAdminMode: true" \
+                "${SUMOLOGIC_BASE_URL}"v2/content/folders/"${INTEGRATIONS_FOLDER_ID}" | \
+                jq '.children[]')"
+      readonly INTEGRATIONS_FOLDER_CHILDREN
+
+      K8S_FOLDER_ID="$( echo "${INTEGRATIONS_FOLDER_CHILDREN}" | \
+                jq -r "select(.name == \"${K8S_FOLDER_NAME}\") | .id" )"
+    }
+
+    load_dashboards_folder_id
+
+    if [[ -z "${K8S_FOLDER_ID}" ]]; then
+      APP_INSTALL_JOB_RESPONSE="$(curl -XPOST -s \
+             -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+             -H "isAdminMode: true" \
+             -H "Content-Type: application/json" \
+             -d "{\"name\":\"${K8S_FOLDER_NAME}\",\"destinationFolderId\":\"${INTEGRATIONS_FOLDER_ID}\",\"description\":\"Kubernetes dashboards provided by Sumo Logic.\"}" \
+             "${SUMOLOGIC_BASE_URL}"v1/apps/"${K8S_APP_UUID}"/install )"
+      readonly APP_INSTALL_JOB_RESPONSE
+
+      APP_INSTALL_JOB_ID="$(echo "${APP_INSTALL_JOB_RESPONSE}" | jq '.id' | tr -d '"' )"
+      readonly APP_INSTALL_JOB_ID
+
+      APP_INSTALL_JOB_STATUS="InProgress"
+      while [[ "${APP_INSTALL_JOB_STATUS}" = "InProgress" ]]; do
+        APP_INSTALL_JOB_STATUS="$(curl -XGET -s \
+              -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+              "${SUMOLOGIC_BASE_URL}"v1/apps/install/"${APP_INSTALL_JOB_ID}"/status | jq '.status' | tr -d '"' )"
+
+        sleep 1
+      done
+
+      if [[ "${APP_INSTALL_JOB_STATUS}" != "Success" ]]; then
+        ERROR_MSG="$(curl -XGET -s \
+              -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+              "${SUMOLOGIC_BASE_URL}"v1/apps/install/"${APP_INSTALL_JOB_ID}"/status )"
+        echo "${ERROR_MSG}"
+
+        echo "Installation of the K8s Dashboards failed."
+        echo "You can still install them manually:"
+        echo "https://www.sumologic.com/help/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
+        exit 2
+      else
+        load_dashboards_folder_id
+
+        ORG_ID="$(curl -XGET -s \
+                -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+                "${SUMOLOGIC_BASE_URL}"v1/account/contract | jq '.orgId' | tr -d '"' )"
+        readonly ORG_ID
+
+        PERMS_ERRORS=$( curl -XPUT -s \
+          -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+          -H "isAdminMode: true" \
+          -H "Content-Type: application/json" \
+          -d "{\"contentPermissionAssignments\": [{\"permissionName\": \"View\",\"sourceType\": \"org\",\"sourceId\": \"${ORG_ID}\",\"contentId\": \"${K8S_FOLDER_ID}\"}],\"notifyRecipients\":false,\"notificationMessage\":\"\"}" \
+          "${SUMOLOGIC_BASE_URL}"v2/content/"${K8S_FOLDER_ID}"/permissions/add | jq '.errors' )
+        readonly PERMS_ERRORS
+
+        if [[ "${PERMS_ERRORS}" != "null" ]]; then
+          echo "Setting permissions for the installed content failed."
+          echo "${PERMS_ERRORS}"
+        fi
+
+        echo "Installation of the K8s Dashboards succeeded."
+      fi
+    else
+      echo "The K8s Dashboards have been already installed."
+      echo "You can (re)install them manually with:"
+      echo "https://www.sumologic.com/help/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
+    fi
+  fields.tf: |
+    resource "sumologic_field" "collection_field" {
+      for_each = var.create_fields ? toset(var.fields) : toset([])
+
+      lifecycle {
+        # ignore changes for name and type, as older installations have been case sensitive
+        # see: https://github.com/SumoLogic/sumologic-kubernetes-collection/issues/2865
+        ignore_changes = [field_name, data_type]
+      }
+
+      field_name = each.key
+      data_type  = "String"
+      state      = "Enabled"
+    }
+  main.tf: |
+    terraform {
+      required_providers {
+        sumologic = {
+          source  = "sumologic/sumologic"
+          version = ">= 3.0.0, < 3.1.5"
+        }
+        kubernetes = {
+          source  = "hashicorp/kubernetes"
+          version = "~> 2.38.0"
+        }
+      }
+    }
+  monitors.sh: |
+    #!/bin/bash
+
+    SUMOLOGIC_ACCESSID=${SUMOLOGIC_ACCESSID:=""}
+    readonly SUMOLOGIC_ACCESSID
+    SUMOLOGIC_ACCESSKEY=${SUMOLOGIC_ACCESSKEY:=""}
+    readonly SUMOLOGIC_ACCESSKEY
+    SUMOLOGIC_BASE_URL=${SUMOLOGIC_BASE_URL:=""}
+    readonly SUMOLOGIC_BASE_URL
+
+    INTEGRATIONS_FOLDER_NAME="Sumo Logic Integrations"
+    MONITORS_FOLDER_NAME="Kubernetes"
+
+    if [[ "${SUMOLOGIC_MONITORS_STATUS:?}" = "enabled" ]]; then
+      MONITORS_DISABLED="false"
+    else
+      MONITORS_DISABLED="true"
+    fi
+
+    MONITORS_CURL_RESPONSE=$(curl -XGET -s \
+            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/root)
+    MONITORS_ROOT_ID="$(echo "${MONITORS_CURL_RESPONSE}" | jq -r '.id' )"
+    readonly MONITORS_ROOT_ID
+
+    # verify if the integrations folder already exists
+    INTEGRATIONS_CURL_RESPONSE=$(curl -XGET -s -G \
+            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
+            --data-urlencode "query=type:folder ${INTEGRATIONS_FOLDER_NAME}")
+    INTEGRATIONS_RESPONSE="$(echo "${INTEGRATIONS_CURL_RESPONSE}" | jq '.[]' )"
+    readonly INTEGRATIONS_RESPONSE
+
+    INTEGRATIONS_FOLDER_ID="$( echo "${INTEGRATIONS_RESPONSE}" | \
+            jq -r "select(.item.name == \"${INTEGRATIONS_FOLDER_NAME}\") | select(.item.parentId == \"${MONITORS_ROOT_ID}\") | .item.id" )"
+
+    # and create it if necessary
+    if [[ -z "${INTEGRATIONS_FOLDER_ID}" ]]; then
+      INTEGRATIONS_FOLDER_CURL_RESPONSE=$(curl -XPOST -s \
+                  -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+                  -H "Content-Type: application/json" \
+                  -d "{\"name\":\"${INTEGRATIONS_FOLDER_NAME}\",\"type\":\"MonitorsLibraryFolder\",\"description\":\"Monitors provided by the Sumo Logic integrations.\"}" \
+                  "${SUMOLOGIC_BASE_URL}"v1/monitors?parentId="${MONITORS_ROOT_ID}")
+      INTEGRATIONS_FOLDER_ID="$(echo "${INTEGRATIONS_FOLDER_CURL_RESPONSE}" | jq -r " .id" )"
+    fi
+
+    # verify if the k8s monitors folder already exists
+    MONITORS_CURL_RESPONSE="$(curl -XGET -s -G \
+            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+            "${SUMOLOGIC_BASE_URL}"v1/monitors/search \
+            --data-urlencode "query=type:folder ${MONITORS_FOLDER_NAME}")"
+    MONITORS_RESPONSE="$(echo "${MONITORS_CURL_RESPONSE}" | jq '.[]' )"
+    readonly MONITORS_RESPONSE
+
+    MONITORS_FOLDER_ID="$( echo "${MONITORS_RESPONSE}" | \
+            jq -r "select(.item.name == \"${MONITORS_FOLDER_NAME}\") | select(.item.parentId == \"${INTEGRATIONS_FOLDER_ID}\") | .item.id" )"
+    readonly MONITORS_FOLDER_ID
+
+    if [[ -z "${MONITORS_FOLDER_ID}" ]]; then
+      # go to monitors directory
+      cd /monitors || exit 2
+
+      # Fall back to init -upgrade to prevent:
+      # Error: Inconsistent dependency lock file
+      terraform init -input=false || terraform init -input=false -upgrade
+
+      # extract environment from SUMOLOGIC_BASE_URL
+      # see: https://www.sumologic.com/help/docs/api/getting-started/#sumo-logic-endpoints-by-deployment-and-firewall-security
+      SUMOLOGIC_ENV=$( echo "${SUMOLOGIC_BASE_URL}" | sed -E 's/https:\/\/.*(au|ca|de|eu|fed|in|jp|kr|ch|esc|us2)\.sumologic\.com.*/\1/' )
+      if [[ "${SUMOLOGIC_BASE_URL}" == "${SUMOLOGIC_ENV}" ]] ; then
+        SUMOLOGIC_ENV="us1"
+      fi
+
+      TERRAFORM_ARGS=(
+        -auto-approve
+        -var="access_id=${SUMOLOGIC_ACCESSID}"
+        -var="access_key=${SUMOLOGIC_ACCESSKEY}"
+        -var="environment=${SUMOLOGIC_ENV}"
+        -var="folder=${MONITORS_FOLDER_NAME}"
+        -var="folder_parent_id=${INTEGRATIONS_FOLDER_ID}"
+        -var="monitors_disabled=${MONITORS_DISABLED}"
+      )
+
+      if [[ -z ${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS+x} ]]; then
+        NOTIFICATIONS_CONTENT="subject=\"Monitor Alert: {{TriggerType}} on {{Name}}\",message_body=\"Triggered {{TriggerType}} alert on {{Name}}: {{QueryURL}}\""
+        NOTIFICATIONS_SETTINGS="recipients=${SUMOLOGIC_MONITORS_NOTIFICATIONS_RECIPIENTS},connection_type=\"Email\",time_zone=\"UTC\""
+        TERRAFORM_ARGS+=(
+          -var="email_notifications_critical=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Critical\", \"ResolvedCritical\"]}]"
+          -var="email_notifications_warning=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"Warning\", \"ResolvedWarning\"]}]"
+          -var="email_notifications_missingdata=[{${NOTIFICATIONS_SETTINGS},${NOTIFICATIONS_CONTENT},run_for_trigger_types=[\"MissingData\", \"ResolvedMissingData\"]}]"
+        )
+      fi
+
+      TF_LOG_PROVIDER=DEBUG terraform apply "${TERRAFORM_ARGS[@]}" \
+          || { echo "Error during applying Terraform monitors."; exit 1; }
+    else
+      echo "The monitors have been already installed in ${MONITORS_FOLDER_NAME}."
+      echo "You can (re)install them manually with:"
+      echo "https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor/tree/main/monitor_packages/kubernetes"
+    fi
+  resources.tf: |
+    resource "sumologic_collector" "collector" {
+      count       = var.use_extension ? 0 : 1
+      name        = var.collector_name
+      description = format("Sumo Logic Kubernetes Collection\nversion: %s", var.chart_version)
+      fields      = var.collector_fields
+    }
+
+    resource "sumologic_token" "collection_token" {
+      count       = (var.use_extension && !var.provided_installation_token) ? 1 : 0
+      name        = format("kubernetes-collection-%s", var.collector_name)
+      description = format("Installation token for Kubernetes Collection\nversion: %s", var.chart_version)
+      type        = "CollectorRegistration"
+      status      = "Active"
+    }
+
+    resource "kubernetes_secret" "sumologic_collection_secret" {
+      count = var.use_extension ? 0 : 1
+
+      metadata {
+        name      = var.secret_name
+        namespace = var.namespace_name
+      }
+
+      data = tomap({
+        for name, config in local.source_configs : config["config-name"] => lookup(local.sources, name).url
+      })
+
+      type                           = "Opaque"
+      wait_for_service_account_token = false
+    }
+
+    # Only created when sourceless mode is on and no token was provided via Helm values.
+    # When installationToken is set in values, extension-secret.yaml owns this secret instead.
+    resource "kubernetes_secret" "extension_secret" {
+      count = (var.use_extension && !var.provided_installation_token) ? 1 : 0
+
+      metadata {
+        name      = var.extension_secret_name
+        namespace = var.namespace_name
+      }
+
+      data = tomap({
+        "SUMOLOGIC_INSTALLATION_TOKEN" = sumologic_token.collection_token[0].encoded_token_and_url
+      })
+
+      type                           = "Opaque"
+      wait_for_service_account_token = false
+    }
+  setup.sh: |
+    #!/bin/bash
+
+    readonly DEBUG_MODE=${DEBUG_MODE:="false"}
+    readonly DEBUG_MODE_ENABLED_FLAG="true"
+    readonly SUMOLOGIC_COLLECTOR_NAME="${SUMOLOGIC_COLLECTOR_NAME:?}"
+    readonly NAMESPACE="${NAMESPACE:?}"
+    readonly SUMOLOGIC_SECRET_NAME="${SUMOLOGIC_SECRET_NAME:?}"
+
+    # Set variables for terraform
+    export TF_VAR_collector_name="${SUMOLOGIC_COLLECTOR_NAME}"
+    export TF_VAR_namespace_name="${NAMESPACE}"
+    export TF_VAR_secret_name="${SUMOLOGIC_SECRET_NAME}"
+    export TF_VAR_chart_version="${CHART_VERSION:?}"
+    export TF_VAR_use_extension="${SUMOLOGIC_USE_EXTENSION:-false}"
+    export TF_VAR_extension_secret_name="${SUMOLOGIC_EXTENSION_SECRET_NAME:-sumologic-extension}"
+    export TF_VAR_provided_installation_token="${SUMOLOGIC_INSTALLATION_TOKEN:+true}"
+    export TF_VAR_provided_installation_token="${TF_VAR_provided_installation_token:-false}"
+
+    # Let's compare the variables ignoring the case with help of ${VARIABLE,,} which makes the string lowercased
+    # so that we don't have to deal with True vs true vs TRUE
+    if [[ ${DEBUG_MODE,,} == "${DEBUG_MODE_ENABLED_FLAG}" ]]; then
+        echo "Entering the debug mode with continuous sleep. No setup will be performed."
+        echo "Please exec into the setup container and run the setup.sh by hand or set the sumologic.setup.debug=false and reinstall."
+
+        while true; do
+            sleep 10
+            DATE=$(date)
+            echo "${DATE} Sleeping in the debug mode..."
+        done
+    fi
+
+    # Apply CRDs if command provided as argument
+    if [[ -n "${1:-}" ]]; then
+        echo "Applying CRDs with command: $1"
+        eval "$1"
+    fi
+
+    function fix_sumo_base_url() {
+      local BASE_URL
+      BASE_URL=${SUMOLOGIC_BASE_URL}
+
+      if [[ "${BASE_URL}" =~ ^\s*$ ]]; then
+        BASE_URL="https://api.sumologic.com/api/"
+      fi
+
+      # shellcheck disable=SC2312
+      OPTIONAL_REDIRECTION="$(curl -XGET -s -o /dev/null -D - \
+              -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+              "${BASE_URL}"v1/collectors \
+              | grep -Fi location )"
+
+      if [[ ! ${OPTIONAL_REDIRECTION} =~ ^\s*$ ]]; then
+        BASE_URL=$( echo "${OPTIONAL_REDIRECTION}" | sed -E 's/.*: (https:\/\/.*(au|ca|de|eu|fed|in|jp|kr|ch|esc|us2)?\.sumologic\.com\/api\/).*/\1/' )
+      fi
+
+      BASE_URL=${BASE_URL%v1*}
+
+      echo "${BASE_URL}"
+    }
+
+    SUMOLOGIC_BASE_URL=$(fix_sumo_base_url)
+    export SUMOLOGIC_BASE_URL
+    # Support proxy for Terraform
+    export HTTP_PROXY=${HTTP_PROXY:=""}
+    export HTTPS_PROXY=${HTTPS_PROXY:=""}
+    export NO_PROXY=${NO_PROXY:=""}
+
+    function get_remaining_fields() {
+        local RESPONSE
+        RESPONSE="$(curl -XGET -s \
+            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+            "${SUMOLOGIC_BASE_URL}"v1/fields/quota)"
+        readonly RESPONSE
+
+        echo "${RESPONSE}"
+    }
+
+    # Check if we'd have at least 10 fields remaining after additional fields
+    # would be created for the collection
+    function should_create_fields() {
+        local RESPONSE
+        RESPONSE=$(get_remaining_fields)
+        readonly RESPONSE
+
+        if ! jq -e <<< "${RESPONSE}" ; then
+            printf "Failed requesting fields API:\n%s\n" "${RESPONSE}"
+            return 1
+        fi
+
+        if ! jq -e '.remaining' <<< "${RESPONSE}" ; then
+            printf "Failed requesting fields API:\n%s\n" "${RESPONSE}"
+            return 1
+        fi
+
+        local REMAINING
+        REMAINING=$(jq -e '.remaining' <<< "${RESPONSE}")
+        readonly REMAINING
+        if [[ $(( REMAINING - ${#FIELDS} )) -ge 10 ]] ; then
+            return 0
+        else
+            return 1
+        fi
+    }
+
+    cp /etc/terraform/* /terraform/
+    cd /terraform || exit 1
+
+    FIELDS_STRING=$(jq -r '.fields[]' terraform.tfvars.json)
+    mapfile -t FIELDS < <(echo "${FIELDS_STRING}")
+
+    # Remove lock file to prevent version conflicts on upgrades
+    if [[ -f .terraform.lock.hcl ]]; then
+        echo "Removing existing Terraform lock file to prevent provider version conflicts"
+        rm -f .terraform.lock.hcl
+    fi
+
+    # Run pre-init script if provided (for downloading providers, etc.)
+    if [[ -f /customer-scripts/terraform_pre-init.sh ]]; then
+        echo "===================================================================="
+        echo "Running pre-init script: /customer-scripts/terraform_pre-init.sh"
+        echo "===================================================================="
+        if ! bash /customer-scripts/terraform_pre-init.sh; then
+            echo "ERROR: Pre-init script failed with exit code $?"
+            echo "Cannot proceed with Terraform setup due to pre-initialization failure."
+            exit 1
+        fi
+        echo "Pre-init script completed successfully"
+    fi
+
+    # Check for custom Terraform CLI config file (for internal registry support)
+    if [[ -f /customer-scripts/terraform_terraformrc ]]; then
+        export TF_CLI_CONFIG_FILE=/customer-scripts/terraform_terraformrc
+        echo "===================================================================="
+        echo "Using custom Terraform CLI config: ${TF_CLI_CONFIG_FILE}"
+        echo "Providers will be downloaded from internal registry as configured."
+        echo "===================================================================="
+    fi
+
+    # Initialize Terraform with upgrade to handle provider version changes
+    terraform init -input=false -upgrade || {
+        echo "Terraform init failed, attempting to clean .terraform directory"
+        rm -rf .terraform
+        terraform init -input=false -upgrade
+    }
+
+    # Sumo Logic fields
+    if should_create_fields ; then
+        readonly CREATE_FIELDS=1
+        # shellcheck disable=SC2312
+        FIELDS_RESPONSE="$(curl -XGET -s \
+            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+            "${SUMOLOGIC_BASE_URL}"v1/fields | jq '.data[]' )"
+        readonly FIELDS_RESPONSE
+
+        for FIELD in "${FIELDS[@]}" ; do
+            FIELD_ID=$( echo "${FIELDS_RESPONSE}" | jq -r "select(.fieldName | ascii_downcase == \"${FIELD}\") | .fieldId" )
+            # Don't try to import non existing fields
+            if [[ -z "${FIELD_ID}" ]]; then
+                continue
+            fi
+
+            terraform import \
+                -var="create_fields=1" \
+                sumologic_field.collection_field[\""${FIELD}"\"] "${FIELD_ID}"
+        done
+    else
+        readonly CREATE_FIELDS=0
+        echo "Couldn't automatically create fields"
+        echo "You do not have enough field capacity to create the required fields automatically."
+        echo "Please refer to https://www.sumologic.com/help/docs/manage/fields/ to manually create the fields after you have removed unused fields to free up capacity."
+    fi
+
+    # Delete hosted collector (and all its sources) via API when cleanup is requested.
+    # Terraform cannot destroy resources it cannot import, so we use the API directly.
+    function delete_hosted_collector() {
+        local RESPONSE COLLECTOR_ID
+        RESPONSE="$(curl -XGET -s --retry 3 --retry-delay 5 \
+            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+            "${SUMOLOGIC_BASE_URL}v1/collectors?filter=hosted&limit=1000" || echo "{}")"
+        local JQ_OUTPUT
+        JQ_OUTPUT=$(jq -r ".collectors[]? | select(.name == \"${SUMOLOGIC_COLLECTOR_NAME}\") | .id" <<< "${RESPONSE}")
+        COLLECTOR_ID=$(head -1 <<< "${JQ_OUTPUT}")
+        if [[ -n "${COLLECTOR_ID}" ]]; then
+            echo "Deleting hosted collector '${SUMOLOGIC_COLLECTOR_NAME}' (${COLLECTOR_ID}) and all its sources..."
+            local DELETE_RESPONSE
+            DELETE_RESPONSE="$(curl -s -XDELETE \
+                -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+                -w "\n%{http_code}" \
+                "${SUMOLOGIC_BASE_URL}v1/collectors/${COLLECTOR_ID}")"
+            local HTTP_CODE DELETE_BODY
+            HTTP_CODE=$(tail -1 <<< "${DELETE_RESPONSE}")
+            DELETE_BODY=$(head -1 <<< "${DELETE_RESPONSE}")
+            if [[ "${HTTP_CODE}" == "200" || "${HTTP_CODE}" == "204" ]]; then
+                echo "Hosted collector deleted."
+            else
+                echo "Failed to delete hosted collector '${SUMOLOGIC_COLLECTOR_NAME}' (${COLLECTOR_ID}). HTTP ${HTTP_CODE}: ${DELETE_BODY}"
+                return 1
+            fi
+        else
+            echo "Hosted collector '${SUMOLOGIC_COLLECTOR_NAME}' not found, nothing to delete."
+        fi
+    }
+
+    if [[ "${SUMOLOGIC_USE_EXTENSION:-false}" == "true" && "${SUMOLOGIC_CLEANUP_HOSTED_COLLECTOR:-false}" == "true" ]]; then
+        delete_hosted_collector
+    fi
+
+    # Sumo Logic Collector and HTTP sources
+    # In extension mode the collector is not managed by Terraform (count=0), so skip import entirely.
+    if [[ "${SUMOLOGIC_USE_EXTENSION:-false}" != "true" ]]; then
+        # Only import sources when collector exists.
+        if terraform import 'sumologic_collector.collector[0]' "${SUMOLOGIC_COLLECTOR_NAME}"; then
+            jq -r '.resource[] | to_entries[] | "\(.key) \(.value.name)"' sources.tf.json | while read -r resource_name source_name; do
+                terraform import "sumologic_http_source.${resource_name}" "${SUMOLOGIC_COLLECTOR_NAME}/${source_name}"
+            done || true
+        fi
+    fi
+
+    # Import existing installation token if extension mode is enabled (prevents recreation on upgrades)
+    function import_installation_token() {
+        local TOKEN_NAME="kubernetes-collection-${SUMOLOGIC_COLLECTOR_NAME}"
+        local RESPONSE TOKEN_ID
+        RESPONSE="$(curl -XGET -s --retry 3 --retry-delay 5 \
+            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+            "${SUMOLOGIC_BASE_URL}v1/tokens?limit=1000" || echo "{}")"
+        local JQ_OUTPUT
+        if ! jq -e '.data' <<< "${RESPONSE}" > /dev/null 2>&1; then
+            echo "WARNING: Token API response does not contain .data — skipping token import."
+            return 0
+        fi
+        JQ_OUTPUT=$(jq -r ".data[]? | select(.name == \"${TOKEN_NAME}\") | .id" <<< "${RESPONSE}")
+        TOKEN_ID=$(head -1 <<< "${JQ_OUTPUT}")
+        if [[ -n "${TOKEN_ID}" ]]; then
+            echo "Importing existing installation token: ${TOKEN_NAME} (${TOKEN_ID})"
+            terraform import \
+                -var="use_extension=true" \
+                'sumologic_token.collection_token[0]' "${TOKEN_ID}" || echo "WARNING: failed to import sumologic_token.collection_token[0] (${TOKEN_ID})"
+        fi
+    }
+
+    # Import existing token only when extension mode is on AND Terraform manages it (no user-provided token).
+    if [[ "${SUMOLOGIC_USE_EXTENSION:-false}" == "true" && "${TF_VAR_provided_installation_token}" != "true" ]]; then
+        import_installation_token
+    fi
+
+    # Kubernetes Secrets
+    if [[ "${SUMOLOGIC_USE_EXTENSION:-false}" != "true" ]]; then
+        terraform import "kubernetes_secret.sumologic_collection_secret[0]" "${NAMESPACE}/${SUMOLOGIC_SECRET_NAME}" || true
+    elif [[ "${TF_VAR_provided_installation_token}" != "true" ]]; then
+        # Extension mode with Terraform-managed token: import the extension secret when token is not provided via values.
+        terraform import "kubernetes_secret.extension_secret[0]" "${NAMESPACE}/${TF_VAR_extension_secret_name}" || true
+    fi
+
+    # Apply planned changes
+    TF_LOG_PROVIDER=DEBUG terraform apply \
+        -auto-approve \
+        -var="create_fields=${CREATE_FIELDS}" \
+        || { echo "Error during applying Terraform changes"; exit 1; }
+
+    # Delete sources that exist on the collector but are not in the current config.
+    # This cleans up sources that became unused after sourceType changes.
+    function cleanup_unused_sources() {
+        echo "Checking for unused sources to clean up..."
+
+        # Get expected source names from the current config
+        local EXPECTED_SOURCES
+        EXPECTED_SOURCES=$(jq -r '.resource.sumologic_http_source | to_entries[] | .value.name' sources.tf.json 2>/dev/null)
+        if [[ -z "${EXPECTED_SOURCES}" ]]; then
+            echo "No sources in config, skipping cleanup."
+            return
+        fi
+
+        # Get collector ID by looking up the collector
+        local COLLECTOR_RESPONSE
+        COLLECTOR_RESPONSE=$(curl -s -G \
+            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+            --data-urlencode "filter=${SUMOLOGIC_COLLECTOR_NAME}" \
+            "${SUMOLOGIC_BASE_URL}v1/collectors")
+
+        local COLLECTOR_ID
+        COLLECTOR_ID=$(echo "${COLLECTOR_RESPONSE}" | jq -r ".collectors[] | select(.name == \"${SUMOLOGIC_COLLECTOR_NAME}\") | .id")
+        if [[ -z "${COLLECTOR_ID}" || "${COLLECTOR_ID}" == "null" ]]; then
+            echo "Could not find collector ID, skipping source cleanup."
+            return
+        fi
+
+        # List all existing sources on the collector
+        local SOURCES_RESPONSE
+        SOURCES_RESPONSE=$(curl -s -XGET \
+            -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+            "${SUMOLOGIC_BASE_URL}v1/collectors/${COLLECTOR_ID}/sources")
+
+        local EXISTING_SOURCES
+        EXISTING_SOURCES=$(echo "${SOURCES_RESPONSE}" | jq -r '.sources[] | "\(.id)\t\(.name)"')
+        if [[ -z "${EXISTING_SOURCES}" ]]; then
+            echo "No existing sources found on collector, skipping cleanup."
+            return
+        fi
+
+        # Get all chart-managed source names (both HTTP and OTLP variants for all signals).
+        # This list is generated from values.yaml at helm render time via
+        # chart-managed-sources.json, ensuring it stays in sync automatically.
+        # Only sources whose names appear in this list are candidates for deletion.
+        # Sources created manually (via UI or API) will never be touched.
+        local KNOWN_CHART_SOURCES
+        KNOWN_CHART_SOURCES=$(jq -r '.sources[]' /etc/terraform/chart-managed-sources.json 2>/dev/null)
+        if [[ -z "${KNOWN_CHART_SOURCES}" ]]; then
+            echo "WARNING: Could not read chart-managed-sources.json, skipping cleanup."
+            return
+        fi
+
+        # Delete sources that are chart-managed but not in the current config
+        while IFS=$'\t' read -r source_id source_name; do
+            # Only consider sources that are known chart-managed sources
+            if ! echo "${KNOWN_CHART_SOURCES}" | grep -qxF "${source_name}"; then
+                continue
+            fi
+            # Delete if not in current expected config
+            if ! echo "${EXPECTED_SOURCES}" | grep -qxF "${source_name}"; then
+                echo "Deleting unused source: ${source_name} (id: ${source_id})"
+                local DELETE_RESPONSE
+                DELETE_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" -XDELETE \
+                    -u "${SUMOLOGIC_ACCESSID}:${SUMOLOGIC_ACCESSKEY}" \
+                    "${SUMOLOGIC_BASE_URL}v1/collectors/${COLLECTOR_ID}/sources/${source_id}")
+                if [[ "${DELETE_RESPONSE}" == "200" ]]; then
+                    echo "  Successfully deleted source: ${source_name}"
+                else
+                    echo "  WARNING: Failed to delete source ${source_name} (HTTP ${DELETE_RESPONSE})"
+                fi
+            fi
+        done <<< "${EXISTING_SOURCES}"
+
+        echo "Source cleanup complete."
+    }
+
+    # shellcheck disable=SC2154
+    if [[ "${CLEANUP_UNUSED_SOURCES}" == "true" ]]; then
+        cleanup_unused_sources
+    else
+        echo "Source cleanup skipped (cleanupUnusedSources is not enabled)."
+    fi
+
+    # Setup Sumo Logic monitors if enabled
+    if [[ "${SUMOLOGIC_MONITORS_ENABLED:?}" = "true" ]]; then
+        bash /etc/terraform/monitors.sh
+    else
+        echo "Installation of the Sumo Logic monitors is disabled."
+        echo "You can install them manually later with:"
+        echo "https://github.com/SumoLogic/terraform-sumologic-sumo-logic-monitor/tree/main/monitor_packages/kubernetes"
+    fi
+
+    # Setup Sumo Logic dashboards if enabled
+    if [[ "${SUMOLOGIC_DASHBOARDS_ENABLED:?}" = "true" ]]; then
+        bash /etc/terraform/dashboards.sh
+    else
+        echo "Installation of the Sumo Logic dashboards is disabled."
+        echo "You can install them manually later with:"
+        echo "https://www.sumologic.com/help/docs/integrations/containers-orchestration/kubernetes#installing-the-kubernetes-app"
+    fi
+
+    # Cleanup env variables
+    export SUMOLOGIC_BASE_URL=
+    export SUMOLOGIC_ACCESSKEY=
+    export SUMOLOGIC_ACCESSID=
+
+    bash /etc/terraform/custom.sh
+  variables.tf: |
+    variable "collector_name" {
+      type = string
+    }
+
+    variable "namespace_name" {
+      type = string
+    }
+
+    variable "secret_name" {
+      type = string
+    }
+
+    variable "create_fields" {
+      description = "If set, Terraform will attempt to create fields at Sumo Logic"
+      type        = bool
+      default     = true
+    }
+
+    variable "fields" {
+      description = "Log fields to create."
+      type        = list(string)
+    }
+
+    variable "collector_fields" {
+      description = "Fields to set on the collector."
+      type        = map(string)
+    }
+
+    variable "chart_version" {
+      description = "The Helm Chart version."
+      type        = string
+    }
+
+    variable "use_extension" {
+      description = "If set, use SumoLogic extension instead of HTTP sources. An installation token is created automatically."
+      type        = bool
+      default     = false
+    }
+
+    variable "extension_secret_name" {
+      description = "Name of the Kubernetes secret that stores the installation token for extension mode."
+      type        = string
+      default     = "sumologic-extension"
+    }
+
+    variable "provided_installation_token" {
+      description = "Whether a pre-existing installation token was provided via Helm values. When true, Terraform skips token creation."
+      type        = bool
+      default     = false
+    }
+  chart-managed-sources.json: |
+    {
+      "sources": [
+        "events",
+        "events-otlp",
+        "logs",
+        "logs-otlp",
+        "apiserver-metrics",
+        "control-plane-metrics",
+        "kube-controller-manager-metrics",
+        "custom-http-metrics",
+        "custom-otlp-metrics",
+        "(default-metrics)",
+        "metrics-otlp",
+        "kubelet-metrics",
+        "node-exporter-metrics",
+        "kube-scheduler-metrics",
+        "kube-state-metrics",
+        "traces",
+        "traces-otlp"
+      ]
+    }
+  providers.tf.json: |
+    {
+      "provider": {
+        "kubernetes": {
+          "cluster_ca_certificate": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt\")}",
+          "host": "https://kubernetes.default.svc",
+          "token": "${file(\"/var/run/secrets/kubernetes.io/serviceaccount/token\")}"
+        },
+        "sumologic": {}
+      }
+    }
+  sources.tf.json: |
+    {
+      "locals": {
+        "source_configs": {
+          "custom_otlp_via_property_metrics_source": {
+            "config-name": "endpoint-custom_otlp_via_property_metrics_source",
+            "name": "custom-otlp-metrics",
+            "properties": {
+              "content_type": "Otlp"
+            }
+          },
+          "default_otlp_events_source": {
+            "config-name": "endpoint-events-otlp",
+            "name": "events-otlp",
+            "properties": {
+              "content_type": "Otlp"
+            }
+          },
+          "default_otlp_logs_source": {
+            "config-name": "endpoint-logs-otlp",
+            "name": "logs-otlp",
+            "properties": {
+              "content_type": "Otlp"
+            }
+          },
+          "default_otlp_metrics_source": {
+            "config-name": "endpoint-metrics-otlp",
+            "name": "metrics-otlp",
+            "properties": {
+              "content_type": "Otlp"
+            }
+          },
+          "default_otlp_traces_source": {
+            "config-name": "endpoint-traces-otlp",
+            "name": "traces-otlp",
+            "properties": {
+              "content_type": "Otlp"
+            }
+          }
+        },
+        "sources": {
+          "custom_otlp_via_property_metrics_source": "${ sumologic_http_source.custom_otlp_via_property_metrics_source }",
+          "default_otlp_events_source": "${ sumologic_http_source.default_otlp_events_source }",
+          "default_otlp_logs_source": "${ sumologic_http_source.default_otlp_logs_source }",
+          "default_otlp_metrics_source": "${ sumologic_http_source.default_otlp_metrics_source }",
+          "default_otlp_traces_source": "${ sumologic_http_source.default_otlp_traces_source }"
+        }
+      },
+      "resource": {
+        "sumologic_http_source": {
+          "custom_otlp_via_property_metrics_source": {
+            "collector_id": "${ sumologic_collector.collector[0].id }",
+            "content_type": "Otlp",
+            "name": "custom-otlp-metrics"
+          },
+          "default_otlp_events_source": {
+            "collector_id": "${ sumologic_collector.collector[0].id }",
+            "content_type": "Otlp",
+            "name": "events-otlp"
+          },
+          "default_otlp_logs_source": {
+            "collector_id": "${ sumologic_collector.collector[0].id }",
+            "content_type": "Otlp",
+            "name": "logs-otlp"
+          },
+          "default_otlp_metrics_source": {
+            "collector_id": "${ sumologic_collector.collector[0].id }",
+            "content_type": "Otlp",
+            "name": "metrics-otlp"
+          },
+          "default_otlp_traces_source": {
+            "collector_id": "${ sumologic_collector.collector[0].id }",
+            "content_type": "Otlp",
+            "name": "traces-otlp"
+          }
+        }
+      }
+    }
+  terraform.tfvars.json: |
+    {
+      "collector_fields": {
+        "sumo.cluster.name": "kubernetes",
+        "sumo.helm.release": "%CURRENT_CHART_VERSION%",
+        "sumo.hostedCollector.subType": "K8s"
+      },
+      "fields": [
+        "cluster",
+        "container",
+        "daemonset",
+        "deployment",
+        "host",
+        "namespace",
+        "node",
+        "pod",
+        "service",
+        "statefulset"
+      ]
+    }


### PR DESCRIPTION
## Summary

- Source type classification in `sources.tf.json` now uses `properties.content_type` instead of the brittle key name suffix (`-otlp`), making it consistent with the env-var injection logic in `_common.tpl`.


Previously, two different mechanisms were used to determine if a source is OTLP:
- Source creation (Terraform): checked if the key name ends with `-otlp`
- Env var injection (pod spec): checked `properties.content_type == "Otlp"`

From this change, all the verification method consistantly use `properties.content_type == "Otlp"`param to validate if the given source is otlp or not.


## Test plan

- [x] Existing golden file tests pass (`TestGoldenFiles/testdata/goldenfile/terraform/`)
- [x] New golden file test (`always_create_sources`) validates that `alwaysCreate: true` sources and `content_type: Otlp` sources are both created with `sourceType: otlp`
- [ ] Manual verification: deployed locally with custom otlp sources